### PR TITLE
Preserve scroll offset when switching rooms

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -324,18 +324,18 @@ module.exports = React.createClass({
         this.setState(newState);
         if (this.scrollStateMap[roomId]) {
             var scrollState = this.scrollStateMap[roomId];
-            this.refs.roomview.restoreScrollState(scrollState);
+            this.refs.roomView.restoreScrollState(scrollState);
         }
     },
 
     // update scrollStateMap according to the current scroll state of the
     // room view.
     _updateScrollMap: function() {
-        if (!this.refs.roomview) {
+        if (!this.refs.roomView) {
             return;
         }
 
-        var roomview = this.refs.roomview;
+        var roomview = this.refs.roomView;
         var state = roomview.getScrollState();
         this.scrollStateMap[roomview.props.roomId] = state;
     },
@@ -608,7 +608,7 @@ module.exports = React.createClass({
                 case this.PageTypes.RoomView:
                     page_element = (
                         <RoomView
-                            ref="roomview"
+                            ref="roomView"
                             roomId={this.state.currentRoom}
                             key={this.state.currentRoom}
                             ConferenceHandler={this.props.ConferenceHandler} />

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -254,21 +254,15 @@ module.exports = React.createClass({
                 });
                 break;
             case 'view_user_settings':
-                this.setState({
-                    page_type: this.PageTypes.UserSettings,
-                });
+                this._setPage(this.PageTypes.UserSettings);
                 this.notifyNewScreen('settings');
                 break;
             case 'view_create_room':
-                this.setState({
-                    page_type: this.PageTypes.CreateRoom,
-                });
+                this._setPage(this.PageTypes.CreateRoom);
                 this.notifyNewScreen('new');
                 break;
             case 'view_room_directory':
-                this.setState({
-                    page_type: this.PageTypes.RoomDirectory,
-                });
+                this._setPage(this.PageTypes.RoomDirectory);
                 this.notifyNewScreen('directory');
                 break;
             case 'notifier_enabled':
@@ -295,6 +289,15 @@ module.exports = React.createClass({
                 });
                 break;
         }
+    },
+
+    _setPage: function(pageType) {
+        // record the scroll state if we're in a room view.
+        this._updateScrollMap();
+
+        this.setState({
+            page_type: this.PageTypes.RoomDirectory,
+        });
     },
 
     _viewRoom: function(roomId) {

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -285,9 +285,6 @@ module.exports = React.createClass({
         var scrollState = this.savedScrollState;
         if (scrollState.atBottom) {
             this.scrollToBottom();
-            if (this.state.numUnreadMessages !== 0) {
-                this.setState({numUnreadMessages: 0});
-            }
         } else if (scrollState.lastDisplayedEvent) {
             this.scrollToEvent(scrollState.lastDisplayedEvent,
                                scrollState.pixelOffset);

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -295,7 +295,6 @@ module.exports = React.createClass({
     },
 
     _paginateCompleted: function() {
-        this.waiting_for_paginate = false;
         this.setState({
             room: MatrixClientPeg.get().getRoom(this.props.roomId)
         });
@@ -326,7 +325,6 @@ module.exports = React.createClass({
                 var cap = Math.min(this.state.messageCap + PAGINATE_SIZE, this.state.room.timeline.length);
                 this.setState({messageCap: cap});
             } else {
-                this.waiting_for_paginate = true;
                 var cap = this.state.messageCap + PAGINATE_SIZE;
                 this.setState({messageCap: cap, paginating: true});
                 MatrixClientPeg.get().scrollback(this.state.room, PAGINATE_SIZE).finally(this._paginateCompleted).done();

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -802,14 +802,14 @@ module.exports = React.createClass({
     //
     // pixel_offset gives the number of pixels between the bottom of the event
     // and the bottom of the container.
-    scrollToEvent: function(event_id, pixel_offset) {
+    scrollToEvent: function(eventId, pixelOffset) {
         var scrollNode = this._getScrollNode();
         if (!scrollNode) return;
 
         var messageWrapper = this.refs.messagePanel;
         if (messageWrapper === undefined) return;
 
-        var idx = this._indexForEventId(event_id);
+        var idx = this._indexForEventId(eventId);
         if (idx === null) {
             // we don't seem to have this event in our timeline. Presumably
             // it's fallen out of scrollback. We ought to backfill until we
@@ -817,19 +817,26 @@ module.exports = React.createClass({
             // looking for a non-existent event.
             //
             // for now, just scroll to the top of the buffer.
-            console.log("Refusing to scroll to unknown event "+event_id);
+            console.log("Refusing to scroll to unknown event "+eventId);
             scrollNode.scrollTop = 0;
             return;
         }
 
         // we might need to roll back the messagecap (to generate tiles for
-        // older messages). Don't roll it back past the timeline we have, though.
+        // older messages). This just means telling getEventTiles to create
+        // tiles for events we already have in our timeline (we already know
+        // the event in question is in our timeline, so we shouldn't need to
+        // backfill).
+        //
+        // we actually wind back slightly further than the event in question,
+        // because we want the event to be at the *bottom* of the container.
+        // Don't roll it back past the timeline we have, though.
         var minCap = this.state.room.timeline.length - Math.min(idx - INITIAL_SIZE, 0);
         if (minCap > this.state.messageCap) {
             this.setState({messageCap: minCap});
         }
 
-        var node = this.eventNodes[event_id];
+        var node = this.eventNodes[eventId];
         if (node === null) {
             // getEventTiles should have sorted this out when we set the
             // messageCap, so this is weird.
@@ -839,7 +846,7 @@ module.exports = React.createClass({
 
         var wrapperRect = ReactDOM.findDOMNode(messageWrapper).getBoundingClientRect();
         var boundingRect = node.getBoundingClientRect();
-        scrollNode.scrollTop += boundingRect.bottom + pixel_offset - wrapperRect.bottom;
+        scrollNode.scrollTop += boundingRect.bottom + pixelOffset - wrapperRect.bottom;
     },
 
     _calculateScrollState: function() {

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -275,8 +275,13 @@ module.exports = React.createClass({
     },
 
     componentDidUpdate: function() {
+        // after adding event tiles, we may need to tweak the scroll (either to
+        // keep at the bottom of the timeline, or to maintain the view after
+        // adding events to the top).
+
         if (!this.refs.messagePanel) return;
 
+        if (this.state.searchResults) return;
         var scrollState = this.savedScrollState;
         if (scrollState.atBottom) {
             this.scrollToBottom();
@@ -357,7 +362,7 @@ module.exports = React.createClass({
     },
 
     onMessageListScroll: function(ev) {
-        if (this.refs.messagePanel) {
+        if (this.refs.messagePanel && !this.state.searchResults) {
             this.savedScrollState = this._calculateScrollState();
             if (this.savedScrollState.atBottom && this.state.numUnreadMessages != 0) {
                 this.setState({numUnreadMessages: 0});


### PR DESCRIPTION
When we change rooms, save the scroll offset, and restore the scroll when we
switch back.

Hopefully this fixes https://github.com/vector-im/vector-web/issues/80.