### PR TITLE
Set the sync limit back to sane levels

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -586,8 +586,7 @@ module.exports = React.createClass({
         Presence.start();
         cli.startClient({
             pendingEventOrdering: "end",
-            // deliberately huge limit for now to avoid hitting gappy /sync's until gappy /sync performance improves
-            initialSyncLimit: 250,
+            initialSyncLimit: 20,
         });
     },
 


### PR DESCRIPTION
Gappy `/sync` performance is now much better, so we can use normal limits again.