### PR TITLE
Don't include src in the test resolve root

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -166,7 +166,6 @@ module.exports = function (config) {
                     'sinon': 'sinon/pkg/sinon.js',
                 },
                 root: [
-                    path.resolve('./src'),
                     path.resolve('./test'),
                 ],
             },

--- a/test/components/views/dialogs/InteractiveAuthDialog-test.js
+++ b/test/components/views/dialogs/InteractiveAuthDialog-test.js
@@ -22,7 +22,7 @@ import ReactTestUtils from 'react-addons-test-utils';
 import sinon from 'sinon';
 
 import sdk from 'matrix-react-sdk';
-import MatrixClientPeg from 'MatrixClientPeg';
+import MatrixClientPeg from '../../../../src/MatrixClientPeg';
 
 import * as test_utils from '../../../test-utils';
 

--- a/test/components/views/rooms/MessageComposerInput-test.js
+++ b/test/components/views/rooms/MessageComposerInput-test.js
@@ -8,7 +8,7 @@ import * as testUtils from '../../../test-utils';
 import sdk from 'matrix-react-sdk';
 import UserSettingsStore from '../../../../src/UserSettingsStore';
 const MessageComposerInput = sdk.getComponent('views.rooms.MessageComposerInput');
-import MatrixClientPeg from 'MatrixClientPeg';
+import MatrixClientPeg from '../../../../src/MatrixClientPeg';
 
 function addTextToDraft(text) {
     const components = document.getElementsByClassName('public-DraftEditor-content');

--- a/test/utils/MegolmExportEncryption-test.js
+++ b/test/utils/MegolmExportEncryption-test.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 "use strict";
 
-import * as MegolmExportEncryption from 'utils/MegolmExportEncryption';
+import * as MegolmExportEncryption from '../../src/utils/MegolmExportEncryption';
 
 import * as testUtils from '../test-utils';
 import expect from 'expect';


### PR DESCRIPTION
Don't include src in resolve root for the karma test, as otherwise
modules from react sdk get pulled in instead of npm libraries like
'extend' which breaks everything in really subtle ways.