### PR TITLE
Only join a room when enter is hit if the join button is shown

### DIFF
--- a/src/components/views/elements/DirectorySearchBox.js
+++ b/src/components/views/elements/DirectorySearchBox.js
@@ -59,7 +59,7 @@ export default class DirectorySearchBox extends React.Component {
     }
 
     _onKeyUp(ev) {
-        if (ev.key == 'Enter') {
+        if (ev.key == 'Enter' && this.props.showJoinButton) {
             if (this.props.onJoinClick) {
                 this.props.onJoinClick(this.state.value);
             }


### PR DESCRIPTION
This makes a bit more sense as there's a return key icon on the "Join" button itself. 

Fixes https://github.com/vector-im/riot-web/issues/3229