### PR TITLE
Fix issue with rooms not scrolling down when new events arrive

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -318,11 +318,7 @@ module.exports = React.createClass({
 
         if (this.state.searchResults) return;
 
-        if (this.needsScrollReset) {
-            if (DEBUG_SCROLL) console.log("Resetting scroll position after tile count change");
-            this._restoreSavedScrollState();
-            this.needsScrollReset = false;
-        }
+        this._restoreSavedScrollState();
 
         // have to fill space in case we're accepting an invite
         if (!this.state.paginating) this.fillSpace();
@@ -682,10 +678,6 @@ module.exports = React.createClass({
                 ret.unshift(dateSeparator);
             }
             ++count;
-        }
-        if (count != this.lastEventTileCount) {
-            if (DEBUG_SCROLL) console.log("Queuing scroll reset (event count changed; now "+count+"; was "+this.lastEventTileCount+")");
-            this.needsScrollReset = true;
         }
         this.lastEventTileCount = count;
         return ret;


### PR DESCRIPTION
Remove an optimisation which tried to avoid recalculating the scroll on every
render. The problem is that sometimes, when new events, the number of event
tiles remains the same, but we still need to do a scroll, because the height of
the message list changes.

The optimisation was a bit of a waste of time anyway - the actual render will
always be much more difficult than recalculating the scroll position.