### PR TITLE
Let electron users complete captchas in a web browser

### DIFF
--- a/src/Signup.js
+++ b/src/Signup.js
@@ -191,7 +191,7 @@ class Register extends Signup {
                     }
                 }
                 if (poll_for_success) {
-                    return q.delay(5000).then(function() {
+                    return q.delay(2000).then(function() {
                         return self._tryRegister(client, authDict, poll_for_success);
                     });
                 } else {

--- a/src/SignupStages.js
+++ b/src/SignupStages.js
@@ -52,7 +52,13 @@ DummyStage.TYPE = "m.login.dummy";
 class RecaptchaStage extends Stage {
     constructor(matrixClient, signupInstance) {
         super(RecaptchaStage.TYPE, matrixClient, signupInstance);
-        this.defer = q.defer(); // resolved with the captcha response
+        this.authDict = {
+            auth: {
+                type: 'm.login.recaptcha',
+                // we'll add in the response param if we get one from the local user.
+            },
+            poll_for_success: true,
+        };
     }
 
     // called when the recaptcha has been completed.
@@ -60,16 +66,15 @@ class RecaptchaStage extends Stage {
         if (!data || !data.response) {
             return;
         }
-        this.defer.resolve({
-            auth: {
-                type: 'm.login.recaptcha',
-                response: data.response,
-            }
-        });
+        this.authDict.response = data.response;
     }
 
     complete() {
-        return this.defer.promise;
+        // we return the authDict with no response, telling Signup to keep polling
+        // the server in case the captcha is filled in on another window (e.g. by
+        // following a nextlink from an email signup).  If the user completes the
+        // captcha locally, then we return at the next poll.
+        return q(this.authDict);
     }
 }
 RecaptchaStage.TYPE = "m.login.recaptcha";

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -273,6 +273,7 @@ module.exports = React.createClass({
                 if (serverParams && serverParams["m.login.recaptcha"]) {
                     publicKey = serverParams["m.login.recaptcha"].public_key;
                 }
+
                 registerStep = (
                     <CaptchaForm sitePublicKey={publicKey}
                         onCaptchaResponse={this.onCaptchaResponse}

--- a/src/components/views/login/CaptchaForm.js
+++ b/src/components/views/login/CaptchaForm.js
@@ -54,8 +54,9 @@ module.exports = React.createClass({
             console.log("Loading recaptcha script...");
             var scriptTag = document.createElement('script');
             window.mx_on_recaptcha_loaded = () => {this._onCaptchaLoaded()};
+            var protocol = global.location.protocol === "file:" ? "https:" : global.location.protocol;
             scriptTag.setAttribute(
-                'src', global.location.protocol+"//www.google.com/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit"
+                'src', protocol+"//www.google.com/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit"
             );
             this.refs.recaptchaContainer.appendChild(scriptTag);
         }

--- a/src/components/views/login/CaptchaForm.js
+++ b/src/components/views/login/CaptchaForm.js
@@ -52,13 +52,24 @@ module.exports = React.createClass({
             this._onCaptchaLoaded();
         } else {
             console.log("Loading recaptcha script...");
-            var scriptTag = document.createElement('script');
             window.mx_on_recaptcha_loaded = () => {this._onCaptchaLoaded()};
-            var protocol = global.location.protocol === "file:" ? "https:" : global.location.protocol;
-            scriptTag.setAttribute(
-                'src', protocol+"//www.google.com/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit"
-            );
-            this.refs.recaptchaContainer.appendChild(scriptTag);
+            var protocol = global.location.protocol;
+            if (protocol === "file:") {
+                var warning = document.createElement('div');
+                // XXX: fix hardcoded app URL.  Better solutions include:
+                // * jumping straight to a hosted captcha page (but we don't support that yet)
+                // * embedding the captcha in an iframe (if that works)
+                // * using a better captcha lib
+                warning.innerHTML = "Robot check is currently unavailable on desktop - please sign up <a href='https://riot.im/app'>using a web browser</a>.";
+                this.refs.recaptchaContainer.appendChild(warning);
+            }
+            else {
+                var scriptTag = document.createElement('script');
+                scriptTag.setAttribute(
+                    'src', protocol+"//www.google.com/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit"
+                );
+                this.refs.recaptchaContainer.appendChild(scriptTag);
+            }
         }
     },
 
@@ -107,6 +118,7 @@ module.exports = React.createClass({
         return (
             <div ref="recaptchaContainer">
                 This Home Server would like to make sure you are not a robot
+                <br/>
                 <div id={DIV_ID}></div>
                 {error}
             </div>


### PR DESCRIPTION
Google's recaptcha doesn't work in electron, breaking sign-up.  As a quick fix, this PR lets the recaptcha signup stage poll for success, letting users complete the captcha elsewhere.  If they follow the typical signup flow of doing email verification and then recaptcha, they'll naturally click the link in their email which will take them to a browser which will then let them recaptcha.  At which point they'll be logged in both on web and on electron, but at least electron will work.

Better solutions include:
 * Seeing if fallback auth in an iframe would work for the recaptcha for Electron
 * Messing around with custom URI handlers to hand control back to the Electron app after doing the captcha