### PR TITLE
Fix stuck notification bug

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1111,7 +1111,7 @@ module.exports = React.createClass({
         // the bottom of the room again, or something.
         if (!this.state.atEndOfLiveTimeline) return;
 
-        var currentReadUpToEventId = this.state.room.getEventReadUpTo(MatrixClientPeg.get().credentials.userId);
+        var currentReadUpToEventId = this.state.room.getEventReadUpTo(MatrixClientPeg.get().credentials.userId, true);
         var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
 
         // We want to avoid sending out read receipts when we are looking at


### PR DESCRIPTION
Use new flag in js-sdk to look at the last read receipt the server actually has and ignore implicit ones, otherwise we can end up not sending an RR because we think there's already a more recent one, even though that one is implicit.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/82
Fixes https://github.com/vector-im/vector-web/issues/763