### PR TITLE
Reskindex to a temp file, to confuse the babel watcher less

### DIFF
--- a/scripts/reskindex.js
+++ b/scripts/reskindex.js
@@ -6,6 +6,7 @@ var args = require('optimist').argv;
 var chokidar = require('chokidar');
 
 var componentIndex = path.join('src', 'component-index.js');
+var componentIndexTmp = componentIndex+".tmp";
 var componentsDir = path.join('src', 'components');
 var componentGlob = '**/*.js';
 var prevFiles = [];
@@ -20,7 +21,7 @@ function reskindex() {
     var header = args.h || args.header;
     var packageJson = JSON.parse(fs.readFileSync('./package.json'));
 
-    var strm = fs.createWriteStream(componentIndex);
+    var strm = fs.createWriteStream(componentIndexTmp);
 
     if (header) {
        strm.write(fs.readFileSync(header));
@@ -35,13 +36,16 @@ function reskindex() {
     strm.write(" */\n\n");
 
     if (packageJson['matrix-react-parent']) {
+        const parentIndex = packageJson['matrix-react-parent'] +
+              '/lib/component-index';
         strm.write(
-            "module.exports.components = require('"+
-            packageJson['matrix-react-parent']+
-            "/lib/component-index').components;\n\n"
-        );
+`let components = require('${parentIndex}').components;
+if (!components) {
+    throw new Error("'${parentIndex}' didn't export components");
+}
+`);
     } else {
-        strm.write("module.exports.components = {};\n");
+        strm.write("let components = {};\n");
     }
 
     for (var i = 0; i < files.length; ++i) {
@@ -51,13 +55,20 @@ function reskindex() {
         var importName = moduleName.replace(/\./g, "$");
 
         strm.write("import " + importName + " from './components/" + file + "';\n");
-        strm.write(importName + " && (module.exports.components['"+moduleName+"'] = " + importName + ");");
+        strm.write(importName + " && (components['"+moduleName+"'] = " + importName + ");");
         strm.write('\n');
         strm.uncork();
     }
 
+    strm.write("export {components};\n");
     strm.end();
-    console.log('Reskindex: completed');
+    fs.rename(componentIndexTmp, componentIndex, function(err) {
+        if(err) {
+            console.err("Error moving new index into place: " + err);
+        } else {
+            console.log('Reskindex: completed');
+        }
+    });
 }
 
 // Expects both arrays of file names to be sorted
@@ -82,7 +93,7 @@ if (!args.w) {
 
 var watchDebouncer = null;
 chokidar.watch(path.join(componentsDir, componentGlob)).on('all', (event, path) => {
-    if (path === componentIndex) return;
+    if (path === componentIndex || path === componentIndexTmp) return;
     if (watchDebouncer) clearTimeout(watchDebouncer);
     watchDebouncer = setTimeout(reskindex, 1000);
 });

--- a/scripts/reskindex.js
+++ b/scripts/reskindex.js
@@ -64,7 +64,7 @@ if (!components) {
     strm.end();
     fs.rename(componentIndexTmp, componentIndex, function(err) {
         if(err) {
-            console.err("Error moving new index into place: " + err);
+            console.error("Error moving new index into place: " + err);
         } else {
             console.log('Reskindex: completed');
         }
@@ -93,7 +93,7 @@ if (!args.w) {
 
 var watchDebouncer = null;
 chokidar.watch(path.join(componentsDir, componentGlob)).on('all', (event, path) => {
-    if (path === componentIndex || path === componentIndexTmp) return;
+    if (path === componentIndex) return;
     if (watchDebouncer) clearTimeout(watchDebouncer);
     watchDebouncer = setTimeout(reskindex, 1000);
 });


### PR DESCRIPTION
I'm seeing a lot of instances where the babel watcher picks up a half-written src/component-index, and generates an empty lib file - which it then doesn't update when src/component-index is updated.

Empirically, this seems to make it better.