### PR TITLE
Remove cachedPassword from localStorage on_logged_out

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -24,6 +24,7 @@ import PageTypes from '../../PageTypes';
 import sdk from '../../index';
 import dis from '../../dispatcher';
 import sessionStore from '../../stores/SessionStore';
+import MatrixClientPeg from '../../MatrixClientPeg';
 
 /**
  * This is what our MatrixChat shows when we are logged in. The precise view is
@@ -89,6 +90,16 @@ export default React.createClass({
         if (this._sessionStoreToken) {
             this._sessionStoreToken.remove();
         }
+    },
+
+    // Child components assume that the client peg will not be null, so give them some
+    // sort of assurance here by only allowing a re-render if the client is truthy.
+    //
+    // This is required because `LoggedInView` maintains its own state and if this state
+    // updates after the client peg has been made null (during logout), then it will
+    // attempt to re-render and the children will throw errors.
+    shouldComponentUpdate: function() {
+        return Boolean(MatrixClientPeg.get());
     },
 
     getScrollStateForRoom: function(roomId) {

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -69,7 +69,9 @@ class SessionStore extends Store {
                 });
                 break;
             case 'on_logged_out':
-                this.reset();
+                this._setState({
+                    cachedPassword: null,
+                });
                 break;
         }
     }

--- a/src/stores/SessionStore.js
+++ b/src/stores/SessionStore.js
@@ -76,10 +76,6 @@ class SessionStore extends Store {
         }
     }
 
-    reset() {
-        this._state = Object.assign({}, INITIAL_STATE);
-    }
-
     getCachedPassword() {
         return this._state.cachedPassword;
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4101

**Bug**: This has the unfortunate bug of causing a re-render after logout which of course means some component tries to render whilst the Matrix client is `null`. This strikes me as a recurring theme. Virtually no component protects against its having a null matrix client. In an ideal world, `SessionStore` would hold onto a reference to the matrix client and make it `null` when logging out so that `loggedIn` and the reference would become null in the same `update` from the store.

For now, the work around is to cause `MatrixChat` to have `state.loggedIn = false` before `on_logged_out` is called. 