### PR TITLE
Add read receipt times to the hovertip of read markers

### DIFF
--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -33,6 +33,7 @@ module.exports = React.createClass({
         onClick: React.PropTypes.func,
         // Whether the onClick of the avatar should be overriden to dispatch 'view_user'
         viewUserOnClick: React.PropTypes.bool,
+        title: React.PropTypes.string,
     },
 
     getDefaultProps: function() {
@@ -58,7 +59,7 @@ module.exports = React.createClass({
         }
         return {
             name: props.member.name,
-            title: props.member.userId,
+            title: props.title || props.member.userId,
             imageUrl: Avatar.avatarUrlForMember(props.member,
                                          props.width,
                                          props.height,

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -290,6 +290,18 @@ module.exports = WithMatrixClient(React.createClass({
 
         var left = 0;
 
+        var readReceiptData = Object.create(null);
+        var room = this.props.matrixClient.getRoom(this.props.mxEvent.getRoomId());
+        if (room) {
+            // [ {type/userId/data} ]
+            room.getReceiptsForEvent(this.props.mxEvent).forEach(function(r) {
+                if (r.type !== "m.read" || !r.data.ts) {
+                    return;
+                }
+                readReceiptData[r.userId] = r.data;
+            })
+        }
+
         var receipts = this.props.readReceipts || [];
         for (var i = 0; i < receipts.length; ++i) {
             var member = receipts[i];
@@ -312,6 +324,8 @@ module.exports = WithMatrixClient(React.createClass({
 
             //console.log("i = " + i + ", MAX_READ_AVATARS = " + MAX_READ_AVATARS + ", allReadAvatars = " + this.state.allReadAvatars + " visibility = " + style.visibility);
 
+            var rData = readReceiptData[member.userId];
+
             // add to the start so the most recent is on the end (ie. ends up rightmost)
             avatars.unshift(
                 <ReadReceiptMarker key={userId} member={member}
@@ -320,6 +334,7 @@ module.exports = WithMatrixClient(React.createClass({
                     checkUnmounting={this.props.checkUnmounting}
                     suppressAnimation={this._suppressReadReceiptAnimation}
                     onClick={this.toggleAllReadAvatars}
+                    timestamp={rData ? rData.ts : null}
                 />
             );
 

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -289,6 +289,16 @@ module.exports = WithMatrixClient(React.createClass({
         var avatars = [];
         var left = 0;
 
+        // It's possible that the receipt was sent several days AFTER the event.
+        // If it is, we want to display the complete date along with the HH:MM:SS,
+        // rather than just HH:MM:SS.
+        let dayAfterEvent = new Date(this.props.mxEvent.getTs());
+        dayAfterEvent.setDate(dayAfterEvent.getDate() + 1)
+        dayAfterEvent.setHours(0);
+        dayAfterEvent.setMinutes(0);
+        dayAfterEvent.setSeconds(0);
+        let dayAfterEventTime = dayAfterEvent.getTime();
+
         var receipts = this.props.readReceipts || [];
         for (var i = 0; i < receipts.length; ++i) {
             var receipt = receipts[i];
@@ -319,6 +329,7 @@ module.exports = WithMatrixClient(React.createClass({
                     suppressAnimation={this._suppressReadReceiptAnimation}
                     onClick={this.toggleAllReadAvatars}
                     timestamp={receipt.ts}
+                    showFullTimestamp={receipt.ts >= dayAfterEventTime}
                 />
             );
 

--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -63,6 +63,9 @@ module.exports = React.createClass({
 
         // Timestamp when the receipt was read
         timestamp: React.PropTypes.number,
+
+        // True to show the full date/time rather than just the time
+        showFullTimestamp: React.PropTypes.bool,
     },
 
     getDefaultProps: function() {
@@ -165,10 +168,18 @@ module.exports = React.createClass({
             visibility: this.props.hidden ? 'hidden' : 'visible',
         };
 
-        var title;
+        let title;
         if (this.props.timestamp) {
-            // "7:05:45 PM (@alice:matrix.org)"
-            title = new Date(this.props.timestamp).toLocaleTimeString() + " (" + this.props.member.userId + ")";
+            let suffix = " (" + this.props.member.userId + ")";
+            let ts = new Date(this.props.timestamp);
+            if (this.props.showFullTimestamp) {
+                // "15/12/2016, 7:05:45 PM (@alice:matrix.org)"
+                title = ts.toLocaleString() + suffix;
+            }
+            else {
+                // "7:05:45 PM (@alice:matrix.org)"
+                title = ts.toLocaleTimeString() + suffix;
+            }
         }
 
         return (

--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -60,6 +60,9 @@ module.exports = React.createClass({
 
         // callback for clicks on this RR
         onClick: React.PropTypes.func,
+
+        // Timestamp when the receipt was read
+        timestamp: React.PropTypes.number,
     },
 
     getDefaultProps: function() {
@@ -162,6 +165,12 @@ module.exports = React.createClass({
             visibility: this.props.hidden ? 'hidden' : 'visible',
         };
 
+        var title;
+        if (this.props.timestamp) {
+            // "7:05:45 PM (@alice:matrix.org)"
+            title = new Date(this.props.timestamp).toLocaleTimeString() + " (" + this.props.member.userId + ")";
+        }
+
         return (
             <Velociraptor
                     startStyles={this.state.startStyles}
@@ -170,6 +179,7 @@ module.exports = React.createClass({
                     member={this.props.member}
                     width={14} height={14} resizeMethod="crop"
                     style={style}
+                    title={title}
                     onClick={this.props.onClick}
                 />
             </Velociraptor>


### PR DESCRIPTION
Fixes vector-im/riot-web#2709. Surprisingly, this data was never passed down to
`ReadReceiptMarker`.