### PR TITLE
Remove DM-guessing code

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -97,7 +97,7 @@ module.exports = React.createClass({
             if (this.props.selectedRoom) {
                 constantTimeDispatcher.dispatch(
                     "RoomTile.select", this.props.selectedRoom, {}
-                );            
+                );
             }
             constantTimeDispatcher.dispatch(
                 "RoomTile.select", nextProps.selectedRoom, { selected: true }
@@ -265,7 +265,7 @@ module.exports = React.createClass({
     },
 
     onRoomStateMember: function(ev, state, member) {
-        if (ev.getStateKey() === MatrixClientPeg.get().credentials.userId && 
+        if (ev.getStateKey() === MatrixClientPeg.get().credentials.userId &&
             ev.getPrevContent() && ev.getPrevContent().membership === "invite")
         {
             this._delayedRefreshRoomList();
@@ -290,7 +290,7 @@ module.exports = React.createClass({
             this._delayedRefreshRoomList();
         }
         else if (ev.getType() == 'm.push_rules') {
-            this._delayedRefreshRoomList();            
+            this._delayedRefreshRoomList();
         }
     },
 
@@ -318,7 +318,7 @@ module.exports = React.createClass({
         // as needed.
         // Alternatively we'd do something magical with Immutable.js or similar.
         this.setState(this.getRoomLists());
-        
+
         // this._lastRefreshRoomListTs = Date.now();
     },
 
@@ -341,7 +341,7 @@ module.exports = React.createClass({
         MatrixClientPeg.get().getRooms().forEach(function(room) {
             const me = room.getMember(MatrixClientPeg.get().credentials.userId);
             if (!me) return;
-            
+
             // console.log("room = " + room.name + ", me.membership = " + me.membership +
             //             ", sender = " + me.events.member.getSender() +
             //             ", target = " + me.events.member.getStateKey() +
@@ -391,51 +391,10 @@ module.exports = React.createClass({
             }
         });
 
-        if (s.lists["im.vector.fake.direct"].length == 0 &&
-            MatrixClientPeg.get().getAccountData('m.direct') === undefined &&
-            !MatrixClientPeg.get().isGuest())
-        {
-            // scan through the 'recents' list for any rooms which look like DM rooms
-            // and make them DM rooms
-            const oldRecents = s.lists["im.vector.fake.recent"];
-            s.lists["im.vector.fake.recent"] = [];
-
-            for (const room of oldRecents) {
-                const me = room.getMember(MatrixClientPeg.get().credentials.userId);
-
-                if (me && Rooms.looksLikeDirectMessageRoom(room, me)) {
-                    self.listsForRoomId[room.roomId].push("im.vector.fake.direct");
-                    s.lists["im.vector.fake.direct"].push(room);
-                } else {
-                    self.listsForRoomId[room.roomId].push("im.vector.fake.recent");
-                    s.lists["im.vector.fake.recent"].push(room);
-                }
-            }
-
-            // save these new guessed DM rooms into the account data
-            const newMDirectEvent = {};
-            for (const room of s.lists["im.vector.fake.direct"]) {
-                const me = room.getMember(MatrixClientPeg.get().credentials.userId);
-                const otherPerson = Rooms.getOnlyOtherMember(room, me);
-                if (!otherPerson) continue;
-
-                const roomList = newMDirectEvent[otherPerson.userId] || [];
-                roomList.push(room.roomId);
-                newMDirectEvent[otherPerson.userId] = roomList;
-            }
-
-            console.warn("Resetting room DM state to be " + JSON.stringify(newMDirectEvent));
-
-            // if this fails, fine, we'll just do the same thing next time we get the room lists
-            MatrixClientPeg.get().setAccountData('m.direct', newMDirectEvent).done();
-        }
-
-        //console.log("calculated new roomLists; im.vector.fake.recent = " + s.lists["im.vector.fake.recent"]);
-
         // we actually apply the sorting to this when receiving the prop in RoomSubLists.
 
         // we'll need this when we get to iterating through lists programatically - e.g. ctrl-shift-up/down
-/*        
+/*
         this.listOrder = [
             "im.vector.fake.invite",
             "m.favourite",


### PR DESCRIPTION
Should fix https://github.com/vector-im/riot-web/issues/3331

@dbkr and I decided that it would be easiest to just not be setting the DM state when rendering. I couldn't find any code path or theorise any accurate state of the app that could lead to a rendering of the `RoomList` being done before `AccountData` had been received.