### PR TITLE
Fix People section a bit

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -485,11 +485,12 @@ module.exports = React.createClass({
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.direct'] }
                              label="People"
-                             editable={ false }
+                             editable={ true }
                              order="recent"
                              selectedRoom={ self.props.selectedRoom }
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             alwaysShowHeader={ true }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />


### PR DESCRIPTION
This does two things:
 - Sets `editable` to true for the "People" `RoomSubList` so that people can be dragged to favourites. This has the downside that you can drag a "People" to "Rooms", but it won't set the direct chat flag. This is because im.vector.fake.direct != m.direct, sadly.
 - Sets `alwaysShowHeader` to `true` so that the `IncomingCallDialog` can be shown when filtering. Fixes https://github.com/vector-im/riot-web/issues/2956.