### PR TITLE
Use HS proxy API for requestToken on adding email

### DIFF
--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -38,7 +38,7 @@ class AddThreepid {
      */
     addEmailAddress(emailAddress, bind) {
         this.bind = bind;
-        return MatrixClientPeg.get().request3pidAddEmailToken(emailAddress, this.clientSecret, 1).then((res) => {
+        return MatrixClientPeg.get().requestAdd3pidEmailToken(emailAddress, this.clientSecret, 1).then((res) => {
             this.sessionId = res.sid;
             return res;
         }, function(err) {

--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -38,11 +38,13 @@ class AddThreepid {
      */
     addEmailAddress(emailAddress, bind) {
         this.bind = bind;
-        return MatrixClientPeg.get().requestEmailToken(emailAddress, this.clientSecret, 1).then((res) => {
+        return MatrixClientPeg.get().request3pidAddEmailToken(emailAddress, this.clientSecret, 1).then((res) => {
             this.sessionId = res.sid;
             return res;
         }, function(err) {
-            if (err.httpStatus) {
+            if (err.errcode == 'M_THREEPID_IN_USE') {
+                err.message = "This email address is already in use";
+            } else if (err.httpStatus) {
                 err.message = err.message + ` (Status ${err.httpStatus})`;
             }
             throw err;

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -214,9 +214,10 @@ module.exports = React.createClass({
                 onFinished: this.onEmailDialogFinished,
             });
         }, (err) => {
+            this.setState({email_add_pending: false});
             Modal.createDialog(ErrorDialog, {
                 title: "Unable to add email address",
-                description: err.toString()
+                description: err.message
             });
         });
         ReactDOM.findDOMNode(this.refs.add_threepid_input).blur();


### PR DESCRIPTION
So we report an error if the email is already taken. Also fix a bug where the spinner wouldn't disappear if adding an email failed (and don't include the raw errcode in the user-facing dialog)