### PR TITLE
Apply heuristic on incoming DMs

### DIFF
--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -68,7 +68,7 @@ export function looksLikeDirectMessageRoom(room, me) {
         // Used to split rooms via tags
         const tagNames = Object.keys(room.tags);
         // Used for 1:1 direct chats
-        const joinedMembers = room.getJoinedMembers();
+        const joinedMembers = room.currentState.getMembers();
 
         // Show 1:1 chats in seperate "Direct Messages" section as long as they haven't
         // been moved to a different tag section

--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -68,11 +68,11 @@ export function looksLikeDirectMessageRoom(room, me) {
         // Used to split rooms via tags
         const tagNames = Object.keys(room.tags);
         // Used for 1:1 direct chats
-        const joinedMembers = room.currentState.getMembers();
+        const members = room.currentState.getMembers();
 
         // Show 1:1 chats in seperate "Direct Messages" section as long as they haven't
         // been moved to a different tag section
-        if (joinedMembers.length === 2 && !tagNames.length) {
+        if (members.length === 2 && !tagNames.length) {
             return true;
         }
     }

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -451,6 +451,7 @@ module.exports = React.createClass({
                 room: room,
                 joining: false,
             });
+
             this._onRoomLoaded(room);
         }
     },
@@ -520,6 +521,17 @@ module.exports = React.createClass({
         // into.
         var me = MatrixClientPeg.get().credentials.userId;
         if (this.state.joining && this.state.room.hasMembershipState(me, "join")) {
+            // Having just joined a room, check to see if it looks like a DM room, and if so,
+            // mark it as one. This is to work around the fact that some clients don't support
+            // is_direct. We should remove this once they do.
+            const me = this.state.room.getMember(MatrixClientPeg.get().credentials.userId);
+            if (Rooms.looksLikeDirectMessageRoom(this.state.room, me)) {
+                // XXX: There's not a whole lot we can really do if this fails: at best
+                // perhaps we could try a couple more times, but since it's a temporary
+                // compatability workaround, let's not bother.
+                Rooms.setDMRoom(this.state.room.roomId, me.events.member.getSender()).done();
+            }
+
             this.setState({
                 joining: false
             });

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -679,9 +679,9 @@ module.exports = React.createClass({
             if (this.state.room) {
                 const me = this.state.room.getMember(MatrixClientPeg.get().credentials.userId);
                 if (me && me.membership == 'invite') {
-                    // The 'direct' hihnt is there, so declare that this is a DM room for
-                    // whoever invited us.
                     if (me.events.member.getContent().is_direct) {
+                        // The 'direct' hint is there, so declare that this is a DM room for
+                        // whoever invited us.
                         return Rooms.setDMRoom(this.state.room.roomId, me.events.member.getSender());
                     }
                 }


### PR DESCRIPTION
Check if a room looks like a DM rooms on joining and mark it as one if so.

Also change the heuristic to only count rooms with 2 total members rather than 2 joined members, otherwise this is going to mark any room as a DM if someone creates a room, invites a bunch of people and you happen to be first to join.

Also fix comment typo and move it to more appropriate place

Fixes https://github.com/vector-im/vector-web/issues/2205