### PR TITLE
Update eventtiles when the events are decrypted

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -146,6 +146,7 @@ module.exports = WithMatrixClient(React.createClass({
         this._suppressReadReceiptAnimation = false;
         this.props.matrixClient.on("deviceVerificationChanged",
                                  this.onDeviceVerificationChanged);
+        this.props.mxEvent.on("Event.decrypted", this._onDecrypted);
     },
 
     componentWillReceiveProps: function (nextProps) {
@@ -170,6 +171,15 @@ module.exports = WithMatrixClient(React.createClass({
         var client = this.props.matrixClient;
         client.removeListener("deviceVerificationChanged",
                               this.onDeviceVerificationChanged);
+        this.props.mxEvent.removeListener("Event.decrypted", this._onDecrypted);
+    },
+
+    /** called when the event is decrypted after we show it.
+     */
+    _onDecrypted: function() {
+        // we need to re-verify the sending device.
+        this._verifyEvent(this.props.mxEvent);
+        this.forceUpdate();
     },
 
     onDeviceVerificationChanged: function(userId, device) {


### PR DESCRIPTION
Events are sometimes decrypted after they arrive, so add an eventlistener for it and update the tile.

(requires https://github.com/matrix-org/matrix-js-sdk/pull/288)