### PR TITLE
Hide e2e features if not enabled

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -258,6 +258,10 @@ module.exports = React.createClass({
     },
 
     _renderDeviceInfo: function() {
+        if (!UserSettingsStore.isFeatureEnabled("e2e_encryption")) {
+            return null;
+        }
+
         var client = MatrixClientPeg.get();
         var deviceId = client.deviceId;
         var olmKey = client.getDeviceEd25519Key() || "<not supported>";

--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -30,6 +30,7 @@ var MatrixClientPeg = require("../../../MatrixClientPeg");
 var dis = require("../../../dispatcher");
 var Modal = require("../../../Modal");
 var sdk = require('../../../index');
+var UserSettingsStore = require('../../../UserSettingsStore');
 var createRoom = require('../../../createRoom');
 
 module.exports = React.createClass({
@@ -506,6 +507,10 @@ module.exports = React.createClass({
     },
 
     _renderDevices: function() {
+        if (!UserSettingsStore.isFeatureEnabled("e2e_encryption")) {
+            return null;
+        }
+
         var devices = this.state.devices;
         var MemberDeviceInfo = sdk.getComponent('rooms.MemberDeviceInfo');
         var Spinner = sdk.getComponent("elements.Spinner");


### PR DESCRIPTION
Don't show the device info in the MemberInfo and UserSettings unless the user
has ticked the 'labs' box.