### PR TITLE
Implement auto-join rooms on registration

### DIFF
--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -179,6 +179,23 @@ module.exports = React.createClass({
                 accessToken: response.access_token
             });
 
+            // Auto-join rooms
+            if (self.props.teamsConfig) {
+                for (let i = 0; i < self.props.teamsConfig.teams.length; i++) {
+                    let team = self.props.teamsConfig.teams[i];
+                    if (self.state.formVals.email.endsWith(team.emailSuffix)) {
+                        console.log("User successfully registered with team " + team.name);
+                        team.rooms.forEach((room) => {
+                            if (room.autoJoin) {
+                                console.log("Auto-joining " + room.id);
+                                MatrixClientPeg.get().joinRoom(room.id);
+                            }
+                        });
+                        break;
+                    }
+                }
+            }
+
             if (self.props.brand) {
                 MatrixClientPeg.get().getPushers().done((resp)=>{
                     var pushers = resp.pushers;

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -57,6 +57,11 @@ module.exports = React.createClass({
                 "name": React.PropTypes.string,
                 // The suffix with which every team email address ends
                 "emailSuffix": React.PropTypes.string,
+                // The rooms to use during auto-join
+                "rooms": React.PropTypes.arrayOf(React.PropTypes.shape({
+                    "id": React.PropTypes.string,
+                    "autoJoin": React.PropTypes.bool,
+                })),
             })).required,
         }),
 
@@ -180,11 +185,14 @@ module.exports = React.createClass({
             });
 
             // Auto-join rooms
-            if (self.props.teamsConfig) {
+            if (self.props.teamsConfig && self.props.teamsConfig.teams) {
                 for (let i = 0; i < self.props.teamsConfig.teams.length; i++) {
                     let team = self.props.teamsConfig.teams[i];
                     if (self.state.formVals.email.endsWith(team.emailSuffix)) {
                         console.log("User successfully registered with team " + team.name);
+                        if (!team.rooms) {
+                            break;
+                        }
                         team.rooms.forEach((room) => {
                             if (room.autoJoin) {
                                 console.log("Auto-joining " + room.id);

--- a/src/components/views/login/RegistrationForm.js
+++ b/src/components/views/login/RegistrationForm.js
@@ -116,10 +116,14 @@ module.exports = React.createClass({
     },
 
     _doSubmit: function() {
+        let email = this.refs.email.value.trim();
+        if (this.state.selectedTeam) {
+            email += "@" + this.state.selectedTeam.emailSuffix;
+        }
         var promise = this.props.onRegisterClick({
             username: this.refs.username.value.trim() || this.props.guestUsername,
             password: this.refs.password.value.trim(),
-            email: this.refs.email.value.trim()
+            email: email,
         });
 
         if (promise) {


### PR DESCRIPTION
Also: This fixes registration with a team #620 : only the email localpart was being used to register.

When a registration is successful, the user will be joined to rooms specified in the config.json teamsConfig:
```json
"teamsConfig" : {
  "supportEmail": "support@riot.im",
  "teams": [
    {
      "name" : "matrix",
      "emailSuffix" : "matrix.org",
      "rooms" : [
        {
          "id" : "#irc_matrix:matrix.org",
          "autoJoin" : true
        }
      ]
    }
  ]
}
```
`autoJoin` can of course be set to `false` if the room should only be displayed on the (forthcoming) welcome page for each team, and not auto-joined.

Addresses https://github.com/vector-im/riot-web/issues/1636