### PR TITLE
Make ScrollPanel keep track of when fill requests are happening

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -43,6 +43,13 @@ var INITIAL_SIZE = 20;
 
 var DEBUG_SCROLL = false;
 
+if (DEBUG_SCROLL) {
+    // using bind means that we get to keep useful line numbers in the console
+    var debuglog = console.log.bind(console);
+} else {
+    var debuglog = function () {};
+}
+
 module.exports = React.createClass({
     displayName: 'RoomView',
     propTypes: {
@@ -344,7 +351,7 @@ module.exports = React.createClass({
     },
 
     _paginateCompleted: function() {
-        if (DEBUG_SCROLL) console.log("paginate complete");
+        debuglog("paginate complete");
 
         this.setState({
             room: MatrixClientPeg.get().getRoom(this.props.roomId)
@@ -355,34 +362,34 @@ module.exports = React.createClass({
 
     onSearchResultsFillRequest: function(backwards) {
         if (!backwards)
-            return false;
+            return q(false);
 
         if (this.nextSearchBatch) {
-            if (DEBUG_SCROLL) console.log("requesting more search results");
+            debuglog("requesting more search results");
             return this._getSearchBatch(this.state.searchTerm,
                                  this.state.searchScope).then(true);
         } else {
-            if (DEBUG_SCROLL) console.log("no more search results");
-            return false;
+            debuglog("no more search results");
+            return q(false);
         }
     },
 
     // set off a pagination request.
     onMessageListFillRequest: function(backwards) {
         if (!backwards)
-            return;
+            return q(false);
 
         // Either wind back the message cap (if there are enough events in the
         // timeline to do so), or fire off a pagination request.
 
         if (this.state.messageCap < this.state.room.timeline.length) {
             var cap = Math.min(this.state.messageCap + PAGINATE_SIZE, this.state.room.timeline.length);
-            if (DEBUG_SCROLL) console.log("winding back message cap to", cap);
+            debuglog("winding back message cap to", cap);
             this.setState({messageCap: cap});
-            return true;
+            return q(true);
         } else if(this.state.room.oldState.paginationToken) {
             var cap = this.state.messageCap + PAGINATE_SIZE;
-            if (DEBUG_SCROLL) console.log("starting paginate to cap", cap);
+            debuglog("starting paginate to cap", cap);
             this.setState({messageCap: cap, paginating: true});
             return MatrixClientPeg.get().scrollback(this.state.room, PAGINATE_SIZE).
                 finally(this._paginateCompleted).then(true);
@@ -492,7 +499,7 @@ module.exports = React.createClass({
         }
 
         this.nextSearchBatch = null;
-        this._getSearchBatch(term, scope);
+        this._getSearchBatch(term, scope).done();
     },
 
     // fire off a request for a batch of search results
@@ -509,11 +516,11 @@ module.exports = React.createClass({
 
         var self = this;
 
-        if (DEBUG_SCROLL) console.log("sending search request");
+        debuglog("sending search request");
         return MatrixClientPeg.get().search({ body: this._getSearchCondition(term, scope),
                                               next_batch: this.nextSearchBatch })
         .then(function(data) {
-            if (DEBUG_SCROLL) console.log("search complete");
+            debuglog("search complete");
             if (!self.state.searching || self.searchId != searchId) {
                 console.error("Discarding stale search results");
                 return;
@@ -559,7 +566,7 @@ module.exports = React.createClass({
             self.setState({
                 searchInProgress: false
             });
-        }).done();
+        });
     },
 
     _getSearchCondition: function(term, scope) {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -150,6 +150,9 @@ module.exports = React.createClass({
             // more messages.
             this._maybeFill(true);
         }
+        if (sn.scrollTop > sn.scrollHeight - sn.clientHeight * 2) {
+            this._maybeFill(false);
+        }
     },
 
     // check if there is already a pending fill request. If not, set one off.


### PR DESCRIPTION
The dance to avoid doing repeated fill requests on every update is common, so
add it to ScrollPanel. Let onFillRequest return a promise, which prevents any
updates until it completes.