### PR TITLE
Bring back lost functionality on login/register/password-reset screens

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -25,6 +25,7 @@ var matrixClient = null;
 var localStorage = window.localStorage;
 
 function deviceId() {
+    // XXX: is Math.random()'s deterministicity a problem here?
     var id = Math.floor(Math.random()*16777215).toString(16);
     id = "W" + "000000".substring(id.length) + id;
     if (localStorage) {
@@ -101,10 +102,12 @@ class MatrixClient {
     // -matthew
 
     replaceUsingUrls(hs_url, is_url) {
+        // ...not to be confused with MatrixClientPeg's createClient...
         matrixClient = Matrix.createClient({
             baseUrl: hs_url,
             idBaseUrl: is_url
         });
+
         // XXX: factor this out with the localStorage setting in replaceUsingAccessToken
         if (localStorage) {
             try {
@@ -115,7 +118,7 @@ class MatrixClient {
             }
         } else {
             console.warn("No local storage available: can't persist HS/IS URLs!");
-        }
+        }    
     }
 
     replaceUsingAccessToken(hs_url, is_url, user_id, access_token, isGuest) {
@@ -123,10 +126,11 @@ class MatrixClient {
             try {
                 localStorage.clear();
             } catch (e) {
-                console.warn("Error using local storage");
+                console.warn("Error clearing local storage", e);
             }
         }
         this.guestAccess.markAsGuest(Boolean(isGuest));
+        // ...not to be confused with Matrix.createClient()...
         createClient(hs_url, is_url, user_id, access_token, this.guestAccess);
         if (localStorage) {
             try {
@@ -136,7 +140,7 @@ class MatrixClient {
                 localStorage.setItem("mx_access_token", access_token);
                 console.log("Session persisted for %s", user_id);
             } catch (e) {
-                console.warn("Error using local storage: can't persist session!");
+                console.warn("Error using local storage: can't persist session!", e);
             }
         } else {
             console.warn("No local storage available: can't persist session!");

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -35,7 +35,7 @@ function deviceId() {
     return id;
 }
 
-function createClient(hs_url, is_url, user_id, access_token, guestAccess) {
+function createClientForPeg(hs_url, is_url, user_id, access_token, guestAccess) {
     var opts = {
         baseUrl: hs_url,
         idBaseUrl: is_url,
@@ -69,7 +69,7 @@ if (localStorage) {
     var guestAccess = new GuestAccess(localStorage);
     if (access_token && user_id && hs_url) {
         console.log("Restoring session for %s", user_id);
-        createClient(hs_url, is_url, user_id, access_token, guestAccess);
+        createClientForPeg(hs_url, is_url, user_id, access_token, guestAccess);
     }
     else {
         console.log("Session not found.");
@@ -92,7 +92,7 @@ class MatrixClient {
 
     // FIXME, XXX: this all seems very convoluted :(
     //   
-    // if we replace the singleton using URLs we bypass our createClient()
+    // if we replace the singleton using URLs we bypass our createClientForPeg()
     // global helper function... but if we replace it using
     // an access_token we don't?
     //
@@ -102,7 +102,6 @@ class MatrixClient {
     // -matthew
 
     replaceUsingUrls(hs_url, is_url) {
-        // ...not to be confused with MatrixClientPeg's createClient...
         matrixClient = Matrix.createClient({
             baseUrl: hs_url,
             idBaseUrl: is_url
@@ -118,7 +117,7 @@ class MatrixClient {
             }
         } else {
             console.warn("No local storage available: can't persist HS/IS URLs!");
-        }    
+        }
     }
 
     replaceUsingAccessToken(hs_url, is_url, user_id, access_token, isGuest) {
@@ -130,8 +129,7 @@ class MatrixClient {
             }
         }
         this.guestAccess.markAsGuest(Boolean(isGuest));
-        // ...not to be confused with Matrix.createClient()...
-        createClient(hs_url, is_url, user_id, access_token, this.guestAccess);
+        createClientForPeg(hs_url, is_url, user_id, access_token, this.guestAccess);
         if (localStorage) {
             try {
                 localStorage.setItem("mx_hs_url", hs_url);

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1003,8 +1003,8 @@ module.exports = React.createClass({
                     guestAccessToken={this.state.guestAccessToken}
                     defaultHsUrl={this.props.config.default_hs_url}
                     defaultIsUrl={this.props.config.default_is_url}
-                    initialHsUrl={this.getCurrentHsUrl()}
-                    initialIsUrl={this.getCurrentIsUrl()}
+                    customHsUrl={this.getCurrentHsUrl()}
+                    customIsUrl={this.getCurrentIsUrl()}
                     registrationUrl={this.props.registrationUrl}
                     onLoggedIn={this.onRegistered}
                     onLoginClick={this.onLoginClick}
@@ -1015,8 +1015,8 @@ module.exports = React.createClass({
                 <ForgotPassword
                     defaultHsUrl={this.props.config.default_hs_url}
                     defaultIsUrl={this.props.config.default_is_url}
-                    initialHsUrl={this.getCurrentHsUrl()}
-                    initialIsUrl={this.getCurrentIsUrl()}
+                    customHsUrl={this.getCurrentHsUrl()}
+                    customIsUrl={this.getCurrentIsUrl()}
                     onComplete={this.onLoginClick}
                     onLoginClick={this.onLoginClick} />
             );
@@ -1027,8 +1027,8 @@ module.exports = React.createClass({
                     onRegisterClick={this.onRegisterClick}
                     defaultHsUrl={this.props.config.default_hs_url}
                     defaultIsUrl={this.props.config.default_is_url}
-                    initialHsUrl={this.getCurrentHsUrl()}
-                    initialIsUrl={this.getCurrentIsUrl()}
+                    customHsUrl={this.getCurrentHsUrl()}
+                    customIsUrl={this.getCurrentIsUrl()}
                     onForgotPasswordClick={this.onForgotPasswordClick} 
                     onLoginAsGuestClick={this.props.enableGuest && this.props.config && this.props.config.default_hs_url ? this._registerAsGuest: undefined}
                     />

--- a/src/components/structures/login/ForgotPassword.js
+++ b/src/components/structures/login/ForgotPassword.js
@@ -27,8 +27,12 @@ module.exports = React.createClass({
     displayName: 'ForgotPassword',
 
     propTypes: {
-        homeserverUrl: React.PropTypes.string,
-        identityServerUrl: React.PropTypes.string,
+        defaultHsUrl: React.PropTypes.string,
+        defaultIsUrl: React.PropTypes.string,
+        initialHsUrl: React.PropTypes.string,
+        initialIsUrl: React.PropTypes.string,
+        onLoginClick: React.PropTypes.func,
+        onRegisterClick: React.PropTypes.func,
         onComplete: React.PropTypes.func.isRequired
     },
 
@@ -152,8 +156,9 @@ module.exports = React.createClass({
         else {
             resetPasswordJsx = (
             <div>
-                To reset your password, enter the email address linked to your account:
-                <br />
+                <div className="mx_Login_prompt">
+                    To reset your password, enter the email address linked to your account:
+                </div>
                 <div>
                     <form onSubmit={this.onSubmitForm}>
                         <input className="mx_Login_field" ref="user" type="text"
@@ -175,11 +180,21 @@ module.exports = React.createClass({
                     </form>
                     <ServerConfig ref="serverConfig"
                         withToggleButton={true}
-                        defaultHsUrl={this.props.homeserverUrl}
-                        defaultIsUrl={this.props.identityServerUrl}
+                        defaultHsUrl={this.props.defaultHsUrl}
+                        defaultIsUrl={this.props.defaultIsUrl}
+                        initialHsUrl={this.props.initialHsUrl}
+                        initialIsUrl={this.props.initialIsUrl}
                         onHsUrlChanged={this.onHsUrlChanged}
                         onIsUrlChanged={this.onIsUrlChanged}
                         delayTimeMs={0}/>
+                    <div className="mx_Login_error">
+                    </div>                        
+                    <a className="mx_Login_create" onClick={this.props.onLoginClick} href="#">
+                        Return to login
+                    </a>
+                    <a className="mx_Login_create" onClick={this.props.onRegisterClick} href="#">
+                        Create a new account
+                    </a>
                     <LoginFooter />
                 </div>
             </div>

--- a/src/components/structures/login/ForgotPassword.js
+++ b/src/components/structures/login/ForgotPassword.js
@@ -29,8 +29,8 @@ module.exports = React.createClass({
     propTypes: {
         defaultHsUrl: React.PropTypes.string,
         defaultIsUrl: React.PropTypes.string,
-        initialHsUrl: React.PropTypes.string,
-        initialIsUrl: React.PropTypes.string,
+        customHsUrl: React.PropTypes.string,
+        customIsUrl: React.PropTypes.string,
         onLoginClick: React.PropTypes.func,
         onRegisterClick: React.PropTypes.func,
         onComplete: React.PropTypes.func.isRequired
@@ -182,8 +182,8 @@ module.exports = React.createClass({
                         withToggleButton={true}
                         defaultHsUrl={this.props.defaultHsUrl}
                         defaultIsUrl={this.props.defaultIsUrl}
-                        initialHsUrl={this.props.initialHsUrl}
-                        initialIsUrl={this.props.initialIsUrl}
+                        customHsUrl={this.props.customHsUrl}
+                        customIsUrl={this.props.customIsUrl}
                         onHsUrlChanged={this.onHsUrlChanged}
                         onIsUrlChanged={this.onIsUrlChanged}
                         delayTimeMs={0}/>

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -31,8 +31,8 @@ module.exports = React.createClass({displayName: 'Login',
     propTypes: {
         onLoggedIn: React.PropTypes.func.isRequired,
 
-        initialHsUrl: React.PropTypes.string,
-        initialIsUrl: React.PropTypes.string,
+        customHsUrl: React.PropTypes.string,
+        customIsUrl: React.PropTypes.string,
         defaultHsUrl: React.PropTypes.string,
         defaultIsUrl: React.PropTypes.string,
 
@@ -48,8 +48,8 @@ module.exports = React.createClass({displayName: 'Login',
         return {
             busy: false,
             errorText: null,
-            enteredHomeserverUrl: this.props.initialHsUrl || this.props.defaultHsUrl,
-            enteredIdentityServerUrl: this.props.initialIsUrl || this.props.defaultIsUrl,
+            enteredHomeserverUrl: this.props.customHsUrl || this.props.defaultHsUrl,
+            enteredIdentityServerUrl: this.props.customIsUrl || this.props.defaultIsUrl,
 
             // used for preserving username when changing homeserver
             username: "",
@@ -220,8 +220,8 @@ module.exports = React.createClass({displayName: 'Login',
                         { this.componentForStep(this._getCurrentFlowStep()) }
                         <ServerConfig ref="serverConfig"
                             withToggleButton={true}
-                            initialHsUrl={this.props.initialHsUrl}
-                            initialIsUrl={this.props.initialIsUrl}
+                            customHsUrl={this.props.customHsUrl}
+                            customIsUrl={this.props.customIsUrl}
                             defaultHsUrl={this.props.defaultHsUrl}
                             defaultIsUrl={this.props.defaultIsUrl}
                             onHsUrlChanged={this.onHsUrlChanged}

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -30,28 +30,29 @@ var ServerConfig = require("../../views/login/ServerConfig");
 module.exports = React.createClass({displayName: 'Login',
     propTypes: {
         onLoggedIn: React.PropTypes.func.isRequired,
-        homeserverUrl: React.PropTypes.string,
-        identityServerUrl: React.PropTypes.string,
+
+        initialHsUrl: React.PropTypes.string,
+        initialIsUrl: React.PropTypes.string,
+        defaultHsUrl: React.PropTypes.string,
+        defaultIsUrl: React.PropTypes.string,
+
         // login shouldn't know or care how registration is done.
         onRegisterClick: React.PropTypes.func.isRequired,
+
         // login shouldn't care how password recovery is done.
         onForgotPasswordClick: React.PropTypes.func,
         onLoginAsGuestClick: React.PropTypes.func,
-    },
-
-    getDefaultProps: function() {
-        return {
-            homeserverUrl: 'https://matrix.org/',
-            identityServerUrl: 'https://matrix.org'
-        };
     },
 
     getInitialState: function() {
         return {
             busy: false,
             errorText: null,
-            enteredHomeserverUrl: this.props.homeserverUrl,
-            enteredIdentityServerUrl: this.props.identityServerUrl
+            enteredHomeserverUrl: this.props.initialHsUrl || this.props.defaultHsUrl,
+            enteredIdentityServerUrl: this.props.initialIsUrl || this.props.defaultIsUrl,
+
+            // used for preserving username when changing homeserver
+            username: "",
         };
     },
 
@@ -76,12 +77,26 @@ module.exports = React.createClass({displayName: 'Login',
         });
     },
 
+    onUsernameChanged: function(username) {
+        this.setState({ username: username });
+    },
+
     onHsUrlChanged: function(newHsUrl) {
-        this._initLoginLogic(newHsUrl);
+        var self = this;
+        this.setState({
+            enteredHomeserverUrl: newHsUrl
+        }, function() {
+            self._initLoginLogic(newHsUrl);
+        });
     },
 
     onIsUrlChanged: function(newIsUrl) {
-        this._initLoginLogic(null, newIsUrl);
+        var self = this;
+        this.setState({
+            enteredIdentityServerUrl: newIsUrl
+        }, function() {
+            self._initLoginLogic(null, newIsUrl);            
+        });
     },
 
     _initLoginLogic: function(hsUrl, isUrl) {
@@ -162,6 +177,8 @@ module.exports = React.createClass({displayName: 'Login',
                 return (
                     <PasswordLogin
                         onSubmit={this.onPasswordLogin}
+                        initialUsername={this.state.username}
+                        onUsernameChanged={this.onUsernameChanged}
                         onForgotPasswordClick={this.props.onForgotPasswordClick} />
                 );
             case 'm.login.cas':
@@ -203,8 +220,10 @@ module.exports = React.createClass({displayName: 'Login',
                         { this.componentForStep(this._getCurrentFlowStep()) }
                         <ServerConfig ref="serverConfig"
                             withToggleButton={true}
-                            defaultHsUrl={this.props.homeserverUrl}
-                            defaultIsUrl={this.props.identityServerUrl}
+                            initialHsUrl={this.props.initialHsUrl}
+                            initialIsUrl={this.props.initialIsUrl}
+                            defaultHsUrl={this.props.defaultHsUrl}
+                            defaultIsUrl={this.props.defaultIsUrl}
                             onHsUrlChanged={this.onHsUrlChanged}
                             onIsUrlChanged={this.onIsUrlChanged}
                             delayTimeMs={1000}/>
@@ -216,7 +235,6 @@ module.exports = React.createClass({displayName: 'Login',
                             Create a new account
                         </a>
                         { loginAsGuestJsx }
-                        <br/>
                         <LoginFooter />
                     </div>
                 </div>

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -36,8 +36,10 @@ module.exports = React.createClass({
         sessionId: React.PropTypes.string,
         registrationUrl: React.PropTypes.string,
         idSid: React.PropTypes.string,
-        hsUrl: React.PropTypes.string,
-        isUrl: React.PropTypes.string,
+        initialHsUrl: React.PropTypes.string,
+        initialIsUrl: React.PropTypes.string,
+        defaultHsUrl: React.PropTypes.string,
+        defaultIsUrl: React.PropTypes.string,
         email: React.PropTypes.string,
         username: React.PropTypes.string,
         guestAccessToken: React.PropTypes.string,
@@ -50,8 +52,6 @@ module.exports = React.createClass({
         return {
             busy: false,
             errorText: null,
-            enteredHomeserverUrl: this.props.hsUrl,
-            enteredIdentityServerUrl: this.props.isUrl
         };
     },
 
@@ -59,7 +59,7 @@ module.exports = React.createClass({
         this.dispatcherRef = dis.register(this.onAction);
         // attach this to the instance rather than this.state since it isn't UI
         this.registerLogic = new Signup.Register(
-            this.props.hsUrl, this.props.isUrl
+            this.props.initialHsUrl, this.props.initialIsUrl
         );
         this.registerLogic.setClientSecret(this.props.clientSecret);
         this.registerLogic.setSessionId(this.props.sessionId);
@@ -242,11 +242,15 @@ module.exports = React.createClass({
                 {busySpinner}
                 <ServerConfig ref="serverConfig"
                     withToggleButton={true}
-                    defaultHsUrl={this.state.enteredHomeserverUrl}
-                    defaultIsUrl={this.state.enteredIdentityServerUrl}
+                    initialHsUrl={this.props.initialHsUrl}
+                    initialIsUrl={this.props.initialIsUrl}
+                    defaultHsUrl={this.props.defaultHsUrl}
+                    defaultIsUrl={this.props.defaultIsUrl}
                     onHsUrlChanged={this.onHsUrlChanged}
                     onIsUrlChanged={this.onIsUrlChanged}
                     delayTimeMs={1000} />
+                <div className="mx_Login_error">
+                </div>
                 <a className="mx_Login_create" onClick={this.props.onLoginClick} href="#">
                     I already have an account
                 </a>
@@ -256,11 +260,13 @@ module.exports = React.createClass({
 
     render: function() {
         var LoginHeader = sdk.getComponent('login.LoginHeader');
+        var LoginFooter = sdk.getComponent('login.LoginFooter');
         return (
             <div className="mx_Login">
                 <div className="mx_Login_box">
                     <LoginHeader />
                     {this._getRegisterContentJsx()}
+                    <LoginFooter />
                 </div>
             </div>
         );

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -36,8 +36,8 @@ module.exports = React.createClass({
         sessionId: React.PropTypes.string,
         registrationUrl: React.PropTypes.string,
         idSid: React.PropTypes.string,
-        initialHsUrl: React.PropTypes.string,
-        initialIsUrl: React.PropTypes.string,
+        customHsUrl: React.PropTypes.string,
+        customIsUrl: React.PropTypes.string,
         defaultHsUrl: React.PropTypes.string,
         defaultIsUrl: React.PropTypes.string,
         email: React.PropTypes.string,
@@ -59,7 +59,7 @@ module.exports = React.createClass({
         this.dispatcherRef = dis.register(this.onAction);
         // attach this to the instance rather than this.state since it isn't UI
         this.registerLogic = new Signup.Register(
-            this.props.initialHsUrl, this.props.initialIsUrl
+            this.props.customHsUrl, this.props.customIsUrl
         );
         this.registerLogic.setClientSecret(this.props.clientSecret);
         this.registerLogic.setSessionId(this.props.sessionId);
@@ -242,8 +242,8 @@ module.exports = React.createClass({
                 {busySpinner}
                 <ServerConfig ref="serverConfig"
                     withToggleButton={true}
-                    initialHsUrl={this.props.initialHsUrl}
-                    initialIsUrl={this.props.initialIsUrl}
+                    customHsUrl={this.props.customHsUrl}
+                    customIsUrl={this.props.customIsUrl}
                     defaultHsUrl={this.props.defaultHsUrl}
                     defaultIsUrl={this.props.defaultIsUrl}
                     onHsUrlChanged={this.onHsUrlChanged}

--- a/src/components/views/login/CustomServerDialog.js
+++ b/src/components/views/login/CustomServerDialog.js
@@ -31,12 +31,11 @@ module.exports = React.createClass({
                         servers by specifying a different Home server URL.
                         <br/>
                         This allows you to use this app with an existing Matrix account on
-                        a different Home server.
+                        a different home server.
                         <br/>
                         <br/>
-                        You can also set a custom Identity server but this will affect
-                        people&#39;s ability to find you if you use a server in a group other
-                        than the main Matrix.org group.
+                        You can also set a custom identity server but this will typically prevent
+                        interaction with users based on email address.
                     </span>
                 </div>
                 <div className="mx_Dialog_buttons">

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -23,13 +23,24 @@ var ReactDOM = require('react-dom');
 module.exports = React.createClass({displayName: 'PasswordLogin',
     propTypes: {
         onSubmit: React.PropTypes.func.isRequired, // fn(username, password)
-        onForgotPasswordClick: React.PropTypes.func // fn()
+        onForgotPasswordClick: React.PropTypes.func, // fn()
+        initialUsername: React.PropTypes.string,
+        initialPassword: React.PropTypes.string,
+        onUsernameChanged: React.PropTypes.func,
+        onPasswordChanged: React.PropTypes.func,
+    },
+
+    getDefaultProps: function() {
+        return {
+            onUsernameChanged: function() {},
+            onPasswordChanged: function() {},
+        };
     },
 
     getInitialState: function() {
         return {
-            username: "",
-            password: ""
+            username: this.props.initialUsername,
+            password: this.props.initialPassword,
         };
     },
 
@@ -40,10 +51,12 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
 
     onUsernameChanged: function(ev) {
         this.setState({username: ev.target.value});
+        this.props.onUsernameChanged(ev.target.value);
     },
 
     onPasswordChanged: function(ev) {
         this.setState({password: ev.target.value});
+        this.props.onPasswordChanged(ev.target.value);
     },
 
     render: function() {

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -34,6 +34,8 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
         return {
             onUsernameChanged: function() {},
             onPasswordChanged: function() {},
+            initialUsername: "",
+            initialPassword: "",
         };
     },
 

--- a/src/components/views/login/ServerConfig.js
+++ b/src/components/views/login/ServerConfig.js
@@ -52,6 +52,8 @@ module.exports = React.createClass({
         return {
             onHsUrlChanged: function() {},
             onIsUrlChanged: function() {},
+            customHsUrl: "",
+            customIsUrl: "",
             withToggleButton: false,
             delayTimeMs: 0
         };


### PR DESCRIPTION
specifically:

1) custom HS/IS urls are now persisted in HTML5 local storage.  As a result, all the login components now distinguish between default HS/IS URLs and custom specified ones again. (
2) custom HS/IS urls are synchronised between the instances of ServerConfig found in the Login, Registration and Forgot Password screens.
3) username are persisted over changing homeserver (but not password, to stop accidentally leaking passwords to the wrong server)
4) correctly interpret a blank URL field as meaning the placeholder text
5) when toggling custom URLs on and off, remember what the custom values were, and use the default URLs if custom mode is not engaged

also, guest access now upholds custom HS/IS URLs found in local storage rather than being limited to the server config ()

also adds assorted comments and improved console debug and a few minor cosmetic changes to the login components.
