### PR TITLE
Store retrieved sid in the signupInstance of EmailIdentityStage

### DIFF
--- a/src/SignupStages.js
+++ b/src/SignupStages.js
@@ -149,6 +149,7 @@ class EmailIdentityStage extends Stage {
             nextLink
         ).then(function(response) {
             self.sid = response.sid;
+            self.signupInstance.setIdSid(self.sid);
             return self._completeVerify();
         }).then(function(request) {
             request.poll_for_success = true;


### PR DESCRIPTION
When registeration is complete, the RTS needs the sid, which was previously only sent to the HS. This update will also store it in the signupInstance so that it can be sent to the RTS.