### PR TITLE
Propagate room join errors to the UI

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -185,7 +185,6 @@ module.exports = React.createClass({
             roomLoading: RoomViewStore.isRoomLoading(),
             roomLoadError: RoomViewStore.getRoomLoadError(),
             joining: RoomViewStore.isJoining(),
-            joinError: RoomViewStore.getJoinError(),
         }, () => {
             this._onHaveRoom();
             this.onRoom(MatrixClientPeg.get().getRoom(this.state.roomId));

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -158,20 +158,16 @@ class RoomViewStore extends Store {
     }
 
     _joinedRoom(payload) {
-        if (payload.room_id === this._state.roomId) {
-            this._setState({
-                joining: false,
-            });
-        }
+        this._setState({
+            joining: false,
+        });
     }
 
     _joinRoomError(payload) {
-        if (payload.room_id === this._state.roomId) {
-            this._setState({
-                joining: false,
-                joinError: payload.err,
-            });
-        }
+        this._setState({
+            joining: false,
+            joinError: payload.err,
+        });
     }
 
     reset() {

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -140,12 +140,10 @@ class RoomViewStore extends Store {
         MatrixClientPeg.get().joinRoom(this._state.roomId, payload.opts).done(() => {
             dis.dispatch({
                 action: 'joined_room',
-                room_id: this._state.roomId,
             });
         }, (err) => {
             dis.dispatch({
                 action: 'join_room_error',
-                room_id: this._state.roomId,
                 err: err,
             });
             const msg = err.message ? err.message : JSON.stringify(err);

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -16,6 +16,9 @@ limitations under the License.
 import dis from '../dispatcher';
 import {Store} from 'flux/utils';
 import MatrixClientPeg from '../MatrixClientPeg';
+import sdk from '../index';
+import Modal from '../Modal';
+import { _t } from '../languageHandler';
 
 const INITIAL_STATE = {
     // Whether we're joining the currently viewed room
@@ -76,6 +79,12 @@ class RoomViewStore extends Store {
             case 'join_room':
                 this._joinRoom(payload);
                 break;
+            case 'joined_room':
+                this._joinedRoom(payload);
+                break;
+            case 'join_room_error':
+                this._joinRoomError(payload);
+                break;
             case 'on_logged_out':
                 this.reset();
                 break;
@@ -128,17 +137,41 @@ class RoomViewStore extends Store {
         this._setState({
             joining: true,
         });
-        MatrixClientPeg.get().joinRoom(this._state.roomId, payload.opts).then(
-        () => {
-            this._setState({
-                joining: false,
+        MatrixClientPeg.get().joinRoom(this._state.roomId, payload.opts).done(() => {
+            dis.dispatch({
+                action: 'joined_room',
+                room_id: this._state.roomId,
             });
         }, (err) => {
-            this._setState({
-                joining: false,
-                joinError: err,
+            dis.dispatch({
+                action: 'join_room_error',
+                room_id: this._state.roomId,
+                err: err,
+            });
+            const msg = err.message ? err.message : JSON.stringify(err);
+            const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
+            Modal.createDialog(ErrorDialog, {
+                title: _t("Failed to join room"),
+                description: msg,
             });
         });
+    }
+
+    _joinedRoom(payload) {
+        if (payload.room_id === this._state.roomId) {
+            this._setState({
+                joining: false,
+            });
+        }
+    }
+
+    _joinRoomError(payload) {
+        if (payload.room_id === this._state.roomId) {
+            this._setState({
+                joining: false,
+                joinError: payload.err,
+            });
+        }
     }
 
     reset() {


### PR DESCRIPTION
Dispatch so we can set the state in RoomViewStore. Show the error
when the room join fails (unsure if it's better to do this from
the component or the store). Remove unused joinError from roomview.