### PR TITLE
Update the gemini panel when we show/hide the TopUnreadMessagesBar

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -920,7 +920,10 @@ module.exports = React.createClass({
         // screen.
         var showBar = (pos < 0);
 
-        this.setState({showTopUnreadMessagesBar: showBar});
+        if (this.state.showTopUnreadMessagesBar != showBar) {
+            this.setState({showTopUnreadMessagesBar: showBar},
+                          this.onChildResize);
+        }
     },
 
     // get the current scroll position of the room, so that it can be


### PR DESCRIPTION
Showing/hiding the TopUnreadMessagesBar resizes the scrollpanel. Make sure that
we update the gemini panel when this happens.

(Fixes an intermittent bug wherein we could get stuck with a 'scroll to bottom'
indicator after jumping to the bottom, with unread messages in the view)