### PR TITLE
Fail hard & fast if linkifyjs version is wrong

### DIFF
--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -22,6 +22,9 @@ function matrixLinkify(linkify) {
     var MultiToken = MT.Base;
     var S_START = linkify.parser.start;
 
+    if (TT.UNDERSCORE === undefined) {
+        throw new Error("linkify-matrix requires linkifyjs 2.1.1: this version is too old.");
+    }
 
     var ROOMALIAS = function(value) {
         MultiToken.call(this, value);


### PR DESCRIPTION
Rather than carrying on an ending up with undefineds deep within the bowels of linkifyjs when we try to linkify a room alias.

https://github.com/vector-im/vector-web/issues/2357