### PR TITLE
Don't forceUpdate the message panel on resize

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -167,7 +167,6 @@ module.exports = React.createClass({
         // we don't need to forceUpdate ourselves here, but we do need to
         // forceUpdate the scrollpanel, which will make the gemini panel update
         // itself and trigger a scroll position check.
-        console.log("MessagePanel.onResize");
         this.refs.scrollPanel.forceUpdate();
     },
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -159,6 +159,18 @@ module.exports = React.createClass({
         }
     },
 
+    // makes the MessagePanel update itself after it is resized (due to other
+    // changes in the DOM)
+    onResize: function() {
+        if (!this.refs.scrollPanel) { return; }
+
+        // we don't need to forceUpdate ourselves here, but we do need to
+        // forceUpdate the scrollpanel, which will make the gemini panel update
+        // itself and trigger a scroll position check.
+        console.log("MessagePanel.onResize");
+        this.refs.scrollPanel.forceUpdate();
+    },
+
     _getEventTiles: function() {
         var EventTile = sdk.getComponent('rooms.EventTile');
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1028,7 +1028,7 @@ module.exports = React.createClass({
         // telling it about it. This also ensures that the scroll offset is
         // updated.
         if (this.refs.messagePanel) {
-            this.refs.messagePanel.forceUpdate();
+            this.refs.messagePanel.onResize();
         }
     },
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -467,6 +467,13 @@ var TimelinePanel = React.createClass({
         return null;
     },
 
+    // makes the TimelinePanel update itself after it is resized (due to other
+    // changes in the DOM)
+    onResize: function() {
+        if (!this.refs.messagePanel) { return; }
+        this.refs.messagePanel.onResize();
+    },
+
     _initTimeline: function(props) {
         var initialEvent = props.eventId;
         var pixelOffset = props.eventPixelOffset;


### PR DESCRIPTION
We don't really need to forceUpdate() the entire timeline panel every time
something might resize it. It is sufficient to forceUpdate the ScrollPanel.