### PR TITLE
Thread teamToken through to LeftPanel for "Home" button

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -232,7 +232,12 @@ export default React.createClass({
             <div className='mx_MatrixChat_wrapper'>
                 {topBar}
                 <div className={bodyClasses}>
-                    <LeftPanel selectedRoom={this.props.currentRoomId} collapsed={this.props.collapse_lhs || false} opacity={this.props.sideOpacity}/>
+                    <LeftPanel
+                        selectedRoom={this.props.currentRoomId}
+                        collapsed={this.props.collapse_lhs || false}
+                        opacity={this.props.sideOpacity}
+                        teamToken={this.props.teamToken}
+                    />
                     <main className='mx_MatrixChat_middlePanel'>
                         {page_element}
                     </main>


### PR DESCRIPTION
This means the riot-web will use the same teamToken used by sdk components. This includes cases where only the fragment query parameter has been provided.

Fixes vector-im/riot-web#3185