### PR TITLE
Prevent crash on login of no guest session

### DIFF
--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-'use strict';
 
 var MatrixClientPeg = require("./MatrixClientPeg");
 var PlatformPeg = require("./PlatformPeg");
@@ -103,7 +102,7 @@ var Notifier = {
     },
 
     stop: function() {
-        if (MatrixClientPeg.get()) {
+        if (MatrixClientPeg.get() && this.boundOnRoomTimeline) {
             MatrixClientPeg.get().removeListener('Room.timeline', this.boundOnRoomTimeline);
             MatrixClientPeg.get().removeListener("Room.receipt", this.boundOnRoomReceipt);
             MatrixClientPeg.get().removeListener('sync', this.boundOnSyncStateChange);


### PR DESCRIPTION
The bound functions are only set when the Notifier is started, so
if stop() was called without start() having been called, the
listener function would be null which would throw an exception.