### PR TITLE
Fix settings resetting on refresh

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -161,6 +161,26 @@ export function setLoggedIn(credentials) {
     console.log("setLoggedIn => %s (guest=%s) hs=%s",
                 credentials.userId, credentials.guest,
                 credentials.homeserverUrl);
+
+    // persist the session
+    if (localStorage) {
+        try {
+            localStorage.setItem("mx_hs_url", hs_url);
+            localStorage.setItem("mx_is_url", is_url);
+
+            if (user_id !== undefined && access_token !== undefined) {
+                localStorage.setItem("mx_user_id", user_id);
+                localStorage.setItem("mx_access_token", access_token);
+                localStorage.setItem("mx_is_guest", JSON.stringify(isGuest));
+                console.log("Session persisted for %s", user_id);
+            }
+        } catch (e) {
+            console.warn("Error using local storage: can't persist session!", e);
+        }
+    } else {
+        console.warn("No local storage available: can't persist session!");
+    }
+
     MatrixClientPeg.replaceUsingCreds(credentials);
 
     dis.dispatch({action: 'on_logged_in'});
@@ -225,6 +245,7 @@ export function onLoggedOut() {
         // preserve our HS & IS URLs for convenience
         // N.B. we cache them in hsUrl/isUrl and can't really inline them
         // as getCurrentHsUrl() may call through to localStorage.
+        // NB. We do clear the device ID (as well as all the settings)
         if (hsUrl) window.localStorage.setItem("mx_hs_url", hsUrl);
         if (isUrl) window.localStorage.setItem("mx_is_url", isUrl);
     }

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -97,32 +97,7 @@ class MatrixClientPeg {
     }
 
     _replaceClient(hs_url, is_url, user_id, access_token, isGuest) {
-        if (localStorage) {
-            try {
-                localStorage.clear();
-            } catch (e) {
-                console.warn("Error clearing local storage", e);
-            }
-        }
         this._createClient(hs_url, is_url, user_id, access_token, isGuest);
-
-        if (localStorage) {
-            try {
-                localStorage.setItem("mx_hs_url", hs_url);
-                localStorage.setItem("mx_is_url", is_url);
-
-                if (user_id !== undefined && access_token !== undefined) {
-                    localStorage.setItem("mx_user_id", user_id);
-                    localStorage.setItem("mx_access_token", access_token);
-                    localStorage.setItem("mx_is_guest", JSON.stringify(isGuest));
-                    console.log("Session persisted for %s", user_id);
-                }
-            } catch (e) {
-                console.warn("Error using local storage: can't persist session!", e);
-            }
-        } else {
-            console.warn("No local storage available: can't persist session!");
-        }
     }
 
     getCredentials(): MatrixClientCreds {


### PR DESCRIPTION
Don't clear localstorage when replacing the client: we clear it when logging out so this is just redundant, and since we now use replaceClient to unpickle a session from localstorage, this was blowing away all our setting on every refresh.

Also Move all of the localstorage code to Lifecycle (except device ID but this will probably be generated on the server soon anyway). We previously cleared localstorage on logout in Lifecycle so persist the session in Lifecycle.setLoggedIn() to be symmetrical.

Fixes https://github.com/vector-im/vector-web/issues/1940