### PR TITLE
Move screen sharing error check into platform

### DIFF
--- a/src/BasePlatform.js
+++ b/src/BasePlatform.js
@@ -73,4 +73,13 @@ export default class BasePlatform {
     getAppVersion() {
         throw new Error("getAppVersion not implemented!");
     }
+
+    /*
+     * If it's not expected that capturing the screen will work
+     * with getUserMedia, return a string explaining why not.
+     * Otherwise, return null.
+     */
+    screenCaptureErrorString() {
+        return "Not implemented";
+    }
 }

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -52,6 +52,7 @@ limitations under the License.
  */
 
 var MatrixClientPeg = require('./MatrixClientPeg');
+var PlatformPeg = require("./PlatformPeg");
 var Modal = require('./Modal');
 var sdk = require('./index');
 var Matrix = require("matrix-js-sdk");
@@ -187,6 +188,12 @@ function _onAction(payload) {
             );
         }
         else if (payload.type === 'screensharing') {
+            const screenCapErrorString = PlatformPeg.get().screenCaptureErrorString();
+            if (screenCapErrorString) {
+                _setCallState(undefined, newCall.roomId, "ended");
+                console.log("Can't capture screen: " + screenCapErrorString);
+                return;
+            }
             newCall.placeScreenSharingCall(
                 payload.remote_element,
                 payload.local_element

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -192,6 +192,11 @@ function _onAction(payload) {
             if (screenCapErrorString) {
                 _setCallState(undefined, newCall.roomId, "ended");
                 console.log("Can't capture screen: " + screenCapErrorString);
+                const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
+                Modal.createDialog(ErrorDialog, {
+                    title: "Unable to capture screen",
+                    description: screenCapErrorString
+                });
                 return;
             }
             newCall.placeScreenSharingCall(


### PR DESCRIPTION
Because on the browser it depends on HTTPS, on electron it doesn't
matter.