### PR TITLE
Fix version going blank after logging in

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -110,6 +110,13 @@ module.exports = React.createClass({
             upgradeUsername: null,
             // The access token we had for our guest account, used when upgrading to a normal account
             guestAccessToken: null,
+
+            // Parameters used in the registration dance with the IS
+            register_client_secret: null,
+            register_session_id: null,
+            register_hs_url: null,
+            register_is_url: null,
+            register_id_sid: null,
         };
         return s;
     },

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -106,7 +106,9 @@ module.exports = React.createClass({
             version: null,
             newVersion: null,
 
+            // The username to default to when upgrading an account from a guest
             upgradeUsername: null,
+            // The access token we had for our guest account, used when upgrading to a normal account
             guestAccessToken: null,
         };
         return s;

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -257,7 +257,7 @@ module.exports = React.createClass({
             guestAccessToken: null,
        };
        newState.update(state);
-       this.setState(state);
+       this.setState(newState);
     },
 
     onAction: function(payload) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -245,6 +245,21 @@ module.exports = React.createClass({
         }
     },
 
+    setStateForNewScreen: function(state) {
+        const newState = {
+            screen: undefined,
+            currentRoomAlias: null,
+            currentRoomId: null,
+            viewUserId: null,
+            logged_in: false,
+            ready: false,
+            upgradeUsername: null,
+            guestAccessToken: null,
+       };
+       newState.update(state);
+       this.setState(state);
+    },
+
     onAction: function(payload) {
         var roomIndexDelta = 1;
 
@@ -273,20 +288,13 @@ module.exports = React.createClass({
                     newState.register_is_url = payload.params.is_url;
                     newState.register_id_sid = payload.params.sid;
                 }
-                this.setState(newState);
+                this.setStateForNewScreen(newState);
                 this.notifyNewScreen('register');
                 break;
             case 'start_login':
                 if (this.state.logged_in) return;
-                this.setState({
+                this.setStateForNewScreen({
                     screen: 'login',
-                    currentRoomAlias: null,
-                    currentRoomId: null,
-                    viewUserId: null,
-                    logged_in: false,
-                    ready: false,
-                    upgradeUsername: null,
-                    guestAccessToken: null,
                 });
                 this.notifyNewScreen('login');
                 break;
@@ -298,13 +306,8 @@ module.exports = React.createClass({
             case 'start_upgrade_registration':
                 // stash our guest creds so we can backout if needed
                 this.guestCreds = MatrixClientPeg.getCredentials();
-                this.setState({
+                this.setStateForNewScreen({
                     screen: "register",
-                    currentRoomAlias: null,
-                    currentRoomId: null,
-                    viewUserId: null,
-                    logged_in: false,
-                    ready: false,
                     upgradeUsername: MatrixClientPeg.get().getUserIdLocalpart(),
                     guestAccessToken: MatrixClientPeg.get().getAccessToken(),
                 });
@@ -312,15 +315,8 @@ module.exports = React.createClass({
                 break;
             case 'start_password_recovery':
                 if (this.state.logged_in) return;
-                this.setState({
+                this.setStateForNewScreen({
                     screen: 'forgot_password',
-                    currentRoomAlias: null,
-                    currentRoomId: null,
-                    viewUserId: null,
-                    logged_in: false,
-                    ready: false,
-                    upgradeUsername: null,
-                    guestAccessToken: null,
                 });
                 this.notifyNewScreen('forgot_password');
                 break;
@@ -626,15 +622,9 @@ module.exports = React.createClass({
      */
     _onLoggedOut: function() {
         this.notifyNewScreen('login');
-        this.setState({
-            screen: undefined,
-            currentRoomAlias: null,
-            currentRoomId: null,
-            viewUserId: null,
+        this.setStateForNewScreen({
             logged_in: false,
             ready: false,
-            upgradeUsername: null,
-            guestAccessToken: null,
             collapse_lhs: false,
             collapse_rhs: false,
         });

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -105,6 +105,9 @@ module.exports = React.createClass({
 
             version: null,
             newVersion: null,
+
+            upgradeUsername: null,
+            guestAccessToken: null,
         };
         return s;
     },
@@ -261,13 +264,20 @@ module.exports = React.createClass({
                     newState.register_is_url = payload.params.is_url;
                     newState.register_id_sid = payload.params.sid;
                 }
-                this.replaceState(newState);
+                this.setState(newState);
                 this.notifyNewScreen('register');
                 break;
             case 'start_login':
                 if (this.state.logged_in) return;
-                this.replaceState({
+                this.setState({
                     screen: 'login',
+                    currentRoomAlias: null,
+                    currentRoomId: null,
+                    viewUserId: null,
+                    logged_in: false,
+                    ready: false,
+                    upgradeUsername: null,
+                    guestAccessToken: null,
                 });
                 this.notifyNewScreen('login');
                 break;
@@ -279,8 +289,13 @@ module.exports = React.createClass({
             case 'start_upgrade_registration':
                 // stash our guest creds so we can backout if needed
                 this.guestCreds = MatrixClientPeg.getCredentials();
-                this.replaceState({
+                this.setState({
                     screen: "register",
+                    currentRoomAlias: null,
+                    currentRoomId: null,
+                    viewUserId: null,
+                    logged_in: false,
+                    ready: false,
                     upgradeUsername: MatrixClientPeg.get().getUserIdLocalpart(),
                     guestAccessToken: MatrixClientPeg.get().getAccessToken(),
                 });
@@ -288,8 +303,15 @@ module.exports = React.createClass({
                 break;
             case 'start_password_recovery':
                 if (this.state.logged_in) return;
-                this.replaceState({
-                    screen: 'forgot_password'
+                this.setState({
+                    screen: 'forgot_password',
+                    currentRoomAlias: null,
+                    currentRoomId: null,
+                    viewUserId: null,
+                    logged_in: false,
+                    ready: false,
+                    upgradeUsername: null,
+                    guestAccessToken: null,
                 });
                 this.notifyNewScreen('forgot_password');
                 break;
@@ -595,9 +617,17 @@ module.exports = React.createClass({
      */
     _onLoggedOut: function() {
         this.notifyNewScreen('login');
-        this.replaceState({
+        this.setState({
+            screen: undefined,
+            currentRoomAlias: null,
+            currentRoomId: null,
+            viewUserId: null,
             logged_in: false,
             ready: false,
+            upgradeUsername: null,
+            guestAccessToken: null,
+            collapse_lhs: false,
+            collapse_rhs: false,
         });
     },
 


### PR DESCRIPTION
Don't use replaceState in MatrixClient: there's lots of stuff in
MatrixClient's state now (including the app version) so replacing
the entire state doesn't really make sense (and also blows away
all of the nice defaults we set in getInitialState). Instead,
setState of the things we actually care about wherever we used
replaceState.

Also add a couple of state variables to getInitialState that were
missing.

Fixes https://github.com/vector-im/vector-web/issues/2322