### PR TITLE
Display avatar initials in typing notifications

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -223,8 +223,7 @@ module.exports = React.createClass({
             users = users.slice(0, limit - 1);
         }
 
-        let avatars = users.map((u, index) => {
-            let showInitial = othersCount === 0 && index === users.length - 1;
+        const avatars = users.map((u) => {
             return (
                 <MemberAvatar
                     key={u.userId}
@@ -232,7 +231,6 @@ module.exports = React.createClass({
                     width={24}
                     height={24}
                     resizeMethod="crop"
-                    defaultToInitialLetter={showInitial}
                 />
             );
         });


### PR DESCRIPTION
It seems they don't overlap hawkwardly anymore, so this displays them always.

Fixes https://github.com/vector-im/riot-web/issues/3084