### PR TITLE
Add option to hide other people's read receipts.

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -44,6 +44,10 @@ const SETTINGS_LABELS = [
         id: 'autoplayGifsAndVideos',
         label: 'Autoplay GIFs and videos',
     },
+    {
+        id: 'hideReadReceipts',
+        label: 'Hide read receipts'
+    },
 /*
     {
         id: 'alwaysShowTimestamps',

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -23,6 +23,7 @@ var Modal = require('../../../Modal');
 var sdk = require('../../../index');
 var TextForEvent = require('../../../TextForEvent');
 import WithMatrixClient from '../../../wrappers/WithMatrixClient';
+import * as UserSettingsStore from "../../../UserSettingsStore";
 
 var ContextualMenu = require('../../structures/ContextualMenu');
 import dis from '../../../dispatcher';
@@ -284,6 +285,11 @@ module.exports = WithMatrixClient(React.createClass({
     },
 
     getReadAvatars: function() {
+        // return early if the user doesn't want any read receipts
+        if (UserSettingsStore.getSyncedSetting('hideReadReceipts', false)) {
+            return (<span className="mx_EventTile_readAvatars"></span>);
+        }
+
         const ReadReceiptMarker = sdk.getComponent('rooms.ReadReceiptMarker');
         const avatars = [];
         const receiptOffset = 15;


### PR DESCRIPTION
Addresses vector-im/riot-web#2526.

Looks a lot like this:
![image](https://cloud.githubusercontent.com/assets/1190097/25295131/8e9536a6-269f-11e7-9d3d-d9fcc5439ec4.png)

![image](https://cloud.githubusercontent.com/assets/1190097/25295123/83635538-269f-11e7-8a83-55a80a42fd06.png)


Signed-off-by: Travis Ralston <travpc@gmail.com>