### PR TITLE
Fix links to IRC rooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fuse.js": "^2.2.0",
     "glob": "^5.0.14",
     "highlight.js": "^8.9.1",
-    "linkifyjs": "^2.1.0",
+    "linkifyjs": "^2.1.1",
     "lodash": "^4.13.1",
     "marked": "^0.3.5",
     "matrix-js-sdk": "matrix-org/matrix-js-sdk#develop",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fuse.js": "^2.2.0",
     "glob": "^5.0.14",
     "highlight.js": "^8.9.1",
-    "linkifyjs": "2.0.0-beta.4",
+    "linkifyjs": "^2.1.0",
     "lodash": "^4.13.1",
     "marked": "^0.3.5",
     "matrix-js-sdk": "matrix-org/matrix-js-sdk#develop",

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -42,7 +42,9 @@ function matrixLinkify(linkify) {
         TT.PLUS,
         TT.NUM,
         TT.DOMAIN,
-        TT.TLD
+        TT.TLD,
+        TT.UNDERSCORE,
+        TT.POUND,
     ];
 
     S_START.on(TT.POUND, S_HASH);

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -45,6 +45,10 @@ function matrixLinkify(linkify) {
         TT.TLD,
         TT.UNDERSCORE,
         TT.POUND,
+
+        // because 'localhost' is tokenised to the localhost token,
+        // usernames @localhost:foo.com are otherwise not matched!
+        TT.LOCALHOST,
     ];
 
     S_START.on(TT.POUND, S_HASH);
@@ -56,6 +60,7 @@ function matrixLinkify(linkify) {
     S_HASH_NAME.on(TT.COLON, S_HASH_NAME_COLON);
 
     S_HASH_NAME_COLON.on(TT.DOMAIN, S_HASH_NAME_COLON_DOMAIN);
+    S_HASH_NAME_COLON.on(TT.LOCALHOST, S_ROOMALIAS); // accept #foo:localhost
     S_HASH_NAME_COLON_DOMAIN.on(TT.DOT, S_HASH_NAME_COLON_DOMAIN_DOT);
     S_HASH_NAME_COLON_DOMAIN_DOT.on(TT.DOMAIN, S_HASH_NAME_COLON_DOMAIN);
     S_HASH_NAME_COLON_DOMAIN_DOT.on(TT.TLD, S_ROOMALIAS);
@@ -77,10 +82,14 @@ function matrixLinkify(linkify) {
 
     var username_tokens = [
         TT.DOT,
+        TT.UNDERSCORE,
         TT.PLUS,
         TT.NUM,
         TT.DOMAIN,
-        TT.TLD
+        TT.TLD,
+
+        // as in roomname_tokens
+        TT.LOCALHOST,
     ];
 
     S_START.on(TT.AT, S_AT);
@@ -92,6 +101,7 @@ function matrixLinkify(linkify) {
     S_AT_NAME.on(TT.COLON, S_AT_NAME_COLON);
 
     S_AT_NAME_COLON.on(TT.DOMAIN, S_AT_NAME_COLON_DOMAIN);
+    S_AT_NAME_COLON.on(TT.LOCALHOST, S_USERID); // accept @foo:localhost
     S_AT_NAME_COLON_DOMAIN.on(TT.DOT, S_AT_NAME_COLON_DOMAIN_DOT);
     S_AT_NAME_COLON_DOMAIN_DOT.on(TT.DOMAIN, S_AT_NAME_COLON_DOMAIN);
     S_AT_NAME_COLON_DOMAIN_DOT.on(TT.TLD, S_USERID);


### PR DESCRIPTION
Fix the linkifier:

 * Update to linkifyjs 2.1.1 now https://github.com/SoapBox/linkifyjs/issues/162 is fixed (so it's won't re-introduce https://github.com/vector-im/vector-web/issues/2010)
 * Fix underscores and hashes in room aliases (Fixes https://github.com/vector-im/vector-web/issues/500)
 * Accept underscores in usernames
 * Accept usernames & room aliases on localhost
 * Accept #localhost:foo.com and @localhost:foo.com

This is mostly from https://github.com/matrix-org/matrix-react-sdk/pull/460 but with the newer linkify version and avoiding any refactoring for this PR. Kudos, @aviraldg 