### PR TITLE
Fix issue with en-* reported by JigmeDatse

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -56,7 +56,7 @@ export function setLanguage(preferredLangs) {
         availLangs = result;
 
         for (let i = 0; i < preferredLangs.length; ++i) {
-            if (preferredLangs[i].indexOf("en-") === 0) {
+            if (preferredLangs[i].startsWith("en-")) {
                 preferredLang = "en";
             } else {
                 preferredLang = preferredLangs[i];

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -55,8 +55,13 @@ export function setLanguage(preferredLangs) {
         availLangs = result;
 
         for (let i = 0; i < preferredLangs.length; ++i) {
-            if (availLangs.hasOwnProperty(preferredLangs[i])) {
-                langToUse = preferredLangs[i];
+            if ((preferredLangs[i] == "en-US") || (preferredLangs[i] == "en-GB")) {
+                const preferredLang = "en";
+            } else {
+                const preferredLang = preferredLangs[i];
+            }
+            if (availLangs.hasOwnProperty(preferredLang)) {
+                langToUse = preferredLang;
                 break;
             }
         }

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -56,7 +56,7 @@ export function setLanguage(preferredLangs) {
         availLangs = result;
 
         for (let i = 0; i < preferredLangs.length; ++i) {
-            if ((preferredLangs[i] == "en-US") || (preferredLangs[i] == "en-GB")) {
+            if (preferredLangs[i].indexOf("en-") === 0) {
                 preferredLang = "en";
             } else {
                 preferredLang = preferredLangs[i];

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -51,14 +51,15 @@ export function setLanguage(preferredLangs) {
 
     let langToUse;
     let availLangs;
+    let preferredLang;
     return getLangsJson().then((result) => {
         availLangs = result;
 
         for (let i = 0; i < preferredLangs.length; ++i) {
             if ((preferredLangs[i] == "en-US") || (preferredLangs[i] == "en-GB")) {
-                const preferredLang = "en";
+                preferredLang = "en";
             } else {
-                const preferredLang = preferredLangs[i];
+                preferredLang = preferredLangs[i];
             }
             if (availLangs.hasOwnProperty(preferredLang)) {
                 langToUse = preferredLang;


### PR DESCRIPTION
If a browser sends en-US or en-GB it fails as it doesn't match en. We only got en and english is the only language which has this issue, so just rewrite en-* to en.