### PR TITLE
Do not show the "Jump to message" if the RM event ID (or RR event ID)…

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -139,13 +139,18 @@ module.exports = React.createClass({
 
     // returns one of:
     //
-    //  null: there is no read marker
+    //  null: there is no read marker (possibly because the event is not paginated)
     //  -1: read marker is above the window
-    //   0: read marker is within the window
+    //   0: read marker is within the window or read marker event ID not set
     //  +1: read marker is below the window
     getReadMarkerPosition: function() {
         var readMarker = this.refs.readMarkerNode;
         var messageWrapper = this.refs.scrollPanel;
+
+        // Pretend that the RM is on screen, despite there not being one
+        if (!this.props.readMarkerEventId) {
+            return 0;
+        }
 
         if (!readMarker || !messageWrapper) {
             return null;

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -385,7 +385,7 @@ module.exports = React.createClass({
 
             var isVisibleReadMarker = false;
 
-            if (eventId == this.props.readMarkerEventId || readMarkerInMels) {
+            if (eventId == this.props.readMarkerEventId) {
                 var visible = this.props.readMarkerVisible;
 
                 // if the read marker comes at the end of the timeline (except

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1278,8 +1278,11 @@ module.exports = React.createClass({
 
         var pos = this.refs.messagePanel.getReadMarkerPosition();
 
-        // we want to show the bar if the read-marker is off the top of the
-        // screen.
+        // We want to show the bar if the read-marker is off the top of the
+        // screen. We use `pos < 0` as opposed to `pos !== 0` because in practice scrolling
+        // down will cause the RM to be in the view-port for a short duration before being
+        // pushed off the screen. This happens frequently causing `pos` to flicker between
+        // 0 (on screen) and 1 (off the bottom of the screen).
         // If pos is null, the event might not be paginated, so show the unread bar!
         var showBar = (pos < 0 || pos === null) && this.refs.messagePanel.isReadMarkerSet();
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1281,7 +1281,7 @@ module.exports = React.createClass({
         // we want to show the bar if the read-marker is off the top of the
         // screen.
         // If pos is null, the event might not be paginated, so show the unread bar!
-        var showBar = pos < 0 || pos === null;
+        var showBar = (pos < 0 || pos === null) && this.refs.messagePanel.isReadMarkerSet();
 
         if (this.state.showTopUnreadMessagesBar != showBar) {
             this.setState({showTopUnreadMessagesBar: showBar},

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -496,10 +496,15 @@ var TimelinePanel = React.createClass({
         if (!MatrixClientPeg.get()) return;
 
         var currentReadUpToEventId = this._getCurrentReadReceipt(true);
-        var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
+        // Take the minimum of both in case they somehow get out of sync where the RM is
+        // far behind the RR.
+        var currentReadUpToEventIndex = Math.min(
+            this._indexForEventId(currentReadUpToEventId),
+            this._indexForEventId(this.state.readMarkerEventId)
+        );
 
         // We want to avoid sending out read receipts when we are looking at
-        // events in the past which are before the latest RR.
+        // events in the past which are before the latest RR and RM.
         //
         // For now, let's apply a heuristic: if (a) the event corresponding to
         // the latest RR (either from the server, or sent by ourselves) doesn't
@@ -752,8 +757,11 @@ var TimelinePanel = React.createClass({
                 return 1;
             }
         }
-
         return null;
+    },
+
+    isReadMarkerSet: function() {
+        return Boolean(this.state.readMarkerEventId);
     },
 
     /**


### PR DESCRIPTION
… has not been sent

Continue to show the jump bar when `pos < 0` (as opposed to `pos !== 0`) because in practice when the RM moves down it may or may not jump entirely off the bottom. So when scrolling down `pos` flickers between 0 and 1. 