### PR TITLE
Use the guest access tokens sent in 3pid invite emails.

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -99,6 +99,18 @@ module.exports = React.createClass({
                 console.log("Not registering as guest; registration.");
                 this._autoRegisterAsGuest = false;
             }
+            else if (this.props.startingQueryParams.guest_user_id &&
+                this.props.startingQueryParams.guest_access_token)
+            {
+                this._autoRegisterAsGuest = false;
+                this.onLoggedIn({
+                    userId: this.props.startingQueryParams.guest_user_id,
+                    accessToken: this.props.startingQueryParams.guest_access_token,
+                    homeserverUrl: this.props.config.default_hs_url,
+                    identityServerUrl: this.props.config.default_is_url,
+                    guest: true
+                });
+            }
             else {
                 this._autoRegisterAsGuest = true;
             }


### PR DESCRIPTION
Users clicking 3pid invite links will now always land in the same account, meaning they can click the link again somewhere else and carry on where they left off.

Requires https://github.com/matrix-org/synapse/pull/627
Fixes https://github.com/vector-im/vector-web/issues/1017

Also attn. @erikjohnston who I've assigned the synapse part of this fix to.