### PR TITLE
Make getCurrent[H|I]SUrl honour the state setting that comes from the url bar

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -86,7 +86,9 @@ module.exports = React.createClass({
     },
 
     getCurrentHsUrl: function() {
-        if (MatrixClientPeg.get()) {
+        if (this.state.register_hs_url) {
+            return this.state.register_hs_url;
+        } else if (MatrixClientPeg.get()) {
             return MatrixClientPeg.get().getHomeserverUrl();
         }
         else if (window.localStorage && window.localStorage.getItem("mx_hs_url")) {
@@ -99,7 +101,9 @@ module.exports = React.createClass({
     },
 
     getCurrentIsUrl: function() {
-        if (MatrixClientPeg.get()) {
+        if (this.state.register_is_url) {
+            return this.state.register_is_url;
+        } else if (MatrixClientPeg.get()) {
             return MatrixClientPeg.get().getIdentityServerUrl();
         }
         else if (window.localStorage && window.localStorage.getItem("mx_is_url")) {


### PR DESCRIPTION
Fixes @ara4n's later bug in https://github.com/vector-im/vector-web/issues/1027 (clicking the email validation link would open a client that uses the default home server instead of the one you started off using).