### PR TITLE
Move the ghost-read-marker logic to MessagePanel

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -82,7 +82,6 @@ module.exports = React.createClass({
             timelineLoading: true, // track whether our room timeline is loading
             canBackPaginate: true,
             readMarkerEventId: this._getCurrentReadReceipt(),
-            readMarkerGhostEventId: null,
         };
     },
 
@@ -200,7 +199,6 @@ module.exports = React.createClass({
 
         this.setState({
             readMarkerEventId: newReadMarker,
-            readMarkerGhostEventId: oldReadMarker,
         });
     },
 
@@ -441,7 +439,6 @@ module.exports = React.createClass({
                     events={ this.state.events }
                     highlightedEventId={ this.props.highlightedEventId }
                     readMarkerEventId={ this.state.readMarkerEventId }
-                    readMarkerGhostEventId={ this.state.readMarkerGhostEventId }
                     suppressFirstDateSeparator={ this.state.canBackPaginate }
                     ourUserId={ MatrixClientPeg.get().credentials.userId }
                     stickyBottom={ stickyBottom }


### PR DESCRIPTION
This PR builds on https://github.com/matrix-org/matrix-react-sdk/pull/158. It
moves the responsibility for figuring out when/if to show a ghost read-marker
from TimelinePanel to MessagePanel. This means that TimelinePanel doesn't need
to second-guess whether TimelinePanel actually showed the read-marker.