### PR TITLE
Display an error message if room not found

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -116,6 +116,7 @@ module.exports = React.createClass({
             callState: null,
             guestsCanJoin: false,
             canPeek: false,
+            roomLoadError: null,
 
             // this is true if we are fully scrolled-down, and are looking at
             // the end of the live timeline. It has the effect of hiding the
@@ -163,6 +164,7 @@ module.exports = React.createClass({
             }, (err) => {
                 this.setState({
                     roomLoading: false,
+                    roomLoadError: err,
                 });
             });
         } else {
@@ -1282,6 +1284,7 @@ module.exports = React.createClass({
 
                     // We have no room object for this room, only the ID.
                     // We've got to this room by following a link, possibly a third party invite.
+                    var room_alias = this.props.roomAddress[0] == '#' ? this.props.roomAddress : null;
                     return (
                         <div className="mx_RoomView">
                             <RoomHeader ref="header"
@@ -1292,7 +1295,8 @@ module.exports = React.createClass({
                             <div className="mx_RoomView_auxPanel">
                                 <RoomPreviewBar onJoinClick={ this.onJoinButtonClicked }
                                                 onRejectClick={ this.onRejectThreepidInviteButtonClicked }
-                                                canJoin={ true } canPreview={ false }
+                                                canPreview={ false } error={ this.state.roomLoadError }
+                                                roomAlias={room_alias}
                                                 spinner={this.state.joining}
                                                 inviterName={inviterName}
                                                 invitedEmail={invitedEmail}
@@ -1330,7 +1334,7 @@ module.exports = React.createClass({
                             <RoomPreviewBar onJoinClick={ this.onJoinButtonClicked }
                                             onRejectClick={ this.onRejectButtonClicked }
                                             inviterName={ inviterName }
-                                            canJoin={ true } canPreview={ false }
+                                            canPreview={ false }
                                             spinner={this.state.joining}
                                             room={this.state.room}
                             />
@@ -1400,7 +1404,7 @@ module.exports = React.createClass({
                 invitedEmail = this.props.thirdPartyInvite.invitedEmail;
             }
             aux = (
-                <RoomPreviewBar onJoinClick={this.onJoinButtonClicked} canJoin={true}
+                <RoomPreviewBar onJoinClick={this.onJoinButtonClicked}
                                 onRejectClick={this.onRejectThreepidInviteButtonClicked}
                                 spinner={this.state.joining}
                                 inviterName={inviterName}

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -117,6 +117,7 @@ module.exports = React.createClass({
             guestsCanJoin: false,
             canPeek: false,
 
+            // error object, as from the matrix client/server API
             // If we failed to load information about the room,
             // store the error here.
             roomLoadError: null,

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -116,6 +116,9 @@ module.exports = React.createClass({
             callState: null,
             guestsCanJoin: false,
             canPeek: false,
+
+            // If we failed to load information about the room,
+            // store the error here.
             roomLoadError: null,
 
             // this is true if we are fully scrolled-down, and are looking at

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -43,6 +43,8 @@ module.exports = React.createClass({
         room: React.PropTypes.object,
 
         // The alias that was used to access this room, if appropriate
+        // If given, this will be how the room is referred to (eg.
+        // in error messages).
         roomAlias: React.PropTypes.object,
     },
 

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -41,6 +41,9 @@ module.exports = React.createClass({
         canPreview: React.PropTypes.bool,
         spinner: React.PropTypes.bool,
         room: React.PropTypes.object,
+
+        // The alias that was used to access this room, if appropriate
+        roomAlias: React.PropTypes.object,
     },
 
     getDefaultProps: function() {

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -33,7 +33,11 @@ module.exports = React.createClass({
 
         // If invited by 3rd party invite, the email address the invite was sent to
         invitedEmail: React.PropTypes.string,
-        canJoin: React.PropTypes.bool,
+
+        // A standard client/server API error object. If supplied, indicates that the
+        // caller was unable to fetch details about the room for the given reason.
+        error: React.PropTypes.object,
+
         canPreview: React.PropTypes.bool,
         spinner: React.PropTypes.bool,
         room: React.PropTypes.object,
@@ -42,7 +46,6 @@ module.exports = React.createClass({
     getDefaultProps: function() {
         return {
             onJoinClick: function() {},
-            canJoin: false,
             canPreview: true,
         };
     },
@@ -115,8 +118,24 @@ module.exports = React.createClass({
             );
 
         }
-        else if (this.props.canJoin) {
-            var name = this.props.room ? this.props.room.name : "";
+        else if (this.props.error) {
+            var name = this.props.roomAlias || "This room";
+            var error;
+            if (this.props.error.errcode == 'M_NOT_FOUND') {
+                error = name + " does not exist";
+            } else {
+                error = name + " is not accessible at this time";
+            }
+            joinBlock = (
+                <div>
+                    <div className="mx_RoomPreviewBar_join_text">
+                        { error }
+                    </div>
+                </div>
+            );
+        }
+        else {
+            var name = this.props.room ? this.props.room.name : (this.props.room_alias || "");
             name = name ? <b>{ name }</b> : "a room";
             joinBlock = (
                 <div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/vector-web/issues/1012

Also remove the canJoin prop from RoomPreviewBar which was only ever set to true.