### PR TITLE
Replace sdkReady with firstSyncPromise, add mx_last_room_id

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -644,7 +644,7 @@ module.exports = React.createClass({
         // Wait for the first sync to complete so that if a room does have an alias,
         // it would have been retrieved.
         let waitFor = q(null);
-        if (!firstSyncComplete) {
+        if (!this.firstSyncComplete) {
             if (!this.firstSyncPromise) {
                 console.warn('Cannot view a room before first sync. room_id:', room_info.room_id);
                 return;
@@ -851,13 +851,8 @@ module.exports = React.createClass({
             self.firstSyncComplete = true;
             self.firstSyncPromise.resolve();
 
-            if (!self.state.page_type) {
-                // Switch to room view but allow _onLoggedIn to specify a room (if any)
-                self.setState({ready: true});
-                dis.dispatch({action: 'focus_composer'});
-            } else {
-                self.setState({ready: true});
-            }
+            dis.dispatch({action: 'focus_composer'});
+            self.setState({ready: true});
         });
         cli.on('Call.incoming', function(call) {
             dis.dispatch({


### PR DESCRIPTION
- Create a promise that will serve as a lock to be blocked on by things that need to wait for the first sync before accessing state.
- Use this promise to block `view_room` calls until a sync has occured instead of just dropping them silently if the sync hasn't happened yet.
- Store the current room ID in a localStorage item `mx_last_room_id` when `view_room` fires. This persists the last viewed room ID so that it can be restored on refresh, browser quit. This replaces the previous logic which set the room following a sync based on the most recent unread room.

Fixes https://github.com/vector-im/riot-web/issues/3559