### PR TITLE
fix the warning shown to users about needing to export e2e keys

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -264,10 +264,10 @@ module.exports = React.createClass({
             title: "Sign out?",
             description:
                 <div>
-                    For security, logging out will delete any end-to-end encryption keys from this browser,
-                    making previous encrypted chat history unreadable if you log back in.
-                    In future this <a href="https://github.com/vector-im/riot-web/issues/2108">will be improved</a>,
-                    but for now be warned.
+                    For security, logging out will delete any end-to-end encryption keys from this browser.
+
+                    If you want to be able to decrypt your conversation history from future Riot sessions,
+                    please export your room keys for safe-keeping.
                 </div>,
             button: "Sign out",
             extraButtons: [

--- a/src/components/structures/login/ForgotPassword.js
+++ b/src/components/structures/login/ForgotPassword.js
@@ -93,11 +93,17 @@ module.exports = React.createClass({
                 description:
                     <div>
                         Resetting password will currently reset any end-to-end encryption keys on all devices,
-                        making encrypted chat history unreadable.
-                        In future this <a href="https://github.com/vector-im/riot-web/issues/2671">may be improved</a>,
-                        but for now be warned.
+                        making encrypted chat history unreadable, unless you first export your room keys
+                        and re-import them afterwards.
+                        In future this <a href="https://github.com/vector-im/riot-web/issues/2671">will be improved</a>.
                     </div>,
                 button: "Continue",
+                extraButtons: [
+                    <button className="mx_Dialog_primary"
+                            onClick={this._onExportE2eKeysClicked}>
+                        Export E2E room keys
+                    </button>
+                ],
                 onFinished: (confirmed) => {
                     if (confirmed) {
                         this.submitPasswordReset(
@@ -108,6 +114,18 @@ module.exports = React.createClass({
                 },
             });
         }
+    },
+
+    _onExportE2eKeysClicked: function() {
+        Modal.createDialogAsync(
+            (cb) => {
+                require.ensure(['../../../async-components/views/dialogs/ExportE2eKeysDialog'], () => {
+                    cb(require('../../../async-components/views/dialogs/ExportE2eKeysDialog'));
+                }, "e2e-export");
+            }, {
+                matrixClient: MatrixClientPeg.get(),
+            }
+        );
     },
 
     onInputChanged: function(stateKey, ev) {

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -73,11 +73,17 @@ module.exports = React.createClass({
             description:
                 <div>
                     Changing password will currently reset any end-to-end encryption keys on all devices,
-                    making encrypted chat history unreadable.
-                    This will be <a href="https://github.com/vector-im/riot-web/issues/2671">improved shortly</a>,
-                    but for now be warned.
+                    making encrypted chat history unreadable, unless you first export your room keys
+                    and re-import them afterwards.
+                    In future this <a href="https://github.com/vector-im/riot-web/issues/2671">will be improved</a>.
                 </div>,
             button: "Continue",
+            extraButtons: [
+                <button className="mx_Dialog_primary"
+                        onClick={this._onExportE2eKeysClicked}>
+                    Export E2E room keys
+                </button>
+            ],
             onFinished: (confirmed) => {
                 if (confirmed) {
                     var authDict = {
@@ -104,6 +110,18 @@ module.exports = React.createClass({
             },
         });
     },
+
+    _onExportE2eKeysClicked: function() {
+        Modal.createDialogAsync(
+            (cb) => {
+                require.ensure(['../../../async-components/views/dialogs/ExportE2eKeysDialog'], () => {
+                    cb(require('../../../async-components/views/dialogs/ExportE2eKeysDialog'));
+                }, "e2e-export");
+            }, {
+                matrixClient: MatrixClientPeg.get(),
+            }
+        );
+    },    
 
     onClickChange: function() {
         var old_password = this.refs.old_input.value;


### PR DESCRIPTION
apparently when we added the buttons to export e2e keys to the Logout button, we didn't change the text warning the user that e2e export was coming soon.  likewise when changing password and forgetting password (where we didn't even have a button to export keys)