### PR TITLE
remove alt tag from Options button

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -465,7 +465,7 @@ module.exports = WithMatrixClient(React.createClass({
         }
 
         var editButton = (
-            <img className="mx_EventTile_editButton" src="img/icon_context_message.svg" width="19" height="19" alt="Options" title="Options" onClick={this.onEditClicked} />
+            <img className="mx_EventTile_editButton" src="img/icon_context_message.svg" width="19" height="19" alt="" title="Options" onClick={this.onEditClicked} />
         );
 
         var e2e;


### PR DESCRIPTION
This solves part of the problem that the word "Options" is copied in your clipboard.

see https://github.com/vector-im/riot-web/issues/893