### PR TITLE
Re-add in post registration steps

### DIFF
--- a/src/controllers/molecules/ChangeAvatar.js
+++ b/src/controllers/molecules/ChangeAvatar.js
@@ -36,6 +36,16 @@ module.exports = {
         }
     },
 
+    componentWillReceiveProps: function(newProps) {
+        if (this.avatarSet) {
+            // don't clobber what the user has just set
+            return;
+        }
+        this.setState({
+            avatarUrl: newProps.initialAvatarUrl
+        });
+    },
+
     setAvatarFromFile: function(file) {
         var newUrl = null;
 

--- a/src/controllers/molecules/ChangeDisplayName.js
+++ b/src/controllers/molecules/ChangeDisplayName.js
@@ -15,10 +15,14 @@ limitations under the License.
 */
 
 'use strict';
-
+var React = require('react');
 var MatrixClientPeg = require("../../MatrixClientPeg");
 
 module.exports = {
+    propTypes: {
+        onFinished: React.PropTypes.func
+    },
+
     getDefaultProps: function() {
         return {
             onFinished: function() {},

--- a/src/controllers/pages/MatrixChat.js
+++ b/src/controllers/pages/MatrixChat.js
@@ -31,7 +31,7 @@ module.exports = {
         RoomView: "room_view",
         UserSettings: "user_settings",
         CreateRoom: "create_room",
-        RoomDirectory: "room_directory",
+        RoomDirectory: "room_directory"
     },
 
     AuxPanel: {
@@ -143,6 +143,11 @@ module.exports = {
                     screen: 'login'
                 });
                 this.notifyNewScreen('login');
+                break;
+            case 'start_post_registration':
+                this.setState({ // don't clobber logged_in status
+                    screen: 'post_registration'
+                });
                 break;
             case 'token_login':
                 if (this.state.logged_in) return;
@@ -298,13 +303,11 @@ module.exports = {
     },
 
     onLoggedIn: function(credentials) {
-        if (credentials) { // registration doesn't do this yet
-            console.log("onLoggedIn => %s", credentials.userId);
-            MatrixClientPeg.replaceUsingAccessToken(
-                credentials.homeserverUrl, credentials.identityServerUrl,
-                credentials.userId, credentials.accessToken
-            );
-        }
+        console.log("onLoggedIn => %s", credentials.userId);
+        MatrixClientPeg.replaceUsingAccessToken(
+            credentials.homeserverUrl, credentials.identityServerUrl,
+            credentials.userId, credentials.accessToken
+        );
         this.setState({
             screen: undefined,
             logged_in: true
@@ -430,6 +433,10 @@ module.exports = {
         } else if (screen == 'directory') {
             dis.dispatch({
                 action: 'view_room_directory',
+            });
+        } else if (screen == 'post_registration') {
+            dis.dispatch({
+                action: 'start_post_registration',
             });
         } else if (screen.indexOf('room/') == 0) {
             var roomString = screen.split('/')[1];

--- a/src/controllers/pages/MatrixChat.js
+++ b/src/controllers/pages/MatrixChat.js
@@ -31,7 +31,7 @@ module.exports = {
         RoomView: "room_view",
         UserSettings: "user_settings",
         CreateRoom: "create_room",
-        RoomDirectory: "room_directory"
+        RoomDirectory: "room_directory",
     },
 
     AuxPanel: {

--- a/src/controllers/pages/MatrixChat.js
+++ b/src/controllers/pages/MatrixChat.js
@@ -459,6 +459,9 @@ module.exports = {
                 });
             }
         }
+        else {
+            console.error("Unknown screen : %s", screen);
+        }
     },
 
     notifyNewScreen: function(screen) {


### PR DESCRIPTION
The registration refactor removed post-registration steps (display name / avatar setting). This PR adds them back in as a distinct component. This also fixes a race in `ChangeAvatar` where if you don't have an `initialAvatarUrl` set initially, you could never update it (in the wild this meant sometimes the default github-style profile pic wouldn't load :cry: )

Related: https://github.com/vector-im/vector-web/pull/403