### PR TITLE
Don't throw exception on stop if no DMRoomMap

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -356,7 +356,7 @@ export function stopMatrixClient() {
     Notifier.stop();
     UserActivity.stop();
     Presence.stop();
-    DMRoomMap.shared().stop();
+    if (DMRoomMap.shared()) DMRoomMap.shared().stop();
     var cli = MatrixClientPeg.get();
     if (cli) {
         cli.stopClient();

--- a/test/components/structures/RoomView-test.js
+++ b/test/components/structures/RoomView-test.js
@@ -60,14 +60,13 @@ describe('RoomView', function () {
         peg.get().getProfileInfo.returns(q({displayname: "foo"}));
         var roomView = ReactDOM.render(<RoomView roomAddress="#alias:ser.ver" />, parentDiv);
 
-        peg.get().joinRoom = sinon.spy();
+        peg.get().joinRoom = function(x) {
+            expect(x).toEqual('#alias:ser.ver');
+            done();
+        }
 
         process.nextTick(function() {
             roomView.onJoinButtonClicked();
-            process.nextTick(function() {
-                expect(peg.get().joinRoom.calledWith('#alias:ser.ver')).toExist();
-                done();
-            });
         });
     });
 });


### PR DESCRIPTION
Prevents an exception when running the riot 'loading' tests in isolation

(Includes https://github.com/matrix-org/matrix-react-sdk/pull/587)