### PR TITLE
Fix the team server integration

### DIFF
--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -59,6 +59,12 @@ export default React.createClass({
         clientSecret: React.PropTypes.string,
         emailSid: React.PropTypes.string,
 
+        // Callback to be run with the auth object, when it
+        // has been created. This allows the component to
+        // access more specific functions only available on
+        // the auth object itself.
+        onAuthObject: React.PropTypes.func,
+
         // If true, poll to see if the auth flow has been completed
         // out-of-band
         poll: React.PropTypes.bool,
@@ -86,6 +92,7 @@ export default React.createClass({
             clientSecret: this.props.clientSecret,
             emailSid: this.props.emailSid,
         });
+        if (this.props.onAuthObject) this.props.onAuthObject(this._authLogic);
 
         this._authLogic.attemptAuth().then((result) => {
             this.props.onAuthFinished(true, result);

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -223,8 +223,8 @@ module.exports = React.createClass({
             this.props.onLoggedIn({
                 userId: response.user_id,
                 deviceId: response.device_id,
-                homeserverUrl: this.registerLogic.getHomeserverUrl(),
-                identityServerUrl: this.registerLogic.getIdentityServerUrl(),
+                homeserverUrl: this._matrixClient.getHomeserverUrl(),
+                identityServerUrl: this._matrixClient.getIdentityServerUrl(),
                 accessToken: response.access_token
             }, teamToken);
         }).then(() => {

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -90,6 +90,7 @@ module.exports = React.createClass({
 
     componentWillMount: function() {
         this._unmounted = false;
+        this._authLogic = null;
 
         this._replaceClient();
 
@@ -168,26 +169,19 @@ module.exports = React.createClass({
             busy: true,
             doingUIAuth: false,
         });
-        this.props.onLoggedIn({
-            userId: response.user_id,
-            deviceId: response.device_id,
-            homeserverUrl: this.state.hsUrl,
-            identityServerUrl: this.state.isUrl,
-            accessToken: response.access_token,
-        });
 
         // Done regardless of `teamSelected`. People registering with non-team emails
         // will just nop. The point of this being we might not have the email address
         // that the user registered with at this stage (depending on whether this
         // is the client they initiated registration).
         let trackPromise = q(null);
-        if (this._rtsClient) {
+        if (this._rtsClient && this._authLogic.getEmailSid()) {
             // Track referral if this.props.referrer set, get team_token in order to
             // retrieve team config and see welcome page etc.
             trackPromise = this._rtsClient.trackReferral(
                 this.props.referrer || '', // Default to empty string = not referred
-                this.registerLogic.params.idSid,
-                this.registerLogic.params.clientSecret
+                this._authLogic.getEmailSid(),
+                this._authLogic.getClientSecret(),
             ).then((data) => {
                 const teamToken = data.team_token;
                 // Store for use /w welcome pages
@@ -229,7 +223,7 @@ module.exports = React.createClass({
             }, teamToken);
         }).then(() => {
             return this._setupPushers();
-        }).done();
+        });
     },
 
     _setupPushers: function() {
@@ -316,12 +310,16 @@ module.exports = React.createClass({
         );
     },
 
-    _getUIAuthInputs() {
+    _getUIAuthInputs: function() {
         return {
             emailAddress: this.state.formVals.email,
             phoneCountry: this.state.formVals.phoneCountry,
             phoneNumber: this.state.formVals.phoneNumber,
         }
+    },
+
+    _onAuthObject: function(authLogic) {
+        this._authLogic = authLogic;
     },
 
     render: function() {
@@ -343,6 +341,7 @@ module.exports = React.createClass({
                     sessionId={this.props.sessionId}
                     clientSecret={this.props.clientSecret}
                     emailSid={this.props.idSid}
+                    onAuthObject={this._onAuthObject}
                     poll={true}
                 />
             );


### PR DESCRIPTION
The UI auth refactor broke team server integration as it used variables from the register Signup class. Get that information (email sid & client secret) from the UI auth session.

I don't love the idea of passing the UI auth session around, I'm not really sure of a better way to do this though.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/383