### PR TITLE
Don't use MatrixClientPeg for temporary clients

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -69,24 +69,10 @@ class MatrixClientPeg {
 
     /**
      * Replace this MatrixClientPeg's client with a client instance that has
-     * Home Server / Identity Server URLs but no credentials
-     */
-    replaceUsingUrls(hs_url, is_url) {
-        this._replaceClient(hs_url, is_url);
-    }
-
-    /**
-     * Replace this MatrixClientPeg's client with a client instance that has
      * Home Server / Identity Server URLs and active credentials
      */
     replaceUsingCreds(creds: MatrixClientCreds) {
-        this._replaceClient(
-            creds.homeserverUrl,
-            creds.identityServerUrl,
-            creds.userId,
-            creds.accessToken,
-            creds.guest,
-        );
+        this._createClient(creds);
     }
 
     start() {
@@ -94,10 +80,6 @@ class MatrixClientPeg {
         // the react sdk doesn't work without this, so don't allow
         opts.pendingEventOrdering = "detached";
         this.get().startClient(opts);
-    }
-
-    _replaceClient(hs_url, is_url, user_id, access_token, isGuest) {
-        this._createClient(hs_url, is_url, user_id, access_token, isGuest);
     }
 
     getCredentials(): MatrixClientCreds {
@@ -110,12 +92,12 @@ class MatrixClientPeg {
         };
     }
 
-    _createClient(hs_url, is_url, user_id, access_token, isGuest) {
+    _createClient(creds: MatrixClientCreds) {
         var opts = {
-            baseUrl: hs_url,
-            idBaseUrl: is_url,
-            accessToken: access_token,
-            userId: user_id,
+            baseUrl: creds.homeserverUrl,
+            idBaseUrl: creds.identityServerUrl,
+            accessToken: creds.accessToken,
+            userId: creds.userId,
             timelineSupport: true,
         };
 
@@ -130,7 +112,7 @@ class MatrixClientPeg {
         // potential number of event listeners is quite high.
         this.matrixClient.setMaxListeners(500);
 
-        this.matrixClient.setGuest(Boolean(isGuest));
+        this.matrixClient.setGuest(Boolean(creds.guest));
     }
 }
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -193,7 +193,7 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount: function() {
-        this._stopMatrixClient();
+        Lifecycle.stopMatrixClient();
         dis.unregister(this.dispatcherRef);
         document.removeEventListener("keydown", this.onKeyDown);
         window.removeEventListener("focus", this.onFocus);
@@ -601,16 +601,6 @@ module.exports = React.createClass({
         });
     },
 
-    // stop all the background processes related to the current client
-    _stopMatrixClient: function() {
-        Notifier.stop();
-        UserActivity.stop();
-        Presence.stop();
-        MatrixClientPeg.get().stopClient();
-        MatrixClientPeg.get().removeAllListeners();
-        MatrixClientPeg.unset();
-    },
-
     onKeyDown: function(ev) {
             /*
             // Remove this for now as ctrl+alt = alt-gr so this breaks keyboards which rely on alt-gr for numbers
@@ -935,10 +925,8 @@ module.exports = React.createClass({
         var NewVersionBar = sdk.getComponent('globals.NewVersionBar');
         var ForgotPassword = sdk.getComponent('structures.login.ForgotPassword');
 
-        // work out the HS URL prompts we should show for
-
-        console.log("rendering; loading="+this.state.loading+"; screen="+this.state.screen +
-                    "; logged_in="+this.state.logged_in+"; ready="+this.state.ready);
+        // console.log("rendering; loading="+this.state.loading+"; screen="+this.state.screen +
+        //             "; logged_in="+this.state.logged_in+"; ready="+this.state.ready);
 
         if (this.state.loading) {
             var Spinner = sdk.getComponent('elements.Spinner');

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -50,8 +50,7 @@ module.exports.stubClient = function() {
     //
     // 'sandbox.restore()' doesn't work correctly on inherited methods,
     // so we do this for each method
-    var methods = ['get', 'unset', 'replaceUsingUrls',
-                   'replaceUsingCreds'];
+    var methods = ['get', 'unset', 'replaceUsingCreds'];
     for (var i = 0; i < methods.length; i++) {
         sandbox.stub(peg, methods[i]);
     }
@@ -184,4 +183,3 @@ module.exports.mkStubRoom = function() {
         },
     };
 };
-


### PR DESCRIPTION
Get rid of MatrixClientPeg.replaceUsingUrls, and instead create local,
temporary MatrixClients for the unauthed steps; we therefore only use
MatrixClientPeg for logged-in clients.