### PR TITLE
Fix more membership change collapsing bugs

### DIFF
--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -156,21 +156,21 @@ module.exports = React.createClass({
         let senders = new Set(eventsToRender.map((e) => e.getSender()));
         senders.forEach(
             (userId) => {
-                // Only push the last event if it isn't the same membership as the first
-
                 let userEvents = eventsToRender.filter((e) => {
                     return e.getSender() === userId;
                 });
 
-                if (userEvents.length === 1) {
-                    filteredEvents.push(userEvents[0]);
-                    return;
-                }
-
+                // NB: These may be the same event, in which case the lastEvent is used
+                // because prev_content should != content
                 let firstEvent = userEvents[0];
                 let lastEvent = userEvents[userEvents.length - 1];
 
-                if (firstEvent.getContent().membership === lastEvent.getContent().membership) {
+                // Membership BEFORE eventsToRender
+                let previousMembership = firstEvent.getPrevContent().membership || "leave";
+
+                // Otherwise, if the last membership event differs from previousMembership,
+                // use that.
+                if (previousMembership !== lastEvent.getContent().membership) {
                     filteredEvents.push(lastEvent);
                 }
             }

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -162,10 +162,15 @@ module.exports = React.createClass({
                     return e.getSender() === userId;
                 });
 
+                if (userEvents.length === 1) {
+                    filteredEvents.push(userEvents[0]);
+                    return;
+                }
+
                 let firstEvent = userEvents[0];
                 let lastEvent = userEvents[userEvents.length - 1];
 
-                if (firstEvent.getContent().membership !== lastEvent.getContent().membership) {
+                if (firstEvent.getContent().membership === lastEvent.getContent().membership) {
                     filteredEvents.push(lastEvent);
                 }
             }


### PR DESCRIPTION
Also, the net change of nil is detected as having the first and last events being _different_. The summary should only include those that have their first and last events being the _same_ because that is a net change (within the block of member events).