### PR TITLE
Treat the literal team token string "undefined" as undefined

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -217,6 +217,12 @@ module.exports = React.createClass({
             window.localStorage.getItem('mx_team_token') ||
             window.sessionStorage.getItem('mx_team_token');
 
+        // Some users have ended up with "undefined" as their local storage team token,
+        // treat that as undefined.
+        if (this._teamToken === "undefined") {
+            this._teamToken = undefined;
+        }
+
         if (this._teamToken) {
             console.info(`Team token set to ${this._teamToken}`);
         }


### PR DESCRIPTION
Some users appear to have gotten team tokens into their local storage. This fix will treat the literal string "undefined" as undefined.

Temporary fix for https://github.com/vector-im/riot-web/issues/3174

I'm still not certain what caused some users to end up with `"undefined"` as a team token. It may have been fixed previously. 