### PR TITLE
Improve the performance of MemberEventListSummary

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -296,6 +296,12 @@ module.exports = React.createClass({
             // Wrap consecutive member events in a ListSummary
             if (isMembershipChange(mxEv)) {
                 let ts1 = mxEv.getTs();
+                // Ensure that the key of the MemberEventListSummary does not change with new
+                // member events. This will prevent it from being re-created necessarily, and
+                // instead will allow new props to be provided. In turn, the shouldComponentUpdate
+                // method on MELS can be used to prevent unnecessary renderings.
+                // `prevEvent` at this point is a non-member event or null.
+                const key = "memberlistsummary-" + (prevEvent ? prevEvent.getId() : "");
 
                 if (this._wantsDateSeparator(prevEvent, ts1)) {
                     let dateSeparator = <li key={ts1+'~'}><DateSeparator key={ts1+'~'} ts={ts1}/></li>;
@@ -332,7 +338,7 @@ module.exports = React.createClass({
 
                 ret.push(
                     <MemberEventListSummary
-                        key={mxEv.getId()}
+                        key={key}
                         events={summarisedEvents}
                         data-scroll-token={eventId}>
                             {eventTiles}

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -297,7 +297,7 @@ module.exports = React.createClass({
             if (isMembershipChange(mxEv)) {
                 let ts1 = mxEv.getTs();
                 // Ensure that the key of the MemberEventListSummary does not change with new
-                // member events. This will prevent it from being re-created necessarily, and
+                // member events. This will prevent it from being re-created unnecessarily, and
                 // instead will allow new props to be provided. In turn, the shouldComponentUpdate
                 // method on MELS can be used to prevent unnecessary renderings.
                 // `prevEvent` at this point is a non-member event or null.

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -300,8 +300,11 @@ module.exports = React.createClass({
                 // member events. This will prevent it from being re-created unnecessarily, and
                 // instead will allow new props to be provided. In turn, the shouldComponentUpdate
                 // method on MELS can be used to prevent unnecessary renderings.
-                // `prevEvent` at this point is a non-member event or null.
-                const key = "memberlistsummary-" + (prevEvent ? mxEv.getId() : "initial");
+                //
+                // Whilst back-paginating with a MELS at the top of the panel, prevEvent will be null,
+                // so use the key "membereventlistsummary-initial". Otherwise, use the ID of the first
+                // membership event, which will not change during forward pagination.
+                const key = "membereventlistsummary-" + (prevEvent ? mxEv.getId() : "initial");
 
                 if (this._wantsDateSeparator(prevEvent, ts1)) {
                     let dateSeparator = <li key={ts1+'~'}><DateSeparator key={ts1+'~'} ts={ts1}/></li>;

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -301,7 +301,7 @@ module.exports = React.createClass({
                 // instead will allow new props to be provided. In turn, the shouldComponentUpdate
                 // method on MELS can be used to prevent unnecessary renderings.
                 // `prevEvent` at this point is a non-member event or null.
-                const key = "memberlistsummary-" + (prevEvent ? prevEvent.getId() : "");
+                const key = "memberlistsummary-" + (prevEvent ? mxEv.getId() : "initial");
 
                 if (this._wantsDateSeparator(prevEvent, ts1)) {
                     let dateSeparator = <li key={ts1+'~'}><DateSeparator key={ts1+'~'} ts={ts1}/></li>;

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -182,9 +182,8 @@ module.exports = React.createClass({
             }
             if (!userEvents[userId].first) {
                 userEvents[userId].first = e;
-            } else {
-                userEvents[userId].last = e;
             }
+            userEvents[userId].last = e;
         });
 
         // Populate the join/leave event arrays with events that represent what happened
@@ -198,10 +197,6 @@ module.exports = React.createClass({
             (userId) => {
                 let firstEvent = userEvents[userId].first;
                 let lastEvent = userEvents[userId].last;
-                // Only one membership event was recorded for this userId
-                if (!lastEvent) {
-                    lastEvent = firstEvent;
-                }
 
                 // Membership BEFORE eventsToRender
                 let previousMembership = firstEvent.getPrevContent().membership || "leave";

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -149,9 +149,11 @@ module.exports = React.createClass({
         //  - The number of summarised events has changed
         //  - or if the summary is currently expanded
         //  - or if the summary is about to toggle to become collapsed
+        //  - or if there are fewEvents, meaning the child eventTiles are shown as-is
         return (
             nextProps.events.length !== this.props.events.length ||
-            this.state.expanded || nextState.expanded
+            this.state.expanded || nextState.expanded ||
+            nextProps.events.length < this.props.threshold
         );
     },
 

--- a/src/components/views/elements/MemberEventListSummary.js
+++ b/src/components/views/elements/MemberEventListSummary.js
@@ -145,9 +145,13 @@ module.exports = React.createClass({
     },
 
     shouldComponentUpdate: function(nextProps, nextState) {
+        // Update if
+        //  - The number of summarised events has changed
+        //  - or if the summary is currently expanded
+        //  - or if the summary is about to toggle to become collapsed
         return (
             nextProps.events.length !== this.props.events.length ||
-            nextState.expanded !== this.state.expanded
+            this.state.expanded || nextState.expanded
         );
     },
 


### PR DESCRIPTION
- The MessagePanel now uses the same key for the MELS instances rendered so that entirely new instances are not created, they are simply passed new props (namely when new events arrive).
- MELS itself now uses `shouldComponentUpdate` so that it only updates if it is given a different number of events to previous or if it is toggled to expand.
- The render event is now linear in complexity as opposed to O(n^2) as it was previously.