### PR TITLE
Improve RoomList performance via side-stepping React

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react": "^15.4.0",
     "react-addons-css-transition-group": "15.3.2",
     "react-dom": "^15.4.0",
-    "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#5e97aef",
+    "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#39d858c",
     "sanitize-html": "^1.11.1",
     "text-encoding-utf-8": "^1.0.1",
     "velocity-vector": "vector-im/velocity#059e3b2",

--- a/src/ConstantTimeDispatcher.js
+++ b/src/ConstantTimeDispatcher.js
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// singleton which dispatches invocations of a given type & argument
+// rather than just a type (as per EventEmitter and Flux's dispatcher etc)
+//
+// This means you can have a single point which listens for an EventEmitter event
+// and then dispatches out to one of thousands of RoomTiles (for instance) rather than
+// having each RoomTile register for the EventEmitter event and having to 
+// iterate over all of them.
+class ConstantTimeDispatcher {
+    constructor() {
+        // type -> arg -> [ listener(arg, params) ]
+        this.listeners = {};
+    }
+
+    register(type, arg, listener) {
+        if (!this.listeners[type]) this.listeners[type] = {};
+        if (!this.listeners[type][arg]) this.listeners[type][arg] = [];
+        this.listeners[type][arg].push(listener);
+    }
+
+    unregister(type, arg, listener) {
+        if (this.listeners[type] && this.listeners[type][arg]) {
+            var i = this.listeners[type][arg].indexOf(listener);
+            if (i > -1) {
+                this.listeners[type][arg].splice(i, 1);
+            }
+        }
+        else {
+            console.warn("Unregistering unrecognised listener (type=" + type + ", arg=" + arg + ")");
+        }
+    }
+
+    dispatch(type, arg, params) {
+        if (!this.listeners[type] || !this.listeners[type][arg]) {
+            console.warn("No registered listeners for dispatch (type=" + type + ", arg=" + arg + ")");
+            return;
+        }
+        this.listeners[type][arg].forEach(listener=>{
+            listener.call(arg, params);
+        });
+    }
+}
+
+if (!global.constantTimeDispatcher) {
+    global.constantTimeDispatcher = new ConstantTimeDispatcher();
+}
+module.exports = global.constantTimeDispatcher;

--- a/src/KeyCode.js
+++ b/src/KeyCode.js
@@ -32,4 +32,5 @@ module.exports = {
     DELETE: 46,
     KEY_D: 68,
     KEY_E: 69,
+    KEY_K: 75,
 };

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -523,9 +523,7 @@ var TimelinePanel = React.createClass({
                 this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
                 dis.dispatch({
                     action: 'on_room_read',
-                    payload: {
-                        room: this.props.timelineSet.room
-                    }
+                    room: this.props.timelineSet.room,
                 });
             }
         }

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -523,6 +523,9 @@ var TimelinePanel = React.createClass({
                 this.props.timelineSet.room.setUnreadNotificationCount('highlight', 0);
                 dis.dispatch({
                     action: 'on_room_read',
+                    payload: {
+                        room: this.props.timelineSet.room
+                    }
                 });
             }
         }

