### PR TITLE
RoomView: Handle joining federated rooms

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1055,7 +1055,7 @@ module.exports = React.createClass({
                     page_element = (
                         <RoomView
                             ref="roomView"
-                            roomAlias={this.state.currentRoom || this.state.currentRoomAlias}
+                            roomAddress={this.state.currentRoom || this.state.currentRoomAlias}
                             eventId={this.state.initialEventId}
                             thirdPartyInvite={this.state.thirdPartyInvite}
                             oobData={this.state.roomOobData}

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -624,10 +624,13 @@ module.exports = React.createClass({
         if (!this.refs.roomView) {
             return;
         }
-
         var roomview = this.refs.roomView;
+        var roomId = this.refs.roomView.getRoomId();
+        if (!roomId) {
+            return;
+        }
         var state = roomview.getScrollState();
-        this.scrollStateMap[roomview.props.roomId] = state;
+        this.scrollStateMap[roomId] = state;
     },
 
     onLoggedIn: function(credentials) {
@@ -1052,8 +1055,7 @@ module.exports = React.createClass({
                     page_element = (
                         <RoomView
                             ref="roomView"
-                            roomId={this.state.currentRoom}
-                            roomAlias={this.state.currentRoomAlias}
+                            roomAlias={this.state.currentRoom || this.state.currentRoomAlias}
                             eventId={this.state.initialEventId}
                             thirdPartyInvite={this.state.thirdPartyInvite}
                             oobData={this.state.roomOobData}

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -62,7 +62,7 @@ module.exports = React.createClass({
         // different components (RoomView, MatrixChat, RoomDirectory,
         // SlashCommands) have logic for turning aliases into rooms, and each
         // of them do it differently and have different edge cases.
-        roomAlias: React.PropTypes.string.isRequired,
+        roomAddress: React.PropTypes.string.isRequired,
 
         // An object representing a third party invite to join this room
         // Fields:
@@ -97,7 +97,7 @@ module.exports = React.createClass({
     },
 
     getInitialState: function() {
-        var room = MatrixClientPeg.get().getRoom(this.props.roomAlias);
+        var room = MatrixClientPeg.get().getRoom(this.props.roomAddress);
         return {
             room: room,
             roomLoading: !room,
@@ -149,9 +149,9 @@ module.exports = React.createClass({
         // We can /peek though. If it fails then we present the join UI. If it
         // succeeds then great, show the preview (but we still may be able to /join!).
         if (!this.state.room) {
-            console.log("Attempting to peek into room %s", this.props.roomAlias);
+            console.log("Attempting to peek into room %s", this.props.roomAddress);
 
-            MatrixClientPeg.get().peekInRoom(this.props.roomAlias).then((room) => {
+            MatrixClientPeg.get().peekInRoom(this.props.roomAddress).then((room) => {
                 this.setState({
                     room: room,
                     roomLoading: false,
@@ -258,7 +258,7 @@ module.exports = React.createClass({
     },
 
     componentWillReceiveProps: function(newProps) {
-        if (newProps.roomAlias != this.props.roomAlias) {
+        if (newProps.roomAddress != this.props.roomAddress) {
             throw new Error("changing room on a RoomView is not supported");
         }
 
@@ -554,7 +554,7 @@ module.exports = React.createClass({
 
         display_name_promise.then(() => {
             var sign_url = this.props.thirdPartyInvite ? this.props.thirdPartyInvite.inviteSignUrl : undefined;
-            return MatrixClientPeg.get().joinRoom(this.props.roomAlias,
+            return MatrixClientPeg.get().joinRoom(this.props.roomAddress,
                                                   { inviteSignUrl: sign_url } )
         }).then(function(resp) {
             var roomId = resp.roomId;
@@ -930,7 +930,7 @@ module.exports = React.createClass({
         this.setState({
             rejecting: true
         });
-        MatrixClientPeg.get().leave(this.props.roomAlias).done(function() {
+        MatrixClientPeg.get().leave(this.props.roomAddress).done(function() {
             dis.dispatch({ action: 'view_next_room' });
             self.setState({
                 rejecting: false


### PR DESCRIPTION
This hopefully fixes an issue where joining a federated room via the directory
would get stuck at a spinner of doom, due to us not recognising the room in
question when it came down the /sync. We now catch the room id in the response
from the /join, and use it to match up the room in onRoom.

props.roomAlias, props.roomId, and state.room.roomId were somewhat confusing,
so I've tried to rationalise them:

 * props.roomAlias (named thus to stop you assuming it's a room id) is the
   thing that the parent component uses to identify the room of interest, and
   can be either an ID or an alias (ie, it replaces props.roomId and
   props.roomAlias)

 * Everything that needs a room ID now has to get it from state.room.roomId.

Also remove the apparently redundant `onRoomName` handler. (The room name is displayed by the `RoomHeader`, which listens to room state changes itself)