### PR TITLE
Add _tJsx()

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -86,7 +86,7 @@ export function _tJsx(jsxText, patterns, subs) {
     // tJsxText may be unsafe if malicious translators try to inject HTML.
     // Run this through sanitize-html and bail if the output isn't identical
     const tJsxText = _t(jsxText);
-    const sanitized = sanitizeHtml(tJsxText);
+    const sanitized = sanitizeHtml(tJsxText, { allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'span' ]) });
     if (tJsxText !== sanitized) {
         throw new Error(`_tJsx: translator error. untrusted HTML supplied. '${tJsxText}' != '${sanitized}'`);
     }


### PR DESCRIPTION
Which supports multi-regexp matching which is required for some translations (e.g compatibility page).

For example usage, see https://github.com/vector-im/riot-web/pull/4084/files#diff-f3c57590a9cf25a0fde9b7999566ab6dR58