### PR TITLE
Fix status bar expanded on tab-complete

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -150,7 +150,9 @@ module.exports = React.createClass({
             (state.usersTyping.length > 0) ||
             props.numUnreadMessages ||
             !props.atEndOfLiveTimeline ||
-            props.hasActiveCall) {
+            props.hasActiveCall ||
+            props.tabComplete.isTabCompleting()
+        ) {
             return STATUS_BAR_EXPANDED;
         } else if (props.tabCompleteEntries) {
             return STATUS_BAR_HIDDEN;


### PR DESCRIPTION
This had regressed when `_getSize` was introduced. It didn't consider tab completing.

Fixes https://github.com/vector-im/riot-web/issues/3291