### PR TITLE
Don't reload the DOM if we can jump straight to the RM

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -444,6 +444,7 @@ var TimelinePanel = React.createClass({
             // the relevant event.
             this.refs.messagePanel.scrollToEvent(this.state.readMarkerEventId,
                                                  0, 1/3);
+            return;
         }
 
         // Looks like we haven't loaded the event corresponding to the read-marker.


### PR DESCRIPTION
Adds a missing 'return' statement which meant that, even if we already had the
relevant event loaded into the DOM, we would rebuild it when the user clicked
on the "(^) Unread messages" bar.