--- a/src/components/views/dialogs/QuestionDialog.js
+++ b/src/components/views/dialogs/QuestionDialog.js
@@ -47,6 +47,12 @@ export default React.createClass({
         this.props.onFinished(false);
     },
 
+    componentDidMount: function() {
+        if (this.props.focus) {
+            this.refs.button.focus();
+        }
+    },
+
     render: function() {
         const BaseDialog = sdk.getComponent('views.dialogs.BaseDialog');
         const cancelButton = this.props.hasCancelButton ? (
@@ -63,7 +69,7 @@ export default React.createClass({
                     {this.props.description}
                 </div>
                 <div className="mx_Dialog_buttons">
-                    <button className="mx_Dialog_primary" onClick={this.onOk} autoFocus={this.props.focus}>
+                    <button ref="button" className="mx_Dialog_primary" onClick={this.onOk}>
                         {this.props.button}
                     </button>
                     {this.props.extraButtons}

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -75,6 +75,12 @@ module.exports = React.createClass({
         this.dispatcherRef = dis.register(this.onAction);
         // Initialise the stickyHeaders when the component is created
         this._updateStickyHeaders(true);
+
+        if (this.props.selectedRoom) {
+            constantTimeDispatcher.dispatch(
+                "RoomTile.select", this.props.selectedRoom, { selected: true }
+            );            
+        }
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -155,8 +161,6 @@ module.exports = React.createClass({
         }
         // cancel any pending calls to the rate_limited_funcs
         this._delayedRefreshRoomList.cancelPendingCall();
-        document.removeEventListener('keydown', this._onKeyDown);
-
     },
 
     onRoom: function(room) {

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -575,10 +575,6 @@ module.exports = React.createClass({
         this.refs.gemscroll.forceUpdate();
     },
 
-    onRoomTileFocus: function(roomId, event) {
-        this.focusedElement = event ? event.target : null;
-    },
-
     render: function() {
         var RoomSubList = sdk.getComponent('structures.RoomSubList');
         var self = this;
@@ -595,7 +591,6 @@ module.exports = React.createClass({
                              collapsed={ self.props.collapsed }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 <RoomSubList list={ self.state.lists['m.favourite'] }
@@ -608,7 +603,6 @@ module.exports = React.createClass({
                              collapsed={ self.props.collapsed }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.direct'] }
@@ -622,7 +616,6 @@ module.exports = React.createClass({
                              alwaysShowHeader={ true }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.recent'] }
@@ -634,7 +627,6 @@ module.exports = React.createClass({
                              collapsed={ self.props.collapsed }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 { Object.keys(self.state.lists).sort().map(function(tagName) {
@@ -650,7 +642,6 @@ module.exports = React.createClass({
                              collapsed={ self.props.collapsed }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />;
 
                     }
@@ -666,7 +657,6 @@ module.exports = React.createClass({
                              collapsed={ self.props.collapsed }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
 
                 <RoomSubList list={ self.state.lists['im.vector.fake.archived'] }
@@ -680,7 +670,6 @@ module.exports = React.createClass({
                              onHeaderClick= { self.onArchivedHeaderClick }
                              incomingCall={ self.state.incomingCall }
                              searchFilter={ self.props.searchFilter }
-                             onRoomTileFocus={ self.onRoomTileFocus }
                              onShowMoreRooms={ self.onShowMoreRooms } />
             </div>
             </GeminiScrollbar>

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -27,7 +27,6 @@ var sdk = require('../../../index');
 var rate_limited_func = require('../../../ratelimitedfunc');
 var Rooms = require('../../../Rooms');
 import DMRoomMap from '../../../utils/DMRoomMap';
-import KeyCode from '../../../KeyCode';
 var Receipt = require('../../../utils/Receipt');
 var constantTimeDispatcher = require('../../../ConstantTimeDispatcher');
 
@@ -71,15 +70,12 @@ module.exports = React.createClass({
 
         // order of the sublists
         this.listOrder = [];
-
-        this.focusedElement = null;
     },
 
     componentDidMount: function() {
         this.dispatcherRef = dis.register(this.onAction);
         // Initialise the stickyHeaders when the component is created
         this._updateStickyHeaders(true);
-        document.addEventListener('keydown', this._onKeyDown);
     },
 
     componentDidUpdate: function() {
@@ -171,83 +167,6 @@ module.exports = React.createClass({
 
     _onMouseOver: function(ev) {
         this._lastMouseOverTs = Date.now();
-    },
-
-    _onKeyDown: function(ev) {
-        if (!this.focusedElement) return;
-        let handled = false;
-
-        switch (ev.keyCode) {
-            case KeyCode.UP:
-                this._onMoveFocus(true);
-                handled = true;
-                break;
-            case KeyCode.DOWN:
-                this._onMoveFocus(false);
-                handled = true;
-                break;
-        }
-
-        if (handled) {
-            ev.stopPropagation();
-            ev.preventDefault();
-        }
-    },
-
-    _onMoveFocus: function(up) {
-        var element = this.focusedElement;
-
-        // unclear why this isn't needed...
-        // var descending = (up == this.focusDirection) ? this.focusDescending : !this.focusDescending;
-        // this.focusDirection = up;
-
-        var descending = false;
-        var classes;
-
-        do {
-            var child = up ? element.lastElementChild : element.firstElementChild;
-            var sibling = up ? element.previousElementSibling : element.nextElementSibling;
-
-            if (descending) {
-                if (child) {
-                    element = child;
-                }
-                else if (sibling) {
-                    element = sibling;
-                }
-                else {
-                    descending = false;
-                    element = element.parentElement;
-                }
-            }
-            else {
-                if (sibling) {
-                    element = sibling;
-                    descending = true;
-                }
-                else {
-                    element = element.parentElement;
-                }
-            }
-
-            if (element) {
-                classes = element.classList;
-                if (classes.contains("mx_LeftPanel")) { // we hit the top
-                    element = up ? element.lastElementChild : element.firstElementChild;
-                    descending = true;
-                }
-            }
-
-        } while(element && !(
-            classes.contains("mx_RoomTile") ||
-            classes.contains("mx_SearchBox_search") ||
-            classes.contains("mx_RoomSubList_ellipsis")));
-
-        if (element) {
-            element.focus();
-            this.focusedElement = element;
-            this.focusedDescending = descending;
-        }
     },
 
     onSubListHeaderClick: function(isHidden, scrollToPosition) {

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -56,6 +56,7 @@ module.exports = React.createClass({
         cli.on("Room.timeline", this.onRoomTimeline);
         cli.on("Room.name", this.onRoomName);
         cli.on("Room.tags", this.onRoomTags);
+        cli.on("Room.receipt", this.onRoomReceipt);
         // cli.on("RoomState.events", this.onRoomStateEvents);
         cli.on("RoomMember.name", this.onRoomMemberName);
         cli.on("accountData", this.onAccountData);
@@ -147,6 +148,7 @@ module.exports = React.createClass({
             MatrixClientPeg.get().removeListener("Room.timeline", this.onRoomTimeline);
             MatrixClientPeg.get().removeListener("Room.name", this.onRoomName);
             MatrixClientPeg.get().removeListener("Room.tags", this.onRoomTags);
+            MatrixClientPeg.get().removeListener("Room.receipt", this.onRoomReceipt);
             // MatrixClientPeg.get().removeListener("RoomState.events", this.onRoomStateEvents);
             MatrixClientPeg.get().removeListener("RoomMember.name", this.onRoomMemberName);
             MatrixClientPeg.get().removeListener("accountData", this.onAccountData);
@@ -212,6 +214,11 @@ module.exports = React.createClass({
                 constantTimeDispatcher.dispatch("RoomSubList.sort", list, { room: room });
             });
         }
+
+        // we have to explicitly hit the roomtile which just changed
+        constantTimeDispatcher.dispatch(
+            "RoomTile.refresh", room.roomId, {}
+        );
     },
 
     onRoomReceipt: function(receiptEvent, room) {
@@ -226,6 +233,11 @@ module.exports = React.createClass({
                     );
                 });
             }
+
+            // we have to explicitly hit the roomtile which just changed
+            constantTimeDispatcher.dispatch(
+                "RoomTile.refresh", room.roomId, {}
+            );
         }
     },
 

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -41,6 +41,12 @@ module.exports = React.createClass({
         searchFilter: React.PropTypes.string,
     },
 
+    shouldComponentUpdate: function(nextProps, nextState) {
+        if (nextProps.collapsed !== this.props.collapsed) return true;
+        if (nextProps.searchFilter !== this.props.searchFilter) return true;
+        return false;
+    },
+
     getInitialState: function() {
         return {
             isLoadingLeftRooms: false,
@@ -75,12 +81,6 @@ module.exports = React.createClass({
         this.dispatcherRef = dis.register(this.onAction);
         // Initialise the stickyHeaders when the component is created
         this._updateStickyHeaders(true);
-
-        if (this.props.selectedRoom) {
-            constantTimeDispatcher.dispatch(
-                "RoomTile.select", this.props.selectedRoom, { selected: true }
-            );            
-        }
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -98,7 +98,7 @@ module.exports = React.createClass({
         }
     },
 
-    componentDidUpdate: function() {
+    componentDidUpdate: function(prevProps, prevState) {
         // Reinitialise the stickyHeaders when the component is updated
         this._updateStickyHeaders(true);
         this._repositionIncomingCallBox(undefined, false);
@@ -265,7 +265,7 @@ module.exports = React.createClass({
 
     onRoomMemberName: function(ev, member) {
         constantTimeDispatcher.dispatch(
-            "RoomTile.refresh", member.room.roomId, {}
+            "RoomTile.refresh", member.roomId, {}
         );
     },
 
@@ -274,6 +274,9 @@ module.exports = React.createClass({
             // XXX: this happens rarely; ideally we should only update the correct
             // sublists when it does (e.g. via a constantTimeDispatch to the right sublist)
             this._delayedRefreshRoomList();
+        }
+        else if (ev.getType() == 'm.push_rules') {
+            this._delayedRefreshRoomList();            
         }
     },
 
@@ -595,6 +598,7 @@ module.exports = React.createClass({
                              order="recent"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />
@@ -607,6 +611,7 @@ module.exports = React.createClass({
                              order="manual"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />
@@ -619,6 +624,7 @@ module.exports = React.createClass({
                              order="recent"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              alwaysShowHeader={ true }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
@@ -631,6 +637,7 @@ module.exports = React.createClass({
                              order="recent"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />
@@ -646,6 +653,7 @@ module.exports = React.createClass({
                              order="manual"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />;
@@ -661,6 +669,7 @@ module.exports = React.createClass({
                              order="recent"
                              incomingCall={ self.state.incomingCall }
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              searchFilter={ self.props.searchFilter }
                              onHeaderClick={ self.onSubListHeaderClick }
                              onShowMoreRooms={ self.onShowMoreRooms } />
@@ -670,6 +679,7 @@ module.exports = React.createClass({
                              editable={ false }
                              order="recent"
                              collapsed={ self.props.collapsed }
+                             selectedRoom={ self.props.selectedRoom }
                              alwaysShowHeader={ true }
                              startAsHidden={ true }
                              showSpinner={ self.state.isLoadingLeftRooms }

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -57,7 +57,7 @@ module.exports = React.createClass({
         cli.on("Room.name", this.onRoomName);
         cli.on("Room.tags", this.onRoomTags);
         cli.on("Room.receipt", this.onRoomReceipt);
-        // cli.on("RoomState.events", this.onRoomStateEvents);
+        cli.on("RoomState.members", this.onRoomStateMember);
         cli.on("RoomMember.name", this.onRoomMemberName);
         cli.on("accountData", this.onAccountData);
 
@@ -149,7 +149,7 @@ module.exports = React.createClass({
             MatrixClientPeg.get().removeListener("Room.name", this.onRoomName);
             MatrixClientPeg.get().removeListener("Room.tags", this.onRoomTags);
             MatrixClientPeg.get().removeListener("Room.receipt", this.onRoomReceipt);
-            // MatrixClientPeg.get().removeListener("RoomState.events", this.onRoomStateEvents);
+            MatrixClientPeg.get().removeListener("RoomState.members", this.onRoomStateMember);
             MatrixClientPeg.get().removeListener("RoomMember.name", this.onRoomMemberName);
             MatrixClientPeg.get().removeListener("accountData", this.onAccountData);
         }
@@ -253,9 +253,11 @@ module.exports = React.createClass({
         this._delayedRefreshRoomList();
     },
 
-    // onRoomStateEvents: function(ev, state) {
-    //     this._delayedRefreshRoomList();
-    // },
+    onRoomStateMember: function(ev, state, member) {
+        constantTimeDispatcher.dispatch(
+            "RoomTile.refresh", member.roomId, {}
+        );
+    },
 
     onRoomMemberName: function(ev, member) {
         constantTimeDispatcher.dispatch(

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -37,7 +37,6 @@ module.exports = React.createClass({
         connectDragSource: React.PropTypes.func,
         connectDropTarget: React.PropTypes.func,
         onClick: React.PropTypes.func,
-        onFocus: React.PropTypes.func,
         isDragging: React.PropTypes.bool,
 
         room: React.PropTypes.object.isRequired,
@@ -118,12 +117,6 @@ module.exports = React.createClass({
     onClick: function() {
         if (this.props.onClick) {
             this.props.onClick(this.props.room.roomId);
-        }
-    },
-
-    onFocus: function(event) {
-        if (this.props.onFocus) {
-            this.props.onFocus(this.props.room.roomId, event);
         }
     },
 
@@ -279,8 +272,7 @@ module.exports = React.createClass({
         let ret = (
             <div> { /* Only native elements can be wrapped in a DnD object. */}
             <AccessibleButton className={classes} tabIndex="0" onClick={this.onClick}
-                              onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}
-                              onFocus={this.onFocus} onBlur={this.onFocus.bind(this, null)}>
+                              onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <div className={avatarClasses}>
                     <div className="mx_RoomTile_avatar_container">
                         <RoomAvatar room={this.props.room} width={24} height={24} />

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -27,6 +27,7 @@ var RoomNotifs = require('../../../RoomNotifs');
 var FormattingUtils = require('../../../utils/FormattingUtils');
 import AccessibleButton from '../elements/AccessibleButton';
 var UserSettingsStore = require('../../../UserSettingsStore');
+var constantTimeDispatcher = require('../../../ConstantTimeDispatcher');
 
 module.exports = React.createClass({
     displayName: 'RoomTile',
@@ -89,14 +90,20 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
+        constantTimeDispatcher.register("RoomTile.refresh", this.props.room.roomId, this.onRefresh);
         MatrixClientPeg.get().on("accountData", this.onAccountData);
     },
 
     componentWillUnmount: function() {
+        constantTimeDispatcher.unregister("RoomTile.refresh", this.props.room.roomId, this.onRefresh);
         var cli = MatrixClientPeg.get();
         if (cli) {
             MatrixClientPeg.get().removeListener("accountData", this.onAccountData);
         }
+    },
+
+    onRefresh: function() {
+        this.forceUpdate();
     },
 
     onClick: function() {

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -101,6 +101,10 @@ module.exports = React.createClass({
         }
     },
 
+    componentWillReceiveProps: function(nextProps) {
+        this.onRefresh();
+    },
+
     onRefresh: function(params) {
         this.setState({
             unread: Unread.doesRoomHaveUnreadMessages(this.props.room),

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -35,6 +35,7 @@ module.exports = React.createClass({
         connectDragSource: React.PropTypes.func,
         connectDropTarget: React.PropTypes.func,
         onClick: React.PropTypes.func,
+        onFocus: React.PropTypes.func,
         isDragging: React.PropTypes.bool,
 
         room: React.PropTypes.object.isRequired,
@@ -101,6 +102,12 @@ module.exports = React.createClass({
     onClick: function() {
         if (this.props.onClick) {
             this.props.onClick(this.props.room.roomId);
+        }
+    },
+
+    onFocus: function() {
+        if (this.props.onFocus) {
+            this.props.onFocus(this.props.room.roomId);
         }
     },
 
@@ -255,7 +262,9 @@ module.exports = React.createClass({
 
         let ret = (
             <div> { /* Only native elements can be wrapped in a DnD object. */}
-            <AccessibleButton className={classes} tabIndex="0" onClick={this.onClick} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+            <AccessibleButton className={classes} tabIndex="0" onClick={this.onClick}
+                              onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}
+                              onFocus={this.onFocus} onBlur={this.onFocus.bind(this, null)}>
                 <div className={avatarClasses}>
                     <div className="mx_RoomTile_avatar_container">
                         <RoomAvatar room={this.props.room} width={24} height={24} />

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -112,9 +112,9 @@ module.exports = React.createClass({
         }
     },
 
-    onFocus: function() {
+    onFocus: function(event) {
         if (this.props.onFocus) {
-            this.props.onFocus(this.props.room.roomId);
+            this.props.onFocus(this.props.room.roomId, event);
         }
     },
 

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -38,6 +38,7 @@ module.exports = React.createClass({
         connectDropTarget: React.PropTypes.func,
         onClick: React.PropTypes.func,
         isDragging: React.PropTypes.bool,
+        selectedRoom: React.PropTypes.string,
 
         room: React.PropTypes.object.isRequired,
         collapsed: React.PropTypes.bool.isRequired,
@@ -53,10 +54,11 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         return({
-            hover : false,
-            badgeHover : false,
+            hover: false,
+            badgeHover: false,
             menuDisplayed: false,
             notifState: RoomNotifs.getRoomNotifsState(this.props.room.roomId),
+            selected: this.props.room ? (this.props.selectedRoom === this.props.room.roomId) : false,
         });
     },
 
@@ -78,28 +80,15 @@ module.exports = React.createClass({
         }
     },
 
-    onAccountData: function(accountDataEvent) {
-        if (accountDataEvent.getType() == 'm.push_rules') {
-            this.setState({
-                notifState: RoomNotifs.getRoomNotifsState(this.props.room.roomId),
-            });
-        }
-    },
-
     componentWillMount: function() {
         constantTimeDispatcher.register("RoomTile.refresh", this.props.room.roomId, this.onRefresh);
         constantTimeDispatcher.register("RoomTile.select", this.props.room.roomId, this.onSelect);
-        MatrixClientPeg.get().on("accountData", this.onAccountData);
-        this.onRefresh();        
+        this.onRefresh();
     },
 
     componentWillUnmount: function() {
         constantTimeDispatcher.unregister("RoomTile.refresh", this.props.room.roomId, this.onRefresh);
         constantTimeDispatcher.unregister("RoomTile.select", this.props.room.roomId, this.onSelect);
-        var cli = MatrixClientPeg.get();
-        if (cli) {
-            MatrixClientPeg.get().removeListener("accountData", this.onAccountData);
-        }
     },
 
     componentWillReceiveProps: function(nextProps) {

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -104,7 +104,7 @@ module.exports = React.createClass({
     onRefresh: function(params) {
         this.setState({
             unread: Unread.doesRoomHaveUnreadMessages(this.props.room),
-            highlight: this.props.room.getUnreadNotificationCount('highlight') > 0 || this.props.label === 'Invites',
+            highlight: this.props.room.getUnreadNotificationCount('highlight') > 0 || this.props.isInvite,
         });
     },
 

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -90,6 +90,7 @@ module.exports = React.createClass({
         constantTimeDispatcher.register("RoomTile.refresh", this.props.room.roomId, this.onRefresh);
         constantTimeDispatcher.register("RoomTile.select", this.props.room.roomId, this.onSelect);
         MatrixClientPeg.get().on("accountData", this.onAccountData);
+        this.onRefresh();        
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
Previously we regenerated the whole RoomList state on pretty much any event from the js-sdk, causing React to them re-render the whole RoomList.  This is incredibly heavy (~350ms on my account), and chews a lot of CPU and makes the UI laggy.

This switches the common paths of handling js-sdk events for selecting rooms, `Room.timeline`, `Room.receipt` and a few easy ones like `Room.name`, `RoomMember.name`, `RoomState.members` to side-step React and prod the specific relevant RoomTile or RoomSubList to update themselves rather than have to poke them via React props.  Rarer ones like `Room.tags`, `Room`, `deleteRoom`, `m.direct` still cause a full regeneration of the room list.

It does this by dispatching an event to them using a new ConstantTimeDispatcher (CTD), which the tiles & sublists use to register themselves to be directly prodded for these events.  CTD works by registering listeners for both an event type and an argument, meaning that only the right listener gets woken up for a given argument rather than iterating over all of them (which could be thousands of RoomTiles).

In a test jig benchmark (changing the name of a single roomtile in a list of 2000), it took 350ms (180ms in prod webpack) of processing when updating the tile by generating a new list, versus 3.5ms when doing a constant time dispatch on the right tile.

Alternative approaches could be to:
 * have RoomTiles subscribe directly to the events emitted from Room objects in the js-sdk (rather than the events as re-emitted from MatrixClient).  @dbkr suggested this after the ConstantTimeDispatcher stuff was already in existence, and given CTD feels like a vaguely useful tool to have around, I haven't had the heart to yank it out again, although if this works it'd simplify the dispatching a bit.
 * have RoomTiles register themselves as references on their RoomSubList, so parents can prod them directly to re-render when needed.
 * use immutable state (e.g. Immutable.js) to force the right React components to re-render on demand, at the expense of generating new data every time anything changes (meaning shouldComponentUpdate can just do a trivial shallow comparison).  This is presumably the most 'reacty' solution.
 
Twinned with https://github.com/vector-im/riot-web/pull/3654 (although oh my god we need to move RoomSubList* into react-sdk)