### PR TITLE
Handle the new Session.logged_out event.

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -621,6 +621,16 @@ module.exports = React.createClass({
                 call: call
             });
         });
+        cli.on('Session.logged_out', function(call) {
+            var ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
+            Modal.createDialog(ErrorDialog, {
+                title: "Logged Out",
+                description: "For security, this session has been logged out. Please log in again."
+            });
+            dis.dispatch({
+                action: 'logout'
+            });
+        });
         Notifier.start();
         UserActivity.start();
         Presence.start();


### PR DESCRIPTION
Log the user out and display a message telling them they've been logged out.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/100 (but safe without)
Fixes https://github.com/vector-im/vector-web/issues/414