### PR TITLE
notification issue fixed

### DIFF
--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -128,7 +128,9 @@ var Notifier = {
         return global.Notification.permission == 'default';
     },
 
-    showToolbar: function() {
+    // Function to be used by clients to check weather or not to
+    // show the toolbar.
+    shouldShowToolbar: function() {
         // Check localStorage for any such meta data
         if (global.localStorage) {
             if (global.localStorage.getItem('notifications_hidden') === 'true')

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -163,7 +163,7 @@ var Notifier = {
                             action: "notifier_enabled",
                             value: false
                         });
-                        self.setToolbarHidden(true);
+                        self.setToolbarHidden(true, false);
                         return;
                     }
                     if (result === 'default') {
@@ -216,7 +216,7 @@ var Notifier = {
         return enabled === 'true';
     },
 
-     setToolbarHidden: function(hidden, persistent) {
+    setToolbarHidden: function(hidden, persistent = true) {
         this.toolbarHidden = hidden;
         dis.dispatch({
             action: "notifier_enabled",

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -150,6 +150,7 @@ var Notifier = {
                     value: true
                 });
             });
+            this.setToolbarHidden(false);
         } else {
             if (!global.localStorage) return;
             global.localStorage.setItem('notifications_enabled', 'false');
@@ -194,7 +195,7 @@ var Notifier = {
 
         // update the info to localStorage for persistent settings
         if (persistent && global.localStorage) {
-            global.localStorage.setItem('notifications_hidden', 'true');
+            global.localStorage.setItem('notifications_hidden', hidden);
         }
     },
 

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -156,14 +156,14 @@ var Notifier = {
             // Case when we do not have the permission as 'granted'
             if (this.isPermissionDefault()) {
                 // Attempt to get permission from user
-                var _this = this;
+                var self = this;
                 global.Notification.requestPermission().then(function(result) {
                     if (result === 'denied') {
                         dis.dispatch({
                             action: "notifier_enabled",
                             value: false
                         });
-                        _this.setToolbarHidden(true);
+                        self.setToolbarHidden(true);
                         return;
                     }
                     if (result === 'default') {
@@ -223,8 +223,9 @@ var Notifier = {
             value: this.isEnabled()
         });
 
-        if (persistent === true)
+        if (persistent) {
             this.setToolbarPersistantHidden();
+        }
     },
 
     setToolbarPersistantHidden: function() {

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -159,7 +159,7 @@ var Notifier = {
             if (this.isPermissionDefault()) {
                 // Attempt to get permission from user
                 var self = this;
-                global.Notification.requestPermission().then(function(result) {
+                global.Notification.requestPermission(function(result) {
                     if (result === 'denied') {
                         dis.dispatch({
                             action: "notifier_enabled",
@@ -225,14 +225,8 @@ var Notifier = {
             value: this.isEnabled()
         });
 
-        if (persistent) {
-            this.setToolbarPersistantHidden();
-        }
-    },
-
-    setToolbarPersistantHidden: function() {
-        // update the info to localStorage
-        if (global.localStorage) {
+        // update the info to localStorage for persistent settings
+        if (persistent && global.localStorage) {
             global.localStorage.setItem('notifications_hidden', 'true');
         }
     },

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -132,8 +132,7 @@ var Notifier = {
             }
         }
 
-        if(enable) {
-            // Case when we do not have the permission as 'granted'
+        if (enable) {
             // Attempt to get permission from user
             global.Notification.requestPermission(function(result) {
                 if (result !== 'granted') {
@@ -141,14 +140,15 @@ var Notifier = {
                     return;
                 }
 
+                if (global.localStorage) {
+                    global.localStorage.setItem('notifications_enabled', 'true');
+                }
+
                 if (callback) callback();
                 dis.dispatch({
                     action: "notifier_enabled",
                     value: true
                 });
-
-                if (!global.localStorage) return;
-                global.localStorage.setItem('notifications_enabled', 'true');
             });
         } else {
             if (!global.localStorage) return;

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1046,7 +1046,7 @@ module.exports = React.createClass({
             if (MatrixClientPeg.get().isGuest()) {
                 topBar = <GuestWarningBar />;
             }
-            else if (Notifier.supportsDesktopNotifications() && Notifier.shouldShowToolbar()) {
+            else if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
                 topBar = <MatrixToolbar />;
             }
             else if (this.state.hasNewVersion) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1046,7 +1046,7 @@ module.exports = React.createClass({
             if (MatrixClientPeg.get().isGuest()) {
                 topBar = <GuestWarningBar />;
             }
-            else if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
+            else if (Notifier.supportsDesktopNotifications() && Notifier.shouldShowToolbar()) {
                 topBar = <MatrixToolbar />;
             }
             else if (this.state.hasNewVersion) {


### PR DESCRIPTION
Signed-off-by: Minhaz A V <minhazav@gmail.com>

Changes
 - `isPermissionDefault()`: `added` a method to check id the current notification preference is `default`.

 - `showToolbar()`: `added` a method that returns bool value corresponding to whether or not we should show the toolbar. It first checks localStorage if the user has clicked on close button of the toolbar, then checks if the status of notification permission isn't default.

- `setEnabled ()`: now uses the `then()` method of `Notification` class to deal with user response to activate notification dialog. Performs necessary actions as per user's response. No changes if the user simply dismisses the dialog.

- `setToolbarHidden ()`: added an extra parameter that defines whether to store the setting persistently or not.

- `setToolbarPersistantHidden ()`: `added` to store the setting to localStorage