### PR TITLE
Referral URL in UserSettings

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -678,6 +678,8 @@ module.exports = React.createClass({
             olmVersionString = olmVersion[0] + "." + olmVersion[1] + "." + olmVersion[2];
         }
 
+        let referralURL = window.location.origin + "/#/register?utm_medium=referral&utm_source=" + this._me;
+
         return (
             <div className="mx_UserSettings">
                 <SimpleRoomHeader
@@ -729,6 +731,11 @@ module.exports = React.createClass({
                     </div>
 
                     {accountJsx}
+                </div>
+
+                <h3>Referral</h3>
+                <div className="mx_UserSettings_section">
+                    Your referral URL: <a href={referralURL}>{referralURL}</a>
                 </div>
 
                 {notification_area}


### PR DESCRIPTION
Include a registration URL in UserSettings that includes `utm_source=userId` and `utm_medium=referral` for tracking registrations by referral. (e.g. http://riot.im/#/register?utm_source=@lb:ldbco.de&utm_medium=referral)

- [ ] I'm guessing we'll need some way to specify the `utm_campaign`?