### PR TITLE
Instead of sending userId, userEmail, send sid, client_secret

### DIFF
--- a/src/RtsClient.js
+++ b/src/RtsClient.js
@@ -50,18 +50,18 @@ export default class RtsClient {
      * Track a referral with the Riot Team Server. This should be called once a referred
      * user has been successfully registered.
      * @param {string} referrer the user ID of one who referred the user to Riot.
-     * @param {string} userId the user ID of the user being referred.
-     * @param {string} userEmail the email address linked to `userId`.
+     * @param {string} sid the sign-up identity server session ID .
+     * @param {string} clientSecret the sign-up client secret.
      * @returns {Promise} a promise that resolves to { team_token: 'sometoken' } upon
      * success.
      */
-    trackReferral(referrer, userId, userEmail) {
+    trackReferral(referrer, sid, clientSecret) {
         return request(this._url + '/register',
             {
                 body: {
                     referrer: referrer,
-                    user_id: userId,
-                    user_email: userEmail,
+                    session_id: sid,
+                    client_secret: clientSecret,
                 },
                 method: 'POST',
             }

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -213,16 +213,19 @@ module.exports = React.createClass({
                 accessToken: response.access_token
             });
 
+            // Done regardless of `teamSelected`. People registering with non-team emails
+            // will just nop. The point of this being we might not have the email address
+            // that the user registered with at this stage (depending on whether this
+            // is the client they initiated registration).
             if (
                 self._rtsClient &&
-                self.props.referrer &&
-                self.state.teamSelected
+                self.props.referrer
             ) {
                 // Track referral, get team_token in order to retrieve team config
                 self._rtsClient.trackReferral(
                     self.props.referrer,
-                    response.user_id,
-                    self.state.formVals.email
+                    self.registerLogic.params.idSid,
+                    self.registerLogic.params.clientSecret
                 ).then((data) => {
                     const teamToken = data.team_token;
                     // Store for use /w welcome pages


### PR DESCRIPTION
This has the benefit of being possible from the _second_ riot instance, which may not actually have the email of the user registering. With these parameters, the RTS can get the email and user ID itself.

(see https://github.com/matrix-org/riot-team-server/pull/15)