### PR TITLE
Fix the vector web version in UserSettings

### DIFF
--- a/src/BasePlatform.js
+++ b/src/BasePlatform.js
@@ -65,4 +65,12 @@ export default class BasePlatform {
 
     displayNotification(title: string, msg: string, avatarUrl: string) {
     }
+
+    /**
+     * Returns a promise that resolves to a string representing
+     * the current version of the application.
+     */
+    getAppVersion() {
+        return q();
+    }
 }

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -167,7 +167,6 @@ export default React.createClass({
             case PageTypes.UserSettings:
                 page_element = <UserSettings
                     onClose={this.props.onUserSettingsClose}
-                    version={this.props.version}
                     brand={this.props.config.brand}
                     collapsedRhs={this.props.collapse_rhs}
                     enableLabs={this.props.config.enableLabs}

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -17,6 +17,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var sdk = require('../../index');
 var MatrixClientPeg = require("../../MatrixClientPeg");
+var PlatformPeg = require("../../PlatformPeg");
 var Modal = require('../../Modal');
 var dis = require("../../dispatcher");
 var q = require('q');
@@ -60,10 +61,21 @@ module.exports = React.createClass({
             threePids: [],
             phase: "UserSettings.LOADING", // LOADING, DISPLAY
             email_add_pending: false,
+            vectorVersion: null,
         };
     },
 
     componentWillMount: function() {
+        if (PlatformPeg.get()) {
+            PlatformPeg.get().getAppVersion().done((appVersion) => {
+                this.setState({
+                    vectorVersion: appVersion,
+                });
+            }, (e) => {
+                console.log("Failed to fetch app version", e);
+            });
+        }
+
         dis.dispatch({
             action: 'ui_opacity',
             sideOpacity: 0.3,
@@ -587,7 +599,7 @@ module.exports = React.createClass({
                     </div>
                     <div className="mx_UserSettings_advanced">
                         matrix-react-sdk version: {REACT_SDK_VERSION}<br/>
-                        vector-web version: {this.props.version}<br/>
+                        vector-web version: {this.state.vectorVersion !== null ? this.state.vectorVersion : 'unknown'}<br/>
                         olm version: {olmVersionString}<br/>
                     </div>
                 </div>


### PR DESCRIPTION
Add a getAppVersion() function to the platform rather than relying
on the updater code firing an event before we know what the app
version is.