### PR TITLE
Flatten arrays of components before adding to messagepanel li

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -198,7 +198,10 @@ module.exports = React.createClass({
             var last = (i == lastShownEventIndex);
 
             if (wantTile) {
-                ret.push(this._getTilesForEvent(prevEvent, mxEv, last));
+                // make sure we unpack the array returned by _getTilesForEvent,
+                // otherwise react will auto-generate keys and we will end up
+                // replacing all of the DOM elements every time we paginate.
+                ret.push(...this._getTilesForEvent(prevEvent, mxEv, last));
                 prevEvent = mxEv;
             } else if (!mxEv.status) {
                 // if we aren't showing the event, put in a dummy scroll token anyway, so


### PR DESCRIPTION
Avoid updating the whole DOM when we paginating by making sure the keys are
right

This will help with https://github.com/vector-im/vector-web/issues/1072