### PR TITLE
Prevent error when clicking 'log in'

### DIFF
--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -67,7 +67,9 @@ export default class MessageComposer extends React.Component {
     }
 
     componentWillUnmount() {
-        MatrixClientPeg.get().removeListener("event", this.onEvent);
+        if (MatrixClientPeg.get()) {
+            MatrixClientPeg.get().removeListener("event", this.onEvent);
+        }
     }
 
     onEvent(event) {


### PR DESCRIPTION
If you joined a room before clicking 'log in', it would throw an
exception here and break.

Fixes https://github.com/vector-im/vector-web/issues/2329