### PR TITLE
Fix pagination issue where recent events are lost

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -265,7 +265,11 @@ var TimelinePanel = React.createClass({
         if (count > 0) {
             debuglog("TimelinePanel: Unpaginating", count, "in direction", dir);
             this._timelineWindow.unpaginate(count, backwards);
+
+            // We can now paginate in the unpaginated direction
+            let canPaginateKey = (backwards) ? 'canBackPaginate' : 'canForwardPaginate';
             this.setState({
+                [canPaginateKey]: true,
                 events: this._getEvents(),
             });
         }

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -267,7 +267,7 @@ var TimelinePanel = React.createClass({
             this._timelineWindow.unpaginate(count, backwards);
 
             // We can now paginate in the unpaginated direction
-            let canPaginateKey = (backwards) ? 'canBackPaginate' : 'canForwardPaginate';
+            const canPaginateKey = (backwards) ? 'canBackPaginate' : 'canForwardPaginate';
             this.setState({
                 [canPaginateKey]: true,
                 events: this._getEvents(),


### PR DESCRIPTION
Scrolling up a few pages followed by scrolling down to the most recent events previously caused some events to go missing. A test has been modified in conjunction with this fix to make sure that this failure mode is tested for in future. This commit should fix the issue, and the most recent events should be paginated back in.