### PR TITLE
Fix expanding/unexapnding read receipts

### DIFF
--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -159,13 +159,14 @@ module.exports = React.createClass({
         }
         if (onClick != null) {
             return (
-                <AccessibleButton className="mx_BaseAvatar" onClick={onClick}>
-                    <img className="mx_BaseAvatar_image" src={imageUrl}
-                        onError={this.onError}
-                        width={width} height={height}
-                        title={title} alt=""
-                        {...otherProps} />
-                </AccessibleButton>
+                <AccessibleButton className="mx_BaseAvatar mx_BaseAvatar_image"
+                    element='img'
+                    src={imageUrl}
+                    onClick={onClick}
+                    onError={this.onError}
+                    width={width} height={height}
+                    title={title} alt=""
+                    {...otherProps} />
             );
         } else {
             return (

--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -192,9 +192,9 @@ module.exports = React.createClass({
                     width={14} height={14} resizeMethod="crop"
                     style={style}
                     title={title}
+                    onClick={this.props.onClick}
                 />
             </Velociraptor>
         );
-        /* onClick={this.props.onClick} */
     },
 });


### PR DESCRIPTION
Make the AccessibleButton element be the img directly rather than
wrapping it in a div which is unnecessary and breaks the rendering.

Fixes https://github.com/vector-im/riot-web/issues/3052