### PR TITLE
Don't setState after unmounting a component

### DIFF
--- a/src/components/views/rooms/LinkPreviewWidget.js
+++ b/src/components/views/rooms/LinkPreviewWidget.js
@@ -45,14 +45,18 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
+        this.unmounted = false;
         MatrixClientPeg.get().getUrlPreview(this.props.link, this.props.mxEvent.getTs()).then((res)=>{
+            if (this.unmounted) {
+                return;
+            }
             this.setState(
                 { preview: res },
                 this.props.onWidgetLoad
             );
         }, (error)=>{
             console.error("Failed to get preview for " + this.props.link + " " + error);
-        });
+        }).done();
     },
 
     componentDidMount: function() {
@@ -63,6 +67,10 @@ module.exports = React.createClass({
     componentDidUpdate: function() {
         if (this.refs.description)
             linkifyElement(this.refs.description, linkifyMatrix.options);
+    },
+
+    componentWillUnmount: function() {
+        this.unmounted = true;
     },
 
     onImageClick: function(ev) {


### PR DESCRIPTION
Fix a warning which happens if a LinkPreviewWidget is unmounted before the
preview request completes.

Also add missing .done to promise chain