### PR TITLE
Fix issue where teamTokenMap was ignored for guests

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -763,9 +763,11 @@ module.exports = React.createClass({
         });
 
         if (teamToken) {
+            // A team member has logged in, not a guest
             this._teamToken = teamToken;
             dis.dispatch({action: 'view_home_page'});
         } else if (this._is_registered) {
+            // The user has just logged in after registering
             dis.dispatch({action: 'view_user_settings'});
         } else {
             this._showScreenAfterLogin();
@@ -788,6 +790,10 @@ module.exports = React.createClass({
                 action: 'view_room',
                 room_id: localStorage.getItem('mx_last_room_id'),
             });
+        } else if (this._teamToken) {
+            // Team token might be set if we're a guest.
+            // Guests do not call _onLoggedIn with a teamToken
+            dis.dispatch({action: 'view_home_page'});
         } else {
             dis.dispatch({action: 'view_room_directory'});
         }


### PR DESCRIPTION
This was an issue because guests do not log in with a teamToken, it is implicitly set by MatrixChat when it mounts. The fix is to view_home_page when a login occurs and MatrixChat has this._teamToken set.