### PR TITLE
Add option to not send read receipts.

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -514,6 +514,7 @@ var TimelinePanel = React.createClass({
         const cli = MatrixClientPeg.get();
         // if no client or client is guest don't send RR or RM
         if (!cli || cli.isGuest()) return;
+        if (UserSettingsStore.getSyncedSetting('dontSendReadReceipts', false)) return;
 
         let shouldSendRR = true;
 

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -64,6 +64,10 @@ const SETTINGS_LABELS = [
         label: 'Autoplay GIFs and videos',
     },
     {
+        id: 'dontSendReadReceipts',
+        label: "Don't send read receipts"
+    },
+    {
         id: 'hideReadReceipts',
         label: 'Hide read receipts',
     },

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -290,6 +290,7 @@
   "Guests cannot join this room even if explicitly invited.": "Guests cannot join this room even if explicitly invited.",
   "had": "had",
   "Hangup": "Hangup",
+  "Don't send read receipts": "Don't send read receipts",
   "Hide read receipts": "Hide read receipts",
   "Hide Text Formatting Toolbar": "Hide Text Formatting Toolbar",
   "Historical": "Historical",


### PR DESCRIPTION
Addresses vector-im/riot-web#2527.
Part of the metabug: vector-im/riot-meta#66

The side effect of this is that notifications remain stuck. Because the RR isn't sent, the unread notification stays on the client. This also ends up affecting riot-android, and likely riot-ios.

Signed-off-by: Travis Ralston <travpc@gmail.com>

**NOTE:** This does leave stuck notifications in riot-web and riot-android. @ara4n mentioned on vector-im/riot-web#2527 that riot-ios is immune to this problem.

Here's an example in riot-web:
![image](https://cloud.githubusercontent.com/assets/1190097/25300202/ffab8990-26c6-11e7-9a81-3a02aaeb5c01.png)
(pictured: Reading notifications in offtopic)