### PR TITLE
Only clear the local notification count if needed

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -473,16 +473,6 @@ var TimelinePanel = React.createClass({
         // we still have a client.
         if (!MatrixClientPeg.get()) return;
 
-        // if we are scrolled to the bottom, do a quick-reset of our unreadNotificationCount
-        // to avoid having to wait from the remote echo from the homeserver.
-        if (this.isAtEndOfLiveTimeline()) {
-            this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
-            this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
-            dis.dispatch({
-                action: 'on_room_read',
-            });
-        }
-
         var currentReadUpToEventId = this._getCurrentReadReceipt(true);
         var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
 
@@ -519,6 +509,14 @@ var TimelinePanel = React.createClass({
             MatrixClientPeg.get().sendReadReceipt(lastReadEvent).catch(() => {
                 // it failed, so allow retries next time the user is active
                 this.last_rr_sent_event_id = undefined;
+            });
+
+            // do a quick-reset of our unreadNotificationCount to avoid having
+            // to wait from the remote echo from the homeserver.
+            this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
+            this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
+            dis.dispatch({
+                action: 'on_room_read',
             });
         }
     },

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -513,11 +513,16 @@ var TimelinePanel = React.createClass({
 
             // do a quick-reset of our unreadNotificationCount to avoid having
             // to wait from the remote echo from the homeserver.
-            this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
-            this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
-            dis.dispatch({
-                action: 'on_room_read',
-            });
+            // we only do this if we're right at the end, because we're just assuming
+            // that sending an RR for the latest message will set our notif counter
+            // to zero: it may not do this if we send an RR for somewhere before the end.
+            if (this.isAtEndOfLiveTimeline()) {
+                this.props.timelineSet.room.setUnreadNotificationCount('total', 0);
+                this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
+                dis.dispatch({
+                    action: 'on_room_read',
+                });
+            }
         }
     },
 


### PR DESCRIPTION
Only zero the local notification count when we actually send a
read receipt, otherwise we cause a re-render of the RoomList every
time the user moves the cursor in the window, basically.