### PR TITLE
Add in a "verify" slash command to confirm signing keys

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -314,11 +314,12 @@ var commands = {
                             <div>
                                 <p>
                                     The signing key you provided matches the signing key you received
-                                    from { userId }'s device { deviceId }
+                                    from { userId }'s device { deviceId }. Device marked as verified.
                                 </p>
                             </div>
                         ),
-                        button: "Accept verification",
+                        button: "Ok",
+                        hasCancelButton: false,
                         onFinished: confirm => {
                             if (confirm) {
                                 MatrixClientPeg.get().setDeviceVerified(

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -298,10 +298,12 @@ var commands = {
 
                 var fingerprint = matches[3];
 
-                if (device.isVerified() && device.getFingerprint() === fingerprint) {
-                    return reject(`Device already verified!`);
-                } else if (device.isVerified() && device.getFingerprint() !== fingerprint) {
-                    return reject(`WARNING: Device already verified, but keys do NOT MATCH!`);
+                if (device.isVerified()) {
+                    if (device.getFingerprint() === fingerprint) {
+                        return reject(`Device already verified!`);
+                    } else {
+                        return reject(`WARNING: Device already verified, but keys do NOT MATCH!`);
+                    }
                 }
 
                 if (device.getFingerprint() === fingerprint) {

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -313,8 +313,8 @@ var commands = {
                         description: (
                             <div>
                                 <p>
-                                    The signing key you provided matches the signing key you received from
-                                    { userId }'s device { deviceId }
+                                    The signing key you provided matches the signing key you received
+                                    from { userId }'s device { deviceId }
                                 </p>
                             </div>
                         ),

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -307,6 +307,11 @@ var commands = {
                 }
 
                 if (device.getFingerprint() === fingerprint) {
+                    MatrixClientPeg.get().setDeviceVerified(
+                            userId, deviceId, true
+                    );
+
+                    // Tell the user we verified everything!
                     const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                     Modal.createDialog(QuestionDialog, {
                         title: "Verified key",
@@ -320,13 +325,6 @@ var commands = {
                         ),
                         button: "Ok",
                         hasCancelButton: false,
-                        onFinished: confirm => {
-                            if (confirm) {
-                                MatrixClientPeg.get().setDeviceVerified(
-                                    userId, deviceId, true
-                                );
-                            }
-                        },
                     });
 
                     return success();

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -309,28 +309,16 @@ var commands = {
                 if (device.getFingerprint() === fingerprint) {
                     const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                     Modal.createDialog(QuestionDialog, {
-                        title: "Approve verified device",
+                        title: "Verified key",
                         description: (
                             <div>
                                 <p>
-                                    The signing key in your slash command matches the signing key you
-                                    received for this user and device!
-                                </p>
-                                <div className="mx_UserSettings_cryptoSection">
-                                    <ul>
-                                        <li><label>User ID:</label> <span>{ userId }</span></li>
-                                        <li><label>Device name:</label> <span>{ device.getDisplayName() }</span></li>
-                                        <li><label>Device ID:</label>   <span><code>{ device.deviceId}</code></span></li>
-                                        <li><label>Device fingerprint:</label>  <span><code><b>{ device.getFingerprint() }</b></code></span></li>
-                                        <li><label>Device key:</label>  <span><code><b>{ device.getIdentityKey() }</b></code></span></li>
-                                    </ul>
-                                </div>
-                                <p>
-                                    If you would like to accept this device as verified, press accept!
+                                    The signing key you provided matches the signing key you received from
+                                    { userId }'s device { deviceId }
                                 </p>
                             </div>
                         ),
-                        button: "Accept this verified key",
+                        button: "Accept verification",
                         onFinished: confirm => {
                             if (confirm) {
                                 MatrixClientPeg.get().setDeviceVerified(
@@ -344,7 +332,7 @@ var commands = {
                 } else {
                     return reject(`WARNING: KEY VERIFICATION FAILED! The signing key for ${userId} and device
                             ${deviceId} is "${device.getFingerprint()}" which does not match the provided key
-                            "${fingerprint}" This could mean your communications are being intercepted!`);
+                            "${fingerprint}". This could mean your communications are being intercepted!`);
                 }
             }
         }

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -289,14 +289,14 @@ var commands = {
         if (args) {
             var matches = args.match(/^(\S+) +(\S+) +(\S+)$/);
             if (matches) {
-                var userId = matches[1];
-                var deviceId = matches[2];
-                var device = MatrixClientPeg.get().getStoredDevice(userId, deviceId);
+                const userId = matches[1];
+                const deviceId = matches[2];
+                const fingerprint = matches[3];
+
+                const device = MatrixClientPeg.get().getStoredDevice(userId, deviceId);
                 if (!device) {
                     return reject(`Unknown (user, device) pair: (${userId}, ${deviceId})`);
                 }
-
-                var fingerprint = matches[3];
 
                 if (device.isVerified()) {
                     if (device.getFingerprint() === fingerprint) {
@@ -307,8 +307,7 @@ var commands = {
                 }
 
                 if (device.getFingerprint() === fingerprint) {
-
-                    var QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
+                    const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                     Modal.createDialog(QuestionDialog, {
                         title: "Approve verified device",
                         description: (
@@ -327,7 +326,7 @@ var commands = {
                                     </ul>
                                 </div>
                                 <p>
-                                    If you would like to accept this device as validated, press accept!
+                                    If you would like to accept this device as verified, press accept!
                                 </p>
                             </div>
                         ),
@@ -344,8 +343,8 @@ var commands = {
                     return success();
                 } else {
                     return reject(`WARNING: KEY VERIFICATION FAILED! The signing key for ${userId} and device
-                            ${deviceId} is \"${device.getFingerprint()}\" which does not match the provided key
-                            \"${fingerprint}\" This could mean your communications are being intercepted!`);
+                            ${deviceId} is "${device.getFingerprint()}" which does not match the provided key
+                            "${fingerprint}" This could mean your communications are being intercepted!`);
                 }
             }
         }

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -298,11 +298,17 @@ var commands = {
 
                 var fingerprint = matches[3];
 
+                if (device.isVerified() && device.getFingerprint() === fingerprint) {
+                    return reject(`Device already verified!`);
+                } else if (device.isVerified() && device.getFingerprint() !== fingerprint) {
+                    return reject(`WARNING: Device already verified, but keys do NOT MATCH!`);
+                }
+
                 if (device.getFingerprint() === fingerprint) {
 
                     var QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                     Modal.createDialog(QuestionDialog, {
-                        title: "Approve validated device",
+                        title: "Approve verified device",
                         description: (
                             <div>
                                 <p>
@@ -323,7 +329,7 @@ var commands = {
                                 </p>
                             </div>
                         ),
-                        button: "Accept this validated key",
+                        button: "Accept this verified key",
                         onFinished: confirm => {
                             if (confirm) {
                                 MatrixClientPeg.get().setDeviceVerified(
@@ -335,7 +341,7 @@ var commands = {
 
                     return success();
                 } else {
-                    return reject(`WARNING: KEY VALIDATION FAILED! The signing key for ${userId} and device
+                    return reject(`WARNING: KEY VERIFICATION FAILED! The signing key for ${userId} and device
                             ${deviceId} is \"${device.getFingerprint()}\" which does not match the provided key
                             \"${fingerprint}\" This could mean your communications are being intercepted!`);
                 }


### PR DESCRIPTION
Allows users to send a text string via an alternative channel (like email
or SMS) which Riot can leverage to confirm that the signing keys match.

Effectively removes the tedium of checking keys until a better mechanism
is completed.

Note that this is dependent on https://github.com/matrix-org/matrix-js-sdk/pull/439