### PR TITLE
tell guests they can't use filepanel until they register

### DIFF
--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -90,7 +90,11 @@ var FilePanel = React.createClass({
     },
 
     render: function() {
-        if (this.noRoom) {
+        if (MatrixClientPeg.get().isGuest()) {
+            return <div className="mx_FilePanel mx_RoomView_messageListWrapper">
+                <div className="mx_RoomView_empty">You must register to use this functionality</div>
+            </div>;
+        } else if (this.noRoom) {
             return <div className="mx_FilePanel mx_RoomView_messageListWrapper">
                 <div className="mx_RoomView_empty">You must join the room to see its files</div>
             </div>;

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -92,7 +92,7 @@ var FilePanel = React.createClass({
     render: function() {
         if (MatrixClientPeg.get().isGuest()) {
             return <div className="mx_FilePanel mx_RoomView_messageListWrapper">
-                <div className="mx_RoomView_empty">You must register to use this functionality</div>
+                <div className="mx_RoomView_empty">You must <a href="#/register">register</a> to use this functionality</div>
             </div>;
         } else if (this.noRoom) {
             return <div className="mx_FilePanel mx_RoomView_messageListWrapper">


### PR DESCRIPTION
re-closes vector-im/riot-web/issues/3889

I chose guest > noRoom
because otherwise they'd get noRoom error and then when they join they'd get guest, would be annoying

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>