### PR TITLE
Add basic support for end-to-end crypto using olm.

### DIFF
--- a/skins/base/views/molecules/UnknownMessageTile.js
+++ b/skins/base/views/molecules/UnknownMessageTile.js
@@ -25,9 +25,10 @@ module.exports = React.createClass({
     mixins: [UnknownMessageTileController],
 
     render: function() {
+        var content = this.props.mxEvent.getContent();
         return (
             <span className="mx_UnknownMessageTile">
-                ?
+                {content.body}
             </span>
         );
     },

--- a/skins/base/views/organisms/CreateRoom.js
+++ b/skins/base/views/organisms/CreateRoom.js
@@ -118,6 +118,12 @@ module.exports = React.createClass({
         })
     },
 
+    onEncryptChanged: function(ev) {
+        this.setState({
+            encrypt: ev.target.checked,
+        });
+    },
+
     render: function() {
         var curr_phase = this.state.phase;
         if (curr_phase == this.phases.CREATING) {
@@ -142,7 +148,7 @@ module.exports = React.createClass({
                     <Presets ref="presets" onChange={this.onPresetChanged} preset={this.state.preset}/> <br />
                     <label><input type="checkbox" ref="is_private" checked={this.state.is_private} onChange={this.onPrivateChanged}/> Make this room private</label>
                     <label><input type="checkbox" ref="share_history" checked={this.state.share_history} onChange={this.onShareHistoryChanged}/> Share message history with new users</label>
-                    <label><input type="checkbox"/> Encrypt room</label>
+                    <label><input type="checkbox" ref="encrypt" checked={this.state.encrypt} onChange={this.onEncryptChanged}/> Encrypt room</label>
                     <CreateRoomButton onCreateRoom={this.onCreateRoom} /> <br />
                     {error_box}
                 </div>

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -23,6 +23,16 @@ var matrixClient = null;
 
 var localStorage = window.localStorage;
 
+function deviceId() {
+    var id = Math.floor(Math.random()*16777215).toString(16);
+    id = "W" + "000000".substring(id.length) + id;
+    if (localStorage) {
+        id = localStorage.getItem("mx_device_id") || id;
+        localStorage.setItem("mx_device_id", id);
+    }
+    return id;
+}
+
 function createClient(hs_url, is_url, user_id, access_token) {
     var opts = {
         baseUrl: hs_url,
@@ -30,6 +40,11 @@ function createClient(hs_url, is_url, user_id, access_token) {
         accessToken: access_token,
         userId: user_id
     };
+
+    if (localStorage) {
+        opts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
+        opts.deviceId = deviceId();
+    }
 
     matrixClient = Matrix.createClient(opts);
 }

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 var MatrixClientPeg = require("./MatrixClientPeg");
 var dis = require("./dispatcher");
+var encryption = require("./encryption");
 
 var reject = function(msg) {
     return {
@@ -40,6 +41,25 @@ var commands = {
             );
         }
         return reject("Usage: /nick <display_name>");
+    },
+
+    encrypt: function(room_id, args) {
+        if (args == "on") {
+            var client = MatrixClientPeg.get();
+            var members = client.getRoom(room_id).currentState.members;
+            var user_ids = Object.keys(members);
+            return success(
+                encryption.enableEncryption(client, room_id, user_ids)
+            );
+        }
+        if (args == "off") {
+            var client = MatrixClientPeg.get();
+            return success(
+                encryption.disableEncryption(client, room_id)
+            );
+
+        }
+        return reject("Usage: encrypt <on/off>");
     },
 
     // Change the room topic

--- a/src/controllers/organisms/CreateRoom.js
+++ b/src/controllers/organisms/CreateRoom.js
@@ -20,6 +20,7 @@ var React = require("react");
 var MatrixClientPeg = require("../../MatrixClientPeg");
 var PresetValues = require('../atoms/create_room/Presets').Presets;
 var q = require('q');
+var encryption = require("../../encryption");
 
 module.exports = {
     propTypes: {
@@ -103,22 +104,14 @@ module.exports = {
         var response;
 
         if (this.state.encrypt) {
-            var deferred = deferred.then(function(res) {
+            deferred = deferred.then(function(res) {
                 response = res;
-                return cli.downloadKeys([cli.credentials.userId]);
-            }).then(function(res) {
-                // TODO: Check the keys are valid.
-                return cli.downloadKeys(options.invite);
-            }).then(function(res) {
-                return cli.setRoomEncryption(response.room_id, {
-                    algorithm: "m.olm.v1.curve25519-aes-sha2",
-                    members: options.invite,
-                });
-            }).then(function(res) {
-                var d = q.defer();
-                d.resolve(response);
-                return d.promise;
-            });
+                return encryption.enableEncryption(
+                    cli, response.roomId, options.invite
+                );
+            }).then(function() {
+                return q(response) }
+            );
         }
 
         this.setState({

--- a/src/encryption.js
+++ b/src/encryption.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2015 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+function enableEncyption(client, roomId, members) {
+    members = members.slice(0);
+    members.push(client.credentials.userId);
+    // TODO: Check the keys actually match what keys the user has.
+    // TODO: Don't redownload keys each time.
+    return client.downloadKeys(members, "forceDownload").then(function(res) {
+        return client.setRoomEncryption(roomId, {
+            algorithm: "m.olm.v1.curve25519-aes-sha2",
+            members: members,
+        });
+    })
+}
+
+function disableEncryption(client, roomId) {
+    return client.disableRoomEncryption(roomId);
+}
+
+
+module.exports = {
+    enableEncryption: enableEncyption,
+    disableEncryption: disableEncryption,
+}


### PR DESCRIPTION
Added a session store to the matrix-js-sdk client so that it will generate account keys.
Hooked up "/encrypt on" and "/encrypt off" commands so that we can test end-to-end.