### PR TITLE
Fix some markdown in the code style doc

### DIFF
--- a/code_style.md
+++ b/code_style.md
@@ -41,7 +41,7 @@ General Style
   "bad" // Bad
   'good' // Good
   ```
-- Use parentheses or `\`` instead of '\\' for line continuation where ever possible
+- Use parentheses or `` ` `` instead of `\` for line continuation where ever possible
 - Open braces on the same line (consistent with Node):
 
   ```javascript


### PR DESCRIPTION
Yeah. That really is the way you embed a backtick in backticks in markdown.