### PR TITLE
Reinstate missing sections from the UserSettings

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -338,10 +338,6 @@ module.exports = React.createClass({
     },
 
     _renderCryptoInfo: function() {
-        if (!UserSettingsStore.isFeatureEnabled("e2e_encryption")) {
-            return null;
-        }
-
         var client = MatrixClientPeg.get();
         var deviceId = client.deviceId;
         var identityKey = client.getDeviceEd25519Key() || "<not supported>";
@@ -362,9 +358,6 @@ module.exports = React.createClass({
     },
 
     _renderDevicesPanel: function() {
-        if (!UserSettingsStore.isFeatureEnabled("e2e_encryption")) {
-            return null;
-        }
         var DevicesPanel = sdk.getComponent('settings.DevicesPanel');
         return (
             <div>


### PR DESCRIPTION
The 'devices' and 'cryptography' sections got removed from UserSettings by #566.