### PR TITLE
Correctly get the path of the js-sdk .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,15 @@
+const path = require('path');
+
+// get the path of the js-sdk so we can extend the config
+// eslint supports loading extended configs by module,
+// but only if they come from a module that starts with eslint-config-
+// So we load the filename directly (and it could be in node_modules/
+// or or ../node_modules/ etc)
+const matrixJsSdkPath = path.dirname(require.resolve('matrix-js-sdk'));
+
 module.exports = {
     parser: "babel-eslint",
-    extends: ["./node_modules/matrix-js-sdk/.eslintrc.js"],
+    extends: [matrixJsSdkPath + "/.eslintrc.js"],
     plugins: [
       "react",
       "flowtype",


### PR DESCRIPTION
So we work correctly when we're included in another module