### PR TITLE
Add support for sending uploaded content as m.video

### DIFF
--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -52,6 +52,36 @@ function infoForImageFile(imageFile) {
     return deferred.promise;
 }
 
+function infoForVideoFile(videoFile) {
+    var deferred = q.defer();
+
+    // Load the file into an html element
+    var video = document.createElement("video");
+
+    var reader = new FileReader();
+    reader.onload = function(e) {
+        video.src = e.target.result;
+
+        // Once ready, returns its size
+        video.onloadedmetadata = function() {
+            deferred.resolve({
+                w: video.videoWidth,
+                h: video.videoHeight
+            });
+        };
+        video.onerror = function(e) {
+            deferred.reject(e);
+        };
+    };
+    reader.onerror = function(e) {
+        deferred.reject(e);
+    };
+    reader.readAsDataURL(videoFile);
+
+    return deferred.promise;
+}
+
+
 class ContentMessages {
     constructor() {
         this.inprogress = [];
@@ -81,6 +111,12 @@ class ContentMessages {
         } else if (file.type.indexOf('audio/') == 0) {
             content.msgtype = 'm.audio';
             def.resolve();
+        } else if (file.type.indexOf('video/') == 0) {
+          content.msgtype = 'm.video';
+          infoForVideoFile(file).then(function (videoInfo) {
+              extend(content.info, videoInfo);
+              def.resolve();
+          });
         } else {
             content.msgtype = 'm.file';
             def.resolve();


### PR DESCRIPTION
Small change to send video/* files as actual video events.

Signed-off-by: Will Hunt half-shot@molrams.com