### PR TITLE
Don't show the Notifications widget for guests…

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -315,6 +315,16 @@ module.exports = React.createClass({
                         onFinished={this.onPasswordChanged} />
             );
         }
+        var notification_area;
+        if (!MatrixClientPeg.get().isGuest()) {
+            notification_area = (<div>
+                <h2>Notifications</h2>
+
+                <div className="mx_UserSettings_section">
+                    <Notifications/>
+                </div>
+            </div>);
+        }
 
         return (
             <div className="mx_UserSettings">
@@ -364,11 +374,7 @@ module.exports = React.createClass({
                     {accountJsx}
                 </div>
 
-                <h2>Notifications</h2>
-
-                <div className="mx_UserSettings_section">
-                    <Notifications/>
-                </div>
+                {notification_area}
 
                 <h2>Advanced</h2>
 


### PR DESCRIPTION
…since they can't use them (and it throws an error if you try to mount it),

Fixes https://github.com/vector-im/vector-web/issues/802 pt. 2.