### PR TITLE
Fix failing test

### DIFF
--- a/test/components/structures/RoomView-test.js
+++ b/test/components/structures/RoomView-test.js
@@ -60,14 +60,13 @@ describe('RoomView', function () {
         peg.get().getProfileInfo.returns(q({displayname: "foo"}));
         var roomView = ReactDOM.render(<RoomView roomAddress="#alias:ser.ver" />, parentDiv);
 
-        peg.get().joinRoom = sinon.spy();
+        peg.get().joinRoom = function(x) {
+            expect(x).toEqual('#alias:ser.ver');
+            done();
+        }
 
         process.nextTick(function() {
             roomView.onJoinButtonClicked();
-            process.nextTick(function() {
-                expect(peg.get().joinRoom.calledWith('#alias:ser.ver')).toExist();
-                done();
-            });
         });
     });
 });

--- a/test/components/structures/RoomView-test.js
+++ b/test/components/structures/RoomView-test.js
@@ -63,7 +63,7 @@ describe('RoomView', function () {
         peg.get().joinRoom = function(x) {
             expect(x).toEqual('#alias:ser.ver');
             done();
-        }
+        };
 
         process.nextTick(function() {
             roomView.onJoinButtonClicked();


### PR DESCRIPTION
For some reason, update webpack causes the promise to no longer
complete by the next tick. Change the test to not depend on how
fast the promise goes through.