### PR TITLE
Use our fork of react-gemini-scrollbar to fix resize issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "q": "^1.4.1",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
-    "react-gemini-scrollbar": "^2.0.1",
+    "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#d9a808d",
     "sanitize-html": "^1.11.1",
     "velocity-animate": "^1.2.3",
     "velocity-ui-pack": "^1.2.2"

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -159,17 +159,6 @@ module.exports = React.createClass({
         }
     },
 
-    // makes the MessagePanel update itself after it is resized (due to other
-    // changes in the DOM)
-    onResize: function() {
-        if (!this.refs.scrollPanel) { return; }
-
-        // we don't need to forceUpdate ourselves here, but we do need to
-        // forceUpdate the scrollpanel, which will make the gemini panel update
-        // itself and trigger a scroll position check.
-        this.refs.scrollPanel.forceUpdate();
-    },
-
     _getEventTiles: function() {
         var EventTile = sdk.getComponent('rooms.EventTile');
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1042,13 +1042,7 @@ module.exports = React.createClass({
     },
 
     onChildResize: function() {
-        // When the video, status bar, or the message composer resizes, the
-        // scroll panel also changes size.  Work around GeminiScrollBar fail by
-        // telling it about it. This also ensures that the scroll offset is
-        // updated.
-        if (this.refs.messagePanel) {
-            this.refs.messagePanel.onResize();
-        }
+        // no longer anything to do here
     },
 
     showSettings: function(show) {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -508,13 +508,6 @@ var TimelinePanel = React.createClass({
         return null;
     },
 
-    // makes the TimelinePanel update itself after it is resized (due to other
-    // changes in the DOM)
-    onResize: function() {
-        if (!this.refs.messagePanel) { return; }
-        this.refs.messagePanel.onResize();
-    },
-
     _initTimeline: function(props) {
         var initialEvent = props.eventId;
         var pixelOffset = props.eventPixelOffset;


### PR DESCRIPTION
Rather than telling react-gemini-scrollbar to update every time something that
changes its size happens, try out our fork of it which uses some hackery to
listen for resizes.