### PR TITLE
Fix people section DropTarget and refactor Rooms

### DIFF
--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -90,11 +90,7 @@ export function guessAndSetDMRoom(room, isDirect) {
         newTarget = null;
     }
 
-    // give some time for the user to see the icon change first, since
-    // this will hide the context menu once it completes
-    return q.delay(500).then(() => {
-        return setDMRoom(room.roomId, newTarget);
-    });
+    return setDMRoom(room.roomId, newTarget);
 }
 
 /**

--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -79,6 +79,24 @@ export function looksLikeDirectMessageRoom(room, me) {
     return false;
 }
 
+export function guessAndSetDMRoom(room, isDirect) {
+    let newTarget;
+    if (isDirect) {
+        const guessedTarget = guessDMRoomTarget(
+            room, room.getMember(MatrixClientPeg.get().credentials.userId),
+        );
+        newTarget = guessedTarget.userId;
+    } else {
+        newTarget = null;
+    }
+
+    // give some time for the user to see the icon change first, since
+    // this will hide the context menu once it completes
+    return q.delay(500).then(() => {
+        return setDMRoom(room.roomId, newTarget);
+    });
+}
+
 /**
  * Marks or unmarks the given room as being as a DM room.
  * @param {string} roomId The ID of the room to modify

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -485,6 +485,8 @@ module.exports = React.createClass({
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.direct'] }
                              label="People"
+                             tagName="im.vector.fake.direct"
+                             verb="tag direct chat"
                              editable={ true }
                              order="recent"
                              selectedRoom={ self.props.selectedRoom }


### PR DESCRIPTION
 - Set the verb for the people section to "tag as direct chat". This requires some CSS modifications to Riot because it's a long bit of text relative to, say, "demote".
 - Because it's quite useful to be able to set the DM status of a room with just a boolean, add a convenience function for guessing a DM member and setting the DM flag on that room with the resulting member.

Requires https://github.com/vector-im/riot-web/pull/3458