### PR TITLE
Show context menu after 500ms mouse hover

### DIFF
--- a/src/components/structures/ContextualMenu.js
+++ b/src/components/structures/ContextualMenu.js
@@ -33,6 +33,7 @@ module.exports = {
         menuHeight: React.PropTypes.number,
         chevronOffset: React.PropTypes.number,
         menuColour: React.PropTypes.string,
+        closeOnMouseLeave: React.PropTypes.boolean,
     },
 
     getOrCreateContainer: function() {
@@ -55,6 +56,12 @@ module.exports = {
 
             if (props && props.onFinished) {
                 props.onFinished.apply(null, arguments);
+            }
+        };
+
+        const onMouseLeave = function() {
+            if (props.closeOnMouseLeave) {
+                closeMenu();
             }
         };
 
@@ -115,7 +122,11 @@ module.exports = {
         // property set here so you can't close the menu from a button click!
         var menu = (
             <div className={className} style={position}>
-                <div className={menuClasses} style={menuStyle}>
+                <div
+                    className={menuClasses}
+                    style={menuStyle}
+                    onMouseLeave={onMouseLeave}
+                >
                     {chevron}
                     <Element {...props} onFinished={closeMenu}/>
                 </div>

--- a/src/components/structures/ContextualMenu.js
+++ b/src/components/structures/ContextualMenu.js
@@ -51,6 +51,12 @@ module.exports = {
     createMenu: function(Element, props) {
         var self = this;
 
+        // Default props
+
+        // hasBackground = true by default
+        props.hasBackground = props.hasBackground === undefined ?
+            true : props.hasBackground;
+
         var closeMenu = function() {
             ReactDOM.unmountComponentAtNode(self.getOrCreateContainer());
 
@@ -118,6 +124,14 @@ module.exports = {
             menuStyle["backgroundColor"] = props.menuColour;
         }
 
+        let background = null;
+        if (props.hasBackground) {
+            background = <div
+                className="mx_ContextualMenu_background"
+                onClick={closeMenu}
+            ></div>;
+        }
+
         // FIXME: If a menu uses getDefaultProps it clobbers the onFinished
         // property set here so you can't close the menu from a button click!
         var menu = (
@@ -130,7 +144,7 @@ module.exports = {
                     {chevron}
                     <Element {...props} onFinished={closeMenu}/>
                 </div>
-                <div className="mx_ContextualMenu_background" onClick={closeMenu}></div>
+                {background}
                 <style>{chevronCSS}</style>
             </div>
         );

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -89,6 +89,7 @@ module.exports = React.createClass({
 
     componentWillMount: function() {
         MatrixClientPeg.get().on("accountData", this.onAccountData);
+        this._closeContextMenu = undefined;
     },
 
     componentWillUnmount: function() {
@@ -115,12 +116,17 @@ module.exports = React.createClass({
         }, 500);
     },
 
-    onMouseLeave: function() {
+    onMouseLeave: function(e) {
         this.setState( { hover : false });
         this.badgeOnMouseLeave();
 
         clearTimeout(this._contextMenuTimeout);
         this._contextMenuTimeout = null;
+
+        // The mouse left the RoomTile itself, not a child
+        if (e.target === e.currentTarget && this._closeContextMenu) {
+            this._closeContextMenu();
+        }
     },
 
     badgeOnMouseEnter: function() {
@@ -150,17 +156,18 @@ module.exports = React.createClass({
         let y = (elementRect.top + (elementRect.height / 2) + window.pageYOffset);
         y = y - (chevronOffset + 8); // where 8 is half the height of the chevron
 
-        ContextualMenu.createMenu(RoomTileContextMenu, {
+        this._closeContextMenu = ContextualMenu.createMenu(RoomTileContextMenu, {
             chevronOffset: chevronOffset,
             left: x,
             top: y,
             closeOnMouseLeave: true,
+            hasBackground: false,
             room: this.props.room,
             onFinished: () => {
                 this.setState({ menuDisplayed: false });
                 this.props.refreshSubList();
             }
-        });
+        }).close;
         this.setState({ menuDisplayed: true });
     },
 


### PR DESCRIPTION
This implements https://github.com/vector-im/riot-web/issues/3439

There's a bit of extra faffing to make the `RoomTileContextMenu` disappear `onMouseLeave`, which seemed better than having it accidentally appearing and needing an extra click to get rid of it. 