### PR TITLE
Make the read-marker less annoying

### DIFF
--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -17,7 +17,7 @@ limitations under the License.
 var dis = require("./dispatcher");
 
 var MIN_DISPATCH_INTERVAL_MS = 500;
-var CURRENTLY_ACTIVE_THRESHOLD_MS = 500;
+var CURRENTLY_ACTIVE_THRESHOLD_MS = 2000;
 
 /**
  * This class watches for user activity (moving the mouse or pressing a key)


### PR DESCRIPTION
We considered the user active if there had been a user_activity event within
the last 500ms, but those events were only raised every 500ms, so it was
possible that we would be considered inactive immediately. Use
UserActivity.userCurrentlyActive() instead, which fixes this.

Also increase CURRENTLY_ACTIVE_THRESHOLD_MS to 2 seconds.