### PR TITLE
Allow user to choose from existing DMs on new chat

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -75,6 +75,8 @@ import views$create_room$RoomAlias from './components/views/create_room/RoomAlia
 views$create_room$RoomAlias && (module.exports.components['views.create_room.RoomAlias'] = views$create_room$RoomAlias);
 import views$dialogs$BaseDialog from './components/views/dialogs/BaseDialog';
 views$dialogs$BaseDialog && (module.exports.components['views.dialogs.BaseDialog'] = views$dialogs$BaseDialog);
+import views$dialogs$ChatCreateOrReuseDialog from './components/views/dialogs/ChatCreateOrReuseDialog';
+views$dialogs$ChatCreateOrReuseDialog && (module.exports.components['views.dialogs.ChatCreateOrReuseDialog'] = views$dialogs$ChatCreateOrReuseDialog);
 import views$dialogs$ChatInviteDialog from './components/views/dialogs/ChatInviteDialog';
 views$dialogs$ChatInviteDialog && (module.exports.components['views.dialogs.ChatInviteDialog'] = views$dialogs$ChatInviteDialog);
 import views$dialogs$ConfirmUserActionDialog from './components/views/dialogs/ConfirmUserActionDialog';

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -28,25 +28,20 @@ export default class CreateOrReuseChatDialog extends React.Component {
 
     constructor(props) {
         super(props);
-        this._onNewDMClick = this._onNewDMClick.bind(this);
-        this.dispatcherRef = dis.register(this._onAction.bind(this));
+        this.onNewDMClick = this.onNewDMClick.bind(this);
+        this.onRoomTileClick = this.onRoomTileClick.bind(this);
     }
 
-    componentWillUnmount() {
-        dis.unregister(this.dispatcherRef);
-    }
-
-    _onAction(payload) {
-        switch(payload.action) {
-            case 'view_room':
-                this.props.onFinished(true);
-                break;
-            default:
-        }
-    }
-
-    _onNewDMClick() {
+    onNewDMClick() {
         createRoom({dmUserId: this.props.userId});
+        this.props.onFinished(true);
+    }
+
+    onRoomTileClick(roomId) {
+        dis.dispatch({
+            action: 'view_room',
+            room_id: roomId,
+        });
         this.props.onFinished(true);
     }
 
@@ -74,6 +69,7 @@ export default class CreateOrReuseChatDialog extends React.Component {
                         unread={Unread.doesRoomHaveUnreadMessages(room)}
                         highlight={highlight}
                         isInvite={me.membership == "invite"}
+                        onClick={this.onRoomTileClick}
                     />
                 );
             }
@@ -85,7 +81,7 @@ export default class CreateOrReuseChatDialog extends React.Component {
         });
         const startNewChat = <AccessibleButton
             className="mx_MemberInfo_createRoom"
-            onClick={this._onNewDMClick}
+            onClick={this.onNewDMClick}
         >
             <div className="mx_RoomTile_avatar">
                 <img src="img/create-big.svg" width="26" height="26" />

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import sdk from '../../../index';
+import dis from '../../../dispatcher';
+import MatrixClientPeg from '../../../MatrixClientPeg';
+import DMRoomMap from '../../../utils/DMRoomMap';
+import AccessibleButton from '../elements/AccessibleButton';
+import Unread from '../../../Unread';
+import classNames from 'classnames';
+import createRoom from '../../../createRoom';
+
+export default class CreateOrReuseChatDialog extends React.Component {
+
+    constructor (props) {
+        super(props);
+        this._onNewDMClick = this._onNewDMClick.bind(this);
+    }
+
+    _onNewDMClick () {
+        createRoom({dmUserId: this.props.userId});
+        this.props.onFinished(true);
+    }
+
+    render () {
+        const client = MatrixClientPeg.get();
+
+        const dmRoomMap = new DMRoomMap(client);
+        const dmRooms = dmRoomMap.getDMRoomsForUserId(this.props.userId);
+
+        const RoomTile = sdk.getComponent("rooms.RoomTile");
+
+        const tiles = [];
+        for (const roomId of dmRooms) {
+            const room = client.getRoom(roomId);
+            if (room) {
+                const me = room.getMember(client.credentials.userId);
+                const highlight = (
+                    room.getUnreadNotificationCount('highlight') > 0 ||
+                    me.membership == "invite"
+                );
+                tiles.push(
+                    <RoomTile key={room.roomId} room={room}
+                        collapsed={false}
+                        selected={false}
+                        unread={Unread.doesRoomHaveUnreadMessages(room)}
+                        highlight={highlight}
+                        isInvite={me.membership == "invite"}
+                        onClick={() => this.props.onFinished(true)}
+                    />
+                );
+            }
+        }
+
+        const labelClasses = classNames({
+            mx_MemberInfo_createRoom_label: true,
+            mx_RoomTile_name: true,
+        });
+        const startNewChat = <AccessibleButton
+            className="mx_MemberInfo_createRoom"
+            onClick={this._onNewDMClick}
+        >
+            <div className="mx_RoomTile_avatar">
+                <img src="img/create-big.svg" width="26" height="26" />
+            </div>
+            <div className={labelClasses}><i>Start new chat</i></div>
+        </AccessibleButton>;
+
+        const BaseDialog = sdk.getComponent('views.dialogs.BaseDialog');
+        return (
+            <BaseDialog className='mx_CreateOrReuseChatDialog'
+                onFinished={() => {
+                    this.props.onFinished(false)
+                }}
+                title='Create a new chat or reuse an existing one'
+            >
+                <h3>Direct chats</h3>
+                {tiles}
+                {startNewChat}
+            </BaseDialog>
+        );
+    }
+}
+
+CreateOrReuseChatDialog.propTyps = {
+    userId: React.PropTypes.string.isRequired,
+    onFinished: React.PropTypes.func.isRequired,
+};

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -29,6 +29,16 @@ export default class CreateOrReuseChatDialog extends React.Component {
     constructor(props) {
         super(props);
         this._onNewDMClick = this._onNewDMClick.bind(this);
+        dis.register(this._onAction.bind(this));
+    }
+
+    _onAction(payload) {
+        switch(payload.action) {
+            case 'view_room':
+                this.props.onFinished(true);
+                break;
+            default:
+        }
     }
 
     _onNewDMClick() {
@@ -60,7 +70,6 @@ export default class CreateOrReuseChatDialog extends React.Component {
                         unread={Unread.doesRoomHaveUnreadMessages(room)}
                         highlight={highlight}
                         isInvite={me.membership == "invite"}
-                        onClick={() => this.props.onFinished(true)}
                     />
                 );
             }
@@ -88,7 +97,7 @@ export default class CreateOrReuseChatDialog extends React.Component {
                 }}
                 title='Create a new chat or reuse an existing one'
             >
