### PR TITLE
Add markdown support (enabled by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "flux": "^2.0.3",
     "glob": "^5.0.14",
     "linkifyjs": "^2.0.0-beta.4",
+    "marked": "^0.3.5",
     "matrix-js-sdk": "https://github.com/matrix-org/matrix-js-sdk.git#develop",
     "optimist": "^0.6.1",
     "q": "^1.4.1",


### PR DESCRIPTION
We could really make this nicer in the long run by allowing `SlashCommands` to modify local component state, but for now this will work (until we want to add in more local commands, when it's probably worth splitting out).