### PR TITLE
Truncate consecutive member events

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -105,6 +105,8 @@ import views$elements$EditableTextContainer from './components/views/elements/Ed
 views$elements$EditableTextContainer && (module.exports.components['views.elements.EditableTextContainer'] = views$elements$EditableTextContainer);
 import views$elements$EmojiText from './components/views/elements/EmojiText';
 views$elements$EmojiText && (module.exports.components['views.elements.EmojiText'] = views$elements$EmojiText);
+import views$elements$MemberEventListSummary from './components/views/elements/MemberEventListSummary';
+views$elements$MemberEventListSummary && (module.exports.components['views.elements.MemberEventListSummary'] = views$elements$MemberEventListSummary);
 import views$elements$PowerSelector from './components/views/elements/PowerSelector';
 views$elements$PowerSelector && (module.exports.components['views.elements.PowerSelector'] = views$elements$PowerSelector);
 import views$elements$ProgressBar from './components/views/elements/ProgressBar';

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -305,8 +305,8 @@ module.exports = React.createClass({
                     }
                     summarisedEvents.push(collapsedMxEv);
                 }
-                // At this point, i = this.props.events.length OR i = the index of the first event
-                // to NOT be a MembershipChange after a sequence of MembershipChanges
+                // At this point, i = this.props.events.length OR i = the index of the last
+                // MembershipChange in a sequence of MembershipChanges
 
                 let renderEvents = (pEvent, events) => {
                     if (events.length === 0) {

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -276,6 +276,11 @@ module.exports = React.createClass({
             this.currentGhostEventId = null;
         }
 
+        var isMembershipChange = (e) =>
+            e.getType() === 'm.room.member'
+            && ['join', 'leave'].indexOf(e.event.content.membership) !== -1
+            && (!e.event.prev_content || e.event.content.membership  !== e.event.prev_content.membership);
+
         for (i = 0; i < this.props.events.length; i++) {
             var mxEv = this.props.events[i];
             var wantTile = true;
@@ -286,11 +291,6 @@ module.exports = React.createClass({
             }
 
             var last = (i == lastShownEventIndex);
-
-            var isMembershipChange = (e) =>
-                e.getType() === 'm.room.member'
-                && ['join', 'leave'].indexOf(e.event.content.membership) !== -1
-                && (!e.event.prev_content || e.event.content.membership  !== e.event.prev_content.membership);
 
             // Wrap consecutive member events in a ListSummary
             if (isMembershipChange(mxEv)) {

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -294,8 +294,6 @@ module.exports = React.createClass({
 
             // Wrap consecutive member events in a ListSummary
             if (isMembershipChange(mxEv)) {
-                // Prevent message continuations between truncations
-                prevEvent = null;
 
                 let summarisedEvents = [mxEv];
                 i++;
@@ -308,15 +306,15 @@ module.exports = React.createClass({
                     }
                     summarisedEvents.push(collapsedMxEv);
                 }
-                let ePrev = null;
+
                 let renderEvents = (events) => {
                     if (events.length === 0) {
                         return null;
                     }
                     return events.map(
                         (e) => {
-                            let ret = this._getTilesForEvent(ePrev, e);
-                            ePrev = e;
+                            // e, e to prevent date seperators
+                            let ret = this._getTilesForEvent(e, e);
                             return ret;
                         }
                     ).reduce((a,b) => a.concat(b));
@@ -327,6 +325,8 @@ module.exports = React.createClass({
                         renderEvents={renderEvents}
                     />
                 );
+                // Use the first member event to create scroll token
+                ret.push(<li key={eventId} data-scroll-token={eventId}/>);
                 continue;
             }
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -308,28 +308,23 @@ module.exports = React.createClass({
                 // At this point, i = this.props.events.length OR i = the index of the last
                 // MembershipChange in a sequence of MembershipChanges
 
-                let renderEvents = (pEvent, events) => {
-                    if (events.length === 0) {
-                        return null;
+                let eventTiles = summarisedEvents.map(
+                    (e) => {
+                        let ret = this._getTilesForEvent(prevEvent, e);
+                        prevEvent = e;
+                        return ret;
                     }
-                    return events.map(
-                        (e) => {
-                            let ret = this._getTilesForEvent(pEvent, e);
-                            pEvent = e;
-                            return ret;
-                        }
-                    ).reduce((a,b) => a.concat(b));
-                };
+                ).reduce((a,b) => a.concat(b));
 
-                let eventTiles = renderEvents(prevEvent, summarisedEvents);
+                if (eventTiles.length === 0) {
+                    eventTiles = null;
+                }
 
                 ret.push(
                     <MemberEventListSummary events={summarisedEvents}>
                         {eventTiles}
                     </MemberEventListSummary>
                 );
-                // Set previous event to last MembershipChange
-                prevEvent = this.props.events[i - 1];
                 continue;
             }
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -328,7 +328,8 @@ module.exports = React.createClass({
                         {eventTiles}
                     </MemberEventListSummary>
                 );
-                prevEvent = mxEv;
+                // Set previous event to last MembershipChange
+                prevEvent = this.props.events[i - 1];
                 continue;
             }
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -20,7 +20,6 @@ var dis = require("../../dispatcher");
 var sdk = require('../../index');
 
 var MatrixClientPeg = require('../../MatrixClientPeg')
-var MemberEventListSummary = require('../views/elements/MemberEventListSummary.js');
 
 /* (almost) stateless UI component which builds the event tiles in the room timeline.
  */
@@ -230,6 +229,7 @@ module.exports = React.createClass({
 
     _getEventTiles: function() {
         var EventTile = sdk.getComponent('rooms.EventTile');
+        const MemberEventListSummary = sdk.getComponent('views.elements.MemberEventListSummary');
 
         this.eventNodes = {};
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -320,12 +320,13 @@ module.exports = React.createClass({
                         }
                     ).reduce((a,b) => a.concat(b));
                 };
+
+                let eventTiles = renderEvents(prevEvent, summarisedEvents);
+
                 ret.push(
-                    <MemberEventListSummary
-                        events={summarisedEvents}
-                        previousEvent={prevEvent}
-                        renderEvents={renderEvents}
-                    />
+                    <MemberEventListSummary events={summarisedEvents}>
+                        {eventTiles}
+                    </MemberEventListSummary>
                 );
                 prevEvent = mxEv;
                 continue;

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -305,6 +305,9 @@ module.exports = React.createClass({
                     }
                     summarisedEvents.push(collapsedMxEv);
                 }
+                // At this point, i = this.props.events.length OR i = the index of the first event
+                // to NOT be a MembershipChange after a sequence of MembershipChanges
+
                 let renderEvents = (pEvent, events) => {
                     if (events.length === 0) {
                         return null;

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -294,7 +294,6 @@ module.exports = React.createClass({
 
             // Wrap consecutive member events in a ListSummary
             if (isMembershipChange(mxEv)) {
-
                 let summarisedEvents = [mxEv];
                 i++;
                 for (;i < this.props.events.length; i++) {
@@ -306,15 +305,14 @@ module.exports = React.createClass({
                     }
                     summarisedEvents.push(collapsedMxEv);
                 }
-
-                let renderEvents = (events) => {
+                let renderEvents = (pEvent, events) => {
                     if (events.length === 0) {
                         return null;
                     }
                     return events.map(
                         (e) => {
-                            // e, e to prevent date seperators
-                            let ret = this._getTilesForEvent(e, e);
+                            let ret = this._getTilesForEvent(pEvent, e);
+                            pEvent = e;
                             return ret;
                         }
                     ).reduce((a,b) => a.concat(b));
@@ -322,11 +320,11 @@ module.exports = React.createClass({
                 ret.push(
                     <MemberEventListSummary
                         events={summarisedEvents}
+                        previousEvent={prevEvent}
                         renderEvents={renderEvents}
                     />
                 );
-                // Use the first member event to create scroll token
-                ret.push(<li key={eventId} data-scroll-token={eventId}/>);
+                prevEvent = mxEv;
                 continue;
             }
 

--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -19,6 +19,7 @@ limitations under the License.
 var React = require('react');
 var Avatar = require('../../../Avatar');
 var sdk = require("../../../index");
+const dispatcher = require("../../../dispatcher");
 
 module.exports = React.createClass({
     displayName: 'MemberAvatar',
@@ -27,14 +28,17 @@ module.exports = React.createClass({
         member: React.PropTypes.object.isRequired,
         width: React.PropTypes.number,
         height: React.PropTypes.number,
-        resizeMethod: React.PropTypes.string
+        resizeMethod: React.PropTypes.string,
+        // Whether the onClick of the avatar should dispatch 'view_user'
+        viewUserOnClick: React.PropTypes.boolean
     },
 
     getDefaultProps: function() {
         return {
             width: 40,
             height: 40,
-            resizeMethod: 'crop'
+            resizeMethod: 'crop',
+            viewUserOnClick: false
         }
     },
 
@@ -65,9 +69,19 @@ module.exports = React.createClass({
 
         var {member, ...otherProps} = this.props;
 
+        var onClick = null;
+        if (this.props.viewUserOnClick) {
+            onClick = () => {
+                dispatcher.dispatch({
+                    action: 'view_user',
+                    member: this.props.member,
+                });
+            }
+        }
+
         return (
             <BaseAvatar {...otherProps} name={this.state.name} title={this.state.title}
-                idName={member.userId} url={this.state.imageUrl} />
+                idName={member.userId} url={this.state.imageUrl} onClick={onClick}/>
         );
     }
 });

--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -30,7 +30,7 @@ module.exports = React.createClass({
         height: React.PropTypes.number,
         resizeMethod: React.PropTypes.string,
         // Whether the onClick of the avatar should dispatch 'view_user'
-        viewUserOnClick: React.PropTypes.boolean
+        viewUserOnClick: React.PropTypes.boolean,
     },
 
     getDefaultProps: function() {
@@ -38,7 +38,7 @@ module.exports = React.createClass({
             width: 40,
             height: 40,
             resizeMethod: 'crop',
-            viewUserOnClick: false
+            viewUserOnClick: false,
         }
     },
 

--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -29,7 +29,9 @@ module.exports = React.createClass({
         width: React.PropTypes.number,
         height: React.PropTypes.number,
         resizeMethod: React.PropTypes.string,
-        // Whether the onClick of the avatar should dispatch 'view_user'
+        // The onClick to give the avatar
+        onClick: React.PropTypes.function,
+        // Whether the onClick of the avatar should be overriden to dispatch 'view_user'
         viewUserOnClick: React.PropTypes.boolean,
     },
 
@@ -67,9 +69,8 @@ module.exports = React.createClass({
     render: function() {
         var BaseAvatar = sdk.getComponent("avatars.BaseAvatar");
 
-        var {member, ...otherProps} = this.props;
+        var {member, onClick, ...otherProps} = this.props;
 
-        var onClick = null;
         if (this.props.viewUserOnClick) {
             onClick = () => {
                 dispatcher.dispatch({

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -92,12 +92,9 @@ module.exports = React.createClass({
     renderSummary: function(joinEvents, leaveEvents) {
         let joiners = this.renderNameList(joinEvents);
         let remainingJoiners = joinEvents.length - this.props.summaryLength;
-
         let leavers = this.renderNameList(leaveEvents);
         let remainingLeavers = leaveEvents.length - this.props.summaryLength;
-
         let joinSummary = null;
-
         if (joiners) {
             joinSummary = (
                 <span>
@@ -105,9 +102,7 @@ module.exports = React.createClass({
                 </span>
             );
         }
-
         let leaveSummary = '';
-
         if (leavers) {
             leaveSummary = (
                 <span>
@@ -115,7 +110,6 @@ module.exports = React.createClass({
                 </span>
             );
         }
-
         return (
             <span>
                 {joinSummary}{joinSummary && leaveSummary?'; ':''}
@@ -124,10 +118,7 @@ module.exports = React.createClass({
         );
     },
 
-
-
     renderAvatars: function(events) {
-
         let avatars = events.slice(0, this.props.avatarsMaxLength).map((e) => {
             let onClickAvatar = () => {
                 dispatcher.dispatch({
@@ -201,7 +192,6 @@ module.exports = React.createClass({
             toggleButton = (
                 <a onClick={this.toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
             );
-
             let noun = (joinAndLeft === 1 ? 'user' : 'others');
 
             summaryContainer = (

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -75,20 +75,20 @@ module.exports = React.createClass({
             return this._getEventSenderName(lastEvent);
         }
 
-        // Special case the last name. ' and ' might be included later
-        // So you have two cases:
-        if (originalNumber <= this.props.summaryLength) {
-            // name1, name2 and name3
-            names += ' and ';
-        } else {
-            // name1, name2, name3 [and 100 others]
-            names += ', ';
+        let lastName = this._getEventSenderName(lastEvent);
+        if (names.length === 0) {
+            // special-case for a single event
+            return lastName;
         }
 
         let remaining = originalNumber - this.props.summaryLength;
-        let remainingDesc = (remaining > 0 ? ' and ' + remaining + ' others ':'');
-
-        return names + this._getEventSenderName(lastEvent) + remainingDesc;
+        if (remaining > 0) {
+            //  name1, name2, name3, and 100 others
+            return names + ', ' + lastName + ', and ' + remaining + ' others';
+        } else {
+            //  name1, name2 and name3
+            return names + ' and ' + lastName;
+        }
     },
 
     _renderSummary: function(joinEvents, leaveEvents) {

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -103,7 +103,7 @@ module.exports = React.createClass({
                 </span>
             );
         }
-        let leaveSummary = '';
+        let leaveSummary = null;
         if (leavers) {
             leaveSummary = (
                 <span>
@@ -186,7 +186,8 @@ module.exports = React.createClass({
             toggleButton = (
                 <a onClick={this._toggleSummary}>{expanded?'collapse':'expand'}</a>
             );
-            let noun = (joinAndLeft === 1 ? 'user' : 'others');
+            let plural = (joinEvents.length + leaveEvents.length > 0) ? 'others' : 'users';
+            let noun = (joinAndLeft === 1 ? 'user' : plural);
 
             summaryContainer = (
                 <div className="mx_EventTile_line">

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -184,7 +184,7 @@ module.exports = React.createClass({
         if (!fewEvents) {
             summary = this._renderSummary(joinEvents, leaveEvents);
             toggleButton = (
-                <a onClick={this._toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
+                <a onClick={this._toggleSummary}>{expanded?'collapse':'expand'}</a>
             );
             let noun = (joinAndLeft === 1 ? 'user' : 'others');
 

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -86,7 +86,7 @@ module.exports = React.createClass({
         }
 
         let remaining = originalNumber - this.props.summaryLength;
-        let remainingDesc = (remaining > 0 ? 'and ' + remaining + ' others ':'');
+        let remainingDesc = (remaining > 0 ? ' and ' + remaining + ' others ':'');
 
         return names + this._getEventSenderName(lastEvent) + remainingDesc;
     },

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -23,6 +23,8 @@ module.exports = React.createClass({
     propTypes: {
         // An array of member events to summarise
         events: React.PropTypes.array.isRequired,
+        // An array of EventTiles to render when expanded
+        children: React.PropTypes.array.isRequired,
         // The maximum number of names to show in either the join or leave summaries
         summaryLength: React.PropTypes.number,
         // The maximum number of avatars to display in the summary

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const React = require('react');
+import React from 'react';
 const MemberAvatar = require('../avatars/MemberAvatar.js');
 const dispatcher = require("../../../dispatcher");
 

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -45,20 +45,20 @@ module.exports = React.createClass({
         };
     },
 
-    toggleSummary: function() {
+    _toggleSummary: function() {
         this.setState({
             expanded: !this.state.expanded,
         });
     },
 
-    getEventSenderName: function(ev) {
+    _getEventSenderName: function(ev) {
         if (!ev) {
             return 'undefined';
         }
         return ev.sender.name || ev.event.content.displayname || ev.getSender();
     },
 
-    renderNameList: function(events) {
+    _renderNameList: function(events) {
         if (events.length === 0) {
             return null;
         }
@@ -67,11 +67,11 @@ module.exports = React.createClass({
         let lastEvent = events.pop();
 
         let names = events.map((ev) => {
-            return this.getEventSenderName(ev);
+            return this._getEventSenderName(ev);
         }).join(', ');
 
         if (names.length === 0) {
-            return this.getEventSenderName(lastEvent);
+            return this._getEventSenderName(lastEvent);
         }
 
         // Special case the last name. ' and ' might be included later
@@ -83,13 +83,13 @@ module.exports = React.createClass({
             // name1, name2, name3 [and 100 others]
             names += ', ';
         }
-        return names + this.getEventSenderName(lastEvent);
+        return names + this._getEventSenderName(lastEvent);
     },
 
-    renderSummary: function(joinEvents, leaveEvents) {
-        let joiners = this.renderNameList(joinEvents);
+    _renderSummary: function(joinEvents, leaveEvents) {
+        let joiners = this._renderNameList(joinEvents);
         let remainingJoiners = joinEvents.length - this.props.summaryLength;
-        let leavers = this.renderNameList(leaveEvents);
+        let leavers = this._renderNameList(leaveEvents);
         let remainingLeavers = leaveEvents.length - this.props.summaryLength;
         let joinSummary = null;
         if (joiners) {
@@ -115,7 +115,7 @@ module.exports = React.createClass({
         );
     },
 
-    renderAvatars: function(events) {
+    _renderAvatars: function(events) {
         let avatars = events.slice(0, this.props.avatarsMaxLength).map((e) => {
             let onClickAvatar = () => {
                 dispatcher.dispatch({
@@ -180,14 +180,14 @@ module.exports = React.createClass({
             expandedEvents = this.props.children;
         }
 
-        let avatars = this.renderAvatars(joinEvents.concat(leaveEvents));
+        let avatars = this._renderAvatars(joinEvents.concat(leaveEvents));
 
         let toggleButton = null;
         let summaryContainer = null;
         if (!fewEvents) {
-            summary = this.renderSummary(joinEvents, leaveEvents);
+            summary = this._renderSummary(joinEvents, leaveEvents);
             toggleButton = (
-                <a onClick={this.toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
+                <a onClick={this._toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
             );
             let noun = (joinAndLeft === 1 ? 'user' : 'others');
 

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -71,10 +71,6 @@ module.exports = React.createClass({
             return this._getEventSenderName(ev);
         }).join(', ');
 
-        if (names.length === 0) {
-            return this._getEventSenderName(lastEvent);
-        }
-
         let lastName = this._getEventSenderName(lastEvent);
         if (names.length === 0) {
             // special-case for a single event

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -22,7 +22,7 @@ module.exports = React.createClass({
 
     propTypes: {
         // An array of member events to summarise
-        events: React.PropTypes.array,
+        events: React.PropTypes.array.isRequired,
         // The maximum number of names to show in either the join or leave summaries
         summaryLength: React.PropTypes.number,
         // The maximum number of avatars to display in the summary

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -31,6 +31,7 @@ module.exports = React.createClass({
         threshold: React.PropTypes.number,
         // The function to render events if they are not being summarised
         renderEvents: React.PropTypes.function,
+        previousEvent: React.PropTypes.object,
     },
 
     getInitialState: function() {
@@ -190,7 +191,7 @@ module.exports = React.createClass({
         let expandedEvents = null;
 
         if (expanded) {
-            expandedEvents = this.props.renderEvents(eventsToRender);
+            expandedEvents = this.props.renderEvents(this.props.previousEvent, eventsToRender);
         }
 
         let avatars = this.renderAvatars(joinEvents.concat(leaveEvents));

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -180,7 +180,7 @@ module.exports = React.createClass({
         let expandedEvents = null;
 
         if (expanded) {
-            expandedEvents = this.props.renderEvents(this.props.previousEvent, eventsToRender);
+            expandedEvents = this.props.children;
         }
 
         let avatars = this.renderAvatars(joinEvents.concat(leaveEvents));

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -1,0 +1,228 @@
+/*
+Copyright 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const React = require('react');
+const MemberAvatar = require('../avatars/MemberAvatar.js');
+const dispatcher = require("../../../dispatcher");
+
+module.exports = React.createClass({
+    displayName: 'MemberEventListSummary',
+
+    propTypes: {
+        // An array of member events to summarise
+        events: React.PropTypes.array,
+        // The maximum number of names to show in either the join or leave summaries
+        summaryLength: React.PropTypes.number,
+        // The maximum number of avatars to display in the summary
+        avatarsMaxLength: React.PropTypes.number,
+        // The minimum number of events needed to trigger summarisation
+        threshold: React.PropTypes.number,
+        // The function to render events if they are not being summarised
+        renderEvents: React.PropTypes.function,
+    },
+
+    getInitialState: function() {
+        return {
+            expanded: false,
+        };
+    },
+
+    getDefaultProps: function() {
+        return {
+            summaryLength: 3,
+            threshold: 3,
+            avatarsMaxLength: 5
+        };
+    },
+
+    toggleSummary: function() {
+        this.setState({
+            expanded: !this.state.expanded,
+        });
+    },
+
+    getEventSenderName: function(ev) {
+        if (!ev) {
+            return 'undefined';
+        }
+        return ev.sender.name || ev.event.content.displayname || ev.getSender();
+    },
+
+    renderNameList: function(events) {
+        if (events.length === 0) {
+            return null;
+        }
+        let originalNumber = events.length;
+        events = events.slice(0, this.props.summaryLength);
+        let lastEvent = events.pop();
+
+        let names = events.map((ev) => {
+            return this.getEventSenderName(ev);
+        }).join(', ');
+
+        if (names.length === 0) {
+            return this.getEventSenderName(lastEvent);
+        }
+
+        // Special case the last name. ' and ' might be included later
+        // So you have two cases:
+        if (originalNumber <= this.props.summaryLength) {
+            // name1, name2 and name3
+            names += ' and ';
+        } else {
+            // name1, name2, name3 [and 100 others]
+            names += ', ';
+        }
+        return names + this.getEventSenderName(lastEvent);
+    },
+
+    renderSummary: function(joinEvents, leaveEvents) {
+        let joiners = this.renderNameList(joinEvents);
+        let remainingJoiners = joinEvents.length - this.props.summaryLength;
+
+        let leavers = this.renderNameList(leaveEvents);
+        let remainingLeavers = leaveEvents.length - this.props.summaryLength;
+
+        let joinSummary = null;
+
+        if (joiners) {
+            joinSummary = (
+                <span>
+                    {joiners} {remainingJoiners > 0 ? 'and ' + remainingJoiners + ' others ':''}joined the room
+                </span>
+            );
+        }
+
+        let leaveSummary = '';
+
+        if (leavers) {
+            leaveSummary = (
+                <span>
+                    {leavers} {remainingLeavers > 0 ? 'and ' + remainingLeavers + ' others ':''}left the room
+                </span>
+            );
+        }
+
+        return (
+            <span>
+                {joinSummary}{joinSummary && leaveSummary?'; ':''}
+                {leaveSummary}
+            </span>
+        );
+    },
+
+
+
+    renderAvatars: function(events) {
+
+        let avatars = events.slice(0, this.props.avatarsMaxLength).map((e) => {
+            let onClickAvatar = () => {
+                dispatcher.dispatch({
+                    action: 'view_user',
+                    member: e.sender,
+                });
+            };
+            return (
+                <MemberAvatar
+                    key={e.getId()}
+                    member={e.sender}
+                    width={14}
+                    height={14}
+                    onClick={onClickAvatar}
+                />
+            );
+        });
+
+        return (
+            <span>
+                {avatars}
+            </span>
+        );
+    },
+
+    render: function() {
+        let summary = null;
+
+        // Reorder events so that joins come before leaves
+        let eventsToRender = this.props.events;
+
+        // Filter out those who joined, then left
+        let filteredEvents = eventsToRender.filter(
+            (e) => {
+                return eventsToRender.filter(
+                    (e2) => {
+                        return e.getSender() === e2.getSender()
+                            && e.event.content.membership !== e2.event.content.membership;
+                    }
+                ).length === 0;
+            }
+        );
+
+        let joinAndLeft = (eventsToRender.length - filteredEvents.length) / 2;
+        if (joinAndLeft <= 0 || joinAndLeft % 1 !== 0) {
+            joinAndLeft = null;
+        }
+
+        let joinEvents = filteredEvents.filter((ev) => {
+            return ev.event.content.membership === 'join';
+        });
+
+        let leaveEvents = filteredEvents.filter((ev) => {
+            return ev.event.content.membership === 'leave';
+        });
+
+        let fewEvents = eventsToRender.length < this.props.threshold;
+        console.log(eventsToRender.length, joinEvents.length, leaveEvents.length, this.state.expanded, fewEvents);
+
+        let expanded = this.state.expanded || fewEvents;
+        let expandedEvents = null;
+
+        if (expanded) {
+            expandedEvents = this.props.renderEvents(eventsToRender);
+        }
+
+        let avatars = this.renderAvatars(joinEvents.concat(leaveEvents));
+
+        let toggleButton = null;
+        let summaryContainer = null;
+        if (!fewEvents) {
+            summary = this.renderSummary(joinEvents, leaveEvents);
+            toggleButton = (
+                <a onClick={this.toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
+            );
+
+            summaryContainer = (
+                <div className="mx_EventTile_line">
+                    <div className="mx_EventTile_info">
+                        <span className="mx_MemberEventListSummary_avatars">
+                            {avatars}
+                        </span>
+                        <span className="mx_TextualEvent mx_MemberEventListSummary_summary">
+                            {summary}{joinAndLeft? '. ' + joinAndLeft + ' others joined and left' : ''}
+                        </span>&nbsp;
+                        {toggleButton}
+                    </div>
+                </div>
+            );
+        }
+
+        return (
+            <div className="mx_MemberEventListSummary">
+                {summaryContainer}
+                {expandedEvents}
+            </div>
+        );
+    },
+});

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -85,19 +85,22 @@ module.exports = React.createClass({
             // name1, name2, name3 [and 100 others]
             names += ', ';
         }
-        return names + this._getEventSenderName(lastEvent);
+
+        let remaining = originalNumber - this.props.summaryLength;
+        let remainingDesc = (remaining > 0 ? 'and ' + remaining + ' others ':'');
+
+        return names + this._getEventSenderName(lastEvent) + remainingDesc;
     },
 
     _renderSummary: function(joinEvents, leaveEvents) {
         let joiners = this._renderNameList(joinEvents);
-        let remainingJoiners = joinEvents.length - this.props.summaryLength;
         let leavers = this._renderNameList(leaveEvents);
-        let remainingLeavers = leaveEvents.length - this.props.summaryLength;
+
         let joinSummary = null;
         if (joiners) {
             joinSummary = (
                 <span>
-                    {joiners} {remainingJoiners > 0 ? 'and ' + remainingJoiners + ' others ':''}joined the room
+                    {joiners} joined the room
                 </span>
             );
         }
@@ -105,7 +108,7 @@ module.exports = React.createClass({
         if (leavers) {
             leaveSummary = (
                 <span>
-                    {leavers} {remainingLeavers > 0 ? 'and ' + remainingLeavers + ' others ':''}left the room
+                    {leavers} left the room
                 </span>
             );
         }

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -184,7 +184,9 @@ module.exports = React.createClass({
         if (!fewEvents) {
             summary = this._renderSummary(joinEvents, leaveEvents);
             toggleButton = (
-                <a onClick={this._toggleSummary}>{expanded?'collapse':'expand'}</a>
+                <a className="mx_MemberEventListSummary_toggle" onClick={this._toggleSummary}>
+                    {expanded ? 'collapse' : 'expand'}
+                </a>
             );
             let plural = (joinEvents.length + leaveEvents.length > 0) ? 'others' : 'users';
             let noun = (joinAndLeft === 1 ? 'user' : plural);

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -185,8 +185,6 @@ module.exports = React.createClass({
         });
 
         let fewEvents = eventsToRender.length < this.props.threshold;
-        console.log(eventsToRender.length, joinEvents.length, leaveEvents.length, this.state.expanded, fewEvents);
-
         let expanded = this.state.expanded || fewEvents;
         let expandedEvents = null;
 
@@ -204,6 +202,8 @@ module.exports = React.createClass({
                 <a onClick={this.toggleSummary} href="javascript:;">{expanded?'collapse':'expand'}</a>
             );
 
+            let noun = (joinAndLeft === 1 ? 'user' : 'others');
+
             summaryContainer = (
                 <div className="mx_EventTile_line">
                     <div className="mx_EventTile_info">
@@ -211,7 +211,7 @@ module.exports = React.createClass({
                             {avatars}
                         </span>
                         <span className="mx_TextualEvent mx_MemberEventListSummary_summary">
-                            {summary}{joinAndLeft? '. ' + joinAndLeft + ' others joined and left' : ''}
+                            {summary}{joinAndLeft? '. ' + joinAndLeft + ' ' + noun + ' joined and left' : ''}
                         </span>&nbsp;
                         {toggleButton}
                     </div>

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -29,9 +29,6 @@ module.exports = React.createClass({
         avatarsMaxLength: React.PropTypes.number,
         // The minimum number of events needed to trigger summarisation
         threshold: React.PropTypes.number,
-        // The function to render events if they are not being summarised
-        renderEvents: React.PropTypes.function,
-        previousEvent: React.PropTypes.object,
     },
 
     getInitialState: function() {

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -15,7 +15,6 @@ limitations under the License.
 */
 import React from 'react';
 const MemberAvatar = require('../avatars/MemberAvatar.js');
-const dispatcher = require("../../../dispatcher");
 
 module.exports = React.createClass({
     displayName: 'MemberEventListSummary',
@@ -122,19 +121,12 @@ module.exports = React.createClass({
 
     _renderAvatars: function(events) {
         let avatars = events.slice(0, this.props.avatarsMaxLength).map((e) => {
-            let onClickAvatar = () => {
-                dispatcher.dispatch({
-                    action: 'view_user',
-                    member: e.sender,
-                });
-            };
             return (
                 <MemberAvatar
                     key={e.getId()}
                     member={e.sender}
                     width={14}
                     height={14}
-                    onClick={onClickAvatar}
                 />
             );
         });

--- a/src/components/views/elements/TruncatedList.js
+++ b/src/components/views/elements/TruncatedList.js
@@ -28,27 +28,15 @@ module.exports = React.createClass({
         createOverflowElement: React.PropTypes.func
     },
 
-    getInitialState: function() {
-        return {
-            enabled: true,
-        };
-    },
-
     getDefaultProps: function() {
         return {
             truncateAt: 2,
-            createOverflowElement: function(overflowCount, totalCount, toggleTruncate, isExpanded) {
+            createOverflowElement: function(overflowCount, totalCount) {
                 return (
                     <div>And {overflowCount} more...</div>
                 );
             }
         };
-    },
-
-    toggleTruncate: function() {
-        this.setState({
-            enabled: !this.state.enabled
-        });
     },
 
     render: function() {
@@ -60,24 +48,18 @@ module.exports = React.createClass({
 
         var childCount = childArray.length;
 
-        if (this.state.enabled && this.props.truncateAt >= 0) {
+        if (this.props.truncateAt >= 0) {
             var overflowCount = childCount - this.props.truncateAt;
 
             if (overflowCount > 1) {
                 overflowJsx = this.props.createOverflowElement(
-                    overflowCount, childCount, this.toggleTruncate
+                    overflowCount, childCount
                 );
-
+                
                 // cut out the overflow elements
                 childArray.splice(childCount - overflowCount, overflowCount);
                 childsJsx = childArray; // use what is left
             }
-        }
-
-        if (!this.state.enabled) {
-            overflowJsx = this.props.createOverflowElement(
-                0, childCount, this.toggleTruncate, true
-            );
         }
 
         return (

--- a/src/components/views/elements/TruncatedList.js
+++ b/src/components/views/elements/TruncatedList.js
@@ -28,15 +28,27 @@ module.exports = React.createClass({
         createOverflowElement: React.PropTypes.func
     },
 
+    getInitialState: function() {
+        return {
+            enabled: true,
+        };
+    },
+
     getDefaultProps: function() {
         return {
             truncateAt: 2,
-            createOverflowElement: function(overflowCount, totalCount) {
+            createOverflowElement: function(overflowCount, totalCount, toggleTruncate, isExpanded) {
                 return (
                     <div>And {overflowCount} more...</div>
                 );
             }
         };
+    },
+
+    toggleTruncate: function() {
+        this.setState({
+            enabled: !this.state.enabled
+        });
     },
 
     render: function() {
@@ -48,18 +60,24 @@ module.exports = React.createClass({
 
         var childCount = childArray.length;
 
-        if (this.props.truncateAt >= 0) {
+        if (this.state.enabled && this.props.truncateAt >= 0) {
             var overflowCount = childCount - this.props.truncateAt;
 
             if (overflowCount > 1) {
                 overflowJsx = this.props.createOverflowElement(
-                    overflowCount, childCount
+                    overflowCount, childCount, this.toggleTruncate
                 );
-                
+
                 // cut out the overflow elements
                 childArray.splice(childCount - overflowCount, overflowCount);
                 childsJsx = childArray; // use what is left
             }
+        }
+
+        if (!this.state.enabled) {
+            overflowJsx = this.props.createOverflowElement(
+                0, childCount, this.toggleTruncate, true
+            );
         }
 
         return (

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -348,13 +348,6 @@ module.exports = React.createClass({
         </span>;
     },
 
-    onMemberAvatarClick: function(event) {
-        dispatcher.dispatch({
-            action: 'view_user',
-            member: this.props.mxEvent.sender,
-        });
-    },
-
     onSenderProfileClick: function(event) {
         var mxEvent = this.props.mxEvent;
         dispatcher.dispatch({
@@ -443,7 +436,7 @@ module.exports = React.createClass({
                     <div className="mx_EventTile_avatar">
                         <MemberAvatar member={this.props.mxEvent.sender}
                             width={avatarSize} height={avatarSize}
-                            onClick={ this.onMemberAvatarClick }
+                            viewUserOnClick={true}
                         />
                     </div>
             );


### PR DESCRIPTION
This is needed for the IRC bridge to be able to do full membership list syncing (with quit/netsplit debouncing) without cluttering the message panel.

![2016-11-08-162009_321x313_scrot](https://cloud.githubusercontent.com/assets/6750344/20107742/847eb254-a5d1-11e6-9f9f-d7035d1b3c54.png)

(See https://github.com/vector-im/vector-web/issues/349)

Also, for CSS changes, see https://github.com/vector-im/vector-web/pull/2565