### PR TITLE
Fix NPE when we don't know the sender of an event

### DIFF
--- a/src/components/views/messages/MessageEvent.js
+++ b/src/components/views/messages/MessageEvent.js
@@ -22,12 +22,6 @@ var sdk = require('../../../index');
 module.exports = React.createClass({
     displayName: 'MessageEvent',
 
-    statics: {
-        needsSenderProfile: function() {
-            return true;
-        }
-    },
-
     propTypes: {
         /* the MatrixEvent to show */
         mxEvent: React.PropTypes.object.isRequired,

--- a/src/components/views/messages/TextualEvent.js
+++ b/src/components/views/messages/TextualEvent.js
@@ -24,12 +24,6 @@ import sdk from '../../../index';
 module.exports = React.createClass({
     displayName: 'TextualEvent',
 
-    statics: {
-        needsSenderProfile: function() {
-            return false;
-        }
-    },
-
     render: function() {
         const EmojiText = sdk.getComponent('elements.EmojiText');
         var text = TextForEvent.textForEvent(this.props.mxEvent);
@@ -39,4 +33,3 @@ module.exports = React.createClass({
         );
     },
 });
-


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/matrix-org/matrix-react-sdk/pull/426.

Particularly when we are showing search results, we may not recognise the sender of an event; attempting to create a MemberAvatar for it will lead to null-reference errors.

Also a bit of untangling of the logic of needsSenderProfile. Since https://github.com/matrix-org/matrix-react-sdk/pull/422, EventTileType.needsSenderProfile was only being called on MessageEvents, and therefore only returned true. It's a shame to see all this logic going into EventTile rather than the individual EventTileTypes, but since it's there, let's not leave the unused logic lying around in the EventTileType implementations.