### PR TITLE
Remove relayoutOnUpdate prop on gemini-scrollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^15.2.1",
     "react-addons-css-transition-group": "^15.2.1",
     "react-dom": "^15.2.1",
-    "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#dbf0abf",
+    "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#5e97aef",
     "sanitize-html": "^1.11.1",
     "velocity-vector": "vector-im/velocity#059e3b2",
     "whatwg-fetch": "^1.0.0"

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -540,7 +540,6 @@ module.exports = React.createClass({
         // it's not obvious why we have a separate div and ol anyway.
         return (<GeminiScrollbar autoshow={true} ref="geminiPanel"
                 onScroll={this.onScroll} onResize={this.onResize}
-                relayoutOnUpdate={false}
                 className={this.props.className} style={this.props.style}>
                     <div className="mx_RoomView_messageListWrapper">
                         <ol ref="itemlist" className="mx_RoomView_MessageList" aria-live="polite">

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -463,7 +463,6 @@ module.exports = React.createClass({
                 <SimpleRoomHeader title="Settings" onCancelClick={ this.props.onClose }/>
 
                 <GeminiScrollbar className="mx_UserSettings_body"
-                                 relayoutOnUpdate={false}
                                  autoshow={true}>
 
                 <h3>Profile</h3>

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -521,7 +521,6 @@ module.exports = React.createClass({
             <div className="mx_MemberList">
                     {inviteMemberListSection}
                     <GeminiScrollbar autoshow={true}
-                                     relayoutOnUpdate={false}
                                      className="mx_MemberList_joined mx_MemberList_outerWrapper">
                         <TruncatedList className="mx_MemberList_wrapper" truncateAt={this.state.truncateAt}
                                 createOverflowElement={this._createOverflowTile}>

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -325,7 +325,6 @@ module.exports = React.createClass({
 
         return (
             <GeminiScrollbar className="mx_RoomList_scrollbar"
-                 relayoutOnUpdate={false}
                  autoshow={true} onScroll={ self._repositionTooltips } ref="gemscroll">
             <div className="mx_RoomList">
                 <RoomSubList list={ self.state.lists['im.vector.fake.invite'] }

--- a/src/components/views/rooms/SearchableEntityList.js
+++ b/src/components/views/rooms/SearchableEntityList.js
@@ -179,7 +179,6 @@ var SearchableEntityList = React.createClass({
             }
             list = (
                 <GeminiScrollbar autoshow={true}
-                                 relayoutOnUpdate={false}
                                  className="mx_SearchableEntityList_listWrapper">
                     { list }
                 </GeminiScrollbar>


### PR DESCRIPTION
The latest gemini-scrollbar makes relayoutOnUpdate redundant, so update to it
and remove the properties.