### PR TITLE
add concept of platform handling loudNotifications (bings/pings/whatHaveYou)

### DIFF
--- a/src/BasePlatform.js
+++ b/src/BasePlatform.js
@@ -71,6 +71,9 @@ export default class BasePlatform {
     displayNotification(title: string, msg: string, avatarUrl: string, room: Object) {
     }
 
+    loudNotification(ev: Event, room: Object) {
+    }
+
     /**
      * Returns a promise that resolves to a string representing
      * the current version of the application.

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -250,6 +250,7 @@ const Notifier = {
                 this._displayPopupNotification(ev, room);
             }
             if (actions.tweaks.sound && this.isAudioEnabled()) {
+                PlatformPeg.get().loudNotification(ev, room);
                 this._playAudioNotification(ev, room);
             }
         }


### PR DESCRIPTION
this is so Electron can handle them separately, namely for Win32's flashFrame feature. It started annoying me tripping on every setBadgeCount, I only want it on **Loud** Notifications

no-op on everything but Electron for now
I guess I could move _playAudioNotification into BasePlatform