### PR TITLE
Fix vector-im/riot-web#2833 : Fail nicely when people try to register numeric user IDs

### DIFF
--- a/src/Signup.js
+++ b/src/Signup.js
@@ -206,14 +206,12 @@ class Register extends Signup {
                     let msg = null;
                     if (error.message) {
                         msg = error.message;
-                    }
-                    else if (error.errcode) {
+                    } else if (error.errcode) {
                         msg = error.errcode;
                     }
                     if (msg) {
                         throw new Error(`Registration failed! (${error.httpStatus}) - ${msg}`);
-                    }
-                    else {
+                    } else {
                         throw new Error(`Registration failed! (${error.httpStatus}) - That's all we know.`);
                     }
                 } else if (error.httpStatus >= 500 && error.httpStatus < 600) {

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -203,7 +203,19 @@ class Register extends Signup {
                 } else if (error.errcode == 'M_INVALID_USERNAME') {
                     throw new Error("User names may only contain alphanumeric characters, underscores or dots!");
                 } else if (error.httpStatus >= 400 && error.httpStatus < 500) {
-                    throw new Error(`Registration failed! (${error.httpStatus})`);
+                    let msg = null;
+                    if (error.message) {
+                        msg = error.message;
+                    }
+                    else if (error.errcode) {
+                        msg = error.errcode;
+                    }
+                    if (msg) {
+                        throw new Error(`Registration failed! (${error.httpStatus}) - ${msg}`);
+                    }
+                    else {
+                        throw new Error(`Registration failed! (${error.httpStatus}) - That's all we know.`);
+                    }
                 } else if (error.httpStatus >= 500 && error.httpStatus < 600) {
                     throw new Error(
                         `Server error during registration! (${error.httpStatus})`


### PR DESCRIPTION
Manually tested all cases. For the numeric case this now displays:

```
Registration failed! (400) - Numeric user IDs are reserved for guest users.
```