### PR TITLE
Display timestamps and profiles for redacted events

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -413,7 +413,7 @@ module.exports = React.createClass({
         var continuation = false;
 
         if (prevEvent !== null
-                && !prevEvent.isRedacted() && prevEvent.sender && mxEv.sender
+                && prevEvent.sender && mxEv.sender
                 && mxEv.sender.userId === prevEvent.sender.userId
                 && mxEv.getType() == prevEvent.getType()) {
             continuation = true;

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -435,10 +435,7 @@ module.exports = WithMatrixClient(React.createClass({
         let avatarSize;
         let needsSenderProfile;
 
-        if (isRedacted) {
-            avatarSize = 0;
-            needsSenderProfile = false;
-        } else if (this.props.tileShape === "notif") {
+        if (this.props.tileShape === "notif") {
             avatarSize = 24;
             needsSenderProfile = true;
         } else if (isInfoMessage) {
@@ -503,8 +500,8 @@ module.exports = WithMatrixClient(React.createClass({
         else if (e2eEnabled) {
             e2e = <img onClick={ this.onCryptoClicked } className="mx_EventTile_e2eIcon" src="img/e2e-unencrypted.svg" width="12" height="12"/>;
         }
-        const timestamp = this.props.mxEvent.isRedacted() ?
-            null : <MessageTimestamp ts={this.props.mxEvent.getTs()} />;
+        const timestamp = this.props.mxEvent.getTs() ?
+            <MessageTimestamp ts={this.props.mxEvent.getTs()} /> : null;
 
         if (this.props.tileShape === "notif") {
             var room = this.props.matrixClient.getRoom(this.props.mxEvent.getRoomId());


### PR DESCRIPTION
This is part of fixing https://github.com/vector-im/riot-web/issues/3390

Now that https://github.com/matrix-org/matrix-js-sdk/pull/394 has landed, this is possible.