### PR TITLE
Remove clause from Unread count if statement

### DIFF
--- a/src/Unread.js
+++ b/src/Unread.js
@@ -27,8 +27,6 @@ module.exports = {
             return false;
         } else if (ev.getType() == "m.room.member") {
             return false;
-        } else if (ev.getType == 'm.room.message' && ev.getContent().msgtype == 'm.notify') {
-            return false;
         }
         var EventTile = sdk.getComponent('rooms.EventTile');
         return EventTile.haveTileForEvent(ev);


### PR DESCRIPTION
There is no 'm.notify' msgtype, it's m.notice, so this clause hasn't been used and we've been including notices in unread counts. Keep the same behaviour and remove the unused code.

https://github.com/vector-im/vector-web/issues/1127
