### PR TITLE
Remove "Current Password" input if mx_pass exists

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -185,6 +185,14 @@ function _registerAsGuest(hsUrl, isUrl, defaultDeviceDisplayName) {
 
 // returns a promise which resolves to true if a session is found in
 // localstorage
+//
+// N.B. Lifecycle.js should not maintain any further localStorage state, we
+//      are moving towards using SessionStore to keep track of state related
+//      to the current session (which is typically backed by localStorage).
+//
+//      The plan is to gradually move the localStorage access done here into
+//      SessionStore to avoid bugs where the view becomes out-of-sync with
+//      localStorage (e.g. teamToken, isGuest etc.)
 function _restoreFromLocalStorage() {
     if (!localStorage) {
         return q(false);

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -289,7 +289,6 @@ export function setLoggedIn(credentials) {
 
     // Resolves by default
     let teamPromise = Promise.resolve(null);
-    let isPasswordStored = false;
 
     // persist the session
     if (localStorage) {
@@ -312,8 +311,11 @@ export function setLoggedIn(credentials) {
             // The user registered as a PWLU (PassWord-Less User), the generated password
             // is cached here such that the user can change it at a later time.
             if (credentials.password) {
-                localStorage.setItem("mx_pass", credentials.password);
-                isPasswordStored = true;
+                // Update SessionStore
+                dis.dispatch({
+                    action: 'cached_password',
+                    cachedPassword: credentials.password,
+                });
             }
 
             console.log("Session persisted for %s", credentials.userId);
@@ -339,10 +341,10 @@ export function setLoggedIn(credentials) {
     MatrixClientPeg.replaceUsingCreds(credentials);
 
     teamPromise.then((teamToken) => {
-        dis.dispatch({action: 'on_logged_in', teamToken: teamToken, isPasswordStored});
+        dis.dispatch({action: 'on_logged_in', teamToken: teamToken});
     }, (err) => {
         console.warn("Failed to get team token on login", err);
-        dis.dispatch({action: 'on_logged_in', teamToken: null, isPasswordStored});
+        dis.dispatch({action: 'on_logged_in', teamToken: null});
     });
 
     startMatrixClient();

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -79,16 +79,16 @@ export default React.createClass({
         document.addEventListener('keydown', this._onKeyDown);
 
         this._sessionStore = sessionStore;
-        this._removeSSListener = this._sessionStore.addListener(
+        this._sessionStoreToken = this._sessionStore.addListener(
             this._setStateFromSessionStore,
-        ).remove;
+        );
         this._setStateFromSessionStore();
     },
 
     componentWillUnmount: function() {
         document.removeEventListener('keydown', this._onKeyDown);
-        if (this._removeSSListener) {
-            this._removeSSListener();
+        if (this._sessionStoreToken) {
+            this._sessionStoreToken.remove();
         }
     },
 

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -216,6 +216,7 @@ export default React.createClass({
                     enableLabs={this.props.config.enableLabs}
                     referralBaseUrl={this.props.config.referralBaseUrl}
                     teamToken={this.props.teamToken}
+                    cachedPassword={this.props.cachedPassword}
                 />;
                 if (!this.props.collapse_rhs) right_panel = <RightPanel opacity={this.props.sideOpacity}/>;
                 break;

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -79,12 +79,17 @@ export default React.createClass({
         document.addEventListener('keydown', this._onKeyDown);
 
         this._sessionStore = sessionStore;
-        this._sessionStore.addListener(this._setStateFromSessionStore);
+        this._removeSSListener = this._sessionStore.addListener(
+            this._setStateFromSessionStore,
+        ).remove;
         this._setStateFromSessionStore();
     },
 
     componentWillUnmount: function() {
         document.removeEventListener('keydown', this._onKeyDown);
+        if (this._removeSSListener) {
+            this._removeSSListener();
+        }
     },
 
     getScrollStateForRoom: function(roomId) {

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -51,7 +51,7 @@ export default React.createClass({
 
         // Has the user generated a password that is stored in local storage?
         // (are they a PWLU?)
-        userHasGeneratedPassword: React.PropTypes.boolean,
+        userHasGeneratedPassword: React.PropTypes.bool,
 
         // and lots and lots of other stuff.
     },
@@ -216,7 +216,6 @@ export default React.createClass({
                     enableLabs={this.props.config.enableLabs}
                     referralBaseUrl={this.props.config.referralBaseUrl}
                     teamToken={this.props.teamToken}
-                    cachedPassword={this.props.cachedPassword}
                 />;
                 if (!this.props.collapse_rhs) right_panel = <RightPanel opacity={this.props.sideOpacity}/>;
                 break;

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -23,6 +23,7 @@ import Notifier from '../../Notifier';
 import PageTypes from '../../PageTypes';
 import sdk from '../../index';
 import dis from '../../dispatcher';
+import sessionStore from '../../stores/SessionStore';
 
 /**
  * This is what our MatrixChat shows when we are logged in. The precise view is
@@ -48,10 +49,6 @@ export default React.createClass({
         onRegistered: React.PropTypes.func,
 
         teamToken: React.PropTypes.string,
-
-        // Has the user generated a password that is stored in local storage?
-        // (are they a PWLU?)
-        userHasGeneratedPassword: React.PropTypes.bool,
 
         // and lots and lots of other stuff.
     },
@@ -80,6 +77,10 @@ export default React.createClass({
         this._scrollStateMap = {};
 
         document.addEventListener('keydown', this._onKeyDown);
+
+        this._sessionStore = sessionStore;
+        this._sessionStore.addListener(this._setStateFromSessionStore);
+        this._setStateFromSessionStore();
     },
 
     componentWillUnmount: function() {
@@ -95,6 +96,12 @@ export default React.createClass({
             return true;
         }
         return this.refs.roomView.canResetTimeline();
+    },
+
+    _setStateFromSessionStore() {
+        this.setState({
+            userHasGeneratedPassword: Boolean(this._sessionStore.getCachedPassword()),
+        });
     },
 
     _onKeyDown: function(ev) {
@@ -257,7 +264,7 @@ export default React.createClass({
             />;
         } else if (this.props.matrixClient.isGuest()) {
             topBar = <GuestWarningBar />;
-        } else if (this.props.userHasGeneratedPassword) {
+        } else if (this.state.userHasGeneratedPassword) {
             topBar = <PasswordNagBar />;
         } else if (Notifier.supportsDesktopNotifications() && !Notifier.isEnabled() && !Notifier.isToolbarHidden()) {
             topBar = <MatrixToolbar />;

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -252,7 +252,7 @@ module.exports = React.createClass({
         }
 
         this._sessionStore = sessionStore;
-        this._sessionStore.on('update', this._setStateFromSessionStore);
+        this._sessionStore.addListener(this._setStateFromSessionStore);
         this._setStateFromSessionStore();
     },
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -138,8 +138,6 @@ module.exports = React.createClass({
             register_hs_url: null,
             register_is_url: null,
             register_id_sid: null,
-
-            userHasGeneratedPassword: false,
         };
         return s;
     },
@@ -1171,7 +1169,6 @@ module.exports = React.createClass({
                     onUserSettingsClose={this.onUserSettingsClose}
                     onRegistered={this.onRegistered}
                     teamToken={this._teamToken}
-                    userHasGeneratedPassword={this.state.userHasGeneratedPassword}
                     {...this.props}
                     {...this.state}
                 />

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -40,7 +40,7 @@ var PageTypes = require('../../PageTypes');
 var createRoom = require("../../createRoom");
 import * as UDEHandler from '../../UnknownDeviceErrorHandler';
 
-import getSessionStore from '../../stores/SessionStore';
+import sessionStore from '../../stores/SessionStore';
 
 module.exports = React.createClass({
     displayName: 'MatrixChat',
@@ -251,7 +251,7 @@ module.exports = React.createClass({
             });
         }
 
-        this._sessionStore = getSessionStore();
+        this._sessionStore = sessionStore;
         this._sessionStore.on('update', this._setStateFromSessionStore);
         this._setStateFromSessionStore();
     },

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -590,6 +590,12 @@ module.exports = React.createClass({
                     payload.releaseNotes
                 );
                 break;
+            case 'password_changed':
+                this.setState({
+                    userHasGeneratedPassword: false,
+                });
+                localStorage.removeItem("mx_pass");
+                break;
         }
     },
 
@@ -1176,7 +1182,8 @@ module.exports = React.createClass({
                     onUserSettingsClose={this.onUserSettingsClose}
                     onRegistered={this.onRegistered}
                     teamToken={this._teamToken}
-                    userHasGeneratedPassword={this.state.userHasGeneratedPassword}
+                    cachedPassword={this.state.userHasGeneratedPassword ?
+                        localStorage.getItem('mx_pass') : null}
                     {...this.props}
                     {...this.state}
                 />

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1183,6 +1183,7 @@ module.exports = React.createClass({
                     onUserSettingsClose={this.onUserSettingsClose}
                     onRegistered={this.onRegistered}
                     teamToken={this._teamToken}
+                    userHasGeneratedPassword={this.state.userHasGeneratedPassword}
                     {...this.props}
                     {...this.state}
                 />

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -40,8 +40,6 @@ var PageTypes = require('../../PageTypes');
 var createRoom = require("../../createRoom");
 import * as UDEHandler from '../../UnknownDeviceErrorHandler';
 
-import sessionStore from '../../stores/SessionStore';
-
 module.exports = React.createClass({
     displayName: 'MatrixChat',
 
@@ -250,10 +248,6 @@ module.exports = React.createClass({
                 register_hs_url: paramHs,
             });
         }
-
-        this._sessionStore = sessionStore;
-        this._sessionStore.addListener(this._setStateFromSessionStore);
-        this._setStateFromSessionStore();
     },
 
     componentDidMount: function() {
@@ -894,12 +888,6 @@ module.exports = React.createClass({
                     });
                 }
             }
-        });
-    },
-
-    _setStateFromSessionStore() {
-        this.setState({
-            userHasGeneratedPassword: Boolean(this._sessionStore.getCachedPassword()),
         });
     },
 

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -139,9 +139,6 @@ module.exports = React.createClass({
         // Team token for the referral link. If falsy, the referral section will
         // not appear
         teamToken: React.PropTypes.string,
-
-        // the user is a PWLU (/w password stashed in localStorage 'mx_pass')
-        cachedPassword: React.PropTypes.string,
     },
 
     getDefaultProps: function() {
@@ -898,7 +895,6 @@ module.exports = React.createClass({
                         rowLabelClassName="mx_UserSettings_profileLabelCell"
                         rowInputClassName="mx_UserSettings_profileInputCell"
                         buttonClassName="mx_UserSettings_button mx_UserSettings_changePasswordButton"
-                        cachedPassword={this.props.cachedPassword}
                         onError={this.onPasswordChangeError}
                         onFinished={this.onPasswordChanged} />
             );

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -139,6 +139,9 @@ module.exports = React.createClass({
         // Team token for the referral link. If falsy, the referral section will
         // not appear
         teamToken: React.PropTypes.string,
+
+        // the user is a PWLU (/w password stashed in localStorage 'mx_pass')
+        cachedPassword: React.PropTypes.string,
     },
 
     getDefaultProps: function() {
@@ -331,6 +334,7 @@ module.exports = React.createClass({
                           receive push notifications on other devices until you
                           log back in to them.`,
         });
+        dis.dispatch({action: 'password_changed'});
     },
 
     onUpgradeClicked: function() {
@@ -894,6 +898,7 @@ module.exports = React.createClass({
                         rowLabelClassName="mx_UserSettings_profileLabelCell"
                         rowInputClassName="mx_UserSettings_profileInputCell"
                         buttonClassName="mx_UserSettings_button mx_UserSettings_changePasswordButton"
+                        cachedPassword={this.props.cachedPassword}
                         onError={this.onPasswordChangeError}
                         onFinished={this.onPasswordChanged} />
             );

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -69,16 +69,16 @@ module.exports = React.createClass({
 
     componentWillMount: function() {
         this._sessionStore = sessionStore;
-        this._removeSSListener = this._sessionStore.addListener(
+        this._sessionStoreToken = this._sessionStore.addListener(
             this._setStateFromSessionStore,
-        ).remove;
+        );
 
         this._setStateFromSessionStore();
     },
 
     componentWillUnmount: function() {
-        if (this._removeSSListener) {
-            this._removeSSListener();
+        if (this._sessionStoreToken) {
+            this._sessionStoreToken.remove();
         }
     },
 

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -22,7 +22,7 @@ var Modal = require("../../../Modal");
 var sdk = require("../../../index");
 import AccessibleButton from '../elements/AccessibleButton';
 
-import getSessionStore from '../../../stores/SessionStore';
+import sessionStore from '../../../stores/SessionStore';
 
 module.exports = React.createClass({
     displayName: 'ChangePassword',
@@ -68,7 +68,7 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
-        this.sessionStore = getSessionStore();
+        this.sessionStore = sessionStore;
         this.sessionStore.on('update', this.setStateFromSessionStore);
 
         this.setStateFromSessionStore();

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -68,15 +68,15 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
-        this.sessionStore = sessionStore;
-        this.sessionStore.on('update', this.setStateFromSessionStore);
+        this._sessionStore = sessionStore;
+        this._sessionStore.addListener(this._setStateFromSessionStore);
 
-        this.setStateFromSessionStore();
+        this._setStateFromSessionStore();
     },
 
-    setStateFromSessionStore: function() {
+    _setStateFromSessionStore: function() {
         this.setState({
-            cachedPassword: this.sessionStore.getCachedPassword(),
+            cachedPassword: this._sessionStore.getCachedPassword(),
         });
     },
 

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -31,7 +31,10 @@ module.exports = React.createClass({
         rowClassName: React.PropTypes.string,
         rowLabelClassName: React.PropTypes.string,
         rowInputClassName: React.PropTypes.string,
-        buttonClassName: React.PropTypes.string
+        buttonClassName: React.PropTypes.string,
+
+        // user is a PWLU (/w password stashed in localStorage 'mx_pass')
+        cachedPassword: React.PropTypes.string,
     },
 
     Phases: {
@@ -121,10 +124,10 @@ module.exports = React.createClass({
                 matrixClient: MatrixClientPeg.get(),
             }
         );
-    },    
+    },
 
     onClickChange: function() {
-        var old_password = this.refs.old_input.value;
+        var old_password = this.props.cachedPassword || this.refs.old_input.value;
         var new_password = this.refs.new_input.value;
         var confirm_password = this.refs.confirm_input.value;
         var err = this.props.onCheckPassword(
@@ -139,23 +142,28 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        var rowClassName = this.props.rowClassName;
-        var rowLabelClassName = this.props.rowLabelClassName;
-        var rowInputClassName = this.props.rowInputClassName;
-        var buttonClassName = this.props.buttonClassName;
+        const rowClassName = this.props.rowClassName;
+        const rowLabelClassName = this.props.rowLabelClassName;
+        const rowInputClassName = this.props.rowInputClassName;
+        const buttonClassName = this.props.buttonClassName;
+
+        let currentPassword = null;
+        if (!this.props.cachedPassword) {
+            currentPassword = <div className={rowClassName}>
+                <div className={rowLabelClassName}>
+                    <label htmlFor="passwordold">Current password</label>
+                </div>
+                <div className={rowInputClassName}>
+                    <input id="passwordold" type="password" ref="old_input" />
+                </div>
+            </div>;
+        }
 
         switch (this.state.phase) {
             case this.Phases.Edit:
                 return (
                     <div className={this.props.className}>
-                        <div className={rowClassName}>
-                            <div className={rowLabelClassName}>
-                                <label htmlFor="passwordold">Current password</label>
-                            </div>
-                            <div className={rowInputClassName}>
-                                <input id="passwordold" type="password" ref="old_input" />
-                            </div>
-                        </div>
+                        { currentPassword }
                         <div className={rowClassName}>
                             <div className={rowLabelClassName}>
                                 <label htmlFor="password1">New password</label>

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -69,9 +69,17 @@ module.exports = React.createClass({
 
     componentWillMount: function() {
         this._sessionStore = sessionStore;
-        this._sessionStore.addListener(this._setStateFromSessionStore);
+        this._removeSSListener = this._sessionStore.addListener(
+            this._setStateFromSessionStore,
+        ).remove;
 
         this._setStateFromSessionStore();
+    },
+
+    componentWillUnmount: function() {
+        if (this._removeSSListener) {
+            this._removeSSListener();
+        }
     },
 
     _setStateFromSessionStore: function() {

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -22,6 +22,8 @@ var Modal = require("../../../Modal");
 var sdk = require("../../../index");
 import AccessibleButton from '../elements/AccessibleButton';
 
+import getSessionStore from '../../../stores/SessionStore';
+
 module.exports = React.createClass({
     displayName: 'ChangePassword',
     propTypes: {
@@ -32,9 +34,6 @@ module.exports = React.createClass({
         rowLabelClassName: React.PropTypes.string,
         rowInputClassName: React.PropTypes.string,
         buttonClassName: React.PropTypes.string,
-
-        // user is a PWLU (/w password stashed in localStorage 'mx_pass')
-        cachedPassword: React.PropTypes.string,
     },
 
     Phases: {
@@ -63,8 +62,22 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         return {
-            phase: this.Phases.Edit
+            phase: this.Phases.Edit,
+            cachedPassword: null,
         };
+    },
+
+    componentWillMount: function() {
+        this.sessionStore = getSessionStore();
+        this.sessionStore.on('update', this.setStateFromSessionStore);
+
+        this.setStateFromSessionStore();
+    },
+
+    setStateFromSessionStore: function() {
+        this.setState({
+            cachedPassword: this.sessionStore.getCachedPassword(),
+        });
     },
 
     changePassword: function(old_password, new_password) {
@@ -127,7 +140,7 @@ module.exports = React.createClass({
     },
 
     onClickChange: function() {
-        var old_password = this.props.cachedPassword || this.refs.old_input.value;
+        var old_password = this.state.cachedPassword || this.refs.old_input.value;
         var new_password = this.refs.new_input.value;
         var confirm_password = this.refs.confirm_input.value;
         var err = this.props.onCheckPassword(
@@ -148,7 +161,7 @@ module.exports = React.createClass({
         const buttonClassName = this.props.buttonClassName;
 
         let currentPassword = null;
-        if (!this.props.cachedPassword) {
+        if (!this.state.cachedPassword) {
             currentPassword = <div className={rowClassName}>
                 <div className={rowLabelClassName}>
                     <label htmlFor="passwordold">Current password</label>

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -1,21 +1,26 @@
 import dis from '../dispatcher';
-import EventEmitter from 'events';
+import {Store} from 'flux/utils';
 
 /**
  * A class for storing application state to do with the session. This is a simple flux
  * store that listens for actions and updates its state accordingly, informing any
- * listeners (views) of state changes via the 'update' event.
+ * listeners (views) of state changes.
+ *
+ * Usage:
+ *  ```
+ *  sessionStore.addListener(() => {
+ *   this.setState({ cachedPassword: sessionStore.getCachedPassword() })
+ *  })
+ *  ```
  */
-class SessionStore extends EventEmitter {
+class SessionStore extends Store {
     constructor() {
-        super();
+        super(dis);
 
         // Initialise state
         this._state = {
             cachedPassword: localStorage.getItem('mx_pass'),
         };
-
-        dis.register(this._onAction.bind(this));
     }
 
     _update() {
@@ -26,7 +31,7 @@ class SessionStore extends EventEmitter {
             localStorage.removeItem('mx_pass', this._state.cachedPassword);
         }
 
-        this.emit('update');
+        this.__emitChange();
     }
 
     _setState(newState) {
@@ -34,7 +39,7 @@ class SessionStore extends EventEmitter {
         this._update();
     }
 
-    _onAction(payload) {
+    __onDispatch(payload) {
         switch (payload.action) {
             case 'cached_password':
                 this._setState({

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -55,9 +55,7 @@ SessionStore.prototype.getCachedPassword = function() {
 
 // Export singleton getter
 let singletonSessionStore = null;
-export default function getSessionStore() {
-    if (!singletonSessionStore) {
-        singletonSessionStore = new SessionStore();
-    }
-    return singletonSessionStore;
+if (!singletonSessionStore) {
+    singletonSessionStore = new SessionStore();
 }
+module.exports = singletonSessionStore;

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -1,0 +1,63 @@
+import dis from '../dispatcher';
+import EventEmitter from 'events';
+
+/**
+ * A class for storing application state to do with the session. This is a simple flux
+ * store that listens for actions and updates its state accordingly, informing any
+ * listeners (views) of state changes via the 'update' event.
+ */
+function SessionStore() {
+    // Initialise state
+    this._state = {
+        cachedPassword: localStorage.getItem('mx_pass'),
+    };
+
+    dis.register(this._onAction.bind(this));
+}
+
+// Inherit from EventEmitter
+SessionStore.prototype = EventEmitter.prototype;
+
+SessionStore.prototype._update = function() {
+    // Persist state to localStorage
+    if (this._state.cachedPassword) {
+        localStorage.setItem('mx_pass', this._state.cachedPassword);
+    } else {
+        localStorage.removeItem('mx_pass', this._state.cachedPassword);
+    }
+
+    this.emit('update');
+};
+
+SessionStore.prototype._setState = function(newState) {
+    this._state = Object.assign(this._state, newState);
+    this._update();
+};
+
+SessionStore.prototype._onAction = function(payload) {
+    switch (payload.action) {
+        case 'cached_password':
+            this._setState({
+                cachedPassword: payload.cachedPassword,
+            });
+            break;
+        case 'password_changed':
+            this._setState({
+                cachedPassword: null,
+            });
+            break;
+    }
+};
+
+SessionStore.prototype.getCachedPassword = function() {
+    return this._state.cachedPassword;
+};
+
+// Export singleton getter
+let singletonSessionStore = null;
+export default function getSessionStore() {
+    if (!singletonSessionStore) {
+        singletonSessionStore = new SessionStore();
+    }
+    return singletonSessionStore;
+}

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -6,52 +6,53 @@ import EventEmitter from 'events';
  * store that listens for actions and updates its state accordingly, informing any
  * listeners (views) of state changes via the 'update' event.
  */
-function SessionStore() {
-    // Initialise state
-    this._state = {
-        cachedPassword: localStorage.getItem('mx_pass'),
-    };
+class SessionStore extends EventEmitter {
+    constructor() {
+        super();
 
-    dis.register(this._onAction.bind(this));
+        // Initialise state
+        this._state = {
+            cachedPassword: localStorage.getItem('mx_pass'),
+        };
+
+        dis.register(this._onAction.bind(this));
+    }
+
+    _update() {
+        // Persist state to localStorage
+        if (this._state.cachedPassword) {
+            localStorage.setItem('mx_pass', this._state.cachedPassword);
+        } else {
+            localStorage.removeItem('mx_pass', this._state.cachedPassword);
+        }
+
+        this.emit('update');
+    }
+
+    _setState(newState) {
+        this._state = Object.assign(this._state, newState);
+        this._update();
+    }
+
+    _onAction(payload) {
+        switch (payload.action) {
+            case 'cached_password':
+                this._setState({
+                    cachedPassword: payload.cachedPassword,
+                });
+                break;
+            case 'password_changed':
+                this._setState({
+                    cachedPassword: null,
+                });
+                break;
+        }
+    }
+
+    getCachedPassword() {
+        return this._state.cachedPassword;
+    }
 }
-
-// Inherit from EventEmitter
-SessionStore.prototype = EventEmitter.prototype;
-
-SessionStore.prototype._update = function() {
-    // Persist state to localStorage
-    if (this._state.cachedPassword) {
-        localStorage.setItem('mx_pass', this._state.cachedPassword);
-    } else {
-        localStorage.removeItem('mx_pass', this._state.cachedPassword);
-    }
-
-    this.emit('update');
-};
-
-SessionStore.prototype._setState = function(newState) {
-    this._state = Object.assign(this._state, newState);
-    this._update();
-};
-
-SessionStore.prototype._onAction = function(payload) {
-    switch (payload.action) {
-        case 'cached_password':
-            this._setState({
-                cachedPassword: payload.cachedPassword,
-            });
-            break;
-        case 'password_changed':
-            this._setState({
-                cachedPassword: null,
-            });
-            break;
-    }
-};
-
-SessionStore.prototype.getCachedPassword = function() {
-    return this._state.cachedPassword;
-};
 
 // Export singleton getter
 let singletonSessionStore = null;

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -54,7 +54,6 @@ class SessionStore extends EventEmitter {
     }
 }
 
-// Export singleton getter
 let singletonSessionStore = null;
 if (!singletonSessionStore) {
     singletonSessionStore = new SessionStore();


### PR DESCRIPTION
If the user is PWLU, do not show "Current Password" field in ChangePassword and when setting a new password, use the cached password.