### PR TITLE
Attempt to fix the flakyness seen with tests

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -845,10 +845,7 @@ module.exports = React.createClass({
             if (state !== "PREPARED") { return; }
             self.sdkReady = true;
 
-            if (self.starting_room_alias_payload) {
-                dis.dispatch(self.starting_room_alias_payload);
-                delete self.starting_room_alias_payload;
-            } else if (!self.state.page_type) {
+            if (!self.state.page_type) {
                 if (!self.state.currentRoomId) {
                     var firstRoom = null;
                     if (cli.getRooms() && cli.getRooms().length) {
@@ -976,12 +973,7 @@ module.exports = React.createClass({
 
             // we can't view a room unless we're logged in
             // (a guest account is fine)
-            if (!this.state.loggedIn) {
-                // we may still be loading (ie, trying to register a guest
-                // session); otherwise we're (probably) already showing a login
-                // screen. Either way, we'll show the room once the client starts.
-                this.starting_room_alias_payload = payload;
-            } else {
+            if (this.state.loggedIn) {
                 dis.dispatch(payload);
             }
         } else if (screen.indexOf('user/') == 0) {


### PR DESCRIPTION
Specifically:
```

JS 2.1.1 (Linux 0.0.0) joining a room over federation should not get stuck at a spinner FAILED
	Did not find exactly one match (found: 0) for componentType:function (props, context, updater) {
```

actually meant that the room directory wasn't displayed - probably because the dispatch `view_room_directory` ended up on another tick of the event loop, meaning that the directory wasn't displayedi. The fix attempted in ths commit is to use `this._setPage` instead to view the directory. This uses `setState` to set the screen to the directory, so I'm not entirely convinced this will solve the problem (as `setState` may also end up doing things on another tick.

and

```
JS 2.1.1 (Linux 0.0.0) loading: MatrixClient rehydrated from stored credentials: shows a room view if we followed a room link FAILED
	MatrixChat still not ready after 5 tries
	awaitRoomView@/home/travis/build/vector-im/riot-web/test/all-tests.js:201363:90
```

was happening probably because in the handler for the `sync` event in `MatrixChat` (around line 840), there was one case in which the `ready` state may not be true (causing all 5 attempts to fail), and this case relied on `starting_room_alias_payload`. This `starting_room_alias_payload` is now redundant because of `initialScreenAfterLogin`, which was added recently.