### PR TITLE
Fix UDD for voip in e2e rooms

### DIFF
--- a/src/UnknownDeviceErrorHandler.js
+++ b/src/UnknownDeviceErrorHandler.js
@@ -18,13 +18,17 @@ import dis from './dispatcher';
 import sdk from './index';
 import Modal from './Modal';
 
+let isDialogOpen = false;
+
 const onAction = function(payload) {
-    if (payload.action === 'unknown_device_error') {
+    if (payload.action === 'unknown_device_error' && !isDialogOpen) {
         var UnknownDeviceDialog = sdk.getComponent("dialogs.UnknownDeviceDialog");
+        isDialogOpen = true;
         Modal.createDialog(UnknownDeviceDialog, {
             devices: payload.err.devices,
             room: payload.room,
             onFinished: (r) => {
+                isDialogOpen = false;
                 // XXX: temporary logging to try to diagnose
                 // https://github.com/vector-im/riot-web/issues/3148
                 console.log('UnknownDeviceDialog closed with '+r);


### PR DESCRIPTION
When starting a call, several events are sent and if some devices are unverified, all three will trigger their own UnknownDeviceError. This causes three overlapping, identical UnknownDeviceDialogs.

This change effectively dedupes the dialogs so that only one is shown. This is safe to do because the UDD allows resending of _all_ events that were left unsent.

Fixes https://github.com/vector-im/riot-web/issues/3285