### PR TITLE
fix i18n in a situation where navigator.languages=[]

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -87,10 +87,10 @@ export function getAllLanguageKeysFromJson() {
 }
 
 export function getLanguagesFromBrowser() {
-    if (navigator.languages) return navigator.languages;
-    if (navigator.language) return [navigator.language]
+    if (navigator.languages && navigator.languages.length) return navigator.languages;
+    if (navigator.language) return [navigator.language];
     return [navigator.userLanguage];
-};
+}
 
 /**
  * Turns a language string, normalises it,


### PR DESCRIPTION
fixes `Unable to set language Error: Unable to find an appropriate language`
encountered in an electron build
