### PR TITLE
Cancel 'join room' action if 'log in' is clicked

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -792,6 +792,9 @@ module.exports = React.createClass({
                         this.props.onRegistered(credentials);
                     } else {
                         dis.dispatch({
+                            action: 'cancel_after_sync_prepared',
+                        });
+                        dis.dispatch({
                             action: 'cancel_join',
                         });
                     }


### PR DESCRIPTION
or 'choose different server'

We canceled the deferred action in the MatrixChat SetMxId dialog
but not the one in roomview.

Fixes https://github.com/vector-im/riot-web/issues/4217