### PR TITLE
Add edit mode for messages (experimental)

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -183,6 +183,8 @@ import views$rooms$MessageComposerInput from './components/views/rooms/MessageCo
 views$rooms$MessageComposerInput && (module.exports.components['views.rooms.MessageComposerInput'] = views$rooms$MessageComposerInput);
 import views$rooms$MessageComposerInputOld from './components/views/rooms/MessageComposerInputOld';
 views$rooms$MessageComposerInputOld && (module.exports.components['views.rooms.MessageComposerInputOld'] = views$rooms$MessageComposerInputOld);
+import views$rooms$MessageEditorInput from './components/views/rooms/MessageEditorInput';
+views$rooms$MessageEditorInput && (module.exports.components['views.rooms.MessageEditorInput'] = views$rooms$MessageEditorInput);
 import views$rooms$PresenceLabel from './components/views/rooms/PresenceLabel';
 views$rooms$PresenceLabel && (module.exports.components['views.rooms.PresenceLabel'] = views$rooms$PresenceLabel);
 import views$rooms$ReadReceiptMarker from './components/views/rooms/ReadReceiptMarker';

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -116,6 +116,14 @@ module.exports = React.createClass({
         //        from the focussedEvent.
         scrollStateMap: React.PropTypes.object,
     },
+    // Can't get contexts to work for some reason
+    // childContextTypes: {
+    //     text: React.PropTypes.object
+    // },
+
+    // getChildContext: function() {
+    //     return { room: this.state.room }
+    // },
 
     getInitialState: function() {
         return {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -177,6 +177,7 @@ var TimelinePanel = React.createClass({
         MatrixClientPeg.get().on("Room.redaction", this.onRoomRedaction);
         MatrixClientPeg.get().on("Room.receipt", this.onRoomReceipt);
         MatrixClientPeg.get().on("Room.localEchoUpdated", this.onLocalEchoUpdated);
+        MatrixClientPeg.get().on("Room.edit", this.onRoomEdit);
 
         this._initTimeline(this.props);
     },
@@ -244,6 +245,7 @@ var TimelinePanel = React.createClass({
             client.removeListener("Room.redaction", this.onRoomRedaction);
             client.removeListener("Room.receipt", this.onRoomReceipt);
             client.removeListener("Room.localEchoUpdated", this.onLocalEchoUpdated);
+            client.removeListener("Room.edit", this.onRoomEdit);
         }
     },
 
@@ -436,6 +438,15 @@ var TimelinePanel = React.createClass({
 
         // we could skip an update if the event isn't in our timeline,
         // but that's probably an early optimisation.
+        this.forceUpdate();
+    },
+
+    onRoomEdit: function(ev, room) {
+        if (this.unmounted) return;
+
+        // ignore events for other rooms
+        if (room !== this.props.timelineSet.room) return;
+
         this.forceUpdate();
     },
 

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -258,6 +258,7 @@ module.exports = WithMatrixClient(React.createClass({
     },
 
     onEditClicked: function(e) {
+        console.log('onEditClicked')
         var MessageContextMenu = sdk.getComponent('context_menus.MessageContextMenu');
         var buttonRect = e.target.getBoundingClientRect()
 
@@ -271,11 +272,26 @@ module.exports = WithMatrixClient(React.createClass({
             left: x,
             top: y,
             eventTileOps: this.refs.tile && this.refs.tile.getEventTileOps ? this.refs.tile.getEventTileOps() : undefined,
+            editEnabled: this.isEditEnabled(),
             onFinished: function() {
                 self.setState({menu: false});
             }
         });
         this.setState({menu: true});
+    },
+
+    isEditEnabled: function() {
+        if (this.props.mxEvent.event.type !== "m.room.message") {
+            return false;
+        }
+
+        var room = this.props.matrixClient.getRoom(this.props.mxEvent.getRoomId());
+        if (room.isEditEnabled && room.isEditEnabled()) {
+            var myUserId = this.props.matrixClient.credentials.userId;
+            return myUserId == this.props.mxEvent.getSender();
+        } else {
+            return false;
+        }
     },
 
     toggleAllReadAvatars: function() {
@@ -397,7 +413,7 @@ module.exports = WithMatrixClient(React.createClass({
         }
 
         var e2eEnabled = this.props.matrixClient.isRoomEncrypted(this.props.mxEvent.getRoomId());
-        var isSending = (['sending', 'queued', 'encrypting'].indexOf(this.props.eventSendStatus) !== -1);
+        var isSending = (['sending', 'queued', 'encrypting', 'hasPendingEdit'].indexOf(this.props.eventSendStatus) !== -1);
 
         var classes = classNames({
             mx_EventTile: true,

--- a/src/components/views/rooms/MessageEditorInput.js
+++ b/src/components/views/rooms/MessageEditorInput.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import type SyntheticKeyboardEvent from 'react/lib/SyntheticKeyboardEvent';
+
+import dis from '../../../dispatcher';
+import { Editor, EditorState, ContentState, RichUtils } from 'draft-js';
+import classNames from 'classnames';
+import escape from 'lodash/escape';
+import Q from 'q';
+
+import MatrixClientPeg from '../../../MatrixClientPeg';
+import type {MatrixClient} from 'matrix-js-sdk/lib/matrix';
+import Modal from '../../../Modal';
+import sdk from '../../../index';
+import Markdown from '../../../Markdown';
+
+/*
+ * The textInput for editing existing messages
+ */
+export default class MessageEditorInput extends React.Component {
+    client: MatrixClient;
+
+    constructor(props, context) {
+        super(props, context);
+        this.handleReturn = this.handleReturn.bind(this);
+        this.onEditorContentChanged = this.onEditorContentChanged.bind(this);
+        this.onEscape = this.onEscape.bind(this);
+        this.state = {
+            editorState: this.createEditorState(props.contentText)
+        };
+
+        this.client = MatrixClientPeg.get();
+    }
+
+    createEditorState(content) {
+        let editorState;
+
+        if (content) {
+            const contentState = ContentState.createFromText(content);
+            editorState = EditorState.createWithContent(contentState);
+        } else {
+            editorState = EditorState.createEmpty();
+        }
+
+        return EditorState.moveFocusToEnd(editorState);
+    }
+
+    onEditorContentChanged(editorState) {
+        this.setState({editorState: editorState});
+        // this.forceUpdate() //WHY U NO UPDATEZ?!1
+    }
+
+    handleReturn(ev) {
+        if (ev.shiftKey) {
+            this.onEditorContentChanged(RichUtils.insertSoftNewline(this.state.editorState));
+            return true;
+        }
+
+        const contentState = this.state.editorState.getCurrentContent();
+        if (!contentState.hasText()) {
+            return true;
+        }
+
+
+        let contentText = contentState.getPlainText();
+        let contentHTML;
+
+        const md = new Markdown(contentText);
+        if (!md.isPlainText()) {
+            contentHTML = md.toHTML();
+        }
+
+        let sendMessageEditPromise;
+        const roomId = this.props.mxEvent.event.room_id;
+        const targetId = this.props.mxEvent.event.event_id;
+        if (contentHTML) {
+            sendMessageEditPromise = this.client.sendHtmlMessageEdit.call(
+                this.client, roomId, targetId, contentText, contentHTML
+            );
+        } else {
+            sendMessageEditPromise = this.client.sendTextMessageEdit.call(
+                this.client, roomId, targetId, contentText
+            );
+        }
+        this.props.onMessageEditSent(sendMessageEditPromise, contentText)
+    }
+
+    onEscape(e) {
+        e.preventDefault()
+        return this.props.onEscape()
+    }
+
+    render() {
+        return (
+            <Editor
+                    editorState={this.state.editorState}
+                    onChange={this.onEditorContentChanged}
+                    handleReturn={this.handleReturn}
+                    onEscape={this.onEscape}
+                    spellCheck={true} />        );
+    }
+};
+
+MessageEditorInput.propTypes = {
+    // // a callback which is called when the height of the composer is
+    // // changed due to a change in content.
+    // onResize: React.PropTypes.func,
+
+    // // js-sdk Room object
+    // mxEvent: React.PropTypes.object.isRequired,
+};
+


### PR DESCRIPTION
Intended to be the companion PR to https://github.com/vector-im/riot-web/pull/2725

Adds an `MessageEditInput` which is a basic wrapper around `Editor` to be triggered when `edit` action is received from dispatcher (triggered on context-menu click). 

Missing:`matrix-js-sdk` methods that send an `edit` message to be functional. 

Escape - cancels edit mode.
Enter - should send edit message. 
