### PR TITLE
Factor out common Avatar code

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -32,6 +32,7 @@ module.exports.components['structures.RoomView'] = require('./components/structu
 module.exports.components['structures.ScrollPanel'] = require('./components/structures/ScrollPanel');
 module.exports.components['structures.UploadBar'] = require('./components/structures/UploadBar');
 module.exports.components['structures.UserSettings'] = require('./components/structures/UserSettings');
+module.exports.components['views.avatars.BaseAvatar'] = require('./components/views/avatars/BaseAvatar');
 module.exports.components['views.avatars.MemberAvatar'] = require('./components/views/avatars/MemberAvatar');
 module.exports.components['views.avatars.RoomAvatar'] = require('./components/views/avatars/RoomAvatar');
 module.exports.components['views.create_room.CreateRoomButton'] = require('./components/views/create_room/CreateRoomButton');

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -1,0 +1,131 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+var React = require('react');
+var AvatarLogic = require("../../../Avatar");
+
+module.exports = React.createClass({
+    displayName: 'BaseAvatar',
+
+    propTypes: {
+        name: React.PropTypes.string.isRequired,
+        idName: React.PropTypes.string, // ID for generating hash colours
+        title: React.PropTypes.string,
+        url: React.PropTypes.string, // highest priority of them all
+        urls: React.PropTypes.array, // [highest_priority, ... , lowest_priority]
+        width: React.PropTypes.number,
+        height: React.PropTypes.number,
+        resizeMethod: React.PropTypes.string,
+        defaultToInitialLetter: React.PropTypes.bool
+    },
+
+    getDefaultProps: function() {
+        return {
+            width: 40,
+            height: 40,
+            resizeMethod: 'crop',
+            defaultToInitialLetter: true
+        }
+    },
+
+    getInitialState: function() {
+        var defaultImageUrl = null;
+        if (this.props.defaultToInitialLetter) {
+            defaultImageUrl = AvatarLogic.defaultAvatarUrlForString(
+                this.props.idName || this.props.name
+            );
+        }
+        return {
+            imageUrl: this.props.url || (this.props.urls ? this.props.urls[0] : null),
+            defaultImageUrl: defaultImageUrl,
+            urlsIndex: 0
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        // retry all the urls again, they may have changed.
+        if (this.props.urls && this.state.urlsIndex > 0) {
+            this.setState({
+                urlsIndex: 0,
+                imageUrl: this.props.urls[0]
+            });
+        }
+    },
+
+    onError: function(ev) {
+        var failedUrl = ev.target.src;
+
+        if (this.props.urls) {
+            var nextIndex = this.state.urlsIndex + 1;
+            if (nextIndex < this.props.urls.length) {
+                // try another
+                this.setState({
+                    urlsIndex: nextIndex,
+                    imageUrl: this.props.urls[nextIndex]
+                });
+                return;
+            }
+        }
+
+        // either no urls array or we've reached the end of it, we may have a default
+        // we can use...
+        if (this.props.defaultToInitialLetter) {
+            if (failedUrl === this.state.defaultImageUrl) {
+                return; // don't tightloop if the browser can't load the default URL
+            }
+            this.setState({ imageUrl: this.state.defaultImageUrl })
+        }
+    },
+
+    _getInitialLetter: function() {
+        var name = this.props.name;
+        var initial = name[0];
+        if (initial === '@' && name[1]) {
+            initial = name[1];
+        }
+        return initial.toUpperCase();
+    },
+
+    render: function() {
+        var name = this.props.name;
+
+        if (this.state.imageUrl === this.state.defaultImageUrl) {
+            var initialLetter = this._getInitialLetter();
+            return (
+                <span className="mx_MemberAvatar" {...this.props}>
+                    <span className="mx_MemberAvatar_initial" aria-hidden="true"
+                            style={{ fontSize: (this.props.width * 0.65) + "px",
+                                    width: this.props.width + "px",
+                                    lineHeight: this.props.height + "px" }}>
+                        { initialLetter }
+                    </span>
+                    <img className="mx_MemberAvatar_image" src={this.state.imageUrl}
+                        title={this.props.title} onError={this.onError}
+                        width={this.props.width} height={this.props.height} />
+                </span>
+            );            
+        }
+        return (
+            <img className="mx_MemberAvatar mx_MemberAvatar_image" src={this.state.imageUrl}
+                onError={this.onError}
+                width={this.props.width} height={this.props.height}
+                title={this.props.title}
+                {...this.props} />
+        );
+    }
+});

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -23,9 +23,9 @@ module.exports = React.createClass({
     displayName: 'BaseAvatar',
 
     propTypes: {
-        name: React.PropTypes.string.isRequired,
+        name: React.PropTypes.string.isRequired, // The name (first initial used as default)
         idName: React.PropTypes.string, // ID for generating hash colours
-        title: React.PropTypes.string,
+        title: React.PropTypes.string, // onHover title text
         url: React.PropTypes.string, // highest priority of them all
         urls: React.PropTypes.array, // [highest_priority, ... , lowest_priority]
         width: React.PropTypes.number,
@@ -95,7 +95,7 @@ module.exports = React.createClass({
     _getInitialLetter: function() {
         var name = this.props.name;
         var initial = name[0];
-        if (initial === '@' && name[1]) {
+        if ((initial === '@' || initial === '#') && name[1]) {
             initial = name[1];
         }
         return initial.toUpperCase();
@@ -107,21 +107,21 @@ module.exports = React.createClass({
         if (this.state.imageUrl === this.state.defaultImageUrl) {
             var initialLetter = this._getInitialLetter();
             return (
-                <span className="mx_MemberAvatar" {...this.props}>
-                    <span className="mx_MemberAvatar_initial" aria-hidden="true"
+                <span className="mx_BaseAvatar" {...this.props}>
+                    <span className="mx_BaseAvatar_initial" aria-hidden="true"
                             style={{ fontSize: (this.props.width * 0.65) + "px",
                                     width: this.props.width + "px",
                                     lineHeight: this.props.height + "px" }}>
                         { initialLetter }
                     </span>
-                    <img className="mx_MemberAvatar_image" src={this.state.imageUrl}
+                    <img className="mx_BaseAvatar_image" src={this.state.imageUrl}
                         title={this.props.title} onError={this.onError}
                         width={this.props.width} height={this.props.height} />
                 </span>
             );            
         }
         return (
-            <img className="mx_MemberAvatar mx_MemberAvatar_image" src={this.state.imageUrl}
+            <img className="mx_BaseAvatar mx_BaseAvatar_image" src={this.state.imageUrl}
                 onError={this.onError}
                 width={this.props.width} height={this.props.height}
                 title={this.props.title}

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -38,43 +38,53 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         return {
-            urls: [
-                this.getRoomAvatarUrl(), // highest priority
-                this.getOneToOneAvatar(),
-                this.getFallbackAvatar() // lowest priority
-            ].filter(function(url) {
-                return url != null;
-            })
+            urls: this.getImageUrls(this.props)
         };
     },
 
-    getRoomAvatarUrl: function() {
-        return this.props.room.getAvatarUrl(
+    componentWillReceiveProps: function(newProps) {
+        this.setState({
+            urls: this.getImageUrls(newProps)
+        })
+    },
+
+    getImageUrls: function(props) {
+        return [
+            this.getRoomAvatarUrl(props), // highest priority
+            this.getOneToOneAvatar(props),
+            this.getFallbackAvatar(props) // lowest priority
+        ].filter(function(url) {
+            return url != null;
+        });
+    },
+
+    getRoomAvatarUrl: function(props) {
+        return props.room.getAvatarUrl(
             MatrixClientPeg.get().getHomeserverUrl(),
-            this.props.width, this.props.height, this.props.resizeMethod,
+            props.width, props.height, props.resizeMethod,
             false
         );
     },
 
-    getOneToOneAvatar: function() {
-        var userIds = Object.keys(this.props.room.currentState.members);
+    getOneToOneAvatar: function(props) {
+        var userIds = Object.keys(props.room.currentState.members);
 
         if (userIds.length == 2) {
             var theOtherGuy = null;
-            if (this.props.room.currentState.members[userIds[0]].userId == MatrixClientPeg.get().credentials.userId) {
-                theOtherGuy = this.props.room.currentState.members[userIds[1]];
+            if (props.room.currentState.members[userIds[0]].userId == MatrixClientPeg.get().credentials.userId) {
+                theOtherGuy = props.room.currentState.members[userIds[1]];
             } else {
-                theOtherGuy = this.props.room.currentState.members[userIds[0]];
+                theOtherGuy = props.room.currentState.members[userIds[0]];
             }
             return theOtherGuy.getAvatarUrl(
                 MatrixClientPeg.get().getHomeserverUrl(),
-                this.props.width, this.props.height, this.props.resizeMethod,
+                props.width, props.height, props.resizeMethod,
                 false
             );
         } else if (userIds.length == 1) {
-            return this.props.room.currentState.members[userIds[0]].getAvatarUrl(
+            return props.room.currentState.members[userIds[0]].getAvatarUrl(
                 MatrixClientPeg.get().getHomeserverUrl(),
-                this.props.width, this.props.height, this.props.resizeMethod,
+                props.width, props.height, props.resizeMethod,
                     false
             );
         } else {
@@ -82,8 +92,8 @@ module.exports = React.createClass({
         }
     },
 
-    getFallbackAvatar: function() {
-        return Avatar.defaultAvatarUrlForString(this.props.room.roomId);
+    getFallbackAvatar: function(props) {
+        return Avatar.defaultAvatarUrlForString(props.room.roomId);
     },
 
     render: function() {

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -16,9 +16,17 @@ limitations under the License.
 var React = require('react');
 var MatrixClientPeg = require('../../../MatrixClientPeg');
 var Avatar = require('../../../Avatar');
+var sdk = require("../../../index");
 
 module.exports = React.createClass({
     displayName: 'RoomAvatar',
+
+    propTypes: {
+        room: React.PropTypes.object.isRequired,
+        width: React.PropTypes.number,
+        height: React.PropTypes.number,
+        resizeMethod: React.PropTypes.string
+    },
 
     getDefaultProps: function() {
         return {
@@ -29,65 +37,25 @@ module.exports = React.createClass({
     },
 
     getInitialState: function() {
-        this._update();
         return {
-            imageUrl: this._nextUrl()
+            urls: [
+                this.getRoomAvatarUrl(), // highest priority
+                this.getOneToOneAvatar(),
+                this.getFallbackAvatar() // lowest priority
+            ].filter(function(url) {
+                return url != null;
+            })
         };
     },
 
-    componentWillReceiveProps: function(nextProps) {
-        this.refreshImageUrl();
-    },
-
-    refreshImageUrl: function(nextProps) {
-        // If the list has changed, we start from scratch and re-check, but
-        // don't do so unless the list has changed or we'd re-try fetching
-        // images each time we re-rendered
-        var newList = this.getUrlList();
-        var differs = false;
-        for (var i = 0; i < newList.length && i < this.urlList.length; ++i) {
-            if (this.urlList[i] != newList[i]) differs = true;
-        }
-        if (this.urlList.length != newList.length) differs = true;
-
-        if (differs) {
-            this._update();
-            this.setState({
-                imageUrl: this._nextUrl()
-            });
-        }
-    },
-
-    _update: function() {
-        this.urlList = this.getUrlList();
-        this.urlListIndex = -1;
-    },
-
-    _nextUrl: function() {
-        do {
-            ++this.urlListIndex;
-        } while (
-            this.urlList[this.urlListIndex] === null &&
-            this.urlListIndex < this.urlList.length
-        );
-        if (this.urlListIndex < this.urlList.length) {
-            return this.urlList[this.urlListIndex];
-        } else {
-            return null;
-        }
-    },
-
-    // provided to the view class for convenience
-    roomAvatarUrl: function() {
-        var url = this.props.room.getAvatarUrl(
+    getRoomAvatarUrl: function() {
+        return this.props.room.getAvatarUrl(
             MatrixClientPeg.get().getHomeserverUrl(),
             this.props.width, this.props.height, this.props.resizeMethod,
             false
         );
-        return url;
     },
 
-    // provided to the view class for convenience
     getOneToOneAvatar: function() {
         var userIds = Object.keys(this.props.room.currentState.members);
 
@@ -114,58 +82,15 @@ module.exports = React.createClass({
         }
     },
 
-
-    onError: function(ev) {
-        this.setState({
-            imageUrl: this._nextUrl()
-        });
-    },
-
-
-
-    ////////////
-
-
-    getUrlList: function() {
-        return [
-            this.roomAvatarUrl(),
-            this.getOneToOneAvatar(),
-            this.getFallbackAvatar()
-        ];
-    },
-
     getFallbackAvatar: function() {
         return Avatar.defaultAvatarUrlForString(this.props.room.roomId);
     },
 
     render: function() {
-        var style = {
-            width: this.props.width,
-            height: this.props.height,
-        };
-
-        // XXX: recalculates fallback avatar constantly
-        if (this.state.imageUrl === this.getFallbackAvatar()) {
-            var initial;
-            if (this.props.room.name[0])
-                initial = this.props.room.name[0].toUpperCase();
-            if ((initial === '@' || initial === '#') && this.props.room.name[1])
-                initial = this.props.room.name[1].toUpperCase();
-         
-            return (
-                <span>
-                    <span className="mx_RoomAvatar_initial" aria-hidden="true"
-                          style={{ fontSize: (this.props.width * 0.65) + "px",
-                                   width: this.props.width + "px",
-                                   lineHeight: this.props.height + "px" }}>{ initial }</span>
-                    <img className="mx_RoomAvatar" src={this.state.imageUrl}
-                            onError={this.onError} style={style} />
-                </span>
-            );
-        }
-        else {
-            return <img className="mx_RoomAvatar" src={this.state.imageUrl}
-                        onError={this.onError} style={style} />
-        }
+        var BaseAvatar = sdk.getComponent("avatars.BaseAvatar");
+        return (
+            <BaseAvatar {...this.props} name={this.props.room.name}
+                idName={this.props.room.roomId} urls={this.state.urls} />
+        );
     }
 });

--- a/src/components/views/rooms/MemberTile.js
+++ b/src/components/views/rooms/MemberTile.js
@@ -151,14 +151,26 @@ module.exports = React.createClass({
         }
 
         var MemberAvatar = sdk.getComponent('avatars.MemberAvatar');
+        var BaseAvatar = sdk.getComponent('avatars.BaseAvatar');
+
+        var av;
+        if (member) {
+            av = (
+                <MemberAvatar member={this.props.member} width={36} height={36} />
+            );
+        }
+        else {
+            av = (
+                <BaseAvatar name={name} width={36} height={36} />
+            );
+        }
 
         return (
             <div className={mainClassName} title={ this.getPowerLabel() }
                     onClick={ this.onClick } onMouseEnter={ this.mouseEnter }
                     onMouseLeave={ this.mouseLeave }>
                 <div className="mx_MemberTile_avatar">
-                    <MemberAvatar member={this.props.member} width={36} height={36}
-                        customDisplayName={this.props.customDisplayName} />
+                    {av}
                 </div>
                 { nameEl }
             </div>

--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -129,7 +129,7 @@ module.exports = React.createClass({
             var roomAvatar = null;
             if (this.props.room) {
                 roomAvatar = (
-                    <RoomAvatar room={this.props.room} width="48" height="48" />
+                    <RoomAvatar room={this.props.room} width={48} height={48} />
                 );
             }
 

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -123,7 +123,7 @@ module.exports = React.createClass({
         return connectDragSource(connectDropTarget(
             <div className={classes} onClick={this.onClick} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <div className="mx_RoomTile_avatar">
-                    <RoomAvatar room={this.props.room} width="24" height="24" />
+                    <RoomAvatar room={this.props.room} width={24} height={24} />
                     { badge }
                 </div>
                 { label }

--- a/src/components/views/settings/ChangeAvatar.js
+++ b/src/components/views/settings/ChangeAvatar.js
@@ -111,7 +111,7 @@ module.exports = React.createClass({
         // Having just set an avatar we just display that since it will take a little
         // time to propagate through to the RoomAvatar.
         if (this.props.room && !this.avatarSet) {
-            avatarImg = <RoomAvatar room={this.props.room} width='240' height='240' resizeMethod='crop' />;
+            avatarImg = <RoomAvatar room={this.props.room} width={240} height={240} resizeMethod='crop' />;
         } else {
             var style = {
                 maxWidth: 240,


### PR DESCRIPTION
This adds a new component `BaseAvatar` which has most of the avatar loading and initial (A,B,C) code. All seems to work (including updates).

`MemberAvatar` and `RoomAvatar` still exist and have the same props, they just create a `<BaseAvatar>` in their `render()` method.

The diff is pretty gnarly unfortunately since I'm removing a bunch of code in weird places.

CSS: https://github.com/vector-im/vector-web/pull/638