### PR TITLE
Fix react warnings when a RR animation is happening during room switch

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -915,7 +915,7 @@ module.exports = React.createClass({
             var hr;
             hr = (<hr className="mx_RoomView_myReadMarker" style={{opacity: 1, width: '99%'}} ref={function(n) {
                 Velocity(n, {opacity: '0', width: '10%'}, {duration: 400, easing: 'easeInSine', delay: 1000, complete: function() {
-                    self.setState({readMarkerGhostEventId: undefined});
+                    if (!self.unmounted) self.setState({readMarkerGhostEventId: undefined});
                 }});
             }} />);
             ret.splice(ghostIndex, 0, (


### PR DESCRIPTION
If the animation of an RR removal is active when we change room, we end up
getting a callback after the RoomView has been unmounted. Guard against this to
avoid getting React warnings.