### PR TITLE
Run highlight.js asynchronously

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -302,13 +302,6 @@ export function bodyToHtml(content, highlights, opts) {
     return <span className={className} dangerouslySetInnerHTML={{ __html: safeBody }} />;
 }
 
-export function highlightDom(element) {
-    var blocks = element.getElementsByTagName("code");
-    for (var i = 0; i < blocks.length; i++) {
-        highlight.highlightBlock(blocks[i]);
-    }
-}
-
 export function emojifyText(text) {
     return {
         __html: unicodeToImage(escape(text)),


### PR DESCRIPTION
Move the very minimal logic of highlightDOM into TextualBody
because then we can avoid scheduling a lot of timeouts which
would ultimately do nothing (ie. any messages that don't have code
blocks).

This makes code blocks initially render unhighlighted and then 'pop' into colour slightly after switching rooms or the message appears. Personally I think this is probably OK?