### PR TITLE
Various Analytics changes/fixes/improvements

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -56,6 +56,7 @@ class Analytics {
      * but this is second best, Piwik should not pull anything implicitly.
      */
     disable() {
+        this.trackEvent('Analytics', 'opt-out');
         this.disabled = true;
     }
 

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -20,9 +20,9 @@ import PlatformPeg from './PlatformPeg';
 import SdkConfig from './SdkConfig';
 
 function getRedactedUrl() {
-    const base = window.location.pathname.split('/').slice(-2).join('/');
     const redactedHash = window.location.hash.replace(/#\/(room|user)\/(.+)/, "#/$1/<redacted>");
-    return base + redactedHash;
+    // hardcoded url to make piwik happy
+    return 'https://riot.im/app/' + redactedHash;
 }
 
 const customVariables = {

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -30,6 +30,7 @@ const customVariables = {
     'App Version': 2,
     'User Type': 3,
     'Chosen Language': 4,
+    'Instance': 5,
 };
 
 
@@ -85,6 +86,10 @@ class Analytics {
         });
 
         this._setVisitVariable('Chosen Language', getCurrentLanguage());
+
+        if (window.location.hostname === 'riot.im') {
+            this._setVisitVariable('Instance', window.location.pathname);
+        }
 
         (function() {
             const g = document.createElement('script');


### PR DESCRIPTION
had a chat with Ben, who showed me the issue of tracking people between analytics on `about.riot.im` and `riot.im` itself, as to GA they just look like drop-offs, Piwik has a "Transition Graph" which would be useful in this gap, but it broke when the CustomURLs weren't URLs anymore so this fixes that and also makes clicking on events a little more sane, as it'll take you to that page in `riot.im/app` though granted with the args redacted.
Also adds tracking of which riot.im instance is being used, i.e `/develop/` or `/app/
and the tracking of the action of opting-out, as Matthew had raised a concern that the Analytics seem on the low side, and it could be down to people opting out, this way we will be able to estimate that number.

More importantly, this now tracks only based on the hash, which will be consistent across web and electron so will group the pages more sanely.

### We are at the initial limit of 5 custom vars, [I'd suggest upping this](https://piwik.org/faq/how-to/faq_17931/)