### PR TITLE
Allow guest access by default (by specifying initial state)

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -382,6 +382,9 @@ module.exports = React.createClass({
 
                 MatrixClientPeg.get().createRoom({
                     preset: "private_chat",
+                    // Allow guests by default since the room is private and they'd
+                    // need an invite. This means clicking on a 3pid invite email can
+                    // actually drop you right in to a chat.
                     initial_state: [
                         {
                             content: {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -381,7 +381,16 @@ module.exports = React.createClass({
                 var modal = Modal.createDialog(Loader);
 
                 MatrixClientPeg.get().createRoom({
-                    preset: "private_chat"
+                    preset: "private_chat",
+                    initial_state: [
+                        {
+                            content: {
+                                guest_access: 'can_join'
+                            },
+                            type: 'm.room.guest_access',
+                            state_key: '',
+                        }
+                    ],
                 }).done(function(res) {
                     modal.close();
                     dis.dispatch({


### PR DESCRIPTION
as rooms are private by default so they'd have to be invited to join. People can't get a 3pid invite & join as guest without this.