### PR TITLE
Show the invite preview bar when we have a 3pid invite

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -883,6 +883,12 @@ module.exports = React.createClass({
         });
     },
 
+    onRejectThreepidInviteButtonClicked: function(ev) {
+        dis.dispatch({
+            action: 'view_room_directory',
+        });
+    },
+
     onSearchClick: function() {
         this.setState({ searching: true });
     },
@@ -1086,6 +1092,7 @@ module.exports = React.createClass({
                             <RoomHeader ref="header" room={this.state.room} oobData={this.props.oobData} />
                             <div className="mx_RoomView_auxPanel">
                                 <RoomPreviewBar onJoinClick={ this.onJoinButtonClicked } 
+                                                onRejectClick={ this.onRejectThreepidInviteButtonClicked }
                                                 canJoin={ true } canPreview={ false }
                                                 spinner={this.state.joining}
                                                 inviterName={inviterName}
@@ -1192,9 +1199,15 @@ module.exports = React.createClass({
         }
         else if (this.state.guestsCanJoin && MatrixClientPeg.get().isGuest() &&
                 (!myMember || myMember.membership !== "join")) {
+            var inviterName = undefined;
+            if (this.props.oobData) {
+                inviterName = this.props.oobData.inviterName;
+            }
             aux = (
                 <RoomPreviewBar onJoinClick={this.onJoinButtonClicked} canJoin={true}
+                                onRejectClick={ this.onRejectThreepidInviteButtonClicked }
                                 spinner={this.state.joining}
+                                inviterName={inviterName}
                 />
             );
         }

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -884,6 +884,10 @@ module.exports = React.createClass({
     },
 
     onRejectThreepidInviteButtonClicked: function(ev) {
+        // We can reject 3pid invites in the same way that we accept them,
+        // using /leave rather than /join. In the short term though, we
+        // just ignore them.
+        // https://github.com/vector-im/vector-web/issues/1134
         dis.dispatch({
             action: 'view_room_directory',
         });

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -25,6 +25,9 @@ module.exports = React.createClass({
     propTypes: {
         onJoinClick: React.PropTypes.func,
         onRejectClick: React.PropTypes.func,
+
+        // if inviterName is specified, the preview bar will shown an invite to the room.
+        // You should also specify onRejectClick if specifiying inviterName
         inviterName: React.PropTypes.string,
         canJoin: React.PropTypes.bool,
         canPreview: React.PropTypes.bool,


### PR DESCRIPTION
...and make the reject button work.

Previously we displayed the 'join this room' rather than, 'X has invited you to a room" if the room was peekable.

Also, the reject button never did anything even for non-peekable rooms.