### PR TITLE
Fix the missing date separator at the start of rooms

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -188,7 +188,7 @@ var TimelinePanel = React.createClass({
 
             debuglog("TimelinePanel: paginate complete backwards:"+backwards+"; success:"+r);
             this.setState({[statekey]: false});
-            this._onTimelineUpdated(r);
+            this._onTimelineUpdated();
             return r;
         });
     },
@@ -555,7 +555,7 @@ var TimelinePanel = React.createClass({
         // calling _onTimelineUpdated and updating the state.
 
         var onLoaded = () => {
-            this._onTimelineUpdated(true);
+            this._onTimelineUpdated();
 
             this.setState({timelineLoading: false}, () => {
                 // initialise the scroll state of the message panel
@@ -586,17 +586,15 @@ var TimelinePanel = React.createClass({
         prom.done();
     },
 
-    _onTimelineUpdated: function(gotResults) {
+    _onTimelineUpdated: function() {
         // we might have switched rooms since the load started - just bin
         // the results if so.
         if (this.unmounted) return;
 
-        if (gotResults) {
-            this.setState({
-                events: this._timelineWindow.getEvents(),
-                canBackPaginate: this._timelineWindow.canPaginate(EventTimeline.BACKWARDS),
-            });
-        }
+        this.setState({
+            events: this._timelineWindow.getEvents(),
+            canBackPaginate: this._timelineWindow.canPaginate(EventTimeline.BACKWARDS),
+        });
     },
 
     _indexForEventId: function(evId) {


### PR DESCRIPTION
When we first hit the start of the room, we still have a pagination token, so
we hide the date separator. When we try to backpaginate again, we get an empty
result, and the pagination token is cleared.

Make sure that we update state. canBackPaginate even when there are no new
results, to handle this case.

Fixes https://github.com/vector-im/vector-web/issues/1014