### PR TITLE
Finish 3PID invites impl

### DIFF
--- a/src/Signup.js
+++ b/src/Signup.js
@@ -116,8 +116,17 @@ class Register extends Signup {
 
     _tryRegister(authDict) {
         var self = this;
+
+        var bindEmail;
+
+        if (this.username && this.password) {
+            // only need to bind_email when sending u/p - sending it at other
+            // times clobbers the u/p resulting in M_MISSING_PARAM (password)
+            bindEmail = true;
+        }
+
         return MatrixClientPeg.get().register(
-            this.username, this.password, this.params.sessionId, authDict
+            this.username, this.password, this.params.sessionId, authDict, bindEmail
         ).then(function(result) {
             self.credentials = result;
             self.setStep("COMPLETE");

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -14,7 +14,8 @@ function textForMemberEvent(ev) {
                 // TODO: When we have third_party_invite.display_name we should
                 // do this as "$displayname received the invitation from $sender"
                 // or equiv
-                return targetName + " received an invitation from " + senderName;
+                return targetName + " received an invitation from " + senderName +
+                    ".";
             }
             else {
                 return senderName + " invited " + targetName + ".";

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -9,7 +9,16 @@ function textForMemberEvent(ev) {
     ) : "";
     switch (ev.getContent().membership) {
         case 'invite':
-            return senderName + " invited " + targetName + ".";
+            var threePidContent = ev.getContent().third_party_invite;
+            if (threePidContent) {
+                // TODO: When we have third_party_invite.display_name we should
+                // do this as "$displayname received the invitation from $sender"
+                // or equiv
+                return targetName + " received an invitation from " + senderName;
+            }
+            else {
+                return senderName + " invited " + targetName + ".";
+            }
         case 'ban':
             return senderName + " banned " + targetName + "." + reason;
         case 'join':
@@ -101,6 +110,12 @@ function textForCallInviteEvent(event) {
     return senderName + " placed a " + type + " call." + supported;
 };
 
+function textForThreePidInviteEvent(event) {
+    var senderName = event.sender ? event.sender.name : event.getSender();
+    return senderName + " sent an invitation to " + event.getContent().display_name +
+     " to join the room.";
+};
+
 var handlers = {
     'm.room.message': textForMessageEvent,
     'm.room.name':    textForRoomNameEvent,
@@ -109,6 +124,7 @@ var handlers = {
     'm.call.invite':  textForCallInviteEvent,
     'm.call.answer':  textForCallAnswerEvent,
     'm.call.hangup':  textForCallHangupEvent,
+    'm.room.third_party_invite': textForThreePidInviteEvent
 };
 
 module.exports = {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -547,9 +547,9 @@ module.exports = React.createClass({
         }
     },
 
-    notifyNewScreen: function(screen, queryParamString) {
+    notifyNewScreen: function(screen) {
         if (this.props.onNewScreen) {
-            this.props.onNewScreen(screen, queryParamString);
+            this.props.onNewScreen(screen);
         }
     },
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -41,7 +41,8 @@ module.exports = React.createClass({
         config: React.PropTypes.object.isRequired,
         ConferenceHandler: React.PropTypes.any,
         onNewScreen: React.PropTypes.func,
-        registrationUrl: React.PropTypes.string
+        registrationUrl: React.PropTypes.string,
+        startingQueryParams: React.PropTypes.object
     },
 
     PageTypes: {
@@ -73,6 +74,12 @@ module.exports = React.createClass({
             }
         }
         return s;
+    },
+
+    getDefaultProps: function() {
+        return {
+            startingQueryParams: {}
+        };
     },
 
     componentDidMount: function() {
@@ -540,9 +547,9 @@ module.exports = React.createClass({
         }
     },
 
-    notifyNewScreen: function(screen) {
+    notifyNewScreen: function(screen, queryParamString) {
         if (this.props.onNewScreen) {
-            this.props.onNewScreen(screen);
+            this.props.onNewScreen(screen, queryParamString);
         }
     },
 
@@ -706,6 +713,7 @@ module.exports = React.createClass({
                     clientSecret={this.state.register_client_secret}
                     sessionId={this.state.register_session_id}
                     idSid={this.state.register_id_sid}
+                    email={this.props.startingQueryParams.email}
                     hsUrl={this.props.config.default_hs_url}
                     isUrl={this.props.config.default_is_url}
                     registrationUrl={this.props.registrationUrl}

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -39,6 +39,7 @@ module.exports = React.createClass({
         idSid: React.PropTypes.string,
         hsUrl: React.PropTypes.string,
         isUrl: React.PropTypes.string,
+        email: React.PropTypes.string,
         // registration shouldn't know or care how login is done.
         onLoginClick: React.PropTypes.func.isRequired
     },
@@ -185,6 +186,7 @@ module.exports = React.createClass({
                 registerStep = (
                     <RegistrationForm
                         showEmail={true}
+                        defaultEmail={this.props.email}
                         minPasswordLength={MIN_PASSWORD_LENGTH}
                         onError={this.onFormValidationFailed}
                         onRegisterClick={this.onFormSubmit} />

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -44,6 +44,7 @@ var eventTileTypes = {
     'm.call.hangup' : 'messages.TextualEvent',
     'm.room.name'   : 'messages.TextualEvent',
     'm.room.topic'  : 'messages.TextualEvent',
+    'm.room.third_party_invite': 'messages.TextualEvent'
 };
 
 var MAX_READ_AVATARS = 5;


### PR DESCRIPTION
This fixes the issues mentioned at https://github.com/vector-im/vector-web/issues/419#issuecomment-165195312

Requires https://github.com/vector-im/vector-web/pull/537

This completes the 3PID invite process for Vector. There are further improvements which need to be done when we have guest access:
 - The link from the invite email `#/room/<room_id_or_alias?email=foo@bar.com` should go straight to the room if it's readable by guests (not specific to 3PID invites). If it is NOT readable by guests, Vector should *logout* the guest account that was made in order do this check and then dump them to the *login* page (with the email pre-population which the PR implements)
 - The text displayed to the user when the 3PID invite turns into a normal invite should be better. We don't get told the `display_name` so we can't make it look nice currently.