### PR TITLE
Two megolm export fixes:

### DIFF
--- a/src/utils/MegolmExportEncryption.js
+++ b/src/utils/MegolmExportEncryption.js
@@ -107,13 +107,13 @@ export function encryptMegolmKeyFile(data, password, options) {
     const salt = new Uint8Array(16);
     window.crypto.getRandomValues(salt);
 
-    // clear bit 63 of the salt to stop us hitting the 64-bit counter boundary
-    // (which would mean we wouldn't be able to decrypt on Android). The loss
-    // of a single bit of salt is a price we have to pay.
-    salt[9] &= 0x7f;
-
     const iv = new Uint8Array(16);
     window.crypto.getRandomValues(iv);
+
+    // clear bit 63 of the IV to stop us hitting the 64-bit counter boundary
+    // (which would mean we wouldn't be able to decrypt on Android). The loss
+    // of a single bit of iv is a price we have to pay.
+    iv[9] &= 0x7f;
 
     return deriveKeys(salt, kdf_rounds, password).then((keys) => {
         const [aes_key, hmac_key] = keys;

--- a/src/utils/MegolmExportEncryption.js
+++ b/src/utils/MegolmExportEncryption.js
@@ -50,7 +50,7 @@ export function decryptMegolmKeyFile(data, password) {
     }
 
     const ciphertextLength = body.length-(1+16+16+4+32);
-    if (body.length < 0) {
+    if (ciphertextLength < 0) {
         throw new Error('Invalid file: too short');
     }
 

--- a/test/utils/MegolmExportEncryption-test.js
+++ b/test/utils/MegolmExportEncryption-test.js
@@ -75,6 +75,16 @@ describe('MegolmExportEncryption', function() {
                 .toThrow('Trailer line not found');
         });
 
+        it('should handle a too-short body', function() {
+            const input=stringToArray(`-----BEGIN MEGOLM SESSION DATA-----
+AXNhbHRzYWx0c2FsdHNhbHSIiIiIiIiIiIiIiIiIiIiIAAAACmIRUW2OjZ3L2l6j9h0lHlV3M2dx
+cissyYBxjsfsAn
+-----END MEGOLM SESSION DATA-----
+`);
+            expect(()=>{MegolmExportEncryption.decryptMegolmKeyFile(input, '')})
+                .toThrow('Invalid file: too short');
+        });
+
         it('should decrypt a range of inputs', function(done) {
             function next(i) {
                 if (i >= TEST_VECTORS.length) {


### PR DESCRIPTION
1. Make sure we throw a sensible error when the body of the data is too short.

2. Apply android workaround to the right array