### PR TITLE
Stop the MatrixClient when the MatrixChat is unmounted

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -183,6 +183,7 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount: function() {
+        this._stopMatrixClient();
         dis.unregister(this.dispatcherRef);
         document.removeEventListener("keydown", this.onKeyDown);
         window.removeEventListener("focus", this.onFocus);
@@ -258,12 +259,7 @@ module.exports = React.createClass({
                     window.localStorage.setItem("mx_hs_url", hsUrl);
                     window.localStorage.setItem("mx_is_url", isUrl);
                 }
-                Notifier.stop();
-                UserActivity.stop();
-                Presence.stop();
-                MatrixClientPeg.get().stopClient();
-                MatrixClientPeg.get().removeAllListeners();
-                MatrixClientPeg.unset();
+                this._stopMatrixClient();
                 this.notifyNewScreen('login');
                 this.replaceState({
                     logged_in: false,
@@ -720,6 +716,16 @@ module.exports = React.createClass({
             pendingEventOrdering: "detached",
             initialSyncLimit: this.props.config.sync_timeline_limit || 20,
         });
+    },
+
+    // stop all the background processes related to the current client
+    _stopMatrixClient: function() {
+        Notifier.stop();
+        UserActivity.stop();
+        Presence.stop();
+        MatrixClientPeg.get().stopClient();
+        MatrixClientPeg.get().removeAllListeners();
+        MatrixClientPeg.unset();
     },
 
     onKeyDown: function(ev) {


### PR DESCRIPTION
The MatrixClient never gets unmounted in the real app, but I've been working on
some tests which would rather like to be able to create and destroy MatrixChats
and not have the clients hang around forever.