### PR TITLE
Redesign mxID chooser, add availability checking 

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -775,7 +775,8 @@ module.exports = React.createClass({
             const SetMxIdDialog = sdk.getComponent('views.dialogs.SetMxIdDialog');
             const defered = q.defer();
             mxIdPromise = defered.promise;
-            Modal.createDialog(SetMxIdDialog, {
+            const close = Modal.createDialog(SetMxIdDialog, {
+                homeserverUrl: cli.getHomeserverUrl(),
                 onFinished: (submitted, credentials) => {
                     if (!submitted) {
                         defered.reject();
@@ -783,8 +784,12 @@ module.exports = React.createClass({
                     }
                     this.props.onRegistered(credentials);
                     defered.resolve();
-                }
-            });
+                },
+                onDifferentServerClicked: (ev) => {
+                    dis.dispatch({action: 'start_registration'});
+                    close();
+                },
+            }).close;
         }
 
         mxIdPromise.then(() => {

--- a/src/components/views/dialogs/SetMxIdDialog.js
+++ b/src/components/views/dialogs/SetMxIdDialog.js
@@ -34,6 +34,8 @@ export default React.createClass({
     displayName: 'SetMxIdDialog',
     propTypes: {
         onFinished: React.PropTypes.func.isRequired,
+        // Called when the user requests to register with a different homeserver
+        onDifferentServerClicked: React.PropTypes.func.isRequired,
     },
 
     getInitialState: function() {


### PR DESCRIPTION
***Blocked on matrix-org/matrix-js-sdk#432 for availability checking***.

Changes:
 - Redesign the dialog to look more like vector-im/riot-web#3604 (comment)
 - Attempt to fix wrong password being stored by generating one per SetMxIdDialog (there's no issue tracking this for now, I shall open one if it persists)
 - Backwards compatible with servers that don't support register/availability - a spinner will appear the first time a username is checked because server support can only be determined after a request.
 - Rate-limited by a 2s debounce
 - General style improvements