### PR TITLE
Write some tests for the RTS UI

### DIFF
--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -98,7 +98,7 @@ module.exports = React.createClass({
             this.props.teamServerConfig.teamServerURL &&
             !this._rtsClient
         ) {
-            this._rtsClient = new RtsClient(this.props.teamServerConfig.teamServerURL);
+            this._rtsClient = this.props.rtsClient || new RtsClient(this.props.teamServerConfig.teamServerURL);
 
             this.setState({
                 teamServerBusy: true,
@@ -221,7 +221,6 @@ module.exports = React.createClass({
         }
 
         trackPromise.then((teamToken) => {
-            console.info('Team token promise',teamToken);
             this.props.onLoggedIn({
                 userId: response.user_id,
                 deviceId: response.device_id,

--- a/test/components/structures/login/Registration-test.js
+++ b/test/components/structures/login/Registration-test.js
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-addons-test-utils');
+const expect = require('expect');
+
+const testUtils = require('test-utils');
+
+const sdk = require('matrix-react-sdk');
+const Registration = sdk.getComponent('structures.login.Registration');
+
+let rtsClient;
+let client;
+
+const TEAM_CONFIG = {
+    supportEmail: 'support@some.domain',
+    teamServerURL: 'http://someteamserver.bla',
+};
+
+const CREDENTIALS = {userId: '@me:here'};
+const MOCK_REG_RESPONSE = {
+    user_id: CREDENTIALS.userId,
+    device_id: 'mydevice',
+    access_token: '2234569864534231',
+};
+
+describe('Registration', function() {
+    beforeEach(function() {
+        testUtils.beforeEach(this);
+        client = testUtils.createTestClient();
+        client.credentials = CREDENTIALS;
+
+        // Mock an RTS client that supports one team and naively returns team tokens when
+        // tracking by mapping email SIDs to team tokens. This is fine because we only
+        // want to assert the client behaviour such that a user recognised by the
+        // rtsClient (which would normally talk to the RTS server) as a team member is
+        // correctly logged in as one (and other such assertions).
+        rtsClient = testUtils.createTestRtsClient(
+            {
+                'myawesometeam123': {
+                    name: 'Team Awesome',
+                    domain: 'team.awesome.net',
+                },
+            },
+            {'someEmailSid1234': 'myawesometeam123'},
+        );
+    });
+
+    it('should track a referral following successful registration of a team member', function(done) {
+        const expectedCreds = {
+            userId: MOCK_REG_RESPONSE.user_id,
+            deviceId: MOCK_REG_RESPONSE.device_id,
+            homeserverUrl: client.getHomeserverUrl(),
+            identityServerUrl: client.getIdentityServerUrl(),
+            accessToken: MOCK_REG_RESPONSE.access_token,
+        };
+        const onLoggedIn = function(creds, teamToken) {
+            expect(creds).toEqual(expectedCreds);
+            expect(teamToken).toBe('myawesometeam123');
+            done();
+        };
+
+        const res = ReactTestUtils.renderIntoDocument(
+            <Registration
+                teamServerConfig={TEAM_CONFIG}
+                onLoggedIn={onLoggedIn}
+                rtsClient={rtsClient}
+            />,
+        );
+
+        res._onUIAuthFinished(true, MOCK_REG_RESPONSE, {emailSid: 'someEmailSid1234'});
+    });
+
+    it('should NOT track a referral following successful registration of a non-team member', function(done) {
+        const onLoggedIn = expect.createSpy().andCall(function(creds, teamToken) {
+            expect(teamToken).toNotExist();
+            done();
+        });
+
+        const res = ReactTestUtils.renderIntoDocument(
+            <Registration
+                teamServerConfig={TEAM_CONFIG}
+                onLoggedIn={onLoggedIn}
+                rtsClient={rtsClient}
+            />,
+        );
+
+        res._onUIAuthFinished(true, MOCK_REG_RESPONSE, {emailSid: 'someOtherEmailSid11'});
+    });
+});

--- a/test/components/views/login/RegistrationForm-test.js
+++ b/test/components/views/login/RegistrationForm-test.js
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const React = require('react');
+const ReactDOM = require("react-dom");
+const ReactTestUtils = require('react-addons-test-utils');
+const expect = require('expect');
+
+const testUtils = require('test-utils');
+
+const sdk = require('matrix-react-sdk');
+const RegistrationForm = sdk.getComponent('views.login.RegistrationForm');
+
+const TEAM_CONFIG = {
+    supportEmail: "support@some.domain",
+    teams: [
+        { name: "The Team Org.", domain: "team.ac.uk" },
+        { name: "The Super Team", domain: "superteam.ac.uk" },
+    ],
+};
+
+function doInputEmail(inputEmail, onTeamSelected) {
+    const res = ReactTestUtils.renderIntoDocument(
+        <RegistrationForm
+            teamsConfig={TEAM_CONFIG}
+            onTeamSelected={onTeamSelected}
+        />,
+    );
+
+    const teamInput = res.refs.email;
+    teamInput.value = inputEmail;
+
+    ReactTestUtils.Simulate.change(teamInput);
+    ReactTestUtils.Simulate.blur(teamInput);
+
+    return res;
+}
+
+function expectTeamSelectedFromEmailInput(inputEmail, expectedTeam) {
+    const onTeamSelected = expect.createSpy();
+    doInputEmail(inputEmail, onTeamSelected);
+
+    expect(onTeamSelected).toHaveBeenCalledWith(expectedTeam);
+}
+
+function expectSupportFromEmailInput(inputEmail, isSupportShown) {
+    const onTeamSelected = expect.createSpy();
+    const res = doInputEmail(inputEmail, onTeamSelected);
+
+    expect(res.state.showSupportEmail).toBe(isSupportShown);
+}
+
+describe('RegistrationForm', function() {
+    beforeEach(function() {
+        testUtils.beforeEach(this);
+    });
+
+    it('should select a team when a team email is entered', function() {
+        expectTeamSelectedFromEmailInput("member@team.ac.uk", TEAM_CONFIG.teams[0]);
+    });
+
+    it('should not select a team when an unrecognised team email is entered', function() {
+        expectTeamSelectedFromEmailInput("member@someunknownteam.ac.uk", null);
+    });
+
+    it('should show support when an unrecognised team email is entered', function() {
+        expectSupportFromEmailInput("member@someunknownteam.ac.uk", true);
+    });
+
+    it('should NOT show support when an unrecognised non-team email is entered', function() {
+        expectSupportFromEmailInput("someone@yahoo.com", false);
+    });
+});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -137,6 +137,20 @@ export function createTestClient() {
     };
 }
 
+export function createTestRtsClient(teamMap, sidMap) {
+    return {
+        getTeamsConfig() {
+            return q(Object.keys(teamMap).map((token) => teamMap[token]));
+        },
+        trackReferral(referrer, emailSid, clientSecret) {
+            return q({team_token: sidMap[emailSid]});
+        },
+        getTeam(teamToken) {
+            return q(teamMap[teamToken]);
+        },
+    };
+}
+
 /**
  * Create an Event.
  * @param {Object} opts Values for the event.


### PR DESCRIPTION
Add tests that make assertions about the UI during registration when registration is done with a user recognised as a team member (by the mock rtsClient).

I'm PRing against `new-guest-access` but I could also merge this into `develop`?

The intention is to test the parts that are hardest to test live. Anything wrong with the home page feature will be quite clear during dog-fooding.