### PR TITLE
Introduce state `peekLoading` to avoid collision with `roomLoading`

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -120,6 +120,7 @@ module.exports = React.createClass({
             room: null,
             roomId: null,
             roomLoading: true,
+            peekLoading: false,
 
             forwardingEvent: null,
             editingRoomSettings: false,
@@ -222,10 +223,13 @@ module.exports = React.createClass({
             } else if (this.state.roomId) {
                 console.log("Attempting to peek into room %s", this.state.roomId);
 
+                this.setState({
+                    peekLoading: true,
+                });
                 MatrixClientPeg.get().peekInRoom(this.state.roomId).then((room) => {
                     this.setState({
                         room: room,
-                        roomLoading: false,
+                        peekLoading: false,
                     });
                     this._onRoomLoaded(room);
                 }, (err) => {
@@ -235,7 +239,7 @@ module.exports = React.createClass({
                     if (err.errcode == "M_GUEST_ACCESS_FORBIDDEN") {
                         // This is fine: the room just isn't peekable (we assume).
                         this.setState({
-                            roomLoading: false,
+                            peekLoading: false,
                         });
                     } else {
                         throw err;
@@ -1422,7 +1426,7 @@ module.exports = React.createClass({
         const TimelinePanel = sdk.getComponent("structures.TimelinePanel");
 
         if (!this.state.room) {
-            if (this.state.roomLoading) {
+            if (this.state.roomLoading || this.state.peekLoading) {
                 return (
                     <div className="mx_RoomView">
                         <Loader />

--- a/src/stores/LifecycleStore.js
+++ b/src/stores/LifecycleStore.js
@@ -41,7 +41,6 @@ class LifecycleStore extends Store {
     __onDispatch(payload) {
         switch (payload.action) {
             case 'do_after_sync_prepared':
-                console.info('Will do after sync', payload.deferred_action);
                 this._setState({
                     deferred_action: payload.deferred_action,
                 });
@@ -50,7 +49,6 @@ class LifecycleStore extends Store {
                 if (payload.state !== 'PREPARED') {
                     break;
                 }
-                console.info('Doing', payload.deferred_action);
                 if (!this._state.deferred_action) break;
                 const deferredAction = Object.assign({}, this._state.deferred_action);
                 this._setState({


### PR DESCRIPTION
The room loading spinner will now be displayed if the alias is being resolved (roomLoading) or if the peek is being loaded for the room `peekLoading`.

Fixes https://github.com/vector-im/riot-web/issues/4164