### PR TITLE
Resend ordering glue

### DIFF
--- a/src/Resend.js
+++ b/src/Resend.js
@@ -21,4 +21,13 @@ module.exports = {
             event: event
         });
     },
+
+    removeFromQueue: function(event) {
+        MatrixClientPeg.get().getScheduler().removeEventFromQueue(event);
+        var room = MatrixClientPeg.get().getRoom(event.getRoomId());
+        if (!room) {
+            return;
+        }
+        room.removeEvents([event.getId()]);
+    }
 };

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -388,7 +388,9 @@ module.exports = React.createClass({
         Notifier.start();
         UserActivity.start();
         Presence.start();
-        cli.startClient();
+        cli.startClient({
+            pendingEventOrdering: "end"
+        });
     },
 
     onKeyDown: function(ev) {


### PR DESCRIPTION
Make React SDK sort pending events by `end` in accordance with https://github.com/matrix-org/matrix-js-sdk/pull/51 in order to resolve https://github.com/vector-im/vector-web/issues/367 - Add a `removeFromQueue` function which is called in vector-web to cancel sending of queued items.