### PR TITLE
import _t, drop two unused imports

### DIFF
--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -15,12 +15,11 @@ limitations under the License.
 */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import Matrix from 'matrix-js-sdk';
 import sdk from '../../index';
 import MatrixClientPeg from '../../MatrixClientPeg';
-import dis from '../../dispatcher';
+import { _t } from '../../languageHandler';
 
 /*
  * Component which shows the filtered file using a TimelinePanel


### PR DESCRIPTION
without this FilePanel would ever-load

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>