### PR TITLE
Add canResetTimeline callback and thread it through to TimelinePanel

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -81,6 +81,13 @@ export default React.createClass({
         return this._scrollStateMap[roomId];
     },
 
+    canResetTimelineInRoom: function(roomId) {
+        if (!this.refs.roomView) {
+            return true;
+        }
+        return this.refs.roomView.canResetTimeline();
+    },
+
     _onKeyDown: function(ev) {
             /*
             // Remove this for now as ctrl+alt = alt-gr so this breaks keyboards which rely on alt-gr for numbers

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -490,6 +490,13 @@ module.exports = React.createClass({
         }
     },
 
+    canResetTimeline: function() {
+        if (!this.refs.messagePanel) {
+            return true;
+        }
+        return this.refs.messagePanel.canResetTimeline();
+    },
+
     // called when state.room is first initialised (either at initial load,
     // after a successful peek, or after we join the room).
     _onRoomLoaded: function(room) {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -431,6 +431,10 @@ var TimelinePanel = React.createClass({
         }
     },
 
+    canResetTimeline: function() {
+        return this.refs.messagePanel && this.refs.messagePanel.isAtBottom();
+    },
+
     onRoomRedaction: function(ev, room) {
         if (this.unmounted) return;
 

--- a/src/components/structures/UploadBar.js
+++ b/src/components/structures/UploadBar.js
@@ -25,12 +25,13 @@ module.exports = React.createClass({displayName: 'UploadBar',
     },
 
     componentDidMount: function() {
-        dis.register(this.onAction);
+        this.dispatcherRef = dis.register(this.onAction);
         this.mounted = true;
     },
 
     componentWillUnmount: function() {
         this.mounted = false;
+        dis.unregister(this.dispatcherRef);
     },
 
     onAction: function(payload) {


### PR DESCRIPTION
Also unregister `UploadBar` listener. Requires https://github.com/matrix-org/matrix-js-sdk/pull/395 for `MatrixClient.setCanResetTimelineCallback`.

Tested by receiving >20 messages whilst offline and:
 - Being scrolled to the bottom (verifying with console logs that TimelinePanel returns true)
 - Being scrolled up a bit (verifying with console logs that TimelinePanel returns false)
 - Not being in that room.