### PR TITLE
Fix checkScroll after image load

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -331,7 +331,7 @@ module.exports = React.createClass({
     // once images in the events load, make the scrollPanel check the
     // scroll offsets.
     _onImageLoad: function() {
-        var scrollPanel = this.refs.messagePanel;
+        var scrollPanel = this.refs.scrollPanel;
         if (scrollPanel) {
             scrollPanel.checkScroll();
         }


### PR DESCRIPTION
Make the onImageLoad handler call checkScroll on the right thing. This was
originally done in commit 99d2392, but got broken in the Great RoomView
Refactor of February 2016.

This should fix https://github.com/vector-im/vector-web/issues/753 and
https://github.com/vector-im/vector-web/issues/1057.