### PR TITLE
Fix peeking and member list vanishing

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -64,6 +64,13 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         var s = {
+            // If we are viewing a room by alias, this contains the alias
+            currentRoomAlias: null,
+
+            // The ID of the room we're viewing. This is either populated directly
+            // in the case where we view a room by ID or by RoomView when it resolves
+            // what ID an alias points at.
+            currentRoomId: null,
             logged_in: !!(MatrixClientPeg.get() && MatrixClientPeg.get().credentials),
             collapse_lhs: false,
             collapse_rhs: false,

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -506,8 +506,8 @@ module.exports = React.createClass({
             page_type: this.PageTypes.RoomView,
             thirdPartyInvite: thirdPartyInvite,
             roomOobData: oob_data,
-            newState.currentRoomAlias: roomAlias,
-            newState.currentRoomId: roomId,
+            currentRoomAlias: roomAlias,
+            currentRoomId: roomId,
         };
 
         // if we aren't given an explicit event id, look for one in the
@@ -1012,8 +1012,7 @@ module.exports = React.createClass({
                     page_element = (
                         <RoomView
                             ref="roomView"
-                            roomId={this.state.currentRoomId}
-                            roomAlias={this.state.currentRoomAlias}
+                            roomAddress={this.state.currentRoomAlias || this.state.currentRoomId}
                             eventId={this.state.initialEventId}
                             thirdPartyInvite={this.state.thirdPartyInvite}
                             oobData={this.state.roomOobData}

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -392,10 +392,10 @@ module.exports = React.createClass({
                 });
                 break;
             case 'view_room':
-                // Takes both room ID and room alias: if switching to a room the client is already
-                // know to be in (eg. user clicks on a room in the recents panel), supply only the
-                // ID. If the user is clicking on a room in the context of the alias being presented
-                // to them, supply the room alias and optionally the room ID.
+                // Takes either a room ID or room alias: if switching to a room the client is already
+                // known to be in (eg. user clicks on a room in the recents panel), supply the ID
+                // If the user is clicking on a room in the context of the alias being presented
+                // to them, supply the room alias. If both are supplied, the room ID will be ignored.
                 this._viewRoom(
                     payload.room_id, payload.room_alias, payload.show_settings, payload.event_id,
                     payload.third_party_invite, payload.oob_data
@@ -507,8 +507,11 @@ module.exports = React.createClass({
             thirdPartyInvite: thirdPartyInvite,
             roomOobData: oob_data,
             currentRoomAlias: roomAlias,
-            currentRoomId: roomId,
         };
+
+        if (!roomAlias) {
+            newState.currentRoomId = roomId;
+        }
 
         // if we aren't given an explicit event id, look for one in the
         // scrollStateMap.
@@ -982,6 +985,13 @@ module.exports = React.createClass({
         }
     },
 
+    onRoomIdResolved: function(room_id) {
+        // It's the RoomView's resposibility to look up room aliases, but we need the
+        // ID to pass into things like the Member List, so the Room View tells us when
+        // its done that resolution so we can display things that take a room ID.
+        this.setState({currentRoomId: room_id});
+    },
+
     render: function() {
         var LeftPanel = sdk.getComponent('structures.LeftPanel');
         var RoomView = sdk.getComponent('structures.RoomView');
@@ -1013,12 +1023,13 @@ module.exports = React.createClass({
                         <RoomView
                             ref="roomView"
                             roomAddress={this.state.currentRoomAlias || this.state.currentRoomId}
+                            onRoomIdResolved={this.onRoomIdResolved}
                             eventId={this.state.initialEventId}
                             thirdPartyInvite={this.state.thirdPartyInvite}
                             oobData={this.state.roomOobData}
                             highlightedEventId={this.state.highlightedEventId}
                             eventPixelOffset={this.state.initialEventPixelOffset}
-                            key={this.state.currentRoomId || this.state.currentRoomAlias}
+                            key={this.state.currentRoomAlias || this.state.currentRoomId}
                             opacity={this.state.middleOpacity}
                             ConferenceHandler={this.props.ConferenceHandler} />
                     );

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -102,23 +102,17 @@ module.exports = React.createClass({
     },
 
     getInitialState: function() {
-        var room;
-        var room_id;
-        if (this.props.roomAddress[0] == '!') {
-            room_id = this.props.roomAddress;
-            room = MatrixClientPeg.get().getRoom(room_id);
-        }
         return {
-            room: room,
-            roomId: room_id,
-            roomLoading: !room,
+            room: null,
+            roomId: null,
+            roomLoading: true,
             editingRoomSettings: false,
             uploadingRoomSettings: false,
             numUnreadMessages: 0,
             draggingFile: false,
             searching: false,
             searchResults: null,
-            hasUnsentMessages: this._hasUnsentMessages(room),
+            hasUnsentMessages: false,
             callState: null,
             guestsCanJoin: false,
             canPeek: false,
@@ -164,15 +158,22 @@ module.exports = React.createClass({
                     room: room,
                     roomId: result.room_id,
                     roomLoading: !room,
+                    hasUnsentMessages: this._hasUnsentMessages(room),
                 }, this.updatePeeking);
             }, (err) => {
                 this.setState({
                     roomLoading: false,
                 });
             });
+        } else {
+            var room = MatrixClientPeg.get().getRoom(this.props.roomAddress);
+            this.setState({
+                roomId: this.props.roomAddress,
+                room: room,
+                roomLoading: !room,
+                hasUnsentMessages: this._hasUnsentMessages(room),
+            }, this.updatePeeking);
         }
-
-        this.updatePeeking();
     },
 
     updatePeeking: function() {

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -61,6 +61,11 @@ module.exports = React.createClass({
         // ID should be supplied.
         roomAddress: React.PropTypes.string.isRequired,
 
+        // If a room alias is passed to roomAddress, a function can be
+        // provided here that will be called with the ID of the room
+        // once it has been resolved.
+        onRoomIdResolved: React.PropTypes.func,
+
         // An object representing a third party invite to join this room
         // Fields:
         // * inviteSignUrl (string) The URL used to join this room from an email invite
@@ -151,9 +156,14 @@ module.exports = React.createClass({
             // right now. We may have joined that alias before but there's
             // no guarantee the alias hasn't subsequently been remapped.
             MatrixClientPeg.get().getRoomIdForAlias(this.props.roomAddress).done((result) => {
+                if (this.props.onRoomIdResolved) {
+                    this.props.onRoomIdResolved(result.room_id);
+                }
+                var room = MatrixClientPeg.get().getRoom(result.room_id);
                 this.setState({
+                    room: room,
                     roomId: result.room_id,
-                    roomLoading: false,
+                    roomLoading: !room,
                 }, this.updatePeeking);
             }, (err) => {
                 this.setState({

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -159,7 +159,7 @@ module.exports = React.createClass({
                     roomId: result.room_id,
                     roomLoading: !room,
                     hasUnsentMessages: this._hasUnsentMessages(room),
-                }, this.updatePeeking);
+                }, this._updatePeeking);
             }, (err) => {
                 this.setState({
                     roomLoading: false,
@@ -172,11 +172,11 @@ module.exports = React.createClass({
                 room: room,
                 roomLoading: !room,
                 hasUnsentMessages: this._hasUnsentMessages(room),
-            }, this.updatePeeking);
+            }, this._updatePeeking);
         }
     },
 
-    updatePeeking: function() {
+    _updatePeeking: function() {
         // if this is an unknown room then we're in one of three states:
         // - This is a room we can peek into (search engine) (we can /peek)
         // - This is a room we can publicly join or were invited to. (we can /join)


### PR DESCRIPTION
Also more room join refactoring. Alias lookups are now done in the roomview, and only in the roomview (apart from possibly SlashCommands which I haven't yet looked at). The room view can be given a callback to call with the resolved room ID.

This also means that when viewing an alias, you always get the current mapping for that alias rather than a room you're in that thinks it has that alias, as you would have before.