### PR TITLE
Fix bug where vector freezes on power level event

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -482,9 +482,7 @@ module.exports = React.createClass({
         }
     },
 
-    // rate limited because a power level change will emit an event for every
-    // member in the room.
-    onRoomStateMember: new rate_limited_func(function(ev, state, member) {
+    onRoomStateMember: function(ev, state, member) {
         // ignore if we don't have a room yet
         if (!this.state.room) {
             return;
@@ -495,6 +493,15 @@ module.exports = React.createClass({
             return;
         }
 
+        if (this.props.ConferenceHandler &&
+            member.userId === this.props.ConferenceHandler.getConferenceUserIdForRoom(member.roomId)) {
+            this._updateConfCallNotification();
+        }
+
+        this._updateRoomMembers();
+    },
+
+    _updateRoomMembers: new rate_limited_func(function() {
         // a member state changed in this room, refresh the tab complete list
         this.tabComplete.loadEntries(this.state.room);
         this._updateAutoComplete();
@@ -507,11 +514,6 @@ module.exports = React.createClass({
             this.setState({
                 joining: false
             });
-        }
-
-        if (this.props.ConferenceHandler &&
-            member.userId === this.props.ConferenceHandler.getConferenceUserIdForRoom(member.roomId)) {
-            this._updateConfCallNotification();
         }
     }, 500),
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -501,6 +501,8 @@ module.exports = React.createClass({
         this._updateRoomMembers();
     },
 
+    // rate limited because a power level change will emit an event for every
+    // member in the room.
     _updateRoomMembers: new rate_limited_func(function() {
         // a member state changed in this room, refresh the tab complete list
         this.tabComplete.loadEntries(this.state.room);

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -482,7 +482,9 @@ module.exports = React.createClass({
         }
     },
 
-    onRoomStateMember: function(ev, state, member) {
+    // rate limited because a power level change will emit an event for every
+    // member in the room.
+    onRoomStateMember: new rate_limited_func(function(ev, state, member) {
         // ignore if we don't have a room yet
         if (!this.state.room) {
             return;
@@ -511,7 +513,7 @@ module.exports = React.createClass({
             member.userId === this.props.ConferenceHandler.getConferenceUserIdForRoom(member.roomId)) {
             this._updateConfCallNotification();
         }
-    },
+    }, 500),
 
     _hasUnsentMessages: function(room) {
         return this._getUnsentMessages(room).length > 0;

--- a/src/ratelimitedfunc.js
+++ b/src/ratelimitedfunc.js
@@ -23,13 +23,13 @@ module.exports = function(f, minIntervalMs) {
         var now = Date.now();
 
         if (self.lastCall < now - minIntervalMs) {
-            f.apply(this);
+            f.apply(this, arguments);
             self.lastCall = now;
         } else if (self.scheduledCall === undefined) {
             self.scheduledCall = setTimeout(
                 () => {
                     self.scheduledCall = undefined;
-                    f.apply(this);
+                    f.apply(this, arguments);
                     self.lastCall = now;
                 },
                 (self.lastCall + minIntervalMs) - now

--- a/src/ratelimitedfunc.js
+++ b/src/ratelimitedfunc.js
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/**
+ * 'debounces' a function to only execute every n milliseconds.
+ * Useful when react-sdk gets many, many events but only wants
+ * to update the interface once for all of them.
+ *
+ * Note that the function must not take arguments, since the args
+ * could be different for each invocarion of the function.
+ */
 module.exports = function(f, minIntervalMs) {
     this.lastCall = 0;
     this.scheduledCall = undefined;
@@ -23,13 +31,13 @@ module.exports = function(f, minIntervalMs) {
         var now = Date.now();
 
         if (self.lastCall < now - minIntervalMs) {
-            f.apply(this, arguments);
+            f.apply(this);
             self.lastCall = now;
         } else if (self.scheduledCall === undefined) {
             self.scheduledCall = setTimeout(
                 () => {
                     self.scheduledCall = undefined;
-                    f.apply(this, arguments);
+                    f.apply(this);
                     self.lastCall = now;
                 },
                 (self.lastCall + minIntervalMs) - now


### PR DESCRIPTION
Make rate_limited_function accept functions with args so we can just ratelimit the event handler & be done with it.

Fixes https://github.com/vector-im/vector-web/issues/1877