### PR TITLE
Correct confirm prompt for disinvite

### DIFF
--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -218,11 +218,13 @@ module.exports = WithMatrixClient(React.createClass({
     },
 
     onKick: function() {
+        const membership = this.props.member.membership;
+        const kickLabel = membership === "invite" ? "Disinvite" : "Kick";
         const ConfirmUserActionDialog = sdk.getComponent("dialogs.ConfirmUserActionDialog");
         Modal.createDialog(ConfirmUserActionDialog, {
             member: this.props.member,
-            action: 'Kick',
-            askReason: true,
+            action: kickLabel,
+            askReason: membership == "join",
             danger: true,
             onFinished: (proceed, reason) => {
                 if (!proceed) return;


### PR DESCRIPTION
It should be 'disinvite' not 'kick', and probably doesn't really
need a reason.

Fixes https://github.com/vector-im/riot-web/issues/3347