### PR TITLE
I18n proposal

### DIFF
--- a/languages/en.js
+++ b/languages/en.js
@@ -1,0 +1,7 @@
+module.exports = {
+    matrix_react_sdk: {
+        room_list: {
+            people: 'People'
+        }
+    }
+};

--- a/languages/pt-BR.js
+++ b/languages/pt-BR.js
@@ -1,0 +1,7 @@
+module.exports = {
+    matrix_react_sdk: {
+        room_list: {
+            people: 'Pessoas'
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "browser-request": "^0.3.3",
     "classnames": "^2.1.2",
     "commonmark": "^0.27.0",
+    "counterpart": "^0.17.8",
     "draft-js": "^0.8.1",
     "draft-js-export-html": "^0.5.0",
     "draft-js-export-markdown": "^0.2.0",

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -29,6 +29,8 @@ var Rooms = require('../../../Rooms');
 import DMRoomMap from '../../../utils/DMRoomMap';
 var Receipt = require('../../../utils/Receipt');
 
+var t = require('counterpart');
+
 var HIDE_CONFERENCE_CHANS = true;
 
 module.exports = React.createClass({
@@ -490,7 +492,7 @@ module.exports = React.createClass({
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.direct'] }
-                             label="People"
+                             label={ t('matrix_react_sdk.room_list.people') } 
                              tagName="im.vector.fake.direct"
                              verb="tag direct chat"
                              editable={ true }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,16 @@ limitations under the License.
 
 var Skinner = require('./Skinner');
 
+var t = require('counterpart');
+
+t.registerTranslations('en', require('../languages/en'));
+t.registerTranslations('pt-BR', require('../languages/pt-BR'));
+
+t.setFallbackLocale('en');
+t.setLocale(window.navigator.languages[0]);
+
+
+
 module.exports.loadSkin = function(skinObject) {
     Skinner.load(skinObject);
 };


### PR DESCRIPTION
Hi,

This merge request is a proposal for starting i18n in matrix-react-sdk. We detected this is an urgent feature which is missing, and want to push this forward.

We used [counterpart](https://github.com/martinandert/counterpart) library, which is wide simpler in comparison to others such as react-intl, which we also considered. 

If this merge is accepted, we plan very shortly to:

1. insert i18n in all strings both at riot-web and matrix-react-sdk;
2. make a script to extract the keys to a translation file
3. Create en.json and pt-BR.json files
