### PR TITLE
First iteration on improving login UI

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -25,6 +25,9 @@ import emojione from 'emojione';
 import classNames from 'classnames';
 
 emojione.imagePathSVG = 'emojione/svg/';
+// Store PNG path for displaying many flags at once (for increased performance over SVG)
+emojione.imagePathPNG = 'emojione/png/';
+// Use SVGs for emojis
 emojione.imageType = 'svg';
 
 const EMOJI_REGEX = new RegExp(emojione.unicodeRegexp+"+", "gi");
@@ -64,15 +67,22 @@ export function unicodeToImage(str) {
  * emoji.
  *
  * @param alt {string} String to use for the image alt text
+ * @param useSvg {boolean} Whether to use SVG image src. If False, PNG will be used.
  * @param unicode {integer} One or more integers representing unicode characters
  * @returns A img node with the corresponding emoji
  */
-export function charactersToImageNode(alt, ...unicode) {
+export function charactersToImageNode(alt, useSvg, ...unicode) {
     const fileName = unicode.map((u) => {
         return u.toString(16);
     }).join('-');
-    return <img alt={alt} src={`${emojione.imagePathSVG}${fileName}.svg${emojione.cacheBustParam}`}/>;
+    const path = useSvg ? emojione.imagePathSVG : emojione.imagePathPNG;
+    const fileType = useSvg ? 'svg' : 'png';
+    return <img
+        alt={alt}
+        src={`${path}${fileName}.${fileType}${emojione.cacheBustParam}`}
+    />;
 }
+
 
 export function stripParagraphs(html: string): string {
     const contentDiv = document.createElement('div');

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -17,13 +17,11 @@ limitations under the License.
 
 'use strict';
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var sdk = require('../../../index');
-var Login = require("../../../Login");
-var PasswordLogin = require("../../views/login/PasswordLogin");
-var CasLogin = require("../../views/login/CasLogin");
-var ServerConfig = require("../../views/login/ServerConfig");
+import React from 'react';
+import ReactDOM from 'react-dom';
+import url from 'url';
+import sdk from '../../../index';
+import Login from '../../../Login';
 
 /**
  * A wire component which glues together login UI components and Login logic
@@ -67,6 +65,7 @@ module.exports = React.createClass({
             username: "",
             phoneCountry: null,
             phoneNumber: "",
+            currentFlow: "m.login.password",
         };
     },
 
@@ -129,23 +128,19 @@ module.exports = React.createClass({
         this.setState({ phoneNumber: phoneNumber });
     },
 
-    onHsUrlChanged: function(newHsUrl) {
+    onServerConfigChange: function(config) {
         var self = this;
-        this.setState({
-            enteredHomeserverUrl: newHsUrl,
+        let newState = {
             errorText: null, // reset err messages
-        }, function() {
-            self._initLoginLogic(newHsUrl);
-        });
-    },
-
-    onIsUrlChanged: function(newIsUrl) {
-        var self = this;
-        this.setState({
-            enteredIdentityServerUrl: newIsUrl,
-            errorText: null, // reset err messages
-        }, function() {
-            self._initLoginLogic(null, newIsUrl);
+        };
+        if (config.hsUrl !== undefined) {
+            newState.enteredHomeserverUrl = config.hsUrl;
+        }
+        if (config.isUrl !== undefined) {
+            newState.enteredIdentityServerUrl = config.isUrl;
+        }
+        this.setState(newState, function() {
+            self._initLoginLogic(config.hsUrl || null, config.isUrl);
         });
     },
 
@@ -161,24 +156,27 @@ module.exports = React.createClass({
         });
         this._loginLogic = loginLogic;
 
-        loginLogic.getFlows().then(function(flows) {
-            // old behaviour was to always use the first flow without presenting
-            // options. This works in most cases (we don't have a UI for multiple
-            // logins so let's skip that for now).
-            loginLogic.chooseFlow(0);
-        }, function(err) {
-            self._setStateFromError(err, false);
-        }).finally(function() {
-            self.setState({
-                busy: false
-            });
-        });
-
         this.setState({
             enteredHomeserverUrl: hsUrl,
             enteredIdentityServerUrl: isUrl,
             busy: true,
             loginIncorrect: false,
+        });
+
+        loginLogic.getFlows().then(function(flows) {
+            // old behaviour was to always use the first flow without presenting
+            // options. This works in most cases (we don't have a UI for multiple
+            // logins so let's skip that for now).
+            loginLogic.chooseFlow(0);
+            self.setState({
+                currentFlow: self._getCurrentFlowStep(),
+            });
+        }, function(err) {
+            self._setStateFromError(err, false);
+        }).finally(function() {
+            self.setState({
+                busy: false,
+            });
         });
     },
 
@@ -231,6 +229,7 @@ module.exports = React.createClass({
     componentForStep: function(step) {
         switch (step) {
             case 'm.login.password':
+                const PasswordLogin = sdk.getComponent('login.PasswordLogin');
                 return (
                     <PasswordLogin
                         onSubmit={this.onPasswordLogin}
@@ -242,9 +241,11 @@ module.exports = React.createClass({
                         onPhoneNumberChanged={this.onPhoneNumberChanged}
                         onForgotPasswordClick={this.props.onForgotPasswordClick}
                         loginIncorrect={this.state.loginIncorrect}
+                        hsDomain={url.parse(this.state.enteredHomeserverUrl).hostname}
                     />
                 );
             case 'm.login.cas':
+                const CasLogin = sdk.getComponent('login.CasLogin');
                 return (
                     <CasLogin onSubmit={this.onCasLogin} />
                 );
@@ -262,10 +263,11 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        var Loader = sdk.getComponent("elements.Spinner");
-        var LoginHeader = sdk.getComponent("login.LoginHeader");
-        var LoginFooter = sdk.getComponent("login.LoginFooter");
-        var loader = this.state.busy ? <div className="mx_Login_loader"><Loader /></div> : null;
+        const Loader = sdk.getComponent("elements.Spinner");
+        const LoginHeader = sdk.getComponent("login.LoginHeader");
+        const LoginFooter = sdk.getComponent("login.LoginFooter");
+        const ServerConfig = sdk.getComponent("login.ServerConfig");
+        const loader = this.state.busy ? <div className="mx_Login_loader"><Loader /></div> : null;
 
         var loginAsGuestJsx;
         if (this.props.enableGuest) {
@@ -291,15 +293,14 @@ module.exports = React.createClass({
                         <h2>Sign in
                             { loader }
                         </h2>
-                        { this.componentForStep(this._getCurrentFlowStep()) }
+                        { this.componentForStep(this.state.currentFlow) }
                         <ServerConfig ref="serverConfig"
                             withToggleButton={true}
                             customHsUrl={this.props.customHsUrl}
                             customIsUrl={this.props.customIsUrl}
                             defaultHsUrl={this.props.defaultHsUrl}
                             defaultIsUrl={this.props.defaultIsUrl}
-                            onHsUrlChanged={this.onHsUrlChanged}
-                            onIsUrlChanged={this.onIsUrlChanged}
+                            onServerConfigChange={this.onServerConfigChange}
                             delayTimeMs={1000}/>
                         <div className="mx_Login_error">
                                 { this.state.errorText }

--- a/src/components/structures/login/Login.js
+++ b/src/components/structures/login/Login.js
@@ -230,6 +230,12 @@ module.exports = React.createClass({
         switch (step) {
             case 'm.login.password':
                 const PasswordLogin = sdk.getComponent('login.PasswordLogin');
+                // HSs that are not matrix.org may not be configured to have their
+                // domain name === domain part.
+                let hsDomain = url.parse(this.state.enteredHomeserverUrl).hostname;
+                if (hsDomain !== 'matrix.org') {
+                    hsDomain = null;
+                }
                 return (
                     <PasswordLogin
                         onSubmit={this.onPasswordLogin}
@@ -241,7 +247,7 @@ module.exports = React.createClass({
                         onPhoneNumberChanged={this.onPhoneNumberChanged}
                         onForgotPasswordClick={this.props.onForgotPasswordClick}
                         loginIncorrect={this.state.loginIncorrect}
-                        hsDomain={url.parse(this.state.enteredHomeserverUrl).hostname}
+                        hsDomain={hsDomain}
                     />
                 );
             case 'm.login.cas':

--- a/src/components/views/elements/Dropdown.js
+++ b/src/components/views/elements/Dropdown.js
@@ -249,7 +249,7 @@ export default class Dropdown extends React.Component {
             );
         });
 
-        if (!this.state.searchQuery) {
+        if (!this.state.searchQuery && this.props.searchEnabled) {
             options.push(
                 <div key="_searchprompt" className="mx_Dropdown_searchPrompt">
                     Type to search...
@@ -267,16 +267,20 @@ export default class Dropdown extends React.Component {
 
         let menu;
         if (this.state.expanded) {
-            currentValue = <input type="text" className="mx_Dropdown_option"
-                ref={this._collectInputTextBox} onKeyPress={this._onInputKeyPress}
-                onKeyUp={this._onInputKeyUp}
-                onChange={this._onInputChange}
-                value={this.state.searchQuery}
-            />;
+            if (this.props.searchEnabled) {
+                currentValue = <input type="text" className="mx_Dropdown_option"
+                    ref={this._collectInputTextBox} onKeyPress={this._onInputKeyPress}
+                    onKeyUp={this._onInputKeyUp}
+                    onChange={this._onInputChange}
+                    value={this.state.searchQuery}
+                />;
+            }
             menu = <div className="mx_Dropdown_menu" style={menuStyle}>
                 {this._getMenuOptions()}
             </div>;
-        } else {
+        }
+
+        if (!currentValue) {
             const selectedChild = this.props.getShortOption ?
                 this.props.getShortOption(this.props.value) :
                 this.childrenByKey[this.props.value];
@@ -313,6 +317,7 @@ Dropdown.propTypes = {
     onOptionChange: React.PropTypes.func.isRequired,
     // Called when the value of the search field changes
     onSearchChange: React.PropTypes.func,
+    searchEnabled: React.PropTypes.boolean,
     // Function that, given the key of an option, returns
     // a node representing that option to be displayed in the
     // box itself as the currently-selected option (ie. as

--- a/src/components/views/elements/Dropdown.js
+++ b/src/components/views/elements/Dropdown.js
@@ -248,13 +248,10 @@ export default class Dropdown extends React.Component {
                 </MenuOption>
             );
         });
-
-        if (!this.state.searchQuery && this.props.searchEnabled) {
-            options.push(
-                <div key="_searchprompt" className="mx_Dropdown_searchPrompt">
-                    Type to search...
-                </div>
-            );
+        if (options.length === 0) {
+            return [<div className="mx_Dropdown_option">
+                No results
+            </div>];
         }
         return options;
     }
@@ -317,7 +314,7 @@ Dropdown.propTypes = {
     onOptionChange: React.PropTypes.func.isRequired,
     // Called when the value of the search field changes
     onSearchChange: React.PropTypes.func,
-    searchEnabled: React.PropTypes.boolean,
+    searchEnabled: React.PropTypes.bool,
     // Function that, given the key of an option, returns
     // a node representing that option to be displayed in the
     // box itself as the currently-selected option (ie. as

--- a/src/components/views/login/CountryDropdown.js
+++ b/src/components/views/login/CountryDropdown.js
@@ -33,8 +33,6 @@ function countryMatchesSearchQuery(query, country) {
     return false;
 }
 
-const MAX_DISPLAYED_ROWS = 2;
-
 export default class CountryDropdown extends React.Component {
     constructor(props) {
         super(props);
@@ -64,7 +62,7 @@ export default class CountryDropdown extends React.Component {
         // Unicode Regional Indicator Symbol letter 'A'
         const RIS_A = 0x1F1E6;
         const ASCII_A = 65;
-        return charactersToImageNode(iso2,
+        return charactersToImageNode(iso2, true,
             RIS_A + (iso2.charCodeAt(0) - ASCII_A),
             RIS_A + (iso2.charCodeAt(1) - ASCII_A),
         );
@@ -91,10 +89,6 @@ export default class CountryDropdown extends React.Component {
             }
         } else {
             displayedCountries = COUNTRIES;
-        }
-
-        if (displayedCountries.length > MAX_DISPLAYED_ROWS) {
-            displayedCountries = displayedCountries.slice(0, MAX_DISPLAYED_ROWS);
         }
 
         const options = displayedCountries.map((country) => {

--- a/src/components/views/login/CountryDropdown.js
+++ b/src/components/views/login/CountryDropdown.js
@@ -111,7 +111,7 @@ export default class CountryDropdown extends React.Component {
         return <Dropdown className={this.props.className}
             onOptionChange={this.props.onOptionChange} onSearchChange={this._onSearchChange}
             menuWidth={298} getShortOption={this._flagImgForIso2}
-            value={value}
+            value={value} searchEnabled={true}
         >
             {options}
         </Dropdown>

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -150,6 +150,7 @@ class PasswordLogin extends React.Component {
                         onChange={this.onPhoneNumberChanged}
                         placeholder="Mobile phone number"
                         value={this.state.phoneNumber}
+                        autoFocus
                     />
                 </div>;
         }

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -118,10 +118,21 @@ class PasswordLogin extends React.Component {
                     autoFocus
                 />;
             case PasswordLogin.LOGIN_FIELD_MXID:
+                const mxidInputClasses = classNames({
+                    "mx_Login_field": true,
+                    "mx_Login_username": true,
+                    "mx_Login_field_has_suffix": Boolean(this.props.hsDomain),
+                });
+                let suffix = null;
+                if (this.props.hsDomain) {
+                    suffix = <div className="mx_Login_username_suffix">
+                        :{this.props.hsDomain}
+                    </div>;
+                }
                 return <div className="mx_Login_username_group">
                     <div className="mx_Login_username_prefix">@</div>
                     <input
-                        className="mx_Login_field mx_Login_username"
+                        className={mxidInputClasses}
                         key="username_input"
                         type="text"
                         name="username" // make it a little easier for browser's remember-password
@@ -130,7 +141,7 @@ class PasswordLogin extends React.Component {
                         value={this.state.username}
                         autoFocus
                     />
-                    <div className="mx_Login_username_suffix">:{this.props.hsDomain}</div>
+                    {suffix}
                 </div>;
             case PasswordLogin.LOGIN_FIELD_PHONE:
                 const CountryDropdown = sdk.getComponent('views.login.CountryDropdown');

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -60,6 +60,7 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
             password: this.props.initialPassword,
             phoneCountry: this.props.initialPhoneCountry,
             phoneNumber: this.props.initialPhoneNumber,
+            loginType: "mxid",
         };
     },
 
@@ -86,6 +87,10 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
     onUsernameChanged: function(ev) {
         this.setState({username: ev.target.value});
         this.props.onUsernameChanged(ev.target.value);
+    },
+
+    onLoginTypeChange: function(loginType) {
+        this.setState({loginType: loginType});
     },
 
     onPhoneCountryChanged: function(country) {
@@ -120,28 +125,46 @@ module.exports = React.createClass({displayName: 'PasswordLogin',
         });
 
         const CountryDropdown = sdk.getComponent('views.login.CountryDropdown');
-        return (
-            <div>
-                <form onSubmit={this.onSubmitForm}>
+        const Dropdown = sdk.getComponent('elements.Dropdown');
+
+        const loginType = {
+            'email':
                 <input className="mx_Login_field mx_Login_username" type="text"
                     name="username" // make it a little easier for browser's remember-password
                     value={this.state.username} onChange={this.onUsernameChanged}
-                    placeholder="Email or user name" autoFocus />
-                or
-                <div className="mx_Login_phoneSection">
-                    <CountryDropdown ref="phone_country" onOptionChange={this.onPhoneCountryChanged}
-                        className="mx_Login_phoneCountry"
-                        value={this.state.phoneCountry}
-                    />
-                    <input type="text" ref="phoneNumber"
-                        onChange={this.onPhoneNumberChanged}
-                        placeholder="Mobile phone number"
-                        className="mx_Login_phoneNumberField mx_Login_field"
-                        value={this.state.phoneNumber}
-                        name="phoneNumber"
-                    />
+                    placeholder="Email or user name" autoFocus />,
+            'mxid':
+                <input className="mx_Login_field mx_Login_username" type="text"
+                    name="username" // make it a little easier for browser's remember-password
+                    value={this.state.username} onChange={this.onUsernameChanged}
+                    placeholder="Email or user name" autoFocus />,
+            'phone': <div className="mx_Login_phoneSection">
+                <CountryDropdown ref="phone_country" onOptionChange={this.onPhoneCountryChanged}
+                    className="mx_Login_phoneCountry"
+                    value={this.state.phoneCountry}
+                />
+                <input type="text" ref="phoneNumber"
+                    onChange={this.onPhoneNumberChanged}
+                    placeholder="Mobile phone number"
+                    className="mx_Login_phoneNumberField mx_Login_field"
+                    value={this.state.phoneNumber}
+                    name="phoneNumber"
+                />
+            </div>
+        }[this.state.loginType];
+
+        return (
+            <div>
+                <form onSubmit={this.onSubmitForm}>
+                <div className="mx_Login_type_container">
+                    <label className="mx_Login_type_label">I want to sign in with my</label>
+                    <Dropdown className="mx_Login_type_dropdown" value={this.state.loginType} onOptionChange={this.onLoginTypeChange}>
+                        <span key="mxid">Matrix ID</span>
+                        <span key="email">Email</span>
+                        <span key="phone">Phone</span>
+                    </Dropdown>
                 </div>
-                <br />
+                {loginType}
                 <input className={pwFieldClass} ref={(e) => {this._passwordField = e;}} type="password"
                     name="password"
                     value={this.state.password} onChange={this.onPasswordChanged}

--- a/src/components/views/login/ServerConfig.js
+++ b/src/components/views/login/ServerConfig.js
@@ -27,8 +27,7 @@ module.exports = React.createClass({
     displayName: 'ServerConfig',
 
     propTypes: {
-        onHsUrlChanged: React.PropTypes.func,
-        onIsUrlChanged: React.PropTypes.func,
+        onServerConfigChange: React.PropTypes.func,
 
         // default URLs are defined in config.json (or the hardcoded defaults)
         // they are used if the user has not overridden them with a custom URL.
@@ -50,8 +49,7 @@ module.exports = React.createClass({
 
     getDefaultProps: function() {
         return {
-            onHsUrlChanged: function() {},
-            onIsUrlChanged: function() {},
+            onServerConfigChange: function() {},
             customHsUrl: "",
             customIsUrl: "",
             withToggleButton: false,
@@ -75,7 +73,10 @@ module.exports = React.createClass({
             this._hsTimeoutId = this._waitThenInvoke(this._hsTimeoutId, function() {
                 var hsUrl = this.state.hs_url.trim().replace(/\/$/, "");
                 if (hsUrl === "") hsUrl = this.props.defaultHsUrl;
-                this.props.onHsUrlChanged(hsUrl);
+                this.props.onServerConfigChange({
+                    hsUrl : this.state.hs_url,
+                    isUrl : this.state.is_url,
+                });
             });
         });
     },
@@ -85,7 +86,10 @@ module.exports = React.createClass({
             this._isTimeoutId = this._waitThenInvoke(this._isTimeoutId, function() {
                 var isUrl = this.state.is_url.trim().replace(/\/$/, "");
                 if (isUrl === "") isUrl = this.props.defaultIsUrl;
-                this.props.onIsUrlChanged(isUrl);
+                this.props.onServerConfigChange({
+                    hsUrl : this.state.hs_url,
+                    isUrl : this.state.is_url,
+                });
             });
         });
     },
@@ -102,12 +106,16 @@ module.exports = React.createClass({
             configVisible: visible
         });
         if (!visible) {
-            this.props.onHsUrlChanged(this.props.defaultHsUrl);
-            this.props.onIsUrlChanged(this.props.defaultIsUrl);
+            this.props.onServerConfigChange({
+                hsUrl : this.props.defaultHsUrl,
+                isUrl : this.props.defaultIsUrl,
+            });
         }
         else {
-            this.props.onHsUrlChanged(this.state.hs_url);
-            this.props.onIsUrlChanged(this.state.is_url);
+            this.props.onServerConfigChange({
+                hsUrl : this.state.hs_url,
+                isUrl : this.state.is_url,
+            });
         }
     },
 


### PR DESCRIPTION
 This implements most of the design in vector-im/riot-web#3524:
 - Improve CountryDropdown by allowing all countries to be displayed at once and using PNGs for performance (trading of quality - the pngs are scaled down from 32px to 25px)
 - "I want to sign in with" dropdown to select login method
 - MXID login field that suffixes HS domain (whether custom or matrix.org) and prefixes "@"
 - Email field which is secretly the same as the username field but with a different placeholder
 - No more login flickering when changing ServerConfig (!) fixes vector-im/riot-web#1517
 - Use the correct icon (picked randomly when loaded into browser) fixes vector-im/riot-web#3577

TODO in this PR:
 - [x] remove `:server.name`

TODO in other PRs:
 - Country code visible once a country has been selected (propbably but as a prefix to the phone number input box.
 - Use square flags
 - Move CountryDropdown above phone input and make it show the full country name when not expanded
 - Auto-select country based on IP
 - Suggest typing less by telling the user not to type `:server.name` in the username box.

Screenshots:
![2017-04-21-114907_374x570_scrot](https://cloud.githubusercontent.com/assets/6750344/25274576/8981e04a-2688-11e7-93d2-9bacdc1bf41e.png)

![2017-04-21-114921_389x572_scrot](https://cloud.githubusercontent.com/assets/6750344/25274586/919e3d8c-2688-11e7-80ae-65d0a0bc10bd.png)

This neglects the phone number login:
![login_with_msisdn](https://cloud.githubusercontent.com/assets/1922197/24864469/30a921fc-1dfc-11e7-95d1-76f619da1402.png)
