### PR TITLE
Fix timeline & notifs panel spuriously being empty

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -993,7 +993,7 @@ var TimelinePanel = React.createClass({
             );
         }
 
-        if (this.state.events.length == 0) {
+        if (this.state.events.length == 0 && !this.state.canBackPaginate && this.props.empty) {
             return (
                     <div className={ this.props.className + " mx_RoomView_messageListWrapper" }>
                         <div className="mx_RoomView_empty">{ this.props.empty }</div>


### PR DESCRIPTION
Only claim there's nothing to display once we've failed to back
paginate, otherwise we'll show the empty message instead of the
MessagePanel and therefore never try to back-paginate.

Fixes https://github.com/vector-im/riot-web/issues/3123