### PR TITLE
Use correct 1-1 room avatar after users leave

### DIFF
--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -86,7 +86,7 @@ module.exports = React.createClass({
         var userIds = [];
         // for .. in optimisation to return early if there are >2 keys
         for (var uid in mlist) {
-            if (mlist.hasOwnProperty(uid)) {
+            if (mlist.hasOwnProperty(uid) && ["join", "invite"].includes(mlist[uid].membership)) {
                 userIds.push(uid);
             }
             if (userIds.length > 2) {

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -84,10 +84,15 @@ module.exports = React.createClass({
 
         var mlist = props.room.currentState.members;
         var userIds = [];
+        var leftUserIds = [];
         // for .. in optimisation to return early if there are >2 keys
         for (var uid in mlist) {
-            if (mlist.hasOwnProperty(uid) && ["join", "invite"].includes(mlist[uid].membership)) {
-                userIds.push(uid);
+            if (mlist.hasOwnProperty(uid)) {
+                if (["join", "invite"].includes(mlist[uid].membership)) {
+                    userIds.push(uid);
+                } else {
+                    leftUserIds.push(uid);
+                }
             }
             if (userIds.length > 2) {
                 return null;
@@ -101,12 +106,21 @@ module.exports = React.createClass({
             } else {
                 theOtherGuy = mlist[userIds[0]];
             }
+
             return theOtherGuy.getAvatarUrl(
                 MatrixClientPeg.get().getHomeserverUrl(),
                 props.width, props.height, props.resizeMethod,
                 false
             );
         } else if (userIds.length == 1) {
+            // The other 1-1 user left, leaving just the current user, so show the left user's avatar
+            if (leftUserIds.length === 1) {
+                return mlist[leftUserIds[0]].getAvatarUrl(
+                    MatrixClientPeg.get().getHomeserverUrl(),
+                    props.width, props.height, props.resizeMethod,
+                        false
+                );
+            }
             return mlist[userIds[0]].getAvatarUrl(
                 MatrixClientPeg.get().getHomeserverUrl(),
                 props.width, props.height, props.resizeMethod,

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -106,7 +106,6 @@ module.exports = React.createClass({
             } else {
                 theOtherGuy = mlist[userIds[0]];
             }
-
             return theOtherGuy.getAvatarUrl(
                 MatrixClientPeg.get().getHomeserverUrl(),
                 props.width, props.height, props.resizeMethod,


### PR DESCRIPTION
The correct 1-1 avatar is used with rooms in which there are only two users with either "join" or "invite" as their membership (importantly, not "leave" or otherwise).

(This is important when a user moves accounts and re-joins previously left 1-1 chats)