### PR TITLE
show the room name in the UDE Dialog

### DIFF
--- a/src/components/views/dialogs/UnknownDeviceDialog.js
+++ b/src/components/views/dialogs/UnknownDeviceDialog.js
@@ -149,7 +149,7 @@ export default React.createClass({
             >
                 <GeminiScrollbar autoshow={false} className="mx_Dialog_content">
                     <h4>
-                        This room contains devices that you haven't seen before.
+                        "{this.props.room.name}" contains devices that you haven't seen before.
                     </h4>
                     { warning }
                     Unknown devices:


### PR DESCRIPTION
especially useful when it appears after you switch rooms
for vector-im/riot-web#3665