### PR TITLE
Use new pendingEventList functionality from matrix-js-sdk

### DIFF
--- a/src/Resend.js
+++ b/src/Resend.js
@@ -32,18 +32,9 @@ module.exports = {
                 event: event
             });
         });
-        dis.dispatch({
-            action: 'message_resend_started',
-            event: event
-        });
     },
 
     removeFromQueue: function(event) {
-        MatrixClientPeg.get().getScheduler().removeEventFromQueue(event);
-        var room = MatrixClientPeg.get().getRoom(event.getRoomId());
-        if (!room) {
-            return;
-        }
-        room.removeEvents([event.getId()]);
-    }
+        MatrixClientPeg.get().cancelPendingEvent(event);
+    },
 };

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -702,7 +702,7 @@ module.exports = React.createClass({
         UserActivity.start();
         Presence.start();
         cli.startClient({
-            pendingEventOrdering: "end",
+            pendingEventOrdering: "detached",
             initialSyncLimit: this.props.config.sync_timeline_limit || 20,
         });
     },

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -213,11 +213,6 @@ module.exports = React.createClass({
                 this.setState({
                     hasUnsentMessages: this._hasUnsentMessages(this.state.room)
                 });
-            case 'message_resend_started':
-                this.setState({
-                    room: MatrixClientPeg.get().getRoom(this.props.roomId)
-                });
-                this.forceUpdate();
                 break;
             case 'notifier_enabled':
             case 'upload_failed':
@@ -397,9 +392,7 @@ module.exports = React.createClass({
 
     _getUnsentMessages: function(room) {
         if (!room) { return []; }
-        // TODO: It would be nice if the JS SDK provided nicer constant-time
-        // constructs rather than O(N) (N=num msgs) on this.
-        return room.timeline.filter(function(ev) {
+        return room.getPendingEvents().filter(function(ev) {
             return ev.status === Matrix.EventStatus.NOT_SENT;
         });
     },


### PR DESCRIPTION
Update react-sdk to use `pendingEventOrdering`==`detached` instead of
`end`. Look for pending events in the pendingEvent list, and use
MatrixClient.cancelPendingEvent to, uh, cancel pending events.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/111 and
https://github.com/matrix-org/matrix-js-sdk/pull/112.

Fixes https://github.com/vector-im/vector-web/issues/989, https://github.com/vector-im/vector-web/issues/1120 and https://github.com/vector-im/vector-web/issues/1145