### PR TITLE
Revert #333

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -87,7 +87,7 @@ var sanitizeHtmlParams = {
         // deliberately no h1/h2 to stop people shouting.
         'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
         'nl', 'li', 'b', 'i', 'u', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
-        'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'img',
+        'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre'
     ],
     allowedAttributes: {
         // custom ones first:
@@ -101,9 +101,7 @@ var sanitizeHtmlParams = {
     selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
     // URL schemes we permit
     allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
-    allowedSchemesByTag: {
-        img: [ 'data' ],
-    },
+    allowedSchemesByTag: {},
 
     transformTags: { // custom to matrix
         // add blank targets to all hyperlinks except vector URLs

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -101,6 +101,10 @@ var sanitizeHtmlParams = {
     selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
     // URL schemes we permit
     allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
+
+    // DO NOT USE. sanitize-html allows all URL starting with '//'
+    // so this will always allow links to whatever scheme the
+    // host page is served over.
     allowedSchemesByTag: {},
 
     transformTags: { // custom to matrix


### PR DESCRIPTION
Revert https://github.com/matrix-org/matrix-react-sdk/pull/333/files since sanitizer blindly allows urls with no scheme, meaning  // links can be used to fetch images over whatever scheme you serve vector over (ie. normally http/https).