### PR TITLE
Test TimelinePanel canForwardPaginate

### DIFF
--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -239,7 +239,6 @@ describe('TimelinePanel', function() {
     });
 
     it("should let you scroll down again after you've scrolled up", function(done) {
-        var TIMELINE_CAP = 100; // needs to be more than we can fit in the div
         var N_EVENTS = 120;     // needs to be more than TIMELINE_CAP
 
         // sadly, loading all those events takes a while
@@ -257,9 +256,7 @@ describe('TimelinePanel', function() {
 
         var scrollDefer;
         var rendered = ReactDOM.render(
-            <WrappedTimelinePanel timelineSet={timelineSet} onScroll={() => {scrollDefer.resolve()}}
-                timelineCap={TIMELINE_CAP}
-            />,
+            <WrappedTimelinePanel timelineSet={timelineSet} onScroll={() => {scrollDefer.resolve()}}/>,
             parentDiv
         );
         console.log("TimelinePanel rendered");
@@ -321,7 +318,6 @@ describe('TimelinePanel', function() {
             expect(messagePanel.props.suppressFirstDateSeparator).toBe(false);
             var events = scryEventTiles(panel);
             expect(events[0].props.mxEvent).toBe(timeline.getEvents()[0]);
-            expect(events.length).toBeLessThanOrEqualTo(TIMELINE_CAP);
 
             // Expect to be able to paginate forwards, having unpaginated a few events
             expect(panel.state.canForwardPaginate).toBe(true);
@@ -342,7 +338,6 @@ describe('TimelinePanel', function() {
             expect(messagePanel.props.suppressFirstDateSeparator).toBe(true);
 
             var events = scryEventTiles(panel);
-            expect(events.length).toBeLessThanOrEqualTo(TIMELINE_CAP);
 
             // we don't really know what the first event tile will be, since that
             // depends on how much the timelinepanel decides to paginate.

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -304,6 +304,19 @@ describe('TimelinePanel', function() {
             });
         }
 
+        function scrollDown(count) {
+            setScrollTop(scrollingDiv.scrollHeight - scrollingDiv.clientHeight);
+            console.log("scrolling down... " + scrollingDiv.scrollTop);
+            return awaitScroll().delay(0).then(() => {
+                if(count > 0) {
+                    // need to go further
+                    count--;
+                    return scrollDown(count).delay(100);
+                }
+                console.log("paginated to end.");
+            });
+        }
+
         // let the first round of pagination finish off
         awaitScroll().then(() => {
             // we should now have loaded the first few events
@@ -323,26 +336,8 @@ describe('TimelinePanel', function() {
             // Expect to be able to paginate forwards, having unpaginated a few events
             expect(panel.state.canForwardPaginate).toBe(true);
 
-            // we should now be able to scroll down, and paginate in the other
-            // direction.
-            setScrollTop(scrollingDiv.scrollHeight);
-
-            // the delay() below is a heinous hack to deal with the fact that,
-            // without it, we may or may not get control back before the
-            // forward pagination completes. The delay means that it should
-            // have completed.
-
-            // Scroll a few more times to ensure that we reach the bottom
-            return awaitScroll().delay(0).then(() => {
-                setScrollTop(scrollingDiv.scrollHeight);
-                return awaitScroll().delay(0);
-            }).then(() => {
-                setScrollTop(scrollingDiv.scrollHeight);
-                return awaitScroll().delay(0);
-            }).then(() => {
-                setScrollTop(scrollingDiv.scrollHeight);
-                return awaitScroll().delay(0);
-            })
+            // scroll all the way to the bottom
+            return scrollDown(3);
         }).then(() => {
             expect(messagePanel.props.backPaginating).toBe(false);
             expect(messagePanel.props.forwardPaginating).toBe(false);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -323,6 +323,9 @@ describe('TimelinePanel', function() {
             expect(events[0].props.mxEvent).toBe(timeline.getEvents()[0]);
             expect(events.length).toBeLessThanOrEqualTo(TIMELINE_CAP);
 
+            // Expect to be able to paginate forwards, having unpaginated a few events
+            expect(panel.state.canForwardPaginate).toBe(true);
+
             // we should now be able to scroll down, and paginate in the other
             // direction.
             setScrollTop(scrollingDiv.scrollHeight);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -335,15 +335,13 @@ describe('TimelinePanel', function() {
         }).then(() => {
             expect(messagePanel.props.backPaginating).toBe(false);
             expect(messagePanel.props.forwardPaginating).toBe(false);
-            expect(messagePanel.props.suppressFirstDateSeparator).toBe(true);
 
             var events = scryEventTiles(panel);
 
-            // we don't really know what the first event tile will be, since that
-            // depends on how much the timelinepanel decides to paginate.
-            //
-            // just check that the first tile isn't event 0.
-            expect(events[0].props.mxEvent).toNotBe(timeline.getEvents()[0]);
+            // Expect to be able to see the most recent event
+            var lastEventInPanel = events[events.length - 1].props.mxEvent;
+            var lastEventInTimeline = timeline.getEvents()[timeline.getEvents().length - 1];
+            expect(lastEventInPanel.getContent()).toBe(lastEventInTimeline.getContent());
 
             console.log("done");
         }).done(done, done);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -304,14 +304,22 @@ describe('TimelinePanel', function() {
             });
         }
 
-        function scrollDown(count) {
+        function scrollDown() {
+            // Scroll the bottom of the viewport to the bottom of the panel
             setScrollTop(scrollingDiv.scrollHeight - scrollingDiv.clientHeight);
             console.log("scrolling down... " + scrollingDiv.scrollTop);
             return awaitScroll().delay(0).then(() => {
-                if(count > 0) {
+
+                let eventTiles = scryEventTiles(panel);
+                let events = timeline.getEvents();
+
+                let lastEventInPanel = eventTiles[eventTiles.length - 1].props.mxEvent;
+                let lastEventInTimeline = events[events.length - 1];
+
+                // Scroll until the last event in the panel = the last event in the timeline
+                if(lastEventInPanel.getId() !== lastEventInTimeline.getId()) {
                     // need to go further
-                    count--;
-                    return scrollDown(count);
+                    return scrollDown();
                 }
                 console.log("paginated to end.");
             });
@@ -337,7 +345,7 @@ describe('TimelinePanel', function() {
             expect(panel.state.canForwardPaginate).toBe(true);
 
             // scroll all the way to the bottom
-            return scrollDown(3);
+            return scrollDown();
         }).then(() => {
             expect(messagePanel.props.backPaginating).toBe(false);
             expect(messagePanel.props.forwardPaginating).toBe(false);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -238,7 +238,7 @@ describe('TimelinePanel', function() {
         }, 0);
     });
 
-    it("should let you scroll down again after you've scrolled up", function(done) {
+    it("should let you scroll down to the bottom after you've scrolled up", function(done) {
         var N_EVENTS = 120;     // needs to be more than TIMELINE_CAP
 
         // sadly, loading all those events takes a while
@@ -270,6 +270,7 @@ describe('TimelinePanel', function() {
         // the TimelinePanel fires a scroll event
         var awaitScroll = function() {
             scrollDefer = q.defer();
+
             return scrollDefer.promise.then(() => {
                 console.log("got scroll event; scrollTop now " +
                             scrollingDiv.scrollTop);
@@ -325,13 +326,23 @@ describe('TimelinePanel', function() {
             // we should now be able to scroll down, and paginate in the other
             // direction.
             setScrollTop(scrollingDiv.scrollHeight);
-            scrollingDiv.scrollTop = scrollingDiv.scrollHeight;
 
             // the delay() below is a heinous hack to deal with the fact that,
             // without it, we may or may not get control back before the
             // forward pagination completes. The delay means that it should
             // have completed.
-            return awaitScroll().delay(0);
+
+            // Scroll a few more times to ensure that we reach the bottom
+            return awaitScroll().delay(0).then(() => {
+                setScrollTop(scrollingDiv.scrollHeight);
+                return awaitScroll().delay(0);
+            }).then(() => {
+                setScrollTop(scrollingDiv.scrollHeight);
+                return awaitScroll().delay(0);
+            }).then(() => {
+                setScrollTop(scrollingDiv.scrollHeight);
+                return awaitScroll().delay(0);
+            })
         }).then(() => {
             expect(messagePanel.props.backPaginating).toBe(false);
             expect(messagePanel.props.forwardPaginating).toBe(false);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -317,9 +317,6 @@ describe('TimelinePanel', function() {
             });
         }
 
-        //// TESTING THAT TRAVIS IS STILL FAILING BUILDS
-        expect(true).toBe(false);
-
         // let the first round of pagination finish off
         awaitScroll().then(() => {
             // we should now have loaded the first few events

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -239,7 +239,7 @@ describe('TimelinePanel', function() {
     });
 
     it("should let you scroll down to the bottom after you've scrolled up", function(done) {
-        var N_EVENTS = 120;     // needs to be more than TIMELINE_CAP
+        var N_EVENTS = 120; // the number of events to simulate being added to the timeline
 
         // sadly, loading all those events takes a while
         this.timeout(N_EVENTS * 50);

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -317,6 +317,9 @@ describe('TimelinePanel', function() {
             });
         }
 
+        //// TESTING THAT TRAVIS IS STILL FAILING BUILDS
+        expect(true).toBe(false);
+
         // let the first round of pagination finish off
         awaitScroll().then(() => {
             // we should now have loaded the first few events

--- a/test/components/structures/TimelinePanel-test.js
+++ b/test/components/structures/TimelinePanel-test.js
@@ -311,7 +311,7 @@ describe('TimelinePanel', function() {
                 if(count > 0) {
                     // need to go further
                     count--;
-                    return scrollDown(count).delay(100);
+                    return scrollDown(count);
                 }
                 console.log("paginated to end.");
             });


### PR DESCRIPTION
Once the test has scrolled the panel to the top, to the earliest events, it should be able to forward paginate, because some degree of unpagination occurs. This does assume that unpagination will occur.

(One test should fail for this)

Attempts to test for vector-im/vector-web#2590