### PR TITLE
Cache the tinted SVGs for MFileBody as data URLs

### DIFF
--- a/src/Tinter.js
+++ b/src/Tinter.js
@@ -153,7 +153,13 @@ function rgbToHex(rgb) {
     return '#' + (0x1000000 + val).toString(16).slice(1)
 }
 
+const tintables = [];
+
 module.exports = {
+    registerTintable : function(tintable) {
+        tintables.push(tintable);
+    },
+
     tint: function(primaryColor, secondaryColor, tertiaryColor) {
 
         if (!cached) {
@@ -201,12 +207,7 @@ module.exports = {
 
         // tell all the SVGs to go fix themselves up
         // we don't do this as a dispatch otherwise it will visually lag
-        var TintableSvg = sdk.getComponent("elements.TintableSvg");
-        if (TintableSvg.mounts) {
-            Object.keys(TintableSvg.mounts).forEach((id) => {
-                TintableSvg.mounts[id].tint();
-            });
-        }
+        tintables.forEach(function(tintable) { tintable(); });
     },
 
     // XXX: we could just move this all into TintableSvg, but as it's so similar
@@ -265,5 +266,5 @@ module.exports = {
             svgFixup.node.setAttribute(svgFixup.attr, colors[svgFixup.index]);
         }
         if (DEBUG) console.log("applySvgFixups end");
-    },
+    }
 };

--- a/src/Tinter.js
+++ b/src/Tinter.js
@@ -153,9 +153,21 @@ function rgbToHex(rgb) {
     return '#' + (0x1000000 + val).toString(16).slice(1)
 }
 
+// List of functions to call when the tint changes.
 const tintables = [];
 
 module.exports = {
+    /**
+     * Register a callback to fire when the tint changes.
+     * This is used to rewrite the tintable SVGs with the new tint.
+     *
+     * It's not possible to unregister a tintable callback. So this can only be
+     * used to register a static callback. If a set of tintables will change
+     * over time then the best bet is to register a single callback for the
+     * entire set.
+     *
+     * @param {Function} tintable Function to call when the tint changes.
+     */
     registerTintable : function(tintable) {
         tintables.push(tintable);
     },
@@ -207,7 +219,9 @@ module.exports = {
 
         // tell all the SVGs to go fix themselves up
         // we don't do this as a dispatch otherwise it will visually lag
-        tintables.forEach(function(tintable) { tintable(); });
+        tintables.forEach(function(tintable) {
+            tintable();
+        });
     },
 
     // XXX: we could just move this all into TintableSvg, but as it's so similar

--- a/src/components/views/elements/TintableSvg.js
+++ b/src/components/views/elements/TintableSvg.js
@@ -74,4 +74,13 @@ var TintableSvg = React.createClass({
     }
 });
 
+// Register with the Tinter so that we will be told if the tint changes
+Tinter.registerTintable(function() {
+    if (TintableSvg.mounts) {
+        Object.keys(TintableSvg.mounts).forEach((id) => {
+            TintableSvg.mounts[id].tint();
+        });
+    }
+});
+
 module.exports = TintableSvg;

--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -22,6 +22,8 @@ import MatrixClientPeg from '../../../MatrixClientPeg';
 import sdk from '../../../index';
 import {decryptFile} from '../../../utils/DecryptFile';
 import Tinter from '../../../Tinter';
+import 'isomorphic-fetch';
+import q from 'q';
 
 // A cached tinted copy of "img/download.svg"
 var tintedDownloadImageURL;
@@ -38,10 +40,10 @@ function updateTintedDownloadImage() {
     // Since we want an XML document maybe XMLHttpRequest actually makes sense?
     // We could cache the XML response here, but since the tint rarely changes
     // it's probably not worth it.
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", "img/download.svg");
-    xhr.onload = function() {
-        const svg = xhr.responseXML;
+    q(fetch("img/download.svg")).then(function(response) {
+        return response.text();
+    }).then(function(svgText) {
+        const svg = new DOMParser().parseFromString(svgText, "image/svg+xml");
         // Apply the fixups to the XML.
         const fixups = Tinter.calcSvgFixups([{contentDocument: svg}]);
         Tinter.applySvgFixups(fixups);
@@ -52,8 +54,7 @@ function updateTintedDownloadImage() {
         Object.keys(mounts).forEach(function(id) {
             mounts[id].tint();
         });
-    };
-    xhr.send();
+    }).done();
 }
 
 Tinter.registerTintable(updateTintedDownloadImage);

--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -37,7 +37,6 @@ const mounts = {};
  */
 function updateTintedDownloadImage() {
     // Download the svg as an XML document.
-    // Since we want an XML document maybe XMLHttpRequest actually makes sense?
     // We could cache the XML response here, but since the tint rarely changes
     // it's probably not worth it.
     q(fetch("img/download.svg")).then(function(response) {

--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -112,7 +112,9 @@ module.exports = React.createClass({
     },
 
     tint: function() {
-        this.refs.downloadImage.src = tintedDownloadImageURL;
+        if (this.refs.downloadImage) {
+            this.refs.downloadImage.src = tintedDownloadImageURL;
+        }
     },
 
     render: function() {


### PR DESCRIPTION
Some of the structure probably looks a bit odd. Why am I making the callbacks specific to MFileBody rather than making a generic component to wrap <img> tags? Stay tuned until the next PR where I try rendering the MFileBody inside an <iframe> where having access to a data URL for the tinted SVG inside a MFileBody specific callback will be actually useful.