### PR TITLE
Add partial support for RTL languages

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -360,7 +360,7 @@ export function bodyToHtml(content, highlights, opts) {
         'mx_EventTile_bigEmoji': emojiBody,
         'markdown-body': isHtml,
     });
-    return <span className={className} dangerouslySetInnerHTML={{ __html: safeBody }} />;
+    return <span className={className} dangerouslySetInnerHTML={{ __html: safeBody }} dir="auto" />;
 }
 
 export function emojifyText(text) {


### PR DESCRIPTION
Added RTL language support for messages (and other containers), by adding dir="auto" attribute to message's containers.

It's only partial solution because it only handles the message's container. Other elements like input elements are not included, because I didn't figure out how can I add attributes to these elements (like Editor, EmojyText, room's name container etc).

Signed-off-by: Shuki Liber liber@tee.org