### PR TITLE
Use server-generated deviceId

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -214,11 +214,19 @@ export function setLoggedIn(credentials) {
         try {
             localStorage.setItem("mx_hs_url", credentials.homeserverUrl);
             localStorage.setItem("mx_is_url", credentials.identityServerUrl);
-
             localStorage.setItem("mx_user_id", credentials.userId);
-            localStorage.setItem("mx_device_id", credentials.deviceId);
             localStorage.setItem("mx_access_token", credentials.accessToken);
             localStorage.setItem("mx_is_guest", JSON.stringify(credentials.guest));
+
+            // if we didn't get a deviceId from the login, leave mx_device_id unset,
+            // rather than setting it to "undefined".
+            //
+            // (in this case MatrixClient doesn't bother with the crypto stuff
+            // - that's fine for us).
+            if (credentials.deviceId) {
+                localStorage.setItem("mx_device_id", credentials.deviceId);
+            }
+
             console.log("Session persisted for %s", credentials.userId);
         } catch (e) {
             console.warn("Error using local storage: can't persist session!", e);

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -128,6 +128,7 @@ function _loginWithToken(queryParams) {
         console.log("Logged in with token");
         setLoggedIn({
             userId: data.user_id,
+            deviceId: data.device_id,
             accessToken: data.access_token,
             homeserverUrl: queryParams.homeserver,
             identityServerUrl: queryParams.identityServer,
@@ -151,6 +152,7 @@ function _registerAsGuest(hsUrl, isUrl) {
         console.log("Registered as guest: %s", creds.user_id);
         setLoggedIn({
             userId: creds.user_id,
+            deviceId: creds.device_id,
             accessToken: creds.access_token,
             homeserverUrl: hsUrl,
             identityServerUrl: isUrl,
@@ -170,6 +172,7 @@ function _restoreFromLocalStorage() {
     const is_url = localStorage.getItem("mx_is_url") || 'https://matrix.org';
     const access_token = localStorage.getItem("mx_access_token");
     const user_id = localStorage.getItem("mx_user_id");
+    const device_id = localStorage.getItem("mx_device_id");
 
     let is_guest;
     if (localStorage.getItem("mx_is_guest") !== null) {
@@ -183,6 +186,7 @@ function _restoreFromLocalStorage() {
         console.log("Restoring session for %s", user_id);
         setLoggedIn({
             userId: user_id,
+            deviceId: device_id,
             accessToken: access_token,
             homeserverUrl: hs_url,
             identityServerUrl: is_url,
@@ -212,6 +216,7 @@ export function setLoggedIn(credentials) {
             localStorage.setItem("mx_is_url", credentials.identityServerUrl);
 
             localStorage.setItem("mx_user_id", credentials.userId);
+            localStorage.setItem("mx_device_id", credentials.deviceId);
             localStorage.setItem("mx_access_token", credentials.accessToken);
             localStorage.setItem("mx_is_guest", JSON.stringify(credentials.guest));
             console.log("Session persisted for %s", credentials.userId);

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -21,21 +21,11 @@ import utils from 'matrix-js-sdk/lib/utils';
 
 const localStorage = window.localStorage;
 
-function deviceId() {
-    // XXX: is Math.random()'s deterministicity a problem here?
-    var id = Math.floor(Math.random()*16777215).toString(16);
-    id = "W" + "000000".substring(id.length) + id;
-    if (localStorage) {
-        id = localStorage.getItem("mx_device_id") || id;
-        localStorage.setItem("mx_device_id", id);
-    }
-    return id;
-}
-
 interface MatrixClientCreds {
     homeserverUrl: string,
     identityServerUrl: string,
     userId: string,
+    deviceId: string,
     accessToken: string,
     guest: boolean,
 }
@@ -87,6 +77,7 @@ class MatrixClientPeg {
             homeserverUrl: this.matrixClient.baseUrl,
             identityServerUrl: this.matrixClient.idBaseUrl,
             userId: this.matrixClient.credentials.userId,
+            deviceId: this.matrixClient.getDeviceId(),
             accessToken: this.matrixClient.getAccessToken(),
             guest: this.matrixClient.isGuest(),
         };
@@ -98,12 +89,12 @@ class MatrixClientPeg {
             idBaseUrl: creds.identityServerUrl,
             accessToken: creds.accessToken,
             userId: creds.userId,
+            deviceId: creds.deviceId,
             timelineSupport: true,
         };
 
         if (localStorage) {
             opts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
-            opts.deviceId = deviceId();
         }
 
         this.matrixClient = Matrix.createClient(opts);

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -330,6 +330,7 @@ class Login extends Signup {
         return client.registerGuest().then((creds) => {
             return {
                 userId: creds.user_id,
+                deviceId: creds.device_id,
                 accessToken: creds.access_token,
                 homeserverUrl: this._hsUrl,
                 identityServerUrl: this._isUrl,
@@ -364,6 +365,7 @@ class Login extends Signup {
                 homeserverUrl: self._hsUrl,
                 identityServerUrl: self._isUrl,
                 userId: data.user_id,
+                deviceId: data.device_id,
                 accessToken: data.access_token
             });
         }, function(error) {
@@ -387,6 +389,7 @@ class Login extends Signup {
                             homeserverUrl: self._fallbackHsUrl,
                             identityServerUrl: self._isUrl,
                             userId: data.user_id,
+                            deviceId: data.device_id,
                             accessToken: data.access_token
                         });
                     }, function(fallback_error) {

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -154,6 +154,7 @@ module.exports = React.createClass({
             }
             self.props.onLoggedIn({
                 userId: response.user_id,
+                deviceId: response.device_id,
                 homeserverUrl: self.registerLogic.getHomeserverUrl(),
                 identityServerUrl: self.registerLogic.getIdentityServerUrl(),
                 accessToken: response.access_token
@@ -279,7 +280,7 @@ module.exports = React.createClass({
 
         var returnToAppJsx;
         if (this.props.onCancelClick) {
-            returnToAppJsx = 
+            returnToAppJsx =
                 <a className="mx_Login_create" onClick={this.props.onCancelClick} href="#">
                     Return to app
                 </a>


### PR DESCRIPTION
This, finally, is what all of the refactoring over the last week has been in aid of. It makes sure that we actually use the same device_id for the crypto bits as we used to log in with. (We actually use the server-generated one to save us the hassle of generating our own everywhere).

Includes the changes in https://github.com/matrix-org/matrix-react-sdk/pull/408