### PR TITLE
Use RVS to indicate "joining" when setting a mxid

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -671,10 +671,6 @@ module.exports = React.createClass({
                 // compatability workaround, let's not bother.
                 Rooms.setDMRoom(this.state.room.roomId, me.events.member.getSender()).done();
             }
-
-            this.setState({
-                joining: false
-            });
         }
     }, 500),
 
@@ -762,12 +758,22 @@ module.exports = React.createClass({
                 },
             });
 
+            // Don't peek whilst registering otherwise getPendingEventList complains
+            // Do this by indicating our intention to join
+            dis.dispatch({
+                action: 'will_join',
+            });
+
             const SetMxIdDialog = sdk.getComponent('views.dialogs.SetMxIdDialog');
             const close = Modal.createDialog(SetMxIdDialog, {
                 homeserverUrl: cli.getHomeserverUrl(),
                 onFinished: (submitted, credentials) => {
                     if (submitted) {
                         this.props.onRegistered(credentials);
+                    } else {
+                        dis.dispatch({
+                            action: 'cancel_join',
+                        });
                     }
                 },
                 onDifferentServerClicked: (ev) => {

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -58,7 +58,16 @@ class RoomViewStore extends Store {
             case 'view_room':
                 this._viewRoom(payload);
                 break;
-
+            case 'will_join':
+                this._setState({
+                    joining: true,
+                });
+                break;
+            case 'cancel_join':
+                this._setState({
+                    joining: false,
+                });
+                break;
             // join_room:
             //      - opts: options for joinRoom
             case 'join_room':


### PR DESCRIPTION
This prevents RoomView from doing any peeking whilst the join/registration is in progress, causing weirdness with TimelinePanel getPendingEventList (which throws an error if called when peeking).

The error would just cause the RoomView spinner to appear forever

This is the nicest way I could think of to solve the immediate problem. However, the assumption that we can peek when not joining and when the user is not joined is re-established with this PR but it would be better to make the assumption (see `_onHaveRoom` of `RoomView`).