### PR TITLE
Fix a pair of warnings from RoomSettings

### DIFF
--- a/src/components/views/elements/PowerSelector.js
+++ b/src/components/views/elements/PowerSelector.js
@@ -34,10 +34,15 @@ module.exports = React.createClass({
 
     propTypes: {
         value: React.PropTypes.number.isRequired,
+
         // if true, the <select/> should be a 'controlled' form element and updated by React
         // to reflect the current value, rather than left freeform.
         // MemberInfo uses controlled; RoomSettings uses non-controlled.
-        controlled: React.PropTypes.bool.isRequired,
+        //
+        // ignored if disabled is truthy. false by default.
+        controlled: React.PropTypes.bool,
+
+        // should the user be able to change the value? false by default.
         disabled: React.PropTypes.bool,
         onChange: React.PropTypes.func,
     },

--- a/src/components/views/rooms/RoomSettings.js
+++ b/src/components/views/rooms/RoomSettings.js
@@ -64,7 +64,7 @@ module.exports = React.createClass({
             tags_changed: false,
             tags: tags,
             areNotifsMuted: areNotifsMuted,
-            isRoomPublished: this._originalIsRoomPublished, // loaded async in componentWillMount
+            isRoomPublished: false, // loaded async in componentWillMount
         };
     },
 


### PR DESCRIPTION
- initialise the 'publish' checkbox correctly so react doesn't grumble about it
  turning from uncontrolled into controlled

- PowerSelector's 'controlled' property isn't really required, so mark it as
  such.