### PR TITLE
CSS classes to colour offline users differently

### DIFF
--- a/src/components/views/rooms/EntityTile.js
+++ b/src/components/views/rooms/EntityTile.js
@@ -42,7 +42,7 @@ function presenceClassForMember(presence_state, last_active_ago) {
     } else if (presence_state) {
         return PRESENCE_CLASS[presence_state];
     } else {
-        return PRESENCE_CLASS['offline'];
+        return PRESENCE_CLASS['offline'] + '_neveractive';
     }
 }
 

--- a/src/components/views/rooms/EntityTile.js
+++ b/src/components/views/rooms/EntityTile.js
@@ -30,17 +30,17 @@ var PRESENCE_CLASS = {
 };
 
 
-function presenceClassForMember(presence_state, last_active_ago) {
+function presenceClassForMember(presenceState, lastActiveAgo) {
     // offline is split into two categories depending on whether we have
     // a last_active_ago for them.
-    if (presence_state == 'offline') {
-        if (last_active_ago) {
+    if (presenceState == 'offline') {
+        if (lastActiveAgo) {
             return PRESENCE_CLASS['offline'] + '_beenactive';
         } else {
             return PRESENCE_CLASS['offline'] + '_neveractive';
         }
-    } else if (presence_state) {
-        return PRESENCE_CLASS[presence_state];
+    } else if (presenceState) {
+        return PRESENCE_CLASS[presenceState];
     } else {
         return PRESENCE_CLASS['offline'] + '_neveractive';
     }

--- a/src/components/views/rooms/EntityTile.js
+++ b/src/components/views/rooms/EntityTile.js
@@ -29,6 +29,23 @@ var PRESENCE_CLASS = {
     "unavailable": "mx_EntityTile_unavailable"
 };
 
+
+function presence_class_for_member(presence_state, last_active_ago) {
+    // offline is split into two categories depending on whether we have
+    // a last_active_ago for them.
+    if (presence_state == 'offline') {
+        if (last_active_ago) {
+            return PRESENCE_CLASS['offline'] + '_beenactive';
+        } else {
+            return PRESENCE_CLASS['offline'] + '_neveractive';
+        }
+    } else if (presence_state) {
+        return PRESENCE_CLASS[presence_state];
+    } else {
+        return PRESENCE_CLASS['offline'];
+    }
+}
+
 module.exports = React.createClass({
     displayName: 'EntityTile',
 
@@ -79,7 +96,10 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        var presenceClass = PRESENCE_CLASS[this.props.presenceState] || "mx_EntityTile_offline";
+        const presenceClass = presence_class_for_member(
+            this.props.presenceState, this.props.presenceLastActiveAgo
+        );
+
         var mainClassName = "mx_EntityTile ";
         mainClassName += presenceClass + (this.props.className ? (" " + this.props.className) : "");
         var nameEl;

--- a/src/components/views/rooms/EntityTile.js
+++ b/src/components/views/rooms/EntityTile.js
@@ -30,7 +30,7 @@ var PRESENCE_CLASS = {
 };
 
 
-function presence_class_for_member(presence_state, last_active_ago) {
+function presenceClassForMember(presence_state, last_active_ago) {
     // offline is split into two categories depending on whether we have
     // a last_active_ago for them.
     if (presence_state == 'offline') {
@@ -96,7 +96,7 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        const presenceClass = presence_class_for_member(
+        const presenceClass = presenceClassForMember(
             this.props.presenceState, this.props.presenceLastActiveAgo
         );
 


### PR DESCRIPTION
So we can use the same 66% opacity as idle tiles for offline-with-last-active-time to reduce the visual jarring

As per https://github.com/vector-im/vector-web/issues/1740

Requires https://github.com/vector-im/vector-web/pull/1798