### PR TITLE
Convert RoomView to using a TimelineWindow

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -39,7 +39,8 @@ function createClient(hs_url, is_url, user_id, access_token, guestAccess) {
         baseUrl: hs_url,
         idBaseUrl: is_url,
         accessToken: access_token,
-        userId: user_id
+        userId: user_id,
+        timelineSupport: true,
     };
 
     if (localStorage) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -463,10 +463,11 @@ module.exports = React.createClass({
             newState.ready = true;
         }
         this.setState(newState);
+        /*
         if (this.scrollStateMap[roomId]) {
             var scrollState = this.scrollStateMap[roomId];
             this.refs.roomView.restoreScrollState(scrollState);
-        }
+        }*/
         if (this.refs.roomView && showSettings) {
             this.refs.roomView.showSettings(true);
         }

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -306,7 +306,11 @@ module.exports = React.createClass({
             }
         }
 
-        // tell the messagepanel to go paginate itself
+        // tell the messagepanel to go paginate itself. This in turn will cause
+        // onMessageListFillRequest to be called, which will call
+        // _onTimelineUpdated, which will update the state with the new event -
+        // so there is no need update the state here.
+        //
         if (this.refs.messagePanel) {
             this.refs.messagePanel.checkFillState();
         }


### PR DESCRIPTION
Instead of using the Room's active timeline directly, use a
TimelineWindow. This shouldn't (yet) have much effect, beyond maybe making
scrollback after a gappy sync slightly more efficient.

For now, I have disabled the 'restoreScrollState' functionality. This will be
reinstated once I land the link-to-event code.