### PR TITLE
if we're not peeking in a room, stop any ongoing peeking

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -168,6 +168,7 @@ module.exports = React.createClass({
                 }
             }).done();
         } else {
+            MatrixClientPeg.get().stopPeeking();
             this._onRoomLoaded(this.state.room);
         }
     },


### PR DESCRIPTION
needs to land alongside matching js-sdk https://github.com/matrix-org/matrix-js-sdk/pull/114