### PR TITLE
Set the device_id on pre-login MatrixClient

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -97,35 +97,20 @@ class MatrixClient {
 
     // FIXME, XXX: this all seems very convoluted :(
     //
-    // if we replace the singleton using URLs we bypass our createClientForPeg()
-    // global helper function... but if we replace it using
-    // an access_token we don't?
-    //
     // Why do we have this peg wrapper rather than just MatrixClient.get()?
     // Why do we name MatrixClient as MatrixClientPeg when we export it?
     //
     // -matthew
 
     replaceUsingUrls(hs_url, is_url) {
-        matrixClient = Matrix.createClient({
-            baseUrl: hs_url,
-            idBaseUrl: is_url
-        });
-
-        // XXX: factor this out with the localStorage setting in replaceUsingAccessToken
-        if (localStorage) {
-            try {
-                localStorage.setItem("mx_hs_url", hs_url);
-                localStorage.setItem("mx_is_url", is_url);
-            } catch (e) {
-                console.warn("Error using local storage: can't persist HS/IS URLs!");
-            }
-        } else {
-            console.warn("No local storage available: can't persist HS/IS URLs!");
-        }
+        this.replaceClient(hs_url, is_url);
     }
 
     replaceUsingAccessToken(hs_url, is_url, user_id, access_token, isGuest) {
+        this.replaceClient(hs_url, is_url, user_id, access_token, isGuest);
+    }
+
+    replaceClient(hs_url, is_url, user_id, access_token, isGuest) {
         if (localStorage) {
             try {
                 localStorage.clear();


### PR DESCRIPTION
In order that device_id is set when we register a new user (or, for that
matter, when we register as a guest), we need to make sure that device_id is
set on the temporary MatrixClient which is created before the user is logged
in - ie, that created by replaceUsingUrls.

In order to achieve this, I've basically removed the distinction between
replaceUsingAccessToken and replaceUsingUrls. There is a side-effect in that
the temporary MatrixClient now gets an e2e sessionStore, but I don't think that
is a bad thing (though it does mean we need https://github.com/matrix-org/matrix-js-sdk/pull/151 to avoid blowing up the js-sdk).