### PR TITLE
Fix the ctrl+e mute camera shortcut

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -358,18 +358,25 @@ module.exports = React.createClass({
     },
 
     onKeyDown: function(ev) {
-        var handled = false;
+        let handled = false;
+        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        let ctrlCmdOnly;
+        if (isMac) {
+            ctrlCmdOnly = ev.metaKey && !ev.altKey && !ev.ctrlKey && !ev.shiftKey;
+        } else {
+            ctrlCmdOnly = ev.ctrlKey && !ev.altKey && !ev.metaKey && !ev.shiftKey;
+        }
 
         switch (ev.keyCode) {
             case KeyCode.KEY_D:
-                if (ev.ctrlKey) {
+                if (ctrlCmdOnly) {
                     this.onMuteAudioClick();
                     handled = true;
                 }
                 break;
 
             case KeyCode.KEY_E:
-                if (ev.ctrlKey) {
+                if (ctrlCmdOnly) {
                     this.onMuteVideoClick();
                     handled = true;
                 }


### PR DESCRIPTION
* Fixes the altgr+e shortcut on Windows
   (Fixes https://github.com/vector-im/vector-web/issues/2561)
 * Fixes the shortcuts to be cmd+e on mac rather than ctrl+e
   which is more normal and doesn't clobber ctrl+e which old
   school unix types use for go-to-end-of-line.