### PR TITLE
Only ignore scroll echoes once

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -170,6 +170,10 @@ module.exports = React.createClass({
             this._saveScrollState();
         } else {
             debuglog("Ignoring scroll echo");
+
+            // only ignore the echo once, otherwise we'll get confused when the
+            // user scrolls away from, and back to, the autoscroll point.
+            this._lastSetScroll = undefined;
         }
 
         this.props.onScroll(ev);


### PR DESCRIPTION
When the user scrolls up, and scrolls back to where they were, we want to save
the final scroll state. We were ignoring it because it looked the same as the
last autoscroll.

Fixes https://github.com/vector-im/vector-web/issues/1162