### PR TITLE
Remove markdown line breaks

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -20,7 +20,7 @@ marked.setOptions({
     renderer: new marked.Renderer(),
     gfm: true,
     tables: true,
-    breaks: true,
+    breaks: false,
     pedantic: false,
     sanitize: true,
     smartLists: true,


### PR DESCRIPTION
Rationale is that users inserting breaks in rooms is awkward, and people are triggering it by mistake when using the `-_-` smiley by itself.

Fixes vector-im/vector-web#2170