### PR TITLE
Fix one read receipt randomly not appearing

### DIFF
--- a/src/Velociraptor.js
+++ b/src/Velociraptor.js
@@ -62,10 +62,10 @@ module.exports = React.createClass({
                             oldNode.style.visibility = c.props.style.visibility;
                         }
                     });
-                    if (oldNode.style.visibility == 'hidden' && c.props.style.visibility == 'visible') {
-                        oldNode.style.visibility = c.props.style.visibility;
-                    }
                     //console.log("translation: "+oldNode.style.left+" -> "+c.props.style.left);
+                }
+                if (oldNode.style.visibility == 'hidden' && c.props.style.visibility == 'visible') {
+                    oldNode.style.visibility = c.props.style.visibility;
                 }
                 self.children[c.key] = old;
             } else {


### PR DESCRIPTION
The velociraptor was only actioning hidden -> visible transitions
if the position had changed, so the one RR that stayed in position
but became visible... didn't become visible.