### PR TITLE
Add shouldComponentUpdate() methods to RoomView and TimelinePanel

### DIFF
--- a/src/ObjectUtils.js
+++ b/src/ObjectUtils.js
@@ -77,3 +77,34 @@ module.exports.getKeyValueArrayDiffs = function(before, after) {
 
     return results;
 };
+
+/**
+ * Shallow-compare two objects for equality: each key and value must be
+ * identical
+ */
+module.exports.shallowEqual = function(objA, objB) {
+    if (objA === objB) {
+        return true;
+    }
+
+    if (typeof objA !== 'object' || objA === null ||
+          typeof objB !== 'object' || objB === null) {
+        return false;
+    }
+
+    var keysA = Object.keys(objA);
+    var keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    for (var i = 0; i < keysA.length; i++) {
+        var key = keysA[i];
+        if (!objB.hasOwnProperty(key) || objA[key] !== objB[key]) {
+            return false;
+        }
+    }
+
+    return true;
+};

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -38,6 +38,7 @@ var SlashCommands = require("../../SlashCommands");
 var dis = require("../../dispatcher");
 var Tinter = require("../../Tinter");
 var rate_limited_func = require('../../ratelimitedfunc');
+var ObjectUtils = require('../../ObjectUtils');
 
 var DEBUG = false;
 
@@ -162,6 +163,11 @@ module.exports = React.createClass({
         } else {
             this._onRoomLoaded(this.state.room);
         }
+    },
+
+    shouldComponentUpdate: function(nextProps, nextState) {
+        return (!ObjectUtils.shallowEqual(this.props, nextProps) ||
+                !ObjectUtils.shallowEqual(this.state, nextState));
     },
 
     componentWillUnmount: function() {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -24,6 +24,7 @@ var EventTimeline = Matrix.EventTimeline;
 var sdk = require('../../index');
 var MatrixClientPeg = require("../../MatrixClientPeg");
 var dis = require("../../dispatcher");
+var ObjectUtils = require('../../ObjectUtils');
 
 var PAGINATE_SIZE = 20;
 var INITIAL_SIZE = 20;
@@ -143,6 +144,11 @@ var TimelinePanel = React.createClass({
                         " (was " + this.props.eventId + ")");
             return this._initTimeline(newProps);
         }
+    },
+
+    shouldComponentUpdate: function(nextProps, nextState) {
+        return (!ObjectUtils.shallowEqual(this.props, nextProps) ||
+                !ObjectUtils.shallowEqual(this.state, nextState));
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
This will avoid re-rendering the whole RoomView every time we get a scroll
event, and might even help with https://github.com/vector-im/vector-web/issues/1056.