### PR TITLE
Fix a NPE when clicking 'login' as a guest

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -64,7 +64,11 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount: function() {
-        MatrixClientPeg.get().removeListener("sync", this.onSyncStateChange);
+        var client = MatrixClientPeg.get();
+        // client may be null on logout.
+        if (client) {
+            client.removeListener("sync", this.onSyncStateChange);
+        }
     },
 
     onSyncStateChange: function(state, prevState) {


### PR DESCRIPTION
Turns out MatrixClientPeg.get() sometimes returns null.

Fixes vector-im/vector-web#930