### PR TITLE
Cancel calls to rate-limited funcs on unmount

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -273,6 +273,9 @@ module.exports = React.createClass({
 
         window.removeEventListener('resize', this.onResize);
 
+        // cancel any pending calls to the rate_limited_funcs
+        this._updateRoomMembers.cancelPendingCall();
+
         // no need to do this as Dir & Settings are now overlays. It just burnt CPU.
         // console.log("Tinter.tint from RoomView.unmount");
         // Tinter.tint(); // reset colourscheme

--- a/src/components/views/rooms/InviteMemberList.js
+++ b/src/components/views/rooms/InviteMemberList.js
@@ -58,6 +58,8 @@ module.exports = React.createClass({
         if (cli) {
             cli.removeListener("RoomState.members", this.onRoomStateMember);
         }
+        // cancel any pending calls to the rate_limited_funcs
+        this._updateList.cancelPendingCall();
     },
 
     _updateList: new rate_limited_func(function() {
@@ -100,7 +102,7 @@ module.exports = React.createClass({
             <EntityTile key="dynamic_invite_tile" suppressOnHover={true} showInviteButton={true}
                 avatarJsx={ <BaseAvatar name="@" width={36} height={36} /> }
                 className="mx_EntityTile_invitePlaceholder"
-                presenceState="online" onClick={this.onThirdPartyInvite} name={"Invite by email"} 
+                presenceState="online" onClick={this.onThirdPartyInvite} name={"Invite by email"}
             />,
             function(query) {
                 return true; // always show this

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -81,6 +81,9 @@ module.exports = React.createClass({
             cli.removeListener("User.lastPresenceTs", this.onUserLastPresenceTs);
             // cli.removeListener("Room.timeline", this.onRoomTimeline);
         }
+
+        // cancel any pending calls to the rate_limited_funcs
+        this._updateList.cancelPendingCall();
     },
 
 /*

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -101,6 +101,8 @@ module.exports = React.createClass({
             MatrixClientPeg.get().removeListener("RoomState.events", this.onRoomStateEvents);
             MatrixClientPeg.get().removeListener("RoomMember.name", this.onRoomMemberName);
         }
+        // cancel any pending calls to the rate_limited_funcs
+        this._delayedRefreshRoomList.cancelPendingCall();
     },
 
     onRoom: function(room) {


### PR DESCRIPTION
The tests were throwing up warnings about state being accessed, and null
MatrixClients being called, after component unmount.