### PR TITLE
Fix /join to be consistent with the other code

### DIFF
--- a/src/MatrixTools.js
+++ b/src/MatrixTools.js
@@ -24,30 +24,5 @@ module.exports = {
     getDisplayAliasForRoom: function(room) {
         return room.getCanonicalAlias() || room.getAliases()[0];
     },
-
-    /**
-     * Given a list of room objects, return the room which has the given alias,
-     * else null.
-     */
-    getRoomForAlias: function(rooms, room_alias) {
-        var room;
-        for (var i = 0; i < rooms.length; i++) {
-            var aliasEvents = rooms[i].currentState.getStateEvents(
-                "m.room.aliases"
-            );
-            for (var j = 0; j < aliasEvents.length; j++) {
-                var aliases = aliasEvents[j].getContent().aliases || [];
-                for (var k = 0; k < aliases.length; k++) {
-                    if (aliases[k] === room_alias) {
-                        room = rooms[i];
-                        break;
-                    }
-                }
-                if (room) { break; }
-            }
-            if (room) { break; }
-        }
-        return room || null;
-    }
 }
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -420,7 +420,7 @@ module.exports = React.createClass({
                 }
                 roomIndex = (roomIndex + roomIndexDelta) % allRooms.length;
                 if (roomIndex < 0) roomIndex = allRooms.length - 1;
-                this._viewRoom({ room_id: allRooms[roomIndex].room_id });
+                this._viewRoom({ room_id: allRooms[roomIndex].roomId });
                 break;
             case 'view_indexed_room':
                 var allRooms = RoomListSorter.mostRecentActivityFirst(

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -489,17 +489,17 @@ module.exports = React.createClass({
     // switch view to the given room
     //
     // @param {Object} room_info Object containing data about the room to be joined
-    // @param {string} room_info.room_id ID of the room to join. One of room_id or room_alias must be given.
-    // @param {string} room_info.room_alias Alias of the room to join. One of room_id or room_alias must be given.
-    // @param {boolean} room_info.auto_join If true, automatically attempt to join the room if not already a member.
-    // @param {string} room_info.show_settings ??
-    // @param {string} room_info.event_id ID of the event in this room to show: this will cause a switch to the
-    //                                    context of that particular event. Optional.
-    // @param {Object} room_info.third_party_invite Object containing data about the third party
+    // @param {string=} room_info.room_id ID of the room to join. One of room_id or room_alias must be given.
+    // @param {string=} room_info.room_alias Alias of the room to join. One of room_id or room_alias must be given.
+    // @param {boolean=} room_info.auto_join If true, automatically attempt to join the room if not already a member.
+    // @param {boolean=} room_info.show_settings Makes RoomView show the room settings dialog.
+    // @param {string=} room_info.event_id ID of the event in this room to show: this will cause a switch to the
+    //                                    context of that particular event.
+    // @param {Object=} room_info.third_party_invite Object containing data about the third party
     //                                    we received to join the room, if any.
-    // @param {string} room_info.third_party_invite.inviteSignUrl 3pid invite sign URL
-    // @param {string} room_info.third_party_invite.invitedwithEmail The email address the invite was sent to
-    // @param {Object} room_info.oob_data Object of additional data about the room
+    // @param {string=} room_info.third_party_invite.inviteSignUrl 3pid invite sign URL
+    // @param {string=} room_info.third_party_invite.invitedEmail The email address the invite was sent to
+    // @param {Object=} room_info.oob_data Object of additional data about the room
     //                               that has been passed out-of-band (eg.
     //                               room name and avatar from an invite email)
     _viewRoom: function(room_info) {
@@ -557,7 +557,7 @@ module.exports = React.createClass({
             }
 
             if (room_info.event_id) {
-                presentedId += "/"+event_id;
+                presentedId += "/"+room_info.event_id;
             }
             this.notifyNewScreen('room/'+presentedId);
             newState.ready = true;

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -159,7 +159,7 @@ module.exports = React.createClass({
                     roomId: result.room_id,
                     roomLoading: !room,
                     hasUnsentMessages: this._hasUnsentMessages(room),
-                }, this._updatePeeking);
+                }, this._onHaveRoom);
             }, (err) => {
                 this.setState({
                     roomLoading: false,
@@ -172,11 +172,11 @@ module.exports = React.createClass({
                 room: room,
                 roomLoading: !room,
                 hasUnsentMessages: this._hasUnsentMessages(room),
-            }, this._updatePeeking);
+            }, this._onHaveRoom);
         }
     },
 
-    _updatePeeking: function() {
+    _onHaveRoom: function() {
         // if this is an unknown room then we're in one of three states:
         // - This is a room we can peek into (search engine) (we can /peek)
         // - This is a room we can publicly join or were invited to. (we can /join)
@@ -187,29 +187,40 @@ module.exports = React.createClass({
         // Note that peeking works by room ID and room ID only, as opposed to joining
         // which must be by alias or invite wherever possible (peeking currently does
         // not work over federation).
-        if (!this.state.room && this.state.roomId) {
-            console.log("Attempting to peek into room %s", this.state.roomId);
 
-            MatrixClientPeg.get().peekInRoom(this.state.roomId).then((room) => {
-                this.setState({
-                    room: room,
-                    roomLoading: false,
-                });
-                this._onRoomLoaded(room);
-            }, (err) => {
-                // This won't necessarily be a MatrixError, but we duck-type
-                // here and say if it's got an 'errcode' key with the right value,
-                // it means we can't peek.
-                if (err.errcode == "M_GUEST_ACCESS_FORBIDDEN") {
-                    // This is fine: the room just isn't peekable (we assume).
+        // NB. We peek if we are not in the room, although if we try to peek into
+        // a room in which we have a member event (ie. we've left) synapse will just
+        // send us the same data as we get in the sync (ie. the last events we saw).
+        var my_member = this.state.room ? this.state.room.getMember(MatrixClientPeg.get().credentials.userId) : null;
+        var user_is_in_room = my_member ? my_member.membership == 'join' : false;
+
+        if (!user_is_in_room && this.state.roomId) {
+            if (this.props.autoJoin) {
+                this.onJoinButtonClicked();
+            } else if (this.state.roomId) {
+                console.log("Attempting to peek into room %s", this.state.roomId);
+
+                MatrixClientPeg.get().peekInRoom(this.state.roomId).then((room) => {
                     this.setState({
+                        room: room,
                         roomLoading: false,
                     });
-                } else {
-                    throw err;
-                }
-            }).done();
-        } else if (this.state.room) {
+                    this._onRoomLoaded(room);
+                }, (err) => {
+                    // This won't necessarily be a MatrixError, but we duck-type
+                    // here and say if it's got an 'errcode' key with the right value,
+                    // it means we can't peek.
+                    if (err.errcode == "M_GUEST_ACCESS_FORBIDDEN") {
+                        // This is fine: the room just isn't peekable (we assume).
+                        this.setState({
+                            roomLoading: false,
+                        });
+                    } else {
+                        throw err;
+                    }
+                }).done();
+            }
+        } else if (user_is_in_room) {
             MatrixClientPeg.get().stopPeeking();
             this._onRoomLoaded(this.state.room);
         }
@@ -992,7 +1003,7 @@ module.exports = React.createClass({
         this.setState({
             rejecting: true
         });
-        MatrixClientPeg.get().leave(this.props.roomAddress).done(function() {
+        MatrixClientPeg.get().leave(this.props.roomId).done(function() {
             dis.dispatch({ action: 'view_next_room' });
             self.setState({
                 rejecting: false

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -191,8 +191,12 @@ module.exports = React.createClass({
         // NB. We peek if we are not in the room, although if we try to peek into
         // a room in which we have a member event (ie. we've left) synapse will just
         // send us the same data as we get in the sync (ie. the last events we saw).
-        var my_member = this.state.room ? this.state.room.getMember(MatrixClientPeg.get().credentials.userId) : null;
-        var user_is_in_room = my_member ? my_member.membership == 'join' : false;
+        var user_is_in_room = null;
+        if (this.state.room) {
+            user_is_in_room = this.state.room.hasMembershipState(
+                MatrixClientPeg.get().credentials.userId, 'join'
+            );
+        }
 
         if (!user_is_in_room && this.state.roomId) {
             if (this.props.autoJoin) {
@@ -1003,7 +1007,7 @@ module.exports = React.createClass({
         this.setState({
             rejecting: true
         });
-        MatrixClientPeg.get().leave(this.props.roomId).done(function() {
+        MatrixClientPeg.get().leave(this.state.roomId).done(function() {
             dis.dispatch({ action: 'view_next_room' });
             self.setState({
                 rejecting: false


### PR DESCRIPTION
Plus a number of other tidyups:

 * Fix /join to dispatch a view_room for the room alias
   with the additional auto_join parameter
 * Make RoomView automatically join the room if the auto_join
   parameter is true and the user isn't already in it
 * Tidy up RoomView's peeking code, also fixing
   https://github.com/vector-im/vector-web/issues/1220
   in react-sdk (although it still requires a synapse change
   to actually fix, but react-sdk does 'the right thing').
 * Remove duplication of usage text from /join command
 * Amalgamate MatrixChat::_viewRoom's many, many parameters
   into an object and sort out case consistency a little.
 * Fix RoomView to always leave by room ID instead of using the room address which may be an alias.
 * Remove now unused MatrixTools.getRoomForAlias()