### PR TITLE
Add null check to start_login

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -351,7 +351,9 @@ module.exports = React.createClass({
                 this.notifyNewScreen('register');
                 break;
             case 'start_login':
-                if (MatrixClientPeg.get().isGuest()) {
+                if (MatrixClientPeg.get() &&
+                    MatrixClientPeg.get().isGuest()
+                ) {
                     this.setState({
                         guestCreds: MatrixClientPeg.getCredentials(),
                     });


### PR DESCRIPTION
This fixes quite a bad regression where whenever `start_login` is the result of clicking a button/link/anything else does not actually lead to the login screen.

Fixes https://github.com/vector-im/riot-web/issues/3427