### PR TITLE
Set referrer qp in nextLink

### DIFF
--- a/src/Signup.js
+++ b/src/Signup.js
@@ -91,6 +91,10 @@ class Register extends Signup {
         this.params.idSid = idSid;
     }
 
+    setReferrer(referrer) {
+        this.params.referrer = referrer;
+    }
+
     setGuestAccessToken(token) {
         this.guestAccessToken = token;
     }

--- a/src/SignupStages.js
+++ b/src/SignupStages.js
@@ -136,6 +136,11 @@ class EmailIdentityStage extends Stage {
                        "&session_id=" +
                        encodeURIComponent(this.signupInstance.getServerData().session);
 
+        // Add the user ID of the referring user, if set
+        if (this.signupInstance.params.referrer) {
+            nextLink += "&referrer=" + encodeURIComponent(this.signupInstance.params.referrer);
+        }
+
         var self = this;
         return this.client.requestRegisterEmailToken(
             this.signupInstance.email,

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -98,6 +98,9 @@ module.exports = React.createClass({
         this.registerLogic.setRegistrationUrl(this.props.registrationUrl);
         this.registerLogic.setIdSid(this.props.idSid);
         this.registerLogic.setGuestAccessToken(this.props.guestAccessToken);
+        if (this.props.referrer) {
+            this.registerLogic.setReferrer(this.props.referrer);
+        }
         this.registerLogic.recheckState();
 
         if (


### PR DESCRIPTION
This is so that when the verification link is clicked from an email, the referrer is set on the new instance of riot when /rts/register is hit