### PR TITLE
Reload the timeline when we get a gappy sync

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -113,6 +113,7 @@ var TimelinePanel = React.createClass({
 
         this.dispatcherRef = dis.register(this.onAction);
         MatrixClientPeg.get().on("Room.timeline", this.onRoomTimeline);
+        MatrixClientPeg.get().on("Room.timelineReset", this.onRoomTimelineReset);
         MatrixClientPeg.get().on("Room.redaction", this.onRoomRedaction);
 
         this._initTimeline(this.props);
@@ -142,6 +143,7 @@ var TimelinePanel = React.createClass({
         var client = MatrixClientPeg.get();
         if (client) {
             client.removeListener("Room.timeline", this.onRoomTimeline);
+            client.removeListener("Room.timelineReset", this.onRoomTimelineReset);
             client.removeListener("Room.redaction", this.onRoomRedaction);
         }
     },
@@ -232,6 +234,14 @@ var TimelinePanel = React.createClass({
         //
         if (this.refs.messagePanel) {
             this.refs.messagePanel.checkFillState();
+        }
+    },
+
+    onRoomTimelineReset: function(room) {
+        if (room !== this.props.room) return;
+
+        if (this.refs.messagePanel && this.refs.messagePanel.isAtBottom()) {
+            this._loadTimeline();
         }
     },
 


### PR DESCRIPTION
After a resume from sleep, we don't want to start paginating through the whole
timeline. If we were in 'stuckAtBottom' mode before, treat a gappy sync
similarly to how we handle the 'scroll to bottom' knob, which is to reload the
timelinewindow starting from scratch.

Fixes https://github.com/vector-im/vector-web/issues/932, and will probably
also fix https://github.com/vector-im/vector-web/issues/943, though I haven't
tested it yet.