### PR TITLE
Fix warnings emanating from Velociraptor elements

### DIFF
--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -163,13 +163,13 @@ module.exports = React.createClass({
         };
 
         return (
-            <Velociraptor>
+            <Velociraptor
+                    startStyles={this.state.startStyles}
+                    enterTransitionOpts={this.state.enterTransitionOpts} >
                 <MemberAvatar
                     member={this.props.member}
                     width={14} height={14} resizeMethod="crop"
                     style={style}
-                    startStyle={this.state.startStyles}
-                    enterTransitionOpts={this.state.enterTransitionOpts}
                     onClick={this.props.onClick}
                 />
             </Velociraptor>


### PR DESCRIPTION
We are no longer allowed to stick random properties on child properties, and
the Velociraptor animations were causing some React warnings.

Move the startStyles and enterTransitionOpts properties up to the Velociraptor
node, and avoid setting arbitrary props on the created children. This is less
flexible, as it assumes that all children will have the same start style;
however, we weren't using the flexibility, and we can always replace the array
with a map or a function or something if we need it in the future.