### PR TITLE
Add MatrixChat.onNewVersion to trigger the new version bar

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -804,6 +804,12 @@ module.exports = React.createClass({
         this.showScreen("settings");
     },
 
+    onNewVersion: function(current, latest) {
+        this.setState({
+            hasNewVersion: true
+        });
+    },
+
     updateFavicon: function() {
         var notifCount = 0;
 
@@ -851,6 +857,7 @@ module.exports = React.createClass({
         var RoomDirectory = sdk.getComponent('structures.RoomDirectory');
         var MatrixToolbar = sdk.getComponent('globals.MatrixToolbar');
         var GuestWarningBar = sdk.getComponent('globals.GuestWarningBar');
+        var NewVersionBar = sdk.getComponent('globals.NewVersionBar');
         var ForgotPassword = sdk.getComponent('structures.login.ForgotPassword');
 
         // needs to be before normal PageTypes as you are logged in technically
@@ -911,6 +918,19 @@ module.exports = React.createClass({
                 return (
                         <div className="mx_MatrixChat_wrapper">
                             <MatrixToolbar />
+                            <div className="mx_MatrixChat mx_MatrixChat_toolbarShowing">
+                                <LeftPanel selectedRoom={this.state.currentRoom} collapsed={this.state.collapse_lhs} />
+                                <main className="mx_MatrixChat_middlePanel">
+                                    {page_element}
+                                </main>
+                                {right_panel}
+                            </div>
+                        </div>
+                );
+            } else if (this.state.hasNewVersion) {
+                return (
+                        <div className="mx_MatrixChat_wrapper">
+                            <NewVersionBar />
                             <div className="mx_MatrixChat mx_MatrixChat_toolbarShowing">
                                 <LeftPanel selectedRoom={this.state.currentRoom} collapsed={this.state.collapse_lhs} />
                                 <main className="mx_MatrixChat_middlePanel">

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -804,9 +804,10 @@ module.exports = React.createClass({
         this.showScreen("settings");
     },
 
-    onNewVersion: function(current, latest) {
+    onVersion: function(current, latest) {
         this.setState({
-            hasNewVersion: true
+            version: current,
+            hasNewVersion: current !== latest
         });
     },
 
@@ -887,7 +888,7 @@ module.exports = React.createClass({
                     right_panel = <RightPanel roomId={this.state.currentRoom} collapsed={this.state.collapse_rhs} />
                     break;
                 case this.PageTypes.UserSettings:
-                    page_element = <UserSettings onClose={this.onUserSettingsClose} />
+                    page_element = <UserSettings onClose={this.onUserSettingsClose} version={this.state.version} />
                     right_panel = <RightPanel collapsed={this.state.collapse_rhs}/>
                     break;
                 case this.PageTypes.CreateRoom:

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -30,6 +30,7 @@ module.exports = React.createClass({
     displayName: 'UserSettings',
 
     propTypes: {
+        version: React.PropTypes.string,
         onClose: React.PropTypes.func
     },
 
@@ -377,6 +378,8 @@ module.exports = React.createClass({
                     </div>
                     <div className="mx_UserSettings_advanced">
                         Version {this.state.clientVersion}
+                        <br />
+                        {this.props.version}
                     </div>
                 </div>
 


### PR DESCRIPTION
Requires the sister PR https://github.com/vector-im/vector-web/pull/856 in order to not crash (as it pulls `NewVersionBar` from `vector-web`).