### PR TITLE
Show spinner whilst processing recaptcha response

### DIFF
--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -141,26 +141,25 @@ export default React.createClass({
     },
 
     _requestCallback: function(auth, background) {
-        // only set the busy flag if this is a non-background request,
-        // otherwise, the user initiated a request, so make the busy
-        // spinner appear and clear and existing error messages.
-        if (!background) {
-            this.setState({
-                busy: true,
-                errorText: null,
-                stageErrorText: null,
-            });
-        }
-        return this.props.makeRequest(auth).finally(() => {
+        const makeRequestPromise = this.props.makeRequest(auth);
+
+        // if it's a background request, just do it: we don't want
+        // it to affect the state of our UI.
+        if (background) return makeRequestPromise;
+
+        // otherwise, manage the state of the spinner and error messages
+        this.setState({
+            busy: true,
+            errorText: null,
+            stageErrorText: null,
+        });
+        return makeRequestPromise.finally(() => {
             if (this._unmounted) {
                 return;
             }
-            // only unset the busy flag if this is a non-background request
-            if (!background) {
-                this.setState({
-                    busy: false,
-                });
-            }
+            this.setState({
+                busy: false,
+            });
         });
     },
 

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -140,9 +140,9 @@ export default React.createClass({
         });
     },
 
-    _requestCallback: function(auth) {
+    _requestCallback: function(auth, background) {
         this.setState({
-            busy: true,
+            busy: !background,
             errorText: null,
             stageErrorText: null,
         });
@@ -150,9 +150,11 @@ export default React.createClass({
             if (this._unmounted) {
                 return;
             }
-            this.setState({
-                busy: false,
-            });
+            if (background) {
+                this.setState({
+                    busy: false,
+                });
+            }
         });
     },
 

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -141,16 +141,20 @@ export default React.createClass({
     },
 
     _requestCallback: function(auth, background) {
-        this.setState({
-            busy: !background,
-            errorText: null,
-            stageErrorText: null,
-        });
+        // only set the busy flag if this is a non-background request
+        if (!background) {
+            this.setState({
+                busy: true,
+                errorText: null,
+                stageErrorText: null,
+            });
+        }
         return this.props.makeRequest(auth).finally(() => {
             if (this._unmounted) {
                 return;
             }
-            if (background) {
+            // only unset the busy flag if this is a non-background request
+            if (!background) {
                 this.setState({
                     busy: false,
                 });

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -141,7 +141,9 @@ export default React.createClass({
     },
 
     _requestCallback: function(auth, background) {
-        // only set the busy flag if this is a non-background request
+        // only set the busy flag if this is a non-background request,
+        // otherwise, the user initiated a request, so make the busy
+        // spinner appear and clear and existing error messages.
         if (!background) {
             this.setState({
                 busy: true,

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -160,6 +160,7 @@ export const RecaptchaAuthEntry = React.createClass({
         submitAuthDict: React.PropTypes.func.isRequired,
         stageParams: React.PropTypes.object.isRequired,
         errorText: React.PropTypes.string,
+        busy: React.PropTypes.bool,
     },
 
     _onCaptchaResponse: function(response) {
@@ -170,6 +171,11 @@ export const RecaptchaAuthEntry = React.createClass({
     },
 
     render: function() {
+        if (this.props.busy) {
+            const Loader = sdk.getComponent("elements.Spinner");
+            return <Loader />;
+        }
+
         const CaptchaForm = sdk.getComponent("views.login.CaptchaForm");
         var sitePublicKey = this.props.stageParams.public_key;
         return (


### PR DESCRIPTION
The fact that we showed no feedback whilst submitting the captcha
response was causing confusion on slower connections where this
took a nontrivial amount of time.

Takes a new flag from the js-sdk that indicates whether the
request being made is a background request, presenting a spinner
appropriately.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/396