### PR TITLE
Flag incoming DMs as such

### DIFF
--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -57,6 +57,9 @@ function createRoom(opts) {
     if (opts.dmUserId && createOpts.invite === undefined) {
         createOpts.invite = [opts.dmUserId];
     }
+    if (opts.dmUserId && createOpts.is_direct === undefined) {
+        createOpts.is_direct = true;
+    }
 
     // Allow guests by default since the room is private and they'd
     // need an invite. This means clicking on a 3pid invite email can


### PR DESCRIPTION
 * Add the 'is_direct' flag to rooms created for DMs
 * For invites, look for the DM flag when getting the DM user ID for a room
 * When accepting an invite, look for the flag and mark the room as a DM room if appropriate.

Fixes points 4 & 5 of https://github.com/vector-im/vector-web/issues/2099

Requires https://github.com/matrix-org/synapse/pull/1108