### PR TITLE
If the home page is somehow accessed, goto directory

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -464,6 +464,10 @@ module.exports = React.createClass({
                 this.notifyNewScreen('directory');
                 break;
             case 'view_home_page':
+                if (!this._teamToken) {
+                    dis.dispatch({action: 'view_room_directory'});
+                    return;
+                }
                 this._setPage(PageTypes.HomePage);
                 this.notifyNewScreen('home');
                 break;


### PR DESCRIPTION
For example, if someone ends up on /home somehow, just redirect to the directory instead of displaying a very awkward "File not found" plain text in the home page iFrame.

Fixes https://github.com/vector-im/riot-web/issues/3197