### PR TITLE
Configure travis to test riot-web after building

### DIFF
--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -6,7 +6,7 @@
 
 set -ev
 
-git clone --depth=1 https://github.com/vector-im/riot-web.git riot-web
+git clone --depth=1 --branch develop https://github.com/vector-im/riot-web.git riot-web
 cd riot-web
 mkdir node_modules
 ln -s ../.. node_modules/matrix-react-sdk

--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -6,15 +6,20 @@
 
 set -ev
 
-git clone --depth=1 --branch develop https://github.com/vector-im/riot-web.git riot-web
-cd riot-web
+RIOT_WEB_DIR=riot-web
+REACT_SDK_DIR=`pwd`
+
+git clone --depth=1 --branch develop https://github.com/vector-im/riot-web.git \
+    "$RIOT_WEB_DIR"
+
+cd "$RIOT_WEB_DIR"
+
 mkdir node_modules
-ln -s ../.. node_modules/matrix-react-sdk
 npm install
 
 (cd node_modules/matrix-js-sdk && npm install)
 
-# https://github.com/webpack/webpack/issues/1472 workaround
-(cd node_modules/matrix-react-sdk && npm install source-map-loader)
+rm -r node_modules/matrix-react-sdk
+ln -s "$REACT_SDK_DIR" node_modules/matrix-react-sdk
 
 npm run test

--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -11,5 +11,10 @@ cd riot-web
 mkdir node_modules
 ln -s ../.. node_modules/matrix-react-sdk
 npm install
+
 (cd node_modules/matrix-js-sdk && npm install)
+
+# https://github.com/webpack/webpack/issues/1472 workaround
+(cd node_modules/matrix-react-sdk && npm install source-map-loader)
+
 npm run test

--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# script which is run by the travis build (after `npm run test`).
+#
+# clones riot-web develop and runs the tests against our version of react-sdk.
+
+set -ev
+
+git clone --depth=1 https://github.com/vector-im/riot-web.git riot-web
+cd riot-web
+mkdir node_modules
+ln -s ../.. node_modules/matrix-react-sdk
+npm install
+(cd node_modules/matrix-js-sdk && npm install)
+npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
 install:
     - npm install
     - (cd node_modules/matrix-js-sdk && npm install)
+script:
+    - npm run test
+    - ./.travis-test-riot.sh


### PR DESCRIPTION
react-sdk contains a lot of application-level stuff, which is then tested by the tests in riot-web - so we should make travis run those tests against react-ssdk PRs.

(Yesterday we failed to stop a breakage introduced in Matthew's skinning changes to react-sdk).