### PR TITLE
Fix 'missing page_type' error

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1171,7 +1171,12 @@ module.exports = React.createClass({
                 <PostRegistration
                     onComplete={this.onFinishPostRegistration} />
             );
-        } else if (this.state.loggedIn && this.state.ready) {
+        }
+
+        // `ready` and `loggedIn` may be set before `page_type` (because the
+        // latter is set via the dispatcher). If we don't yet have a `page_type`,
+        // keep showing the spinner for now.
+        if (this.state.loggedIn && this.state.ready && this.state.page_type) {
             /* for now, we stuff the entirety of our props and state into the LoggedInView.
              * we should go through and figure out what we actually need to pass down, as well
              * as using something like redux to avoid having a billion bits of state kicking around.


### PR DESCRIPTION
LoggedInView will complain if it is instantiated without a page_type, so let's
keep showing the syncing spinner until we have one.