### PR TITLE
Update header, create ReskindexPlugin

### DIFF
--- a/header
+++ b/header
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/utils/ReskindexPlugin.js
+++ b/src/utils/ReskindexPlugin.js
@@ -15,7 +15,7 @@ ReskindexPlugin.prototype._reskin = function() {
 
     // Do not index again if the files being indexed have not changed
     if (prevFiles && files.join('') === prevFiles) {
-        console.log("Not indexing");
+        console.log("Reskindex: Not indexing because file names have not changed");
         return;
     }
     prevFiles = files.join('');
@@ -58,7 +58,7 @@ ReskindexPlugin.prototype._reskin = function() {
 
     strm.end();
 
-    console.log('Reskindex Complete');
+    console.log('Reskindex: Completed index');
 }
 
 ReskindexPlugin.prototype.apply = function(compiler) {

--- a/src/utils/ReskindexPlugin.js
+++ b/src/utils/ReskindexPlugin.js
@@ -1,0 +1,73 @@
+var fs = require('fs');
+var path = require('path');
+var glob = require('glob');
+
+function ReskindexPlugin(header) {
+    console.log('Resk index plugin creteated');
+    this._header = header;
+};
+
+var prevFiles = null;
+
+ReskindexPlugin.prototype._reskin = function() {
+    var componentsDir = path.join('src', 'components');
+    var files = glob.sync('**/*.js', {cwd: componentsDir}).sort();
+
+    if (prevFiles && files.join('') === prevFiles) {
+        console.log("Not indexing");
+        return;
+    }
+    prevFiles = files.join('');
+
+    var componentIndex = path.join('src', 'component-index.js');
+
+    var packageJson = JSON.parse(fs.readFileSync('./package.json'));
+
+    var strm = fs.createWriteStream(componentIndex);
+
+    const header = this._header;
+
+    if (header) {
+       strm.write(fs.readFileSync(header));
+       strm.write('\n');
+    }
+
+    strm.write("/*\n");
+    strm.write(" * THIS FILE IS AUTO-GENERATED\n");
+    strm.write(" * You can edit it you like, but your changes will be overwritten,\n");
+    strm.write(" * so you'd just be trying to swim upstream like a salmon.\n");
+    strm.write(" * You are not a salmon.\n");
+    strm.write(" */\n\n");
+
+    if (packageJson['matrix-react-parent']) {
+        strm.write("module.exports.components = require('"+packageJson['matrix-react-parent']+"/lib/component-index').components;\n\n");
+    } else {
+        strm.write("module.exports.components = {};\n");
+    }
+
+    for (var i = 0; i < files.length; ++i) {
+        var file = files[i].replace('.js', '');
+
+        var moduleName = (file.replace(/\//g, '.'));
+        var importName = moduleName.replace(/\./g, "$");
+
+        strm.write("import " + importName + " from './components/" + file + "';\n");
+        strm.write(importName + " && (module.exports.components['"+moduleName+"'] = " + importName + ");");
+        strm.write('\n');
+        strm.uncork();
+    }
+
+    strm.end();
+
+    console.log('Reskindex Complete');
+}
+
+ReskindexPlugin.prototype.apply = function(compiler) {
+    var self = this;
+    compiler.plugin("watch-run", function(compilation, callback) {
+        self._reskin();
+        callback();
+    });
+}
+
+module.exports = ReskindexPlugin;

--- a/src/utils/ReskindexPlugin.js
+++ b/src/utils/ReskindexPlugin.js
@@ -1,17 +1,17 @@
-var fs = require('fs');
-var path = require('path');
-var glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
 
 function ReskindexPlugin(header) {
     console.log('Resk index plugin creteated');
     this._header = header;
 };
 
-var prevFiles = null;
+let prevFiles = null;
 
 ReskindexPlugin.prototype._reskin = function() {
-    var componentsDir = path.join('src', 'components');
-    var files = glob.sync('**/*.js', {cwd: componentsDir}).sort();
+    const componentsDir = path.join('src', 'components');
+    const files = glob.sync('**/*.js', {cwd: componentsDir}).sort();
 
     // Do not index again if the files being indexed have not changed
     if (prevFiles && files.join('') === prevFiles) {
@@ -20,11 +20,9 @@ ReskindexPlugin.prototype._reskin = function() {
     }
     prevFiles = files.join('');
 
-    var componentIndex = path.join('src', 'component-index.js');
+    const packageJson = JSON.parse(fs.readFileSync('./package.json'));
 
-    var packageJson = JSON.parse(fs.readFileSync('./package.json'));
-
-    var strm = fs.createWriteStream(componentIndex);
+    const strm = fs.createWriteStream(path.join('src', 'component-index.js'));
 
     const header = this._header;
 
@@ -46,11 +44,11 @@ ReskindexPlugin.prototype._reskin = function() {
         strm.write("module.exports.components = {};\n");
     }
 
-    for (var i = 0; i < files.length; ++i) {
-        var file = files[i].replace('.js', '');
+    for (let i = 0; i < files.length; ++i) {
+        const file = files[i].replace('.js', '');
 
-        var moduleName = (file.replace(/\//g, '.'));
-        var importName = moduleName.replace(/\./g, "$");
+        const moduleName = (file.replace(/\//g, '.'));
+        const importName = moduleName.replace(/\./g, "$");
 
         strm.write("import " + importName + " from './components/" + file + "';\n");
         strm.write(importName + " && (module.exports.components['"+moduleName+"'] = " + importName + ");");
@@ -64,9 +62,8 @@ ReskindexPlugin.prototype._reskin = function() {
 }
 
 ReskindexPlugin.prototype.apply = function(compiler) {
-    var self = this;
-    compiler.plugin("watch-run", function(compilation, callback) {
-        self._reskin();
+    compiler.plugin("watch-run", (compilation, callback) => {
+        this._reskin();
         callback();
     });
 }

--- a/src/utils/ReskindexPlugin.js
+++ b/src/utils/ReskindexPlugin.js
@@ -13,6 +13,7 @@ ReskindexPlugin.prototype._reskin = function() {
     var componentsDir = path.join('src', 'components');
     var files = glob.sync('**/*.js', {cwd: componentsDir}).sort();
 
+    // Do not index again if the files being indexed have not changed
     if (prevFiles && files.join('') === prevFiles) {
         console.log("Not indexing");
         return;


### PR DESCRIPTION
This is a webpack plugin that can be run as part of a webpack build process to generate component-index.js automatically without it being run manually.

The only caveat is that it will necessarily cause a second rebuild with the new index bundled, but this takes a small amount of time and is only required when a file is added/removed/renamed or if the bundle has only been built once.

The plugin uses names of the files that are bundled to check whether it needs to run again. This is how it determines whether files have been added/removed/renamed since the last reskindex.