### PR TITLE
Fix scroll jumping when a video is decrypted

### DIFF
--- a/src/components/views/messages/MVideoBody.js
+++ b/src/components/views/messages/MVideoBody.js
@@ -27,6 +27,14 @@ import q from 'q';
 module.exports = React.createClass({
     displayName: 'MVideoBody',
 
+    propTypes: {
+        /* the MatrixEvent to show */
+        mxEvent: React.PropTypes.object.isRequired,
+
+        /* called when the video has loaded */
+        onWidgetLoad: React.PropTypes.func.isRequired,
+    },
+
     getInitialState: function() {
         return {
             decryptedUrl: null,
@@ -100,6 +108,7 @@ module.exports = React.createClass({
                         decryptedThumbnailUrl: thumbnailUrl,
                         decryptedBlob: decryptedBlob,
                     });
+                    this.props.onWidgetLoad();
                 });
             }).catch((err) => {
                 console.warn("Unable to decrypt attachment: ", err)


### PR DESCRIPTION
Call the `onWidgetLoad` prop on MVideoBody to notify the scroll panel to keep it's position when the size of the video widget updates. 

Should fix https://github.com/vector-im/riot-web/issues/2744