### PR TITLE
Add the MatrixClient to the react context

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -28,6 +28,8 @@ import sdk from '../../index';
  *
  * Currently it's very tightly coupled with MatrixChat. We should try to do
  * something about that.
+ *
+ * Components mounted below us can access the matrix client via the react context.
  */
 export default React.createClass({
     displayName: 'LoggedInView',
@@ -42,7 +44,20 @@ export default React.createClass({
         // and lots and lots of other stuff.
     },
 
+    childContextTypes: {
+        matrixClient: React.PropTypes.instanceOf(Matrix.MatrixClient),
+    },
+
+    getChildContext: function() {
+        return {
+            matrixClient: this._matrixClient,
+        };
+    },
+
     componentWillMount: function() {
+        // stash the MatrixClient in case we log out before we are unmounted
+        this._matrixClient = this.props.matrixClient;
+
         // _scrollStateMap is a map from room id to the scroll state returned by
         // RoomView.getScrollState()
         this._scrollStateMap = {};

--- a/src/wrappers/WithMatrixClient.js
+++ b/src/wrappers/WithMatrixClient.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as Matrix from 'matrix-js-sdk';
+import React from 'react';
+
+/**
+ * Wraps a react class, pulling the MatrixClient from the context and adding it
+ * as a 'matrixClient' property instead.
+ *
+ * This abstracts the use of the context API, so that we can use a different
+ * mechanism in future.
+ */
+export default function(WrappedComponent) {
+    return React.createClass({
+        displayName: "MatrixClient<" + WrappedComponent.displayName + ">",
+
+        contextTypes: {
+            matrixClient: React.PropTypes.instanceOf(Matrix.MatrixClient).isRequired,
+        },
+
+        render: function() {
+            return <WrappedComponent {...this.props} matrixClient={this.context.matrixClient} />;
+        },
+    });
+};


### PR DESCRIPTION
Because that's the reacty way. Also a wrapper which can be put around components wanting to get hold of the matrix client.

(includes #535)