### PR TITLE
Set `mx_team_token` on startup from query param

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -93,6 +93,10 @@ export function loadSession(opts) {
         }
     }
 
+    if (fragmentQueryParams.team_token) {
+        window.localStorage.setItem('mx_team_token', fragmentQueryParams.team_token);
+    }
+
     if (enableGuest &&
         fragmentQueryParams.guest_user_id &&
         fragmentQueryParams.guest_access_token


### PR DESCRIPTION
This is so that referral links with the `team_token` query parameter will set the client up accordingly.