### PR TITLE
Reinstate max-len lint configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,8 @@ module.exports = {
             // apparently people believe the length limit shouldn't apply
             // to JSX.
             ignorePattern: '^\\s*<',
+            ignoreComments: true,
+            code: 90,
         }],
         "valid-jsdoc": ["warn"],
         "new-cap": ["warn"],


### PR DESCRIPTION
Apparenltly setting the ignorePattern on max-len (as per cf049f2) makes eslint
forget the `ignoreComments` and `code` settings from js-sdk, so reinstate
these.