### PR TITLE
Fix off-by-one error in read-marker advancing

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -392,7 +392,7 @@ var TimelinePanel = React.createClass({
 
         // now think about advancing it
         var myUserId = MatrixClientPeg.get().credentials.userId;
-        for (; i < events.length; i++) {
+        for (i++; i < events.length; i++) {
             var ev = events[i];
             if (!ev.sender || ev.sender.userId != myUserId) {
                 break;


### PR DESCRIPTION
The fix to https://github.com/vector-im/vector-web/issues/1241 introduced an
off-by-one error which meant we would show the RM before the last event in a
room. We were actually winding the RM back one if the last message wasn't sent
by us.