### PR TITLE
Make the links we emit for room URLs valid

### DIFF
--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -114,6 +114,17 @@ matrixLinkify.options = {
                     }
                 };
         }
+    },
+
+    formatHref: function (href, type) {
+        switch (type) {
+             case 'roomalias':
+                 return '#/room/' + href;
+             case 'userid':
+                 return '#';
+             default:
+                 return href;
+        }
     }
 };
 


### PR DESCRIPTION
rather than relying on the onClick handler (ie. make them work if you c+p them)

Fixes https://github.com/vector-im/vector-web/issues/803