### PR TITLE
Do not push a dummy element with a scroll token for invisible events

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -362,10 +362,6 @@ module.exports = React.createClass({
                 // replacing all of the DOM elements every time we paginate.
                 ret.push(...this._getTilesForEvent(prevEvent, mxEv, last));
                 prevEvent = mxEv;
-            } else if (!mxEv.status) {
-                // if we aren't showing the event, put in a dummy scroll token anyway, so
-                // that we can scroll to the right place.
-                ret.push(<li key={eventId} data-scroll-token={eventId}/>);
             }
 
             var isVisibleReadMarker = false;


### PR DESCRIPTION
If an event does not `wantTile`, do not add a dummy element with a scroll token, as this can be unperformant with 1000s of events.

This undoes part of https://github.com/matrix-org/matrix-react-sdk/pull/162, which made sure that invisible events could still be scrolled to, but ultimately they're invisible so there's no need to be able to scroll to them.