### PR TITLE
Directory search join button

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -59,6 +59,7 @@ module.exports.components['views.dialogs.TextInputDialog'] = require('./componen
 module.exports.components['views.elements.AddressSelector'] = require('./components/views/elements/AddressSelector');
 module.exports.components['views.elements.AddressTile'] = require('./components/views/elements/AddressTile');
 module.exports.components['views.elements.DeviceVerifyButtons'] = require('./components/views/elements/DeviceVerifyButtons');
+module.exports.components['views.elements.DirectorySearchBox'] = require('./components/views/elements/DirectorySearchBox');
 module.exports.components['views.elements.EditableText'] = require('./components/views/elements/EditableText');
 module.exports.components['views.elements.EditableTextContainer'] = require('./components/views/elements/EditableTextContainer');
 module.exports.components['views.elements.EmojiText'] = require('./components/views/elements/EmojiText');

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -24,6 +24,7 @@ export default class DirectorySearchBox extends React.Component {
         this.onClearClick = this.onClearClick.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
+        this.onJoinButtonClick = this.onJoinButtonClick.bind(this);
 
         this.input = null;
     }
@@ -59,11 +60,27 @@ export default class DirectorySearchBox extends React.Component {
         }
     }
 
+    onJoinButtonClick() {
+    }
+
+    _contentLooksLikeAlias() {
+        return true;
+    }
+
     render() {
         const searchbox_classes = {
             mx_DirectorySearchBox: true,
         };
         searchbox_classes[this.props.className] = true;
+
+        let join_button;
+        if (this._contentLooksLikeAlias()) {
+            join_button = <span className="mx_DirectorySearchBox_joinButton"
+                onClick={this.onJoinButtonClick}
+            >
+                Join
+            </span>;
+        }
 
         return <span className={classnames(searchbox_classes)}>
             <input type="text" size="64"
@@ -72,6 +89,7 @@ export default class DirectorySearchBox extends React.Component {
                 onChange={this.onChange} onKeyUp={this.onKeyUp}
                 placeholder="Find a room by keyword or room ID (#matrix:matrix.org)"
             />
+            {join_button}
             <span className="mx_DirectorySearchBox_clear" onClick={this.onClearClick} />
         </span>;
     }

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -76,7 +76,7 @@ export default class DirectorySearchBox extends React.Component {
         if (!this.input) return false;
 
         // liberal test for things that look like room aliases
-        return /^#.+:.+/.test(this.state.value);
+        return /^#.+:/.test(this.state.value);
     }
 
     render() {

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -76,7 +76,7 @@ export default class DirectorySearchBox extends React.Component {
         if (!this.input) return false;
 
         // liberal test for things that look like room aliases
-        return /#.+:.+/.test(this.state.value);
+        return /^#.+:.+/.test(this.state.value);
     }
 
     render() {

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -83,14 +83,18 @@ export default class DirectorySearchBox extends React.Component {
         }
 
         return <span className={classnames(searchbox_classes)}>
-            <input type="text" size="64"
-                className="mx_DirectorySearchBox_input"
-                ref={this.collectInput}
-                onChange={this.onChange} onKeyUp={this.onKeyUp}
-                placeholder="Find a room by keyword or room ID (#matrix:matrix.org)"
-            />
-            {join_button}
-            <span className="mx_DirectorySearchBox_clear" onClick={this.onClearClick} />
+            <div className="mx_DirectorySearchBox_container">
+                <input type="text" size="64"
+                    className="mx_DirectorySearchBox_input"
+                    ref={this.collectInput}
+                    onChange={this.onChange} onKeyUp={this.onKeyUp}
+                    placeholder="Find a room by keyword or room ID (#matrix:matrix.org)"
+                />
+                {join_button}
+                <span className="mx_DirectorySearchBox_clear_wrapper">
+                    <span className="mx_DirectorySearchBox_clear" onClick={this.onClearClick} />
+                </span>
+            </div>
         </span>;
     }
 }

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -1,0 +1,85 @@
+/*
+Copyright 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import classnames from 'classnames';
+
+export default class DirectorySearchBox extends React.Component {
+    constructor() {
+        super();
+        this.collectInput = this.collectInput.bind(this);
+        this.onClearClick = this.onClearClick.bind(this);
+        this.onChange = this.onChange.bind(this);
+        this.onKeyUp = this.onKeyUp.bind(this);
+
+        this.input = null;
+    }
+
+    collectInput(e) {
+        this.input = e;
+    }
+
+    onClearClick() {
+        if (this.input) {
+            this.input.value = '';
+            this.input.focus();
+
+            if (this.props.onClear) {
+                this.props.onClear();
+            }
+        }
+    }
+
+    onChange() {
+        if (!this.input) return;
+
+        if (this.props.onChange) {
+            this.props.onChange(this.input.value);
+        }
+    }
+
+    onKeyUp(ev) {
+        if (ev.key == 'Enter') {
+            if (this.props.onJoinClick) {
+                this.props.onJoinClick(this.input.value);
+            }
+        }
+    }
+
+    render() {
+        const searchbox_classes = {
+            mx_DirectorySearchBox: true,
+        };
+        searchbox_classes[this.props.className] = true;
+
+        return <span className={classnames(searchbox_classes)}>
+            <input type="text" size="64"
+                className="mx_DirectorySearchBox_input"
+                ref={this.collectInput}
+                onChange={this.onChange} onKeyUp={this.onKeyUp}
+                placeholder="Find a room by keyword or room ID (#matrix:matrix.org)"
+            />
+            <span className="mx_DirectorySearchBox_clear" onClick={this.onClearClick} />
+        </span>;
+    }
+}
+
+DirectorySearchBox.propTypes = {
+    className: React.PropTypes.string,
+    onChange: React.PropTypes.func,
+    onClear: React.PropTypes.func,
+    onJoinClick: React.PropTypes.func,
+};

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -27,6 +27,10 @@ export default class DirectorySearchBox extends React.Component {
         this.onJoinButtonClick = this.onJoinButtonClick.bind(this);
 
         this.input = null;
+
+        this.state = {
+            value: '',
+        };
     }
 
     collectInput(e) {
@@ -34,8 +38,9 @@ export default class DirectorySearchBox extends React.Component {
     }
 
     onClearClick() {
+        this.setState({value: ''});
+
         if (this.input) {
-            this.input.value = '';
             this.input.focus();
 
             if (this.props.onClear) {
@@ -44,27 +49,34 @@ export default class DirectorySearchBox extends React.Component {
         }
     }
 
-    onChange() {
+    onChange(ev) {
         if (!this.input) return;
+        this.setState({value: ev.target.value});
 
         if (this.props.onChange) {
-            this.props.onChange(this.input.value);
+            this.props.onChange(this.state.value);
         }
     }
 
     onKeyUp(ev) {
         if (ev.key == 'Enter') {
             if (this.props.onJoinClick) {
-                this.props.onJoinClick(this.input.value);
+                this.props.onJoinClick(this.state.value);
             }
         }
     }
 
     onJoinButtonClick() {
+        if (this.props.onJoinClick) {
+            this.props.onJoinClick(this.state.value);
+        }
     }
 
     _contentLooksLikeAlias() {
-        return true;
+        if (!this.input) return false;
+
+        // liberal test for things that look like room aliases
+        return /#.+:.+/.test(this.state.value);
     }
 
     render() {
@@ -84,7 +96,7 @@ export default class DirectorySearchBox extends React.Component {
 
         return <span className={classnames(searchbox_classes)}>
             <div className="mx_DirectorySearchBox_container">
-                <input type="text" size="64"
+                <input type="text" value={this.state.value}
                     className="mx_DirectorySearchBox_input"
                     ref={this.collectInput}
                     onChange={this.onChange} onKeyUp={this.onKeyUp}

--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -20,11 +20,11 @@ import classnames from 'classnames';
 export default class DirectorySearchBox extends React.Component {
     constructor() {
         super();
-        this.collectInput = this.collectInput.bind(this);
-        this.onClearClick = this.onClearClick.bind(this);
-        this.onChange = this.onChange.bind(this);
-        this.onKeyUp = this.onKeyUp.bind(this);
-        this.onJoinButtonClick = this.onJoinButtonClick.bind(this);
+        this._collectInput = this._collectInput.bind(this);
+        this._onClearClick = this._onClearClick.bind(this);
+        this._onChange = this._onChange.bind(this);
+        this._onKeyUp = this._onKeyUp.bind(this);
+        this._onJoinButtonClick = this._onJoinButtonClick.bind(this);
 
         this.input = null;
 
@@ -33,11 +33,11 @@ export default class DirectorySearchBox extends React.Component {
         };
     }
 
-    collectInput(e) {
+    _collectInput(e) {
         this.input = e;
     }
 
-    onClearClick() {
+    _onClearClick() {
         this.setState({value: ''});
 
         if (this.input) {
@@ -49,7 +49,7 @@ export default class DirectorySearchBox extends React.Component {
         }
     }
 
-    onChange(ev) {
+    _onChange(ev) {
         if (!this.input) return;
         this.setState({value: ev.target.value});
 
@@ -58,7 +58,7 @@ export default class DirectorySearchBox extends React.Component {
         }
     }
 
-    onKeyUp(ev) {
+    _onKeyUp(ev) {
         if (ev.key == 'Enter') {
             if (this.props.onJoinClick) {
                 this.props.onJoinClick(this.state.value);
@@ -66,7 +66,7 @@ export default class DirectorySearchBox extends React.Component {
         }
     }
 
-    onJoinButtonClick() {
+    _onJoinButtonClick() {
         if (this.props.onJoinClick) {
             this.props.onJoinClick(this.state.value);
         }
@@ -88,7 +88,7 @@ export default class DirectorySearchBox extends React.Component {
         let join_button;
         if (this._contentLooksLikeAlias()) {
             join_button = <span className="mx_DirectorySearchBox_joinButton"
-                onClick={this.onJoinButtonClick}
+                onClick={this._onJoinButtonClick}
             >
                 Join
             </span>;
@@ -98,13 +98,13 @@ export default class DirectorySearchBox extends React.Component {
             <div className="mx_DirectorySearchBox_container">
                 <input type="text" value={this.state.value}
                     className="mx_DirectorySearchBox_input"
-                    ref={this.collectInput}
-                    onChange={this.onChange} onKeyUp={this.onKeyUp}
+                    ref={this._collectInput}
+                    onChange={this._onChange} onKeyUp={this._onKeyUp}
                     placeholder="Find a room by keyword or room ID (#matrix:matrix.org)"
                 />
                 {join_button}
                 <span className="mx_DirectorySearchBox_clear_wrapper">
-                    <span className="mx_DirectorySearchBox_clear" onClick={this.onClearClick} />
+                    <span className="mx_DirectorySearchBox_clear" onClick={this._onClearClick} />
                 </span>
             </div>
         </span>;


### PR DESCRIPTION
Implement 'join' button that appears in room directory search box when you type a valid(ish) alias.

Also factors out the directory search box to a different component now it's a lot more complex (and also adds the clear button that was in the designs).

Fixes https://github.com/vector-im/vector-web/issues/2217