### PR TITLE
Fix scroll token selection logic

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -589,24 +589,35 @@ module.exports = React.createClass({
         var itemlist = this.refs.itemlist;
         var wrapperRect = ReactDOM.findDOMNode(this).getBoundingClientRect();
         var messages = itemlist.children;
+        let newScrollState = null;
 
         for (var i = messages.length-1; i >= 0; --i) {
             var node = messages[i];
             if (!node.dataset.scrollToken) continue;
 
             var boundingRect = node.getBoundingClientRect();
-            if (boundingRect.bottom < wrapperRect.bottom) {
-                this.scrollState = {
-                    stuckAtBottom: false,
-                    trackedScrollToken: node.dataset.scrollToken,
-                    pixelOffset: wrapperRect.bottom - boundingRect.bottom,
-                };
-                debuglog("ScrollPanel: saved scroll state", this.scrollState);
-                return;
+            newScrollState = {
+                stuckAtBottom: false,
+                trackedScrollToken: node.dataset.scrollToken,
+                pixelOffset: wrapperRect.bottom - boundingRect.bottom,
+            };
+            // If the bottom of the panel intersects the ClientRect of node, use this node
+            // as the scrollToken.
+            // If this is false for the entire for-loop, we default to the last node
+            // (which is why newScrollState is set on every iteration).
+            if (boundingRect.top < wrapperRect.bottom &&
+                wrapperRect.bottom < boundingRect.bottom) {
+                // Use this node as the scrollToken
+                break;
             }
         }
-
-        debuglog("ScrollPanel: unable to save scroll state: found no children in the viewport");
+        // This is only false if there were no nodes with `node.dataset.scrollToken` set.
+        if (newScrollState) {
+            this.scrollState = newScrollState;
+            debuglog("ScrollPanel: saved scroll state", this.scrollState);
+        } else {
+            debuglog("ScrollPanel: unable to save scroll state: found no children in the viewport");
+        }
     },
 
     _restoreSavedScrollState: function() {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -344,17 +344,17 @@ module.exports = React.createClass({
         // pagination.
         //
         // If backwards is true, we unpaginate (remove) tiles from the back (top).
-        let i = backwards ? 0 : tiles.length - 1;
-        while (
-            (backwards ? i < tiles.length : i > 0) && excessHeight > tiles[i].clientHeight
-        ) {
+        for (let i = 0; i < tiles.length; i++) {
+            const tile = tiles[backwards ? tiles.length - 1 - i : i];
             // Subtract height of tile as if it were unpaginated
-            excessHeight -= tiles[i].clientHeight;
+            excessHeight -= tile.clientHeight;
             // The tile may not have a scroll token, so guard it
-            if (tiles[i].dataset.scrollToken) {
-                markerScrollToken = tiles[i].dataset.scrollToken;
+            if (tile.dataset.scrollToken) {
+                markerScrollToken = tile.dataset.scrollToken;
             }
-            i += backwards ? 1 : -1;
+            if (tile.clientHeight > excessHeight) {
+                break;
+            }
         }
 
         if (markerScrollToken) {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -333,34 +333,28 @@ module.exports = React.createClass({
         if (excessHeight <= 0) {
             return;
         }
-        var itemlist = this.refs.itemlist;
-        var tiles = itemlist.children;
+        const tiles = this.refs.itemlist.children;
 
         // The scroll token of the first/last tile to be unpaginated
         let markerScrollToken = null;
 
-        // Subtract clientHeights to simulate the events being unpaginated whilst counting
-        // the events to be unpaginated.
-        if (backwards) {
-            // Iterate forwards from start of tiles, subtracting event tile height
-            let i = 0;
-            while (i < tiles.length && excessHeight > tiles[i].clientHeight) {
-                excessHeight -= tiles[i].clientHeight;
-                if (tiles[i].dataset.scrollToken) {
-                    markerScrollToken = tiles[i].dataset.scrollToken;
-                }
-                i++;
+        // Subtract heights of tiles to simulate the tiles being unpaginated until the
+        // excess height is less than the height of the next tile to subtract. This
+        // prevents excessHeight becoming negative, which could lead to future
+        // pagination.
+        //
+        // If backwards is true, we unpaginate (remove) tiles from the back (top).
+        let i = backwards ? 0 : tiles.length - 1;
+        while (
+            (backwards ? i < tiles.length : i > 0) && excessHeight > tiles[i].clientHeight
+        ) {
+            // Subtract height of tile as if it were unpaginated
+            excessHeight -= tiles[i].clientHeight;
+            // The tile may not have a scroll token, so guard it
+            if (tiles[i].dataset.scrollToken) {
+                markerScrollToken = tiles[i].dataset.scrollToken;
             }
-        } else {
-            // Iterate backwards from end of tiles, subtracting event tile height
-            let i = tiles.length - 1;
-            while (i > 0 && excessHeight > tiles[i].clientHeight) {
-                excessHeight -= tiles[i].clientHeight;
-                if (tiles[i].dataset.scrollToken) {
-                    markerScrollToken = tiles[i].dataset.scrollToken;
-                }
-                i--;
-            }
+            i += backwards ? 1 : -1;
         }
 
         if (markerScrollToken) {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -599,8 +599,7 @@ module.exports = React.createClass({
             // as the scrollToken.
             // If this is false for the entire for-loop, we default to the last node
             // (which is why newScrollState is set on every iteration).
-            if (boundingRect.top < wrapperRect.bottom &&
-                wrapperRect.bottom < boundingRect.bottom) {
+            if (boundingRect.top < wrapperRect.bottom) {
                 // Use this node as the scrollToken
                 break;
             }

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -263,7 +263,7 @@ var TimelinePanel = React.createClass({
             }
         );
 
-        let count = backwards ? marker : this.state.events.length - marker;
+        let count = backwards ? marker + 1 : this.state.events.length - marker;
 
         if (count > 0) {
             debuglog("TimelinePanel: Unpaginating", count, "in direction", dir);

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -263,7 +263,7 @@ var TimelinePanel = React.createClass({
             }
         );
 
-        let count = backwards ? marker + 1 : this.state.events.length - marker;
+        let count = backwards ? marker : this.state.events.length - marker;
 
         if (count > 0) {
             debuglog("TimelinePanel: Unpaginating", count, "in direction", dir);

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -251,10 +251,12 @@ var TimelinePanel = React.createClass({
     },
 
     onMessageListUnfillRequest: function(backwards, scrollToken) {
+        // If backwards, unpaginate from the back
         let dir = backwards ? EventTimeline.BACKWARDS : EventTimeline.FORWARDS;
         debuglog("TimelinePanel: unpaginating events in direction", dir);
 
-        // All tiles are inserted by MessagePanel to have a scrollToken === eventId
+        // All tiles are inserted by MessagePanel to have a scrollToken === eventId, and
+        // this particular event should be the first or last to be unpaginated.
         let eventId = scrollToken;
 
         let marker = this.state.events.findIndex(

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -251,7 +251,7 @@ var TimelinePanel = React.createClass({
     },
 
     onMessageListUnfillRequest: function(backwards, scrollToken) {
-        // If backwards, unpaginate from the back
+        // If backwards, unpaginate from the back (i.e. the start of the timeline)
         let dir = backwards ? EventTimeline.BACKWARDS : EventTimeline.FORWARDS;
         debuglog("TimelinePanel: unpaginating events in direction", dir);
 


### PR DESCRIPTION
When unpaginating in the backwards direction.

Confirmed this fixes https://github.com/vector-im/riot-web/issues/3175.