### PR TITLE
Use new method of getting team icon

### DIFF
--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -428,7 +428,7 @@ module.exports = React.createClass({
                 <div className="mx_Login_box">
                     <LoginHeader
                         icon={this.state.teamSelected ?
-                            "https://riot.im/rts/static/common/" +
+                            this.props.teamServerConfig.teamServerURL + "/static/common/" +
                             this.state.teamSelected.domain + "/icon.png" :
                             null}
                     />

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -426,7 +426,12 @@ module.exports = React.createClass({
         return (
             <div className="mx_Login">
                 <div className="mx_Login_box">
-                    <LoginHeader icon={this.state.teamSelected ? this.state.teamSelected.icon : null}/>
+                    <LoginHeader
+                        icon={this.state.teamSelected ?
+                            "https://riot.im/rts/static/common/" +
+                            this.state.teamSelected.domain + "/icon.png" :
+                            null}
+                    />
                     {this._getRegisterContentJsx()}
                     <LoginFooter />
                 </div>


### PR DESCRIPTION
This was necessary because the team token may not be known when registering, but domain is. Storing the icon under the "common" directory is the chosen solution to this.