### PR TITLE
Improve zeroing of RoomList notification badges

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -476,9 +476,10 @@ var TimelinePanel = React.createClass({
         // if we are scrolled to the bottom, do a quick-reset of our unreadNotificationCount
         // to avoid having to wait from the remote echo from the homeserver.
         if (this.isAtEndOfLiveTimeline()) {
+            this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
+            this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
             dis.dispatch({
                 action: 'on_room_read',
-                room: this.props.timelineSet.room,
             });
         }
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -476,9 +476,10 @@ var TimelinePanel = React.createClass({
         // if we are scrolled to the bottom, do a quick-reset of our unreadNotificationCount
         // to avoid having to wait from the remote echo from the homeserver.
         if (this.isAtEndOfLiveTimeline()) {
-            this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
-            this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
-            // XXX: i'm a bit surprised we don't have to emit an event or dispatch to get this picked up
+            dis.dispatch({
+                action: 'on_room_read',
+                room: this.props.timelineSet.room,
+            });
         }
 
         var currentReadUpToEventId = this._getCurrentReadReceipt(true);

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -97,9 +97,9 @@ module.exports = React.createClass({
                 }
                 break;
             case 'on_room_read':
-                payload.room.setUnreadNotificationCount('total', 0);
-                payload.room.setUnreadNotificationCount('highlight', 0);
-                // Force an update because this state is too deep to cause an update
+                // Force an update because the notif count state is too deep to cause
+                // an update. This forces the local echo of reading notifs to be
+                // reflected by the RoomTiles.
                 this.forceUpdate();
                 break;
         }

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -96,6 +96,12 @@ module.exports = React.createClass({
                     });
                 }
                 break;
+            case 'on_room_read':
+                payload.room.setUnreadNotificationCount('total', 0);
+                payload.room.setUnreadNotificationCount('highlight', 0);
+                // Force an update because this state is too deep to cause an update
+                this.forceUpdate();
+                break;
         }
     },
 


### PR DESCRIPTION
Use an action and force an update when zeroing the number of notifications in a room. This is better than waiting for a `render` to happen at some point. This will probably not fix https://github.com/vector-im/riot-web/issues/3257