### PR TITLE
Fix RM not updating if RR event unpaginated

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -575,7 +575,7 @@ module.exports = React.createClass({
         var boundingRect = node.getBoundingClientRect();
         var scrollDelta = boundingRect.bottom + pixelOffset - wrapperRect.bottom;
 
-        console.log("ScrollPanel: scrolling to token '" + scrollToken + "'+" +
+        debuglog("ScrollPanel: scrolling to token '" + scrollToken + "'+" +
                  pixelOffset + " (delta: "+scrollDelta+")");
 
         if(scrollDelta != 0) {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -575,7 +575,7 @@ module.exports = React.createClass({
         var boundingRect = node.getBoundingClientRect();
         var scrollDelta = boundingRect.bottom + pixelOffset - wrapperRect.bottom;
 
-        debuglog("ScrollPanel: scrolling to token '" + scrollToken + "'+" +
+        console.log("ScrollPanel: scrolling to token '" + scrollToken + "'+" +
                  pixelOffset + " (delta: "+scrollDelta+")");
 
         if(scrollDelta != 0) {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -177,7 +177,7 @@ var TimelinePanel = React.createClass({
     componentWillMount: function() {
         debuglog("TimelinePanel: mounting");
 
-        this.lastRRSentSentId = undefined;
+        this.lastRRSentEventId = undefined;
         this.lastRMSentEventId = undefined;
 
         this.dispatcherRef = dis.register(this.onAction);
@@ -541,7 +541,7 @@ var TimelinePanel = React.createClass({
             // the current RR event.
             lastReadEventIndex > currentReadUpToEventIndex &&
             // Only send a RR if the last RR set != the one we would send
-            this.lastRRSentSentId != lastReadEvent.getId();
+            this.lastRRSentEventId != lastReadEvent.getId();
 
         // Only send a RM if the last RM sent != the one we would send
         const shouldSendReadMarker =
@@ -551,7 +551,7 @@ var TimelinePanel = React.createClass({
         // same one at the server repeatedly
         if (shouldSendReadReceipt || shouldSendReadMarker) {
             if (shouldSendReadReceipt) {
-                this.lastRRSentSentId = lastReadEvent.getId();
+                this.lastRRSentEventId = lastReadEvent.getId();
             } else {
                 lastReadEvent = null;
             }
@@ -572,11 +572,11 @@ var TimelinePanel = React.createClass({
                     return MatrixClientPeg.get().sendReadReceipt(
                         lastReadEvent,
                     ).catch(() => {
-                        this.lastRRSentSentId = undefined;
+                        this.lastRRSentEventId = undefined;
                     });
                 }
                 // it failed, so allow retries next time the user is active
-                this.lastRRSentSentId = undefined;
+                this.lastRRSentEventId = undefined;
                 this.lastRMSentEventId = undefined;
             });
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -177,8 +177,8 @@ var TimelinePanel = React.createClass({
     componentWillMount: function() {
         debuglog("TimelinePanel: mounting");
 
-        this.last_rr_sent_event_id = undefined;
-        this.last_rm_sent_event_id = undefined;
+        this.lastRRSentSentId = undefined;
+        this.lastRMSentEventId = undefined;
 
         this.dispatcherRef = dis.register(this.onAction);
         MatrixClientPeg.get().on("Room.timeline", this.onRoomTimeline);
@@ -509,8 +509,8 @@ var TimelinePanel = React.createClass({
 
         let shouldSendReadReceipt = true;
 
-        var currentReadUpToEventId = this._getCurrentReadReceipt(true);
-        var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
+        const currentReadUpToEventId = this._getCurrentReadReceipt(true);
+        const currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
         // We want to avoid sending out read receipts when we are looking at
         // events in the past which are before the latest RR.
         //
@@ -529,33 +529,33 @@ var TimelinePanel = React.createClass({
             shouldSendReadReceipt = false;
         }
 
-        var lastReadEventIndex = this._getLastDisplayedEventIndex({
-            ignoreOwn: true
+        const lastReadEventIndex = this._getLastDisplayedEventIndex({
+            ignoreOwn: true,
         });
         if (lastReadEventIndex === null) {
             shouldSendReadReceipt = false;
         }
-
-        var lastReadEvent = this.state.events[lastReadEventIndex];
+        let lastReadEvent = this.state.events[lastReadEventIndex];
         shouldSendReadReceipt = shouldSendReadReceipt &&
             // Only send a RR if the last read Event is ahead in the timeline relative to
             // the current RR event.
             lastReadEventIndex > currentReadUpToEventIndex &&
             // Only send a RR if the last RR set != the one we would send
-            this.last_rr_sent_event_id != lastReadEvent.getId();
+            this.lastRRSentSentId != lastReadEvent.getId();
 
         // Only send a RM if the last RM sent != the one we would send
-        const shouldSendReadMarker = this.last_rm_sent_event_id != this.state.readMarkerEventId;
+        const shouldSendReadMarker =
+            this.lastRMSentEventId != this.state.readMarkerEventId;
 
         // we also remember the last read receipt we sent to avoid spamming the
         // same one at the server repeatedly
         if (shouldSendReadReceipt || shouldSendReadMarker) {
             if (shouldSendReadReceipt) {
-                this.last_rr_sent_event_id = lastReadEvent.getId();
+                this.lastRRSentSentId = lastReadEvent.getId();
             } else {
                 lastReadEvent = null;
             }
-            this.last_rm_sent_event_id = this.state.readMarkerEventId;
+            this.lastRMSentEventId = this.state.readMarkerEventId;
 
             debuglog('TimelinePanel: Sending Read Markers for ',
                 this.props.timelineSet.room.roomId,
@@ -572,12 +572,12 @@ var TimelinePanel = React.createClass({
                     return MatrixClientPeg.get().sendReadReceipt(
                         lastReadEvent,
                     ).catch(() => {
-                        this.last_rr_sent_event_id = undefined;
+                        this.lastRRSentSentId = undefined;
                     });
                 }
                 // it failed, so allow retries next time the user is active
-                this.last_rr_sent_event_id = undefined;
-                this.last_rm_sent_event_id = undefined;
+                this.lastRRSentSentId = undefined;
+                this.lastRMSentEventId = undefined;
             });
 
             // do a quick-reset of our unreadNotificationCount to avoid having

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -507,10 +507,10 @@ var TimelinePanel = React.createClass({
         // if no client or client is guest don't send RR or RM
         if (!cli || cli.isGuest()) return;
 
-        let shouldSendReadReceipt = true;
+        let shouldSendRR = true;
 
-        const currentReadUpToEventId = this._getCurrentReadReceipt(true);
-        const currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
+        const currentRREventId = this._getCurrentReadReceipt(true);
+        const currentRREventIndex = this._indexForEventId(currentRREventId);
         // We want to avoid sending out read receipts when we are looking at
         // events in the past which are before the latest RR.
         //
@@ -524,33 +524,33 @@ var TimelinePanel = React.createClass({
         // RRs) - but that is a bit of a niche case. It will sort itself out when
         // the user eventually hits the live timeline.
         //
-        if (currentReadUpToEventId && currentReadUpToEventIndex === null &&
+        if (currentRREventId && currentRREventIndex === null &&
                 this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
-            shouldSendReadReceipt = false;
+            shouldSendRR = false;
         }
 
         const lastReadEventIndex = this._getLastDisplayedEventIndex({
             ignoreOwn: true,
         });
         if (lastReadEventIndex === null) {
-            shouldSendReadReceipt = false;
+            shouldSendRR = false;
         }
         let lastReadEvent = this.state.events[lastReadEventIndex];
-        shouldSendReadReceipt = shouldSendReadReceipt &&
+        shouldSendRR = shouldSendRR &&
             // Only send a RR if the last read event is ahead in the timeline relative to
             // the current RR event.
-            lastReadEventIndex > currentReadUpToEventIndex &&
+            lastReadEventIndex > currentRREventIndex &&
             // Only send a RR if the last RR set != the one we would send
             this.lastRRSentEventId != lastReadEvent.getId();
 
         // Only send a RM if the last RM sent != the one we would send
-        const shouldSendReadMarker =
+        const shouldSendRM =
             this.lastRMSentEventId != this.state.readMarkerEventId;
 
         // we also remember the last read receipt we sent to avoid spamming the
         // same one at the server repeatedly
-        if (shouldSendReadReceipt || shouldSendReadMarker) {
-            if (shouldSendReadReceipt) {
+        if (shouldSendRR || shouldSendRM) {
+            if (shouldSendRR) {
                 this.lastRRSentEventId = lastReadEvent.getId();
             } else {
                 lastReadEvent = null;

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -510,8 +510,10 @@ var TimelinePanel = React.createClass({
         var currentReadUpToEventId = this._getCurrentReadReceipt(true);
         var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
 
+        currentReadUpToEventIndex = currentReadUpToEventIndex ||
+            this._indexForEventId(this.state.readMarkerEventId);
         // We want to avoid sending out read receipts when we are looking at
-        // events in the past which are before the latest RR.
+        // events in the past which are before the latest RR/RM.
         //
         // For now, let's apply a heuristic: if (a) the event corresponding to
         // the latest RR (either from the server, or sent by ourselves) doesn't
@@ -523,6 +525,7 @@ var TimelinePanel = React.createClass({
         // RRs) - but that is a bit of a niche case. It will sort itself out when
         // the user eventually hits the live timeline.
         //
+        console.log(currentReadUpToEventId, currentReadUpToEventIndex, this._timelineWindow.canPaginate(EventTimeline.FORWARDS));
         if (currentReadUpToEventId && currentReadUpToEventIndex === null &&
                 this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
             return;
@@ -544,6 +547,11 @@ var TimelinePanel = React.createClass({
             this.last_rr_sent_event_id = lastReadEvent.getId();
             this.last_rm_sent_event_id = this.state.readMarkerEventId;
 
+            console.log('TimelinePanel: Sending Read Markers for ',
+                this.props.timelineSet.room.roomId,
+                'rm', this.state.readMarkerEventId,
+                'rr', lastReadEvent.getId(),
+            );
             MatrixClientPeg.get().setRoomReadMarkers(
                 this.props.timelineSet.room.roomId,
                 this.state.readMarkerEventId,

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -525,7 +525,6 @@ var TimelinePanel = React.createClass({
         // RRs) - but that is a bit of a niche case. It will sort itself out when
         // the user eventually hits the live timeline.
         //
-        console.log(currentReadUpToEventId, currentReadUpToEventIndex, this._timelineWindow.canPaginate(EventTimeline.FORWARDS));
         if (currentReadUpToEventId && currentReadUpToEventIndex === null &&
                 this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
             return;

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -537,7 +537,7 @@ var TimelinePanel = React.createClass({
         }
         let lastReadEvent = this.state.events[lastReadEventIndex];
         shouldSendReadReceipt = shouldSendReadReceipt &&
-            // Only send a RR if the last read Event is ahead in the timeline relative to
+            // Only send a RR if the last read event is ahead in the timeline relative to
             // the current RR event.
             lastReadEventIndex > currentReadUpToEventIndex &&
             // Only send a RR if the last RR set != the one we would send

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -507,7 +507,7 @@ var TimelinePanel = React.createClass({
         // if no client or client is guest don't send RR or RM
         if (!cli || cli.isGuest()) return;
 
-        let shouldSendRR = true;
+        let shouldSendReadReceipt = true;
 
         var currentReadUpToEventId = this._getCurrentReadReceipt(true);
         var currentReadUpToEventIndex = this._indexForEventId(currentReadUpToEventId);
@@ -526,26 +526,30 @@ var TimelinePanel = React.createClass({
         //
         if (currentReadUpToEventId && currentReadUpToEventIndex === null &&
                 this._timelineWindow.canPaginate(EventTimeline.FORWARDS)) {
-            shouldSendRR = false;
+            shouldSendReadReceipt = false;
         }
 
         var lastReadEventIndex = this._getLastDisplayedEventIndex({
             ignoreOwn: true
         });
         if (lastReadEventIndex === null) {
-            shouldSendRR = false;
+            shouldSendReadReceipt = false;
         }
 
         var lastReadEvent = this.state.events[lastReadEventIndex];
-        shouldSendRR = shouldSendRR &&
-            (lastReadEventIndex > currentReadUpToEventIndex &&
-            this.last_rr_sent_event_id != lastReadEvent.getId());
+        shouldSendReadReceipt = shouldSendReadReceipt &&
+            // Only send a RR if the last read Event is ahead in the timeline relative to
+            // the current RR event.
+            lastReadEventIndex > currentReadUpToEventIndex &&
+            // Only send a RR if the last RR set != the one we would send
+            this.last_rr_sent_event_id != lastReadEvent.getId();
 
-        const shouldSendRM = this.last_rm_sent_event_id != this.state.readMarkerEventId;
+        // Only send a RM if the last RM sent != the one we would send
+        const shouldSendReadMarker = this.last_rm_sent_event_id != this.state.readMarkerEventId;
 
         // we also remember the last read receipt we sent to avoid spamming the
         // same one at the server repeatedly
-        if (shouldSendRR || shouldSendRM) {
+        if (shouldSendReadReceipt || shouldSendReadMarker) {
             this.last_rr_sent_event_id = lastReadEvent.getId();
             this.last_rm_sent_event_id = this.state.readMarkerEventId;
 


### PR DESCRIPTION
If the RR event has been unpaginated, the logic in `sendReadReceipt` will now fallback on the event ID of the RM which in theory is always =< RR event ID stream-wise.

Also add some logging to debug RM bugs.