### PR TITLE
Pass correct arguments to onFinished in Modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -41,7 +41,7 @@ module.exports = {
         var closeDialog = function() {
             ReactDOM.unmountComponentAtNode(self.getOrCreateContainer());
 
-            if (props && props.onFinished) props.onFinished.apply(null, arguments);
+            if (props && props.onFinished) props.onFinished.call(null, false);
         };
 
         var dialog = (
@@ -64,7 +64,7 @@ module.exports = {
         var closeDialog = function() {
             ReactDOM.unmountComponentAtNode(self.getOrCreateContainer());
 
-            if (props && props.onFinished) props.onFinished.apply(null, arguments);
+            if (props && props.onFinished) props.onFinished.call(null, false);
         };
 
         // FIXME: If a dialog uses getDefaultProps it clobbers the onFinished

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -38,10 +38,10 @@ module.exports = {
     createDialogWithElement: function(element, props, className) {
         var self = this;
 
-        var closeDialog = function() {
+        var closeDialog = function(accepted) {
             ReactDOM.unmountComponentAtNode(self.getOrCreateContainer());
 
-            if (props && props.onFinished) props.onFinished.call(null, false);
+            if (props && props.onFinished) props.onFinished.call(null, (accepted === true) || false);
         };
 
         var dialog = (
@@ -61,10 +61,10 @@ module.exports = {
     createDialog: function (Element, props, className) {
         var self = this;
 
-        var closeDialog = function() {
+        var closeDialog = function(accepted) {
             ReactDOM.unmountComponentAtNode(self.getOrCreateContainer());
 
-            if (props && props.onFinished) props.onFinished.call(null, false);
+            if (props && props.onFinished) props.onFinished.call(null, (accepted === true)  || false);
         };
 
         // FIXME: If a dialog uses getDefaultProps it clobbers the onFinished
@@ -81,5 +81,5 @@ module.exports = {
         ReactDOM.render(dialog, this.getOrCreateContainer());
 
         return {close: closeDialog};
-    },
+    }
 };


### PR DESCRIPTION
Fixes vector-im/vector-web#1169

Works, and I couldn't find a case where this breaks existing behaviour, but since there are no tests to verify I can't be sure.