### PR TITLE
Give our input fields names

### DIFF
--- a/src/components/structures/login/ForgotPassword.js
+++ b/src/components/structures/login/ForgotPassword.js
@@ -162,16 +162,19 @@ module.exports = React.createClass({
                 <div>
                     <form onSubmit={this.onSubmitForm}>
                         <input className="mx_Login_field" ref="user" type="text"
+                            name="reset_email" // define a name so browser's password autofill gets less confused
                             value={this.state.email}
                             onChange={this.onInputChanged.bind(this, "email")}
                             placeholder="Email address" autoFocus />
                         <br />
                         <input className="mx_Login_field" ref="pass" type="password"
+                            name="reset_password"
                             value={this.state.password}
                             onChange={this.onInputChanged.bind(this, "password")}
                             placeholder="New password" />
                         <br />
                         <input className="mx_Login_field" ref="pass" type="password"
+                            name="reset_password_confirm"
                             value={this.state.password2}
                             onChange={this.onInputChanged.bind(this, "password2")}
                             placeholder="Confirm your new password" />

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -96,10 +96,12 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
             <div>
                 <form onSubmit={this.onSubmitForm}>
                 <input className="mx_Login_field" type="text"
+                    name="username" // make it a little easier for browser's remember-password
                     value={this.state.username} onChange={this.onUsernameChanged}
                     placeholder="Email or user name" autoFocus />
                 <br />
                 <input className={pwFieldClass} ref={(e) => {this._passwordField = e;}} type="password"
+                    name="password"
                     value={this.state.password} onChange={this.onPasswordChanged}
                     placeholder="Password" />
                 <br />


### PR DESCRIPTION
Otherwise browsers' 'Remember Password' feature has to guess
badly and ends up putting the login username / password in the
first two password reset fields which is a bit odd.

Fixes https://github.com/vector-im/vector-web/issues/2469