### PR TITLE
Add <ol start="..."> to allowed attributes list

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -96,6 +96,7 @@ var sanitizeHtmlParams = {
         // We don't currently allow img itself by default, but this
         // would make sense if we did
         img: ['src'],
+        ol: ['start'],
     },
     // Lots of these won't come up by default because we don't allow them
     selfClosing: ['img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta'],


### PR DESCRIPTION
Fixes vector-im/riot-web#3273

Currently not tested, but should work. :)

Signed-off-by: Shell Turner <cam.turn@gmail.com>