### PR TITLE
Scalar Messaging: Expose join_rules and restrict to currently viewed room

### DIFF
--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -189,6 +189,27 @@ function setBotOptions(event, roomId, userId) {
     });
 }
 
+function setBotPower(event, roomId, userId, level) {
+    if (!(Number.isInteger(level) && level >= 0)) {
+        sendError(event, "Power level must be positive integer.");
+        return;
+    }
+
+    console.log(`Received request to set power level for bot ${userId} in room ${roomId}.`);
+    const client = MatrixClientPeg.get();
+    if (!client) {
+        sendError(event, "You need to be logged in.");
+        return;
+    }
+    client.setPowerLevel(roomId, userId, level).done(() => {
+        sendResponse(event, {
+            success: true,
+        });
+    }, (err) => {
+        sendError(event, err.message ? err.message : "Failed to send request.", err);
+    });
+}
+
 function getMembershipState(event, roomId, userId) {
     console.log(`membership_state of ${userId} in room ${roomId} requested.`);
     returnStateEvent(event, roomId, "m.room.member", userId);
@@ -280,6 +301,9 @@ const onMessage = function(event) {
             break;
         case "set_bot_options":
             setBotOptions(event, roomId, userId);
+            break;
+        case "set_bot_power":
+            setBotPower(event, roomId, userId, event.data.level);
             break;
         case "join_rules_state":
             getJoinRules(event, roomId);

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -203,17 +203,15 @@ function setBotPower(event, roomId, userId, level) {
         return;
     }
 
-    client.getStateEvent(roomId, "m.room.power_levels", "").then((rawPowerState) => {
-        console.log(rawPowerState);
+    client.getStateEvent(roomId, "m.room.power_levels", "").then((powerLevels) => {
         let powerEvent = new MatrixEvent(
             {
                 type: "m.room.power_levels",
-                content: rawPowerState,
+                content: powerLevels,
             }
         );
 
         client.setPowerLevel(roomId, userId, level, powerEvent).done(() => {
-            console.log('Power level has been set');
             sendResponse(event, {
                 success: true,
             });

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -228,7 +228,7 @@ var currentRoomId = null;
 // Listen for when a room is viewed
 dis.register(onAction);
 function onAction(payload) {
-    if (payload.action !== "view_room")
+    if (payload.action !== "view_room") {
         return;
     }
     currentRoomId = payload.room_id;

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -272,10 +272,6 @@ const onMessage = function(event) {
 
     const roomId = event.data.room_id;
     const userId = event.data.user_id;
-    if (!userId) {
-        sendError(event, "Missing user_id in request");
-        return;
-    }
     if (!roomId) {
         sendError(event, "Missing room_id in request");
         return;
@@ -289,6 +285,16 @@ const onMessage = function(event) {
         return;
     }
 
+    // Getting join rules does not require userId
+    if (event.data.action === "join_rules_state") {
+        getJoinRules(event, roomId);
+        return;
+    }
+
+    if (!userId) {
+        sendError(event, "Missing user_id in request");
+        return;
+    }
     switch (event.data.action) {
         case "membership_state":
             getMembershipState(event, roomId, userId);
@@ -304,9 +310,6 @@ const onMessage = function(event) {
             break;
         case "set_bot_power":
             setBotPower(event, roomId, userId, event.data.level);
-            break;
-        case "join_rules_state":
-            getJoinRules(event, roomId);
             break;
         default:
             console.warn("Unhandled postMessage event with action '" + event.data.action +"'");

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -196,7 +196,7 @@ function setBotPower(event, roomId, userId, level) {
         return;
     }
 
-    console.log(`Received request to set power level for bot ${userId} in room ${roomId}.`);
+    console.log(`Received request to set power level to ${level} for bot ${userId} in room ${roomId}.`);
     const client = MatrixClientPeg.get();
     if (!client) {
         sendError(event, "You need to be logged in.");

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -196,7 +196,7 @@ function getMembershipState(event, roomId, userId) {
 
 function getJoinRules(event, roomId) {
     console.log(`join_rules of ${roomId} requested.`);
-    returnStateEvent(event, roomId, "m.room.join_rules");
+    returnStateEvent(event, roomId, "m.room.join_rules", "");
 }
 
 function botOptions(event, roomId, userId) {
@@ -228,11 +228,10 @@ var currentRoomId = null;
 // Listen for when a room is viewed
 dis.register(onAction);
 function onAction(payload) {
-    switch (payload.action) {
-        case 'view_room':
-            currentRoomId = payload.room_id;
-        break;
+    if (payload.action !== "view_room")
+        return;
     }
+    currentRoomId = payload.room_id;
 }
 
 const onMessage = function(event) {
@@ -265,7 +264,7 @@ const onMessage = function(event) {
         return;
     }
     if (roomId !== currentRoomId) {
-        sendError(event, "Room " + roomId + " not in view");
+        sendError(event, "Room " + roomId + " not visible");
         return;
     }
 

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -123,7 +123,7 @@ Example:
 
 const SdkConfig = require('./SdkConfig');
 const MatrixClientPeg = require("./MatrixClientPeg");
-var dis = require("../../dispatcher");
+var dis = require("./dispatcher");
 
 function sendResponse(event, res) {
     const data = JSON.parse(JSON.stringify(event.data));

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -265,7 +265,7 @@ const onMessage = function(event) {
         return;
     }
     if (roomId !== currentRoomId) {
-        sendError(event, "Room not in view");
+        sendError(event, "Room " + roomId + " not in view");
         return;
     }
 

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -193,6 +193,11 @@ function getMembershipState(event, roomId, userId) {
     returnStateEvent(event, roomId, "m.room.member", userId);
 }
 
+function getJoinRules(event, roomId) {
+    console.log(`join_rules of ${roomId} requested.`);
+    returnStateEvent(event, roomId, "m.room.join_rules");
+}
+
 function botOptions(event, roomId, userId) {
     console.log(`bot_options of ${userId} in room ${roomId} requested.`);
     returnStateEvent(event, roomId, "m.room.bot.options", "_" + userId);
@@ -255,6 +260,9 @@ const onMessage = function(event) {
             break;
         case "set_bot_options":
             setBotOptions(event, roomId, userId);
+            break;
+        case "join_rules_state":
+            getJoinRules(event, roomId);
             break;
         default:
             console.warn("Unhandled postMessage event with action '" + event.data.action +"'");


### PR DESCRIPTION
The post message API now:
- exposes a way of getting the join rules for a room (which must be public in some cases);
- returns an error if the ```room_id``` specified is not the one of the room currently being views.

(@Kegsay, I'm hoping you know how one could test this...)