### PR TITLE
Fix join/part collapsing regressions

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -229,6 +229,7 @@ module.exports = React.createClass({
 
     _getEventTiles: function() {
         var EventTile = sdk.getComponent('rooms.EventTile');
+        var DateSeparator = sdk.getComponent('messages.DateSeparator');
         const MemberEventListSummary = sdk.getComponent('views.elements.MemberEventListSummary');
 
         this.eventNodes = {};
@@ -294,6 +295,13 @@ module.exports = React.createClass({
 
             // Wrap consecutive member events in a ListSummary
             if (isMembershipChange(mxEv)) {
+                let ts1 = mxEv.getTs();
+
+                if (this._wantsDateSeparator(prevEvent, ts1)) {
+                    let dateSeparator = <li key={ts1+'~'}><DateSeparator key={ts1+'~'} ts={ts1}/></li>;
+                    ret.push(dateSeparator);
+                }
+
                 let summarisedEvents = [mxEv];
                 i++;
                 for (;i < this.props.events.length; i++) {
@@ -311,7 +319,7 @@ module.exports = React.createClass({
 
                 let eventTiles = summarisedEvents.map(
                     (e) => {
-                        let ret = this._getTilesForEvent(prevEvent, e);
+                        let ret = this._getTilesForEvent(e, e);
                         prevEvent = e;
                         return ret;
                     }

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -278,8 +278,8 @@ module.exports = React.createClass({
 
         var isMembershipChange = (e) =>
             e.getType() === 'm.room.member'
-            && ['join', 'leave'].indexOf(e.event.content.membership) !== -1
-            && (!e.event.prev_content || e.event.content.membership  !== e.event.prev_content.membership);
+            && ['join', 'leave'].indexOf(e.getContent().membership) !== -1
+            && (!e.getPrevContent() || e.getContent().membership  !== e.getPrevContent().membership);
 
         for (i = 0; i < this.props.events.length; i++) {
             var mxEv = this.props.events[i];

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -541,6 +541,14 @@ module.exports = React.createClass({
         }
     },
 
+    getExcessHeight: function(backwards) {
+        return this.refs.scrollPanel.getExcessHeight(backwards);
+    },
+
+    getEventTileContainer: function() {
+        return this.refs.scrollPanel.getItemList();
+    },
+
     onResize: function() {
         dis.dispatch({ action: 'timeline_resize' }, true);
     },

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -299,7 +299,8 @@ module.exports = React.createClass({
                 for (;i < this.props.events.length; i++) {
                     let collapsedMxEv = this.props.events[i];
 
-                    if (!isMembershipChange(collapsedMxEv)) {
+                    if (!isMembershipChange(collapsedMxEv) ||
+                        this._wantsDateSeparator(this.props.events[i-1], collapsedMxEv.getTs())) {
                         i--;
                         break;
                     }

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -226,6 +226,19 @@ module.exports = React.createClass({
         return sn.scrollHeight - Math.ceil(sn.scrollTop) <= sn.clientHeight + 3;
     },
 
+    getExcessHeight: function(backwards) {
+        var sn = this._getScrollNode();
+        if (backwards) {
+            return sn.scrollTop - sn.clientHeight;
+        } else {
+            return sn.scrollHeight - (sn.scrollTop + 2*sn.clientHeight);
+        }
+    },
+
+    getItemList: function() {
+        return this.refs.itemlist;
+    },
+
     // check the scroll state and send out backfill requests if necessary.
     checkFillState: function() {
         if (this.unmounted) {
@@ -258,20 +271,13 @@ module.exports = React.createClass({
         //   `---------'                            -
         //
 
-        console.log({
-            scrollTop: sn.scrollTop,
-            clientHeight: sn.clientHeight,
-            scrollHeight: sn.scrollHeight
-        });
         if (sn.scrollTop < sn.clientHeight) {
-            console.log('backfill');
             // need to back-fill
             this._maybeFill(true);
         }
-        if (sn.scrollTop > sn.scrollHeight - sn.clientHeight) {
-            console.log('forfill');
+        if (sn.scrollTop > sn.scrollHeight - sn.clientHeight * 2) {
             // need to forward-fill
-            // this._maybeFill(false);
+            this._maybeFill(false);
         }
     },
 

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -20,8 +20,8 @@ var GeminiScrollbar = require('react-gemini-scrollbar');
 var q = require("q");
 var KeyCode = require('../../KeyCode');
 
+// var DEBUG_SCROLL = false;
 var DEBUG_SCROLL = false;
-// var DEBUG_SCROLL = true;
 
 if (DEBUG_SCROLL) {
     // using bind means that we get to keep useful line numbers in the console
@@ -258,13 +258,20 @@ module.exports = React.createClass({
         //   `---------'                            -
         //
 
+        console.log({
+            scrollTop: sn.scrollTop,
+            clientHeight: sn.clientHeight,
+            scrollHeight: sn.scrollHeight
+        });
         if (sn.scrollTop < sn.clientHeight) {
+            console.log('backfill');
             // need to back-fill
             this._maybeFill(true);
         }
-        if (sn.scrollTop > sn.scrollHeight - sn.clientHeight * 2) {
+        if (sn.scrollTop > sn.scrollHeight - sn.clientHeight) {
+            console.log('forfill');
             // need to forward-fill
-            this._maybeFill(false);
+            // this._maybeFill(false);
         }
     },
 

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -20,8 +20,8 @@ var GeminiScrollbar = require('react-gemini-scrollbar');
 var q = require("q");
 var KeyCode = require('../../KeyCode');
 
-// var DEBUG_SCROLL = false;
 var DEBUG_SCROLL = false;
+// var DEBUG_SCROLL = true;
 
 if (DEBUG_SCROLL) {
     // using bind means that we get to keep useful line numbers in the console

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -245,6 +245,63 @@ var TimelinePanel = React.createClass({
         }
     },
 
+    _unpaginateEvents: function(backwards) {
+        let dir = backwards ? EventTimeline.BACKWARDS : EventTimeline.FORWARDS;
+        debuglog("TimelinePanel: unpaginating events in direction", dir);
+        // The number of events to unpaginate
+        let count = 0;
+        // The parent (ScrollPanel) of event tiles including MemberEventListSummary elements
+        let eventTileContainer = this.refs.messagePanel.getEventTileContainer();
+        let tiles = ReactDOM.findDOMNode(eventTileContainer).children || [];
+
+        // No tiles rendered; no unpagination required
+        if (tiles.length === 0) {
+            return;
+        }
+
+        // Count the events for each tile, with a default of one per element, but for any
+        // element that specifies 'data-number-events' in its attributes, use that instead.
+        // This is to handle MemberEventListSummary elements, which can represent more than one
+        // event in a fixed height.
+        let eventCounts = Array.from(tiles).map((element) => {
+            return parseInt(element.getAttribute('data-number-events')) || 1;
+        });
+
+        // The amount of height that can be removed from the ScrollPanel without causing
+        // further pagination
+        let excessHeight = this.refs.messagePanel.getExcessHeight(backwards);
+        if (excessHeight < 0) {
+            return;
+        }
+
+        // Subtract clientHeights to simulate the events being unpaginated whilst counting
+        // the events to be unpaginated.
+        if (backwards) {
+            // Iterate forwards from start of tiles, subtracting event tile height
+            let i = 0;
+            while (i < tiles.length && excessHeight > tiles[i].clientHeight) {
+                excessHeight -= tiles[i].clientHeight;
+                count += eventCounts[i];
+                i++;
+            }
+        } else {
+            // Iterate backwards from end of tiles, subtracting event tile height
+            let i = tiles.length - 1;
+            while (i >= 0 && excessHeight > tiles[i].clientHeight) {
+                excessHeight -= tiles[i].clientHeight;
+                count += eventCounts[i];
+                i--;
+            }
+        }
+
+        if (count > 0) {
+            this._timelineWindow._unpaginate(count, backwards);
+            this.setState({
+                events: this._getEvents(),
+            });
+        }
+    },
+
     // set off a pagination request.
     onMessageListFillRequest: function(backwards) {
         var dir = backwards ? EventTimeline.BACKWARDS : EventTimeline.FORWARDS;
@@ -269,6 +326,9 @@ var TimelinePanel = React.createClass({
             if (this.unmounted) { return; }
 
             debuglog("TimelinePanel: paginate complete backwards:"+backwards+"; success:"+r);
+
+            // Unpaginate events gratuitously after every paginate
+            this._unpaginateEvents(!backwards);
 
             var newState = {
                 [paginatingKey]: false,
@@ -723,7 +783,7 @@ var TimelinePanel = React.createClass({
     _loadTimeline: function(eventId, pixelOffset, offsetBase) {
         this._timelineWindow = new Matrix.TimelineWindow(
             MatrixClientPeg.get(), this.props.timelineSet,
-            {windowLimit: this.props.timelineCap});
+            {windowLimit: 10000});
 
         var onLoaded = () => {
             this._reloadEvents();

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -300,6 +300,10 @@ var TimelinePanel = React.createClass({
         }
 
         if (count > 0) {
+            // Minimum number of events following unpagination should = this.props.timelineCap
+            if (count > this.state.events.length - this.props.timelineCap) {
+                count = this.state.events.length - this.props.timelineCap;
+            }
             this._timelineWindow._unpaginate(count, backwards);
         }
     },

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -246,6 +246,11 @@ var TimelinePanel = React.createClass({
     },
 
     _unpaginateEvents: function(backwards) {
+        // Do not unpaginate below timelineCap
+        if (this.state.events.length < this.props.timelineCap) {
+            return;
+        }
+
         let dir = backwards ? EventTimeline.BACKWARDS : EventTimeline.FORWARDS;
         debuglog("TimelinePanel: unpaginating events in direction", dir);
         // The number of events to unpaginate
@@ -296,9 +301,6 @@ var TimelinePanel = React.createClass({
 
         if (count > 0) {
             this._timelineWindow._unpaginate(count, backwards);
-            this.setState({
-                events: this._getEvents(),
-            });
         }
     },
 
@@ -328,9 +330,7 @@ var TimelinePanel = React.createClass({
             debuglog("TimelinePanel: paginate complete backwards:"+backwards+"; success:"+r);
 
             // Unpaginate events gratuitously after every paginate
-            if (this.state.events.length > 250) {
-                this._unpaginateEvents(!backwards);
-            }
+            this._unpaginateEvents(!backwards);
 
             var newState = {
                 [paginatingKey]: false,

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -896,7 +896,6 @@ var TimelinePanel = React.createClass({
     _getEvents: function() {
         var events = this._timelineWindow.getEvents();
 
-        console.log('EVENTS', events.length);
         // if we're at the end of the live timeline, append the pending events
         if (!this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
             events.push(... this.props.timelineSet.getPendingEvents());

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -328,7 +328,9 @@ var TimelinePanel = React.createClass({
             debuglog("TimelinePanel: paginate complete backwards:"+backwards+"; success:"+r);
 
             // Unpaginate events gratuitously after every paginate
-            this._unpaginateEvents(!backwards);
+            if (this.state.events.length > 250) {
+                this._unpaginateEvents(!backwards);
+            }
 
             var newState = {
                 [paginatingKey]: false,

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -108,7 +108,7 @@ var TimelinePanel = React.createClass({
 
     getDefaultProps: function() {
         return {
-            timelineCap: 250,
+            timelineCap: 1000,
             className: 'mx_RoomView_messagePanel',
         };
     },
@@ -301,8 +301,8 @@ var TimelinePanel = React.createClass({
 
         if (count > 0) {
             // Minimum number of events following unpagination should = this.props.timelineCap
-            if (count > this.state.events.length - this.props.timelineCap) {
-                count = this.state.events.length - this.props.timelineCap;
+            if (count > this.props.timelineCap - this.state.events.length) {
+                count = this.props.timelineCap - this.state.events.length;
             }
             this._timelineWindow._unpaginate(count, backwards);
         }
@@ -789,7 +789,7 @@ var TimelinePanel = React.createClass({
     _loadTimeline: function(eventId, pixelOffset, offsetBase) {
         this._timelineWindow = new Matrix.TimelineWindow(
             MatrixClientPeg.get(), this.props.timelineSet,
-            {windowLimit: 10000});
+            {windowLimit: this.props.timelineCap});
 
         var onLoaded = () => {
             this._reloadEvents();

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -836,6 +836,7 @@ var TimelinePanel = React.createClass({
     _getEvents: function() {
         var events = this._timelineWindow.getEvents();
 
+        console.log('EVENTS', events.length);
         // if we're at the end of the live timeline, append the pending events
         if (!this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
             events.push(... this.props.timelineSet.getPendingEvents());

--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -69,9 +69,9 @@ module.exports = React.createClass({
     render: function() {
         var BaseAvatar = sdk.getComponent("avatars.BaseAvatar");
 
-        var {member, onClick, ...otherProps} = this.props;
+        var {member, onClick, viewUserOnClick, ...otherProps} = this.props;
 
-        if (this.props.viewUserOnClick) {
+        if (viewUserOnClick) {
             onClick = () => {
                 dispatcher.dispatch({
                     action: 'view_user',

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -219,7 +219,7 @@ module.exports = React.createClass({
         }
 
         return (
-            <div className="mx_MemberEventListSummary">
+            <div className="mx_MemberEventListSummary" data-number-events={this.props.children.length}>
                 {summaryContainer}
                 {expandedEvents}
             </div>

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -107,6 +107,11 @@ module.exports = React.createClass({
                 </span>
             );
         }
+
+        if (!joinSummary && !leaveSummary) {
+            return null;
+        }
+
         return (
             <span>
                 {joinSummary}{joinSummary && leaveSummary?'; ':''}
@@ -210,7 +215,7 @@ module.exports = React.createClass({
                             {avatars}
                         </span>
                         <span className="mx_TextualEvent mx_MemberEventListSummary_summary">
-                            {summary}{joinAndLeft? '. ' + joinAndLeft + ' ' + noun + ' joined and left' : ''}
+                            {summary}{summary ? '. ': ''}{joinAndLeft ? joinAndLeft + ' ' + noun + ' joined and left' : ''}
                         </span>&nbsp;
                         {toggleButton}
                     </div>


### PR DESCRIPTION
This fixes the following problems. Previously:

- more than one join or part lead to incorrect rendering. Sequences of joins and parts are now reduced to the final event per-user when summarised.
- display name changes were included as joins. These changes are now ignored (and encrypted member events are also handled).
- an issue was causing the browser to hang (see vector-im/vector-web#2020). This has been fixed by unpaginating according to the vertical space that has been scrolled off screen but also the height that events would _remove_ if unpaginated.

Edit: I did just remember that `DateSeparator`s are not correctly put in position before a long list of join/parts. The solution to this was breaking them into two groups when they span a date boundary. I think I'll include that here...