### PR TITLE
Show password nag bar when user is PWLU

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -284,6 +284,7 @@ export function setLoggedIn(credentials) {
 
     // Resolves by default
     let teamPromise = Promise.resolve(null);
+    let isPasswordStored = false;
 
     // persist the session
     if (localStorage) {
@@ -307,6 +308,7 @@ export function setLoggedIn(credentials) {
             // is cached here such that the user can change it at a later time.
             if (credentials.password) {
                 localStorage.setItem("mx_pass", credentials.password);
+                isPasswordStored = true;
             }
 
             console.log("Session persisted for %s", credentials.userId);
@@ -332,10 +334,10 @@ export function setLoggedIn(credentials) {
     MatrixClientPeg.replaceUsingCreds(credentials);
 
     teamPromise.then((teamToken) => {
-        dis.dispatch({action: 'on_logged_in', teamToken: teamToken});
+        dis.dispatch({action: 'on_logged_in', teamToken: teamToken, isPasswordStored});
     }, (err) => {
         console.warn("Failed to get team token on login", err);
-        dis.dispatch({action: 'on_logged_in', teamToken: null});
+        dis.dispatch({action: 'on_logged_in', teamToken: null, isPasswordStored});
     });
 
     startMatrixClient();

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -49,6 +49,10 @@ export default React.createClass({
 
         teamToken: React.PropTypes.string,
 
+        // Has the user generated a password that is stored in local storage?
+        // (are they a PWLU?)
+        userHasGeneratedPassword: React.PropTypes.boolean,
+
         // and lots and lots of other stuff.
     },
 
@@ -177,6 +181,7 @@ export default React.createClass({
         const MatrixToolbar = sdk.getComponent('globals.MatrixToolbar');
         const GuestWarningBar = sdk.getComponent('globals.GuestWarningBar');
         const NewVersionBar = sdk.getComponent('globals.NewVersionBar');
+        const PasswordNagBar = sdk.getComponent('globals.PasswordNagBar');
 
         let page_element;
         let right_panel = '';
@@ -250,11 +255,11 @@ export default React.createClass({
             topBar = <NewVersionBar version={this.props.version} newVersion={this.props.newVersion}
                 releaseNotes={this.props.newVersionReleaseNotes}
             />;
-        }
-        else if (this.props.matrixClient.isGuest()) {
+        } else if (this.props.matrixClient.isGuest()) {
             topBar = <GuestWarningBar />;
-        }
-        else if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
+        } else if (this.props.userHasGeneratedPassword) {
+            topBar = <PasswordNagBar />;
+        } else if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
             topBar = <MatrixToolbar />;
         }
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -138,6 +138,9 @@ module.exports = React.createClass({
             register_hs_url: null,
             register_is_url: null,
             register_id_sid: null,
+
+            // Initially, use localStorage as source of truth
+            userHasGeneratedPassword: localStorage && localStorage.getItem('mx_pass'),
         };
         return s;
     },
@@ -569,7 +572,7 @@ module.exports = React.createClass({
                 this.setState({loggingIn: true});
                 break;
             case 'on_logged_in':
-                this._onLoggedIn(payload.teamToken);
+                this._onLoggedIn(payload.teamToken, payload.isPasswordStored);
                 break;
             case 'on_logged_out':
                 this._onLoggedOut();
@@ -755,11 +758,15 @@ module.exports = React.createClass({
     /**
      * Called when a new logged in session has started
      */
-    _onLoggedIn: function(teamToken) {
+    _onLoggedIn: function(teamToken, isPasswordStored) {
         this.setState({
             guestCreds: null,
             loggedIn: true,
             loggingIn: false,
+            // isPasswordStored only true when ROU sets a username and becomes PWLU.
+            // (the password was randomly generated and stored in localStorage).
+            userHasGeneratedPassword:
+                this.state.userHasGeneratedPassword || isPasswordStored,
         });
 
         if (teamToken) {
@@ -1168,6 +1175,7 @@ module.exports = React.createClass({
                     onUserSettingsClose={this.onUserSettingsClose}
                     onRegistered={this.onRegistered}
                     teamToken={this._teamToken}
+                    userHasGeneratedPassword={this.state.userHasGeneratedPassword}
                     {...this.props}
                     {...this.state}
                 />


### PR DESCRIPTION
Requires https://github.com/vector-im/riot-web/pull/3817

Starts off by looking at localStorage, but the user might not have generated a password yet. When they do, they'll login with the password generated and a flag is passed to `_onLoggedIn` that indicates thus. 

Part of https://github.com/vector-im/riot-web/issues/3602