### PR TITLE
Make UserSettings use the right teamToken

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -175,6 +175,7 @@ export default React.createClass({
                     collapsedRhs={this.props.collapse_rhs}
                     enableLabs={this.props.config.enableLabs}
                     referralBaseUrl={this.props.config.referralBaseUrl}
+                    teamToken={this.props.teamToken}
                 />;
                 if (!this.props.collapse_rhs) right_panel = <RightPanel opacity={this.props.sideOpacity}/>;
                 break;

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -109,6 +109,10 @@ module.exports = React.createClass({
 
         // true if RightPanel is collapsed
         collapsedRhs: React.PropTypes.bool,
+
+        // Team token for the referral link. If falsy, the referral section will
+        // not appear
+        teamToken: React.PropTypes.string,
     },
 
     getDefaultProps: function() {
@@ -462,7 +466,7 @@ module.exports = React.createClass({
     },
 
     _renderReferral: function() {
-        const teamToken = window.localStorage.getItem('mx_team_token');
+        const teamToken = this.props.teamToken;
         if (!teamToken) {
             return null;
         }


### PR DESCRIPTION
This threads the correct teamToken through to UserSettings for generating the referral section.

Fixes https://github.com/vector-im/riot-web/issues/3241