### PR TITLE
Unbranded error messages

### DIFF
--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -280,7 +280,7 @@ function _onAction(payload) {
                 var QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                 Modal.createDialog(QuestionDialog, {
                     title: "Warning!",
-                    description: "Conference calling in Riot is in development and may not be reliable.",
+                    description: "Conference calling is in development and may not be reliable.",
                     onFinished: confirm=>{
                         if (confirm) {
                             ConferenceHandler.createNewMatrixCall(

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -810,7 +810,7 @@ var TimelinePanel = React.createClass({
                     });
                 };
             }
-            var message = "Riot was trying to load a specific point in this room's timeline but ";
+            var message = "Tried to load a specific point in this room's timeline, but ";
             if (error.errcode == 'M_FORBIDDEN') {
                 message += "you do not have permission to view the message in question.";
             } else {

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -203,7 +203,7 @@ module.exports = React.createClass({
                  !this.state.enteredHomeserverUrl.startsWith("http")))
             {
                 errorText = <span>
-                    Can't connect to homeserver via HTTP when using Riot served by HTTPS.
+                    Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar.
                     Either use HTTPS or <a href='https://www.google.com/search?&q=enable%20unsafe%20scripts'>enable unsafe scripts</a>
                 </span>;
             }

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -94,7 +94,7 @@ module.exports = React.createClass({
             if (this.props.invitedEmail) {
                 if (this.state.threePidFetchError) {
                     emailMatchBlock = <div className="error">
-                        Riot was unable to ascertain that the address this invite was
+                        Unable to ascertain that the address this invite was
                         sent to matches one associated with your account.
                     </div>
                 } else if (this.state.invitedEmailMxid != MatrixClientPeg.get().credentials.userId) {


### PR DESCRIPTION
As I understand, in the long run, matrix-react-sdk is intended as an SDK that client authors (like Riot) can use to implement a matrix client. As such, I think having error messages which avoid reference to a specific client will make implementer's lives easier. 

There are two other references to Riot that I am aware of that this pull request does not address:
src/components/structures/MatrixChat.js line 922
src/components/views/elements/AddressTile.js line 78

I'm not presently familiar enough with this codebase to understand how those references should best be addressed.

Signed-off-by: Daniel Dent <matrixcontrib@contactdaniel.net>