### PR TITLE
Add missing enum value to registration password complexity check

### DIFF
--- a/src/controllers/templates/Register.js
+++ b/src/controllers/templates/Register.js
@@ -22,7 +22,8 @@ module.exports = {
         PasswordMismatch: 'PasswordMismatch',
         TooShort: 'TooShort',
         Missing: 'Missing',
-        InUse: 'InUse'
+        InUse: 'InUse',
+        Length: 'Length'
     },
 
     getInitialState: function() {


### PR DESCRIPTION
Enums are evil because they break subtly when you forget to add them / typo when you use them. If we aren't using a static type checker they buy us absolutely nothing, we shouldn't be using them.

Context: Spent 30 minutes figuring out why `onBadFields` was firing with `{ }`, because it was being set to `{ password: undefined }`. If we actually used hard-coded strings it would've been clearer what was going on (and there isn't any increased typo risk).
