### PR TITLE
Change the name of the database

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -122,8 +122,11 @@ class MatrixClientPeg {
             opts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
         }
         if (window.indexedDB && localStorage) {
+            // FIXME: bodge to remove old database. Remove this after a few weeks.
+            window.indexedDB.deleteDatabase("matrix-js-sdk:default");
+
             opts.store = new Matrix.IndexedDBStore(
-                new Matrix.IndexedDBStoreBackend(window.indexedDB),
+                new Matrix.IndexedDBStoreBackend(window.indexedDB, "riot-web-sync"),
                 new Matrix.SyncAccumulator(), {
                     localStorage: localStorage,
                 }


### PR DESCRIPTION
Full name is now `matrix-js-sdk:riot-web-sync`. `matrix-js-sdk:` is hard-coded into the JS SDK in order to namespace its own databases from other ones the app may be using.