### PR TITLE
Prevent spamming emails by reusing client secret

### DIFF
--- a/src/Signup.js
+++ b/src/Signup.js
@@ -135,6 +135,10 @@ class Register extends Signup {
         // generate one for this session. It will only be used if
         // we do email verification, but far simpler to just make
         // sure we have one.
+        // We re-use this same secret over multiple calls to register
+        // so that the identity server can honour the sendAttempt
+        // parameter and not re-send email unless we actually want
+        // another mail to be sent.
         if (!this.params.clientSecret) {
             this.params.clientSecret = client.generateClientSecret();
         }

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -130,6 +130,14 @@ class Register extends Signup {
         this.password = password;
         const client = this._createTemporaryClient();
         this.activeStage = null;
+
+        // If there hasn't been a client secret set by this point,
+        // generate one for this session. It will only be used if
+        // we do email verification, but far simpler to just make
+        // sure we have one.
+        if (!this.params.clientSecret) {
+            this.params.clientSecret = client.generateClientSecret();
+        }
         return this._tryRegister(client);
     }
 

--- a/src/SignupStages.js
+++ b/src/SignupStages.js
@@ -158,7 +158,11 @@ class EmailIdentityStage extends Stage {
             return this._completeVerify();
         }
 
-        this.clientSecret = this.client.generateClientSecret();
+        this.clientSecret = this.signupInstance.params.clientSecret;
+        if (!this.clientSecret) {
+            return q.reject(new Error("No client secret specified by Signup class!"));
+        }
+
         var nextLink = this.signupInstance.params.registrationUrl +
                        '?client_secret=' +
                        encodeURIComponent(this.clientSecret) +


### PR DESCRIPTION
Generate a client secret in the Signup class (if we don't already have one) and re-use it for subsequent attempts to register, that way the IS can honour the sendAttempt flag and not re-send
the email if we're just retrying and requestToken becomes idempotent.