### PR TITLE
Make 3pid invite failures show errors

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -202,12 +202,12 @@ module.exports = React.createClass({
         var promise = inviteWarningDefer.promise;
         if (isEmailAddress) {
             promise = promise.then(function() {
-                 MatrixClientPeg.get().inviteByEmail(self.props.roomId, inputText);
+                 return MatrixClientPeg.get().inviteByEmail(self.props.roomId, inputText);
             });
         }
         else {
             promise = promise.then(function() {
-                MatrixClientPeg.get().invite(self.props.roomId, inputText);
+                return MatrixClientPeg.get().invite(self.props.roomId, inputText);
             });
         }
 


### PR DESCRIPTION
Return the promise so the failure actually propagates through the promise chain. Makes the invite error handling code work.

Fixes https://github.com/vector-im/vector-web/issues/691