### PR TITLE
Hack around a react warning

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1093,7 +1093,7 @@ module.exports = React.createClass({
                 <div className="mx_MatrixChat_wrapper">
                     {topBar}
                     <div className={bodyClasses}>
-                        <LeftPanel selectedRoom={this.state.currentRoomId} collapsed={this.state.collapse_lhs} opacity={this.state.sideOpacity}/>
+                        <LeftPanel selectedRoom={this.state.currentRoomId} collapsed={this.state.collapse_lhs || false} opacity={this.state.sideOpacity}/>
                         <main className="mx_MatrixChat_middlePanel">
                             {page_element}
                         </main>

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -33,7 +33,7 @@ module.exports = React.createClass({
 
     propTypes: {
         ConferenceHandler: React.PropTypes.any,
-        collapsed: React.PropTypes.bool,
+        collapsed: React.PropTypes.bool.isRequired,
         currentRoom: React.PropTypes.string,
         searchFilter: React.PropTypes.string,
     },


### PR DESCRIPTION
when login completes, we replace the whole state, which means we unset
collapse_lhs, which then leads to complaints from the RoomList.

I think the 'default view' for MatrixChat ought to be factored out to another
component, which could manage collapse_lhs properly; but for now, hack around
it.