### PR TITLE
Remove non-functional session load error

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -194,9 +194,6 @@ module.exports = React.createClass({
     componentWillMount: function() {
         SdkConfig.put(this.props.config);
 
-        // if the automatic session load failed, the error
-        this.sessionLoadError = null;
-
         if (this.props.config.sync_timeline_limit) {
             MatrixClientPeg.opts.initialSyncLimit = this.props.config.sync_timeline_limit;
         }
@@ -285,7 +282,6 @@ module.exports = React.createClass({
             });
         }).catch((e) => {
             console.error("Unable to load session", e);
-            this.sessionLoadError = e.message;
         }).done(()=>{
             // stuff this through the dispatcher so that it happens
             // after the on_logged_in action.
@@ -1240,7 +1236,7 @@ module.exports = React.createClass({
             );
         } else {
             const Login = sdk.getComponent('structures.login.Login');
-            var r = (
+            return (
                 <Login
                     onLoggedIn={Lifecycle.setLoggedIn}
                     onRegisterClick={this.onRegisterClick}
@@ -1253,16 +1249,8 @@ module.exports = React.createClass({
                     onForgotPasswordClick={this.onForgotPasswordClick}
                     enableGuest={this.props.enableGuest}
                     onCancelClick={this.state.guestCreds ? this.onReturnToGuestClick : null}
-                    initialErrorText={this.sessionLoadError}
                 />
             );
-
-            // we only want to show the session load error the first time the
-            // Login component is rendered. This is pretty hacky but I can't
-            // think of another way to achieve it.
-            this.sessionLoadError = null;
-
-            return r;
         }
     }
 });

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -53,14 +53,12 @@ module.exports = React.createClass({
         // login shouldn't care how password recovery is done.
         onForgotPasswordClick: React.PropTypes.func,
         onCancelClick: React.PropTypes.func,
-
-        initialErrorText: React.PropTypes.string,
     },
 
     getInitialState: function() {
         return {
             busy: false,
-            errorText: this.props.initialErrorText,
+            errorText: null,
             loginIncorrect: false,
             enteredHomeserverUrl: this.props.customHsUrl || this.props.defaultHsUrl,
             enteredIdentityServerUrl: this.props.customIsUrl || this.props.defaultIsUrl,


### PR DESCRIPTION
MatrixChat was trying to display an error if the session failed to
restore, but it was never actually being shown because it was just
set as a member variable and therefore never actually caused
a re-render for the error to be displayed. Almost all errors are
caught by _restoreFromLocalStorage which displays the fancy dialog
if your session can't be restored, so I'm not convinced this ever
even tried to do anything anyway. Remove it.

Based off of https://github.com/matrix-org/matrix-react-sdk/pull/782