### PR TITLE
Always show the spinner during the first sync

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -507,7 +507,7 @@ module.exports = React.createClass({
                 this._onSetTheme(payload.value);
                 break;
             case 'on_logging_in':
-                this.setState({loggingIn: true});
+                this.setState({loggingIn: true, ready: false});
                 break;
             case 'on_logged_in':
                 this._onLoggedIn(payload.teamToken);

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -507,6 +507,10 @@ module.exports = React.createClass({
                 this._onSetTheme(payload.value);
                 break;
             case 'on_logging_in':
+                // We are now logging in, so set the state to reflect that
+                // and also that we're not ready (we'll be marked as logged
+                // in once the login completes, then ready once the sync
+                // completes).
                 this.setState({loggingIn: true, ready: false});
                 break;
             case 'on_logged_in':


### PR DESCRIPTION
Before, we were relying on the fact that `ready` would still have
been false from before. This was not the case, for example, if we
naviagted straight to /#/login (which causes a guest session to be
set up and the sync for that completes after we navigate to the
login screen).

We should always mark ourselves as not-ready after login since we
will always have to wait for the sync.