### PR TITLE
Put the room preview bar back for rooms that aren't peekable

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -163,10 +163,7 @@ module.exports = React.createClass({
 
             console.log("Attempting to peek into room %s", this.props.roomId);
 
-            roomProm = MatrixClientPeg.get().peekInRoom(this.props.roomId).catch((err) => {
-                console.error("Failed to peek into room: %s", err);
-                throw err;
-            }).then((room) => {
+            roomProm = MatrixClientPeg.get().peekInRoom(this.props.roomId).then((room) => {
                 this.setState({
                     room: room
                 });
@@ -180,6 +177,11 @@ module.exports = React.createClass({
         roomProm.then((room) => {
             this._calculatePeekRules(room);
             return this._initTimeline(this.props);
+        }).catch(() => {
+            // This is fine: the room just isn't peekable (we assume).
+            this.setState({
+                timelineLoading: false,
+            });
         }).done();
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -426,7 +426,7 @@ module.exports = React.createClass({
         // set it in our state and start using it (ie. init the timeline)
         // This will happen if we start off viewing a room we're not joined,
         // then join it whilst RoomView is looking at that room.
-        if (room.roomId == this.props.roomId && !this.state.room) {
+        if (room.roomId == this.props.roomId) {
             this.setState({
                 room: room
             });

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -274,6 +274,7 @@ module.exports = React.createClass({
         }
         dis.unregister(this.dispatcherRef);
         if (MatrixClientPeg.get()) {
+            MatrixClientPeg.get().removeListener("Room", this.onRoom);
             MatrixClientPeg.get().removeListener("Room.timeline", this.onRoomTimeline);
             MatrixClientPeg.get().removeListener("Room.name", this.onRoomName);
             MatrixClientPeg.get().removeListener("Room.accountData", this.onRoomAccountData);

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -420,6 +420,7 @@ module.exports = React.createClass({
             this.setState({
                 room: room
             });
+            this._initTimeline(this.props);
         }
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -122,6 +122,7 @@ module.exports = React.createClass({
     componentWillMount: function() {
         this.last_rr_sent_event_id = undefined;
         this.dispatcherRef = dis.register(this.onAction);
+        MatrixClientPeg.get().on("Room", this.onRoom);
         MatrixClientPeg.get().on("Room.timeline", this.onRoomTimeline);
         MatrixClientPeg.get().on("Room.name", this.onRoomName);
         MatrixClientPeg.get().on("Room.accountData", this.onRoomAccountData);
@@ -418,12 +419,20 @@ module.exports = React.createClass({
         }
     },
 
+    onRoom: function(room) {
+        if (room.roomId == this.props.roomId) {
+            this.setState({
+                room: room
+            });
+            this._initTimeline(this.props).done();
+        }
+    },
+
     onRoomName: function(room) {
         if (room.roomId == this.props.roomId) {
             this.setState({
                 room: room
             });
-            this._initTimeline(this.props);
         }
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -421,7 +421,12 @@ module.exports = React.createClass({
     },
 
     onRoom: function(room) {
-        if (room.roomId == this.props.roomId) {
+        // This event is fired when the room is 'stored' by the JS SDK, which
+        // means it's now a fully-fledged room object ready to be used, so
+        // set it in our state and start using it (ie. init the timeline)
+        // This will happen if we start off viewing a room we're not joined,
+        // then join it whilst RoomView is looking at that room.
+        if (room.roomId == this.props.roomId && !this.state.room) {
             this.setState({
                 room: room
             });
@@ -705,6 +710,10 @@ module.exports = React.createClass({
             // NOT when it comes down /sync. If there is no room, we'll keep the
             // joining flag set until we see it. Likewise, if our state is not
             // "join" we'll keep this flag set until it comes down /sync.
+
+            // We'll need to initialise the timeline when joining, but due to
+            // the above, we can't do it here: we do it in onRoom instead,
+            // once we have a useable room object.
             var room = MatrixClientPeg.get().getRoom(self.props.roomId);
             var me = MatrixClientPeg.get().credentials.userId;
             self.setState({

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -177,11 +177,15 @@ module.exports = React.createClass({
         roomProm.then((room) => {
             this._calculatePeekRules(room);
             return this._initTimeline(this.props);
-        }).catch(() => {
-            // This is fine: the room just isn't peekable (we assume).
-            this.setState({
-                timelineLoading: false,
-            });
+        }).catch((err) => {
+            if (err.errcode == "M_GUEST_ACCESS_FORBIDDEN") {
+                // This is fine: the room just isn't peekable (we assume).
+                this.setState({
+                    timelineLoading: false,
+                });
+            } else {
+                throw err;
+            }
         }).done();
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -178,6 +178,9 @@ module.exports = React.createClass({
             this._calculatePeekRules(room);
             return this._initTimeline(this.props);
         }).catch((err) => {
+            // This won't necessarily be a MatrixError, but we duck-type
+            // here and say if it's got an 'errcode' key with the right value,
+            // it means we can't peek.
             if (err.errcode == "M_GUEST_ACCESS_FORBIDDEN") {
                 // This is fine: the room just isn't peekable (we assume).
                 this.setState({


### PR DESCRIPTION
since we always tried to peek, it would fail which would reject the promise and cause loadingTimeline to stay true forever.