### PR TITLE
Pin filesize ver to fix break upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "draft-js-export-markdown": "^0.2.0",
     "emojione": "2.2.3",
     "file-saver": "^1.3.3",
-    "filesize": "^3.1.2",
+    "filesize": "3.5.6",
     "flux": "^2.0.3",
     "fuse.js": "^2.2.0",
     "glob": "^5.0.14",


### PR DESCRIPTION
https://travis-ci.org/vector-im/riot-web/builds/227340622
https://github.com/avoidwork/filesize.js/issues/87
3.5.7 and 3.5.8 ver released <24h ago and broke stuff for us

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>