### PR TITLE
Implement tab-complete for slash commands

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -354,8 +354,12 @@ module.exports = {
     },
 
     getCommandList: function() {
-        return Object.keys(commands).sort().map(function(cmdKey) {
+        // Return all the commands plus /me which isn't handled like normal commands
+        var cmds = Object.keys(commands).sort().map(function(cmdKey) {
             return commands[cmdKey];
-        });
+        })
+        cmds.push(new Command("me", "<action>", function(){}));
+
+        return cmds;
     }
 };

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -318,7 +318,9 @@ var commands = {
 };
 
 // helpful aliases
-commands.j = commands.join;
+var aliases = {
+    j: "join"
+}
 
 module.exports = {
     /**
@@ -338,6 +340,9 @@ module.exports = {
             var cmd = bits[1].substring(1).toLowerCase();
             var args = bits[3];
             if (cmd === "me") return null;
+            if (aliases[cmd]) {
+                cmd = aliases[cmd];
+            }
             if (commands[cmd]) {
                 return commands[cmd].run(roomId, args);
             }

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -69,7 +69,7 @@ var commands = {
     }),
 
     // Changes the colorscheme of your current room
-    tint: new Command("tint", "<primaryColor> [<secondaryColor>]", function(room_id, args) {
+    tint: new Command("tint", "<color1> [<color2>]", function(room_id, args) {
         if (args) {
             var matches = args.match(/^(#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}))( +(#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})))?$/);
             if (matches) {
@@ -89,7 +89,7 @@ var commands = {
         return reject(this.getUsage());
     }),
 
-    encrypt: new Command("encrypt", "<on/off>", function(room_id, args) {
+    encrypt: new Command("encrypt", "<on|off>", function(room_id, args) {
         if (args == "on") {
             var client = MatrixClientPeg.get();
             var members = client.getRoom(room_id).currentState.members;
@@ -354,7 +354,7 @@ module.exports = {
     },
 
     getCommandList: function() {
-        return Object.keys(commands).map(function(cmdKey) {
+        return Object.keys(commands).sort().map(function(cmdKey) {
             return commands[cmdKey];
         });
     }

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -322,5 +322,11 @@ module.exports = {
             }
         }
         return null; // not a command
+    },
+
+    getCommandList: function() {
+        return Object.keys(commands).map(function(cmd) {
+            return "/" + cmd;
+        });
     }
 };

--- a/src/TabComplete.js
+++ b/src/TabComplete.js
@@ -32,8 +32,6 @@ const MATCH_REGEX = /(^|\s)(\S+)$/;
 class TabComplete {
 
     constructor(opts) {
-        opts.startingWordSuffix = opts.startingWordSuffix || "";
-        opts.wordSuffix = opts.wordSuffix || "";
         opts.allowLooping = opts.allowLooping || false;
         opts.autoEnterTabComplete = opts.autoEnterTabComplete || false;
         opts.onClickCompletes = opts.onClickCompletes || false;
@@ -96,7 +94,9 @@ class TabComplete {
      * @param {Entry} entry The tab-complete entry to complete to.
      */
     completeTo(entry) {
-        this.textArea.value = this._replaceWith(entry.getText(), true, entry.getOverrideSuffix());
+        this.textArea.value = this._replaceWith(
+            entry.getText(), true, entry.getSuffix(this.isFirstWord)
+        );
         this.stopTabCompleting();
         // keep focus on the text area
         this.textArea.focus();
@@ -224,7 +224,7 @@ class TabComplete {
             this.textArea.value = this._replaceWith(
                 this.matchedList[this.currentIndex].getText(),
                 this.currentIndex !== 0, // don't suffix the original text!
-                this.matchedList[this.currentIndex].getOverrideSuffix()
+                this.matchedList[this.currentIndex].getSuffix(this.isFirstWord)
             );
         }
 
@@ -244,7 +244,7 @@ class TabComplete {
         }
     }
 
-    _replaceWith(newVal, includeSuffix, overrideSuffix) {
+    _replaceWith(newVal, includeSuffix, suffix) {
         // The regex to replace the input matches a character of whitespace AND
         // the partial word. If we just use string.replace() with the regex it will
         // replace the partial word AND the character of whitespace. We want to
@@ -259,14 +259,9 @@ class TabComplete {
             boundaryChar = "";
         }
 
-        var suffix = "";
-        if (includeSuffix) {
-            if (overrideSuffix) {
-                suffix = overrideSuffix;
-            }
-            else {
-                suffix = (this.isFirstWord ? this.opts.startingWordSuffix : this.opts.wordSuffix);
-            }
+        suffix = suffix || "";
+        if (!includeSuffix) {
+            suffix = "";
         }
 
         var replacementText = boundaryChar + newVal + suffix;

--- a/src/TabComplete.js
+++ b/src/TabComplete.js
@@ -95,7 +95,7 @@ class TabComplete {
      */
     completeTo(entry) {
         this.textArea.value = this._replaceWith(
-            entry.getText(), true, entry.getSuffix(this.isFirstWord)
+            entry.getFillText(), true, entry.getSuffix(this.isFirstWord)
         );
         this.stopTabCompleting();
         // keep focus on the text area
@@ -222,7 +222,7 @@ class TabComplete {
         if (!this.inPassiveMode) {
             // set textarea to this new value
             this.textArea.value = this._replaceWith(
-                this.matchedList[this.currentIndex].getText(),
+                this.matchedList[this.currentIndex].getFillText(),
                 this.currentIndex !== 0, // don't suffix the original text!
                 this.matchedList[this.currentIndex].getSuffix(this.isFirstWord)
             );

--- a/src/TabComplete.js
+++ b/src/TabComplete.js
@@ -58,7 +58,7 @@ class TabComplete {
             // assign onClick listeners for each entry to complete the text
             this.list.forEach((l) => {
                 l.onClick = () => {
-                    this.completeTo(l.getText());
+                    this.completeTo(l);
                 }
             });
         }
@@ -93,10 +93,10 @@ class TabComplete {
 
     /**
      * Do an auto-complete with the given word. This terminates the tab-complete.
-     * @param {string} someVal
+     * @param {Entry} entry The tab-complete entry to complete to.
      */
-    completeTo(someVal) {
-        this.textArea.value = this._replaceWith(someVal, true);
+    completeTo(entry) {
+        this.textArea.value = this._replaceWith(entry.getText(), true, entry.getOverrideSuffix());
         this.stopTabCompleting();
         // keep focus on the text area
         this.textArea.focus();
@@ -222,8 +222,9 @@ class TabComplete {
         if (!this.inPassiveMode) {
             // set textarea to this new value
             this.textArea.value = this._replaceWith(
-                this.matchedList[this.currentIndex].text,
-                this.currentIndex !== 0 // don't suffix the original text!
+                this.matchedList[this.currentIndex].getText(),
+                this.currentIndex !== 0, // don't suffix the original text!
+                this.matchedList[this.currentIndex].getOverrideSuffix()
             );
         }
 
@@ -243,7 +244,7 @@ class TabComplete {
         }
     }
 
-    _replaceWith(newVal, includeSuffix) {
+    _replaceWith(newVal, includeSuffix, overrideSuffix) {
         // The regex to replace the input matches a character of whitespace AND
         // the partial word. If we just use string.replace() with the regex it will
         // replace the partial word AND the character of whitespace. We want to
@@ -258,13 +259,17 @@ class TabComplete {
             boundaryChar = "";
         }
 
-        var replacementText = (
-            boundaryChar + newVal + (
-                includeSuffix ?
-                    (this.isFirstWord ? this.opts.startingWordSuffix : this.opts.wordSuffix) :
-                    ""
-            )
-        );
+        var suffix = "";
+        if (includeSuffix) {
+            if (overrideSuffix) {
+                suffix = overrideSuffix;
+            }
+            else {
+                suffix = (this.isFirstWord ? this.opts.startingWordSuffix : this.opts.wordSuffix);
+            }
+        }
+
+        var replacementText = boundaryChar + newVal + suffix;
         return this.originalText.replace(MATCH_REGEX, function() {
             return replacementText; // function form to avoid `$` special-casing
         });

--- a/src/TabCompleteEntries.js
+++ b/src/TabCompleteEntries.js
@@ -43,10 +43,10 @@ class Entry {
     }
 
     /**
-     * @return {?string} The suffix to override whatever the default is, or null to
+     * @return {?string} The suffix to append to the tab-complete, or null to
      * not do this.
      */
-    getOverrideSuffix() {
+    getSuffix(isFirstWord) {
         return null;
     }
 
@@ -67,7 +67,7 @@ class CommandEntry extends Entry {
         return this.getText();
     }
 
-    getOverrideSuffix() {
+    getSuffix(isFirstWord) {
         return " "; // force a space after the command.
     }
 }
@@ -93,6 +93,10 @@ class MemberEntry extends Entry {
 
     getKey() {
         return this.member.userId;
+    }
+
+    getSuffix(isFirstWord) {
+        return isFirstWord ? ": " : " ";
     }
 }
 

--- a/src/TabCompleteEntries.js
+++ b/src/TabCompleteEntries.js
@@ -43,11 +43,39 @@ class Entry {
     }
 
     /**
+     * @return {?string} The suffix to override whatever the default is, or null to
+     * not do this.
+     */
+    getOverrideSuffix() {
+        return null;
+    }
+
+    /**
      * Called when this entry is clicked.
      */
     onClick() {
         // NOP
     }
+}
+
+class CommandEntry extends Entry {
+    constructor(command) {
+        super(command);
+    }
+
+    getKey() {
+        return this.getText();
+    }
+
+    getOverrideSuffix() {
+        return " "; // force a space after the command.
+    }
+}
+
+CommandEntry.fromStrings = function(commandArray) {
+    return commandArray.map(function(cmd) {
+        return new CommandEntry(cmd);
+    });
 }
 
 class MemberEntry extends Entry {
@@ -99,3 +127,4 @@ MemberEntry.fromMemberList = function(members) {
 
 module.exports.Entry = Entry;
 module.exports.MemberEntry = MemberEntry;
+module.exports.CommandEntry = CommandEntry;

--- a/src/TabCompleteEntries.js
+++ b/src/TabCompleteEntries.js
@@ -29,6 +29,14 @@ class Entry {
     }
 
     /**
+     * @return {string} The text to insert into the input box. Most of the time
+     * this is the same as getText().
+     */
+    getFillText() {
+        return this.text;
+    }
+
+    /**
      * @return {ReactClass} Raw JSX
      */
     getImageJsx() {
@@ -59,12 +67,17 @@ class Entry {
 }
 
 class CommandEntry extends Entry {
-    constructor(command) {
-        super(command);
+    constructor(cmd, cmdWithArgs) {
+        super(cmdWithArgs);
+        this.cmd = cmd;
+    }
+
+    getFillText() {
+        return this.cmd;
     }
 
     getKey() {
-        return this.getText();
+        return this.getFillText();
     }
 
     getSuffix(isFirstWord) {
@@ -72,9 +85,9 @@ class CommandEntry extends Entry {
     }
 }
 
-CommandEntry.fromStrings = function(commandArray) {
+CommandEntry.fromCommands = function(commandArray) {
     return commandArray.map(function(cmd) {
-        return new CommandEntry(cmd);
+        return new CommandEntry(cmd.getCommand(), cmd.getCommandWithArgs());
     });
 }
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -35,7 +35,9 @@ var sdk = require('../../index');
 var CallHandler = require('../../CallHandler');
 var TabComplete = require("../../TabComplete");
 var MemberEntry = require("../../TabCompleteEntries").MemberEntry;
+var CommandEntry = require("../../TabCompleteEntries").CommandEntry;
 var Resend = require("../../Resend");
+var SlashCommands = require("../../SlashCommands");
 var dis = require("../../dispatcher");
 var Tinter = require("../../Tinter");
 
@@ -416,7 +418,9 @@ module.exports = React.createClass({
             return;
         }
         this.tabComplete.setCompletionList(
-            MemberEntry.fromMemberList(room.getJoinedMembers())
+            MemberEntry.fromMemberList(room.getJoinedMembers()).concat(
+                CommandEntry.fromStrings(SlashCommands.getCommandList())
+            )
         );
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -96,8 +96,6 @@ module.exports = React.createClass({
         // xchat-style tab complete, add a colon if tab
         // completing at the start of the text
         this.tabComplete = new TabComplete({
-            startingWordSuffix: ": ",
-            wordSuffix: " ",
             allowLooping: false,
             autoEnterTabComplete: true,
             onClickCompletes: true,

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -417,7 +417,7 @@ module.exports = React.createClass({
         }
         this.tabComplete.setCompletionList(
             MemberEntry.fromMemberList(room.getJoinedMembers()).concat(
-                CommandEntry.fromStrings(SlashCommands.getCommandList())
+                CommandEntry.fromCommands(SlashCommands.getCommandList())
             )
         );
     },

--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -341,7 +341,7 @@ module.exports = React.createClass({
                 MatrixClientPeg.get().sendTextMessage(this.props.room.roomId, contentText);
         }
 
-        sendMessagePromise.then(function() {
+        sendMessagePromise.done(function() {
             dis.dispatch({
                 action: 'message_sent'
             });

--- a/src/components/views/rooms/TabCompleteBar.js
+++ b/src/components/views/rooms/TabCompleteBar.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 var React = require('react');
 var MatrixClientPeg = require("../../../MatrixClientPeg");
+var CommandEntry = require("../../../TabCompleteEntries").CommandEntry;
 
 module.exports = React.createClass({
     displayName: 'TabCompleteBar',
@@ -31,8 +32,9 @@ module.exports = React.createClass({
             <div className="mx_TabCompleteBar">
             {this.props.entries.map(function(entry, i) {
                 return (
-                    <div key={entry.getKey() || i + ""} className="mx_TabCompleteBar_item"
-                            onClick={entry.onClick.bind(entry)} >
+                    <div key={entry.getKey() || i + ""}
+                         className={ "mx_TabCompleteBar_item " + (entry instanceof CommandEntry ? "mx_TabCompleteBar_command" : "") } 
+                         onClick={entry.onClick.bind(entry)} >
                         {entry.getImageJsx()}
                         <span className="mx_TabCompleteBar_text">
                             {entry.getText()}


### PR DESCRIPTION
This needed a new interface function `getOverrideSuffix()` so we didn't suffix
commands at the start with ": ". All seems to work.

Fixes https://github.com/vector-im/vector-web/issues/417