### PR TITLE
Request correct dimensions for image thumbnails

### DIFF
--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -106,12 +106,16 @@ module.exports = React.createClass({
             }
             return this.state.decryptedUrl;
         } else {
-            const cappedWidth = Math.min(800, content.info.w);
-            return MatrixClientPeg.get().mxcUrlToHttp(
-                content.url,
-                cappedWidth,
-                Math.floor(content.info.h * (cappedWidth / content.info.w)),
-            );
+            if (content.info) {
+                const cappedWidth = Math.min(800, content.info.w);
+                return MatrixClientPeg.get().mxcUrlToHttp(
+                    content.url,
+                    cappedWidth,
+                    Math.floor(content.info.h * (cappedWidth / content.info.w)),
+                );
+            } else {
+                return MatrixClientPeg.get().mxcUrlToHttp(content.url, 800, 600);
+            }
         }
     },
 

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -106,7 +106,8 @@ module.exports = React.createClass({
             }
             return this.state.decryptedUrl;
         } else {
-            return MatrixClientPeg.get().mxcUrlToHttp(content.url, 800, 600);
+            const scaledWidth = Math.min(800, content.info.w);
+            return MatrixClientPeg.get().mxcUrlToHttp(content.url, scaledWidth, Math.floor(content.info.h * (scaledWidth / content.info.w)));
         }
     },
 

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -106,11 +106,11 @@ module.exports = React.createClass({
             }
             return this.state.decryptedUrl;
         } else {
-            const scaledWidth = Math.min(800, content.info.w);
+            const cappedWidth = Math.min(800, content.info.w);
             return MatrixClientPeg.get().mxcUrlToHttp(
                 content.url,
-                scaledWidth,
-                Math.floor(content.info.h * (scaledWidth / content.info.w)),
+                cappedWidth,
+                Math.floor(content.info.h * (cappedWidth / content.info.w)),
             );
         }
     },

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -107,7 +107,11 @@ module.exports = React.createClass({
             return this.state.decryptedUrl;
         } else {
             const scaledWidth = Math.min(800, content.info.w);
-            return MatrixClientPeg.get().mxcUrlToHttp(content.url, scaledWidth, Math.floor(content.info.h * (scaledWidth / content.info.w)));
+            return MatrixClientPeg.get().mxcUrlToHttp(
+                content.url,
+                scaledWidth,
+                Math.floor(content.info.h * (scaledWidth / content.info.w)),
+            );
         }
     },
 


### PR DESCRIPTION
With dynamic thumbnails enabled:

Before changes:
![2017-02-16-104837_994x337_scrot](https://cloud.githubusercontent.com/assets/6750344/23018359/99541c5c-f435-11e6-95b2-475e1c61d385.png)

After changes:
![2017-02-16-104233_1010x376_scrot](https://cloud.githubusercontent.com/assets/6750344/23018358/99533314-f435-11e6-9c4b-58331daf3cc2.png)

This is for when dynamic thumbnails are enabled on the home server, which will scale to exactly the dimensions provided. Synapse comments allude to clients specifying the correct width and height when requesting thumbnails.