-                <h3>Direct chats</h3>
+                You already have existing direct chats with this user:
                 {tiles}
                 {startNewChat}
             </BaseDialog>

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -29,7 +29,11 @@ export default class CreateOrReuseChatDialog extends React.Component {
     constructor(props) {
         super(props);
         this._onNewDMClick = this._onNewDMClick.bind(this);
-        dis.register(this._onAction.bind(this));
+        this.dispatcherRef = dis.register(this._onAction.bind(this));
+    }
+
+    componentWillUnmount() {
+        dis.unregister(this.dispatcherRef);
     }
 
     _onAction(payload) {

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -26,17 +26,17 @@ import createRoom from '../../../createRoom';
 
 export default class CreateOrReuseChatDialog extends React.Component {
 
-    constructor (props) {
+    constructor(props) {
         super(props);
         this._onNewDMClick = this._onNewDMClick.bind(this);
     }
 
-    _onNewDMClick () {
+    _onNewDMClick() {
         createRoom({dmUserId: this.props.userId});
         this.props.onFinished(true);
     }
 
-    render () {
+    render() {
         const client = MatrixClientPeg.get();
 
         const dmRoomMap = new DMRoomMap(client);

--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -553,6 +553,13 @@ module.exports = WithMatrixClient(React.createClass({
         Modal.createDialog(ImageView, params, "mx_Dialog_lightbox");
     },
 
+    onRoomTileClick(roomId) {
+        dis.dispatch({
+            action: 'view_room',
+            room_id: roomId,
+        });
+    },
+
     _renderDevices: function() {
         if (!this._enableDevices) {
             return null;
@@ -613,6 +620,7 @@ module.exports = WithMatrixClient(React.createClass({
                             unread={Unread.doesRoomHaveUnreadMessages(room)}
                             highlight={highlight}
                             isInvite={me.membership == "invite"}
+                            onClick={this.onRoomTileClick}
                         />
                     );
                 }

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -19,7 +19,6 @@ limitations under the License.
 var React = require('react');
 var ReactDOM = require("react-dom");
 var classNames = require('classnames');
-var dis = require("../../../dispatcher");
 var MatrixClientPeg = require('../../../MatrixClientPeg');
 import DMRoomMap from '../../../utils/DMRoomMap';
 var sdk = require('../../../index');

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -35,6 +35,7 @@ module.exports = React.createClass({
     propTypes: {
         connectDragSource: React.PropTypes.func,
         connectDropTarget: React.PropTypes.func,
+        onClick: React.PropTypes.func,
         isDragging: React.PropTypes.bool,
 
         room: React.PropTypes.object.isRequired,
@@ -104,6 +105,9 @@ module.exports = React.createClass({
             action: 'view_room',
             room_id: this.props.room.roomId,
         });
+        if (this.props.onClick) {
+            this.props.onClick();
+        }
     },
 
     onMouseEnter: function() {

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -101,12 +101,8 @@ module.exports = React.createClass({
     },
 
     onClick: function() {
-        dis.dispatch({
-            action: 'view_room',
-            room_id: this.props.room.roomId,
-        });
         if (this.props.onClick) {
-            this.props.onClick();
+            this.props.onClick(this.props.room.roomId);
         }
     },
 


### PR DESCRIPTION
When creating a new chat with one person, show a dialog that asks the user whether they'd like to use an existing chat or actually create a new room.

Fixes https://github.com/vector-im/riot-web/issues/2760