### PR TITLE
Set image thumbnail height in `render` rather than `componentDidMount`

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -202,6 +202,17 @@ export default React.createClass({
         }
     },
 
+    chatWidth: function() {
+        const windowWidth = window.innerWidth;
+        const collapsedLhs = this.props.collapse_lhs || false;
+        const leftWidth = collapsedLhs ? 60 : 235;
+        const collapsedRhs = this.props.collapse_rhs;
+        const rightWidth = collapsedRhs ? 0 : 235;
+        const constantExtraWidth = 251;
+        const chatWidth = windowWidth - leftWidth - rightWidth - constantExtraWidth;
+        return chatWidth;
+    },
+
     render: function() {
         const LeftPanel = sdk.getComponent('structures.LeftPanel');
         const RightPanel = sdk.getComponent('structures.RightPanel');
@@ -228,6 +239,7 @@ export default React.createClass({
                         eventPixelOffset={this.props.initialEventPixelOffset}
                         key={this.props.currentRoomId || 'roomview'}
                         opacity={this.props.middleOpacity}
+                        chatWidth={this.chatWidth()}
                         collapsedRhs={this.props.collapse_rhs}
                         ConferenceHandler={this.props.ConferenceHandler}
                         scrollStateMap={this._scrollStateMap}

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -208,7 +208,7 @@ export default React.createClass({
         const leftWidth = collapsedLhs ? 60 : 235;
         const collapsedRhs = this.props.collapse_rhs;
         const rightWidth = collapsedRhs ? 0 : 235;
-        const constantExtraWidth = 251;
+        const constantExtraWidth = 263;
         const chatWidth = windowWidth - leftWidth - rightWidth - constantExtraWidth;
         return chatWidth;
     },

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -93,6 +93,9 @@ module.exports = React.createClass({
 
         // hide redacted events as per old behaviour
         hideRedactions: React.PropTypes.bool,
+
+        // Width for calculating the size of images in chat, passed to MImageBody
+        chatWidth: React.PropTypes.number,
     },
 
     componentWillMount: function() {
@@ -493,7 +496,10 @@ module.exports = React.createClass({
                         eventSendStatus={mxEv.status}
                         tileShape={this.props.tileShape}
                         isTwelveHour={this.props.isTwelveHour}
-                        last={last} isSelectedEvent={highlight}/>
+                        last={last} 
+                        isSelectedEvent={highlight}
+                        chatWidth={this.props.chatWidth}
+                    />
                 </li>
         );
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -85,6 +85,9 @@ module.exports = React.createClass({
 
         // is the RightPanel collapsed?
         collapsedRhs: React.PropTypes.bool,
+
+        // Width for calculating the size of images in chat, passed to MImageBody
+        chatWidth: React.PropTypes.number,
     },
 
     getInitialState: function() {
@@ -1688,6 +1691,7 @@ module.exports = React.createClass({
                 showUrlPreview = { this.state.showUrlPreview }
                 opacity={ this.props.opacity }
                 className="mx_RoomView_messagePanel"
+                chatWidth={this.props.chatWidth}
             />);
 
         var topUnreadMessagesBar = null;

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -102,6 +102,9 @@ var TimelinePanel = React.createClass({
 
         // placeholder text to use if the timeline is empty
         empty: React.PropTypes.string,
+
+        // Width for calculating the size of images in chat, passed to MImageBody
+        chatWidth: React.PropTypes.number,
     },
 
     statics: {
@@ -1142,6 +1145,7 @@ var TimelinePanel = React.createClass({
                           alwaysShowTimestamps={ this.state.alwaysShowTimestamps }
                           className={ this.props.className }
                           tileShape={ this.props.tileShape }
+                          chatWidth={this.props.chatWidth}
             />
         );
     },

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -37,6 +37,9 @@ module.exports = React.createClass({
 
         /* called when the image has loaded */
         onWidgetLoad: React.PropTypes.func.isRequired,
+
+        // Width for calculating the size of images in chat
+        chatWidth: React.PropTypes.number,
     },
 
     getInitialState: function() {
@@ -120,7 +123,6 @@ module.exports = React.createClass({
 
     componentDidMount: function() {
         this.dispatcherRef = dis.register(this.onAction);
-        this.fixupHeight();
         const content = this.props.mxEvent.getContent();
         if (content.file !== undefined && this.state.decryptedUrl === null) {
             let thumbnailPromise = q(null);
@@ -158,20 +160,10 @@ module.exports = React.createClass({
         dis.unregister(this.dispatcherRef);
     },
 
-    onAction: function(payload) {
-        if (payload.action === "timeline_resize") {
-            this.fixupHeight();
-        }
-    },
-
-    fixupHeight: function() {
-        if (!this.refs.image) {
-            console.warn("Refusing to fix up height on MImageBody with no image element");
-            return;
-        }
-
+    calculateHeight: function() {
         const content = this.props.mxEvent.getContent();
-        const timelineWidth = this.refs.body.offsetWidth;
+        const timelineWidth = this.props.chatWidth;
+        
         const maxHeight = 600; // let images take up as much width as they can so long as the height doesn't exceed 600px.
         // the alternative here would be 600*timelineWidth/800; to scale them down to fit inside a 4:3 bounding box
 
@@ -180,8 +172,7 @@ module.exports = React.createClass({
         if (content.info) {
             thumbHeight = ImageUtils.thumbHeight(content.info.w, content.info.h, timelineWidth, maxHeight);
         }
-        this.refs.image.style.height = thumbHeight + "px";
-        // console.log("Image height now", thumbHeight);
+        return thumbHeight;
     },
 
     render: function() {
@@ -229,6 +220,9 @@ module.exports = React.createClass({
                 <span className="mx_MImageBody" ref="body">
                     <a href={contentUrl} onClick={ this.onClick }>
                         <img className="mx_MImageBody_thumbnail" src={thumbUrl} ref="image"
+                            style={{
+                                "height": this.calculateHeight() + "px"
+                            }}
                             alt={content.body}
                             onMouseEnter={this.onImageEnter}
                             onMouseLeave={this.onImageLeave} />

--- a/src/components/views/messages/MessageEvent.js
+++ b/src/components/views/messages/MessageEvent.js
@@ -40,6 +40,9 @@ module.exports = React.createClass({
 
         /* the shsape of the tile, used */
         tileShape: React.PropTypes.string,
+
+        // Width for calculating the size of images in chat, passed to MImageBody
+        chatWidth: React.PropTypes.number,
     },
 
     getEventTileOps: function() {
@@ -73,6 +76,7 @@ module.exports = React.createClass({
                     highlightLink={this.props.highlightLink}
                     showUrlPreview={this.props.showUrlPreview}
                     tileShape={this.props.tileShape}
+                    chatWidth={this.props.chatWidth}
                     onWidgetLoad={this.props.onWidgetLoad} />;
     },
 });

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -135,6 +135,9 @@ module.exports = WithMatrixClient(React.createClass({
 
         // show twelve hour timestamps
         isTwelveHour: React.PropTypes.bool,
+
+        // Width for calculating the size of images in chat, passed to MImageBody
+        chatWidth: React.PropTypes.number,
     },
 
     getInitialState: function() {
@@ -530,7 +533,9 @@ module.exports = WithMatrixClient(React.createClass({
                             highlights={this.props.highlights}
                             highlightLink={this.props.highlightLink}
                             showUrlPreview={this.props.showUrlPreview}
-                            onWidgetLoad={this.props.onWidgetLoad} />
+                            onWidgetLoad={this.props.onWidgetLoad} 
+                            chatWidth={this.props.chatWidth}
+                        />
                     </div>
                 </div>
             );
@@ -545,7 +550,9 @@ module.exports = WithMatrixClient(React.createClass({
                             highlightLink={this.props.highlightLink}
                             showUrlPreview={this.props.showUrlPreview}
                             tileShape={this.props.tileShape}
-                            onWidgetLoad={this.props.onWidgetLoad} />
+                            onWidgetLoad={this.props.onWidgetLoad} 
+                            chatWidth={this.props.chatWidth}
+                        />
                     </div>
                     <a
                         className="mx_EventTile_senderDetailsLink"
@@ -578,7 +585,9 @@ module.exports = WithMatrixClient(React.createClass({
                             highlights={this.props.highlights}
                             highlightLink={this.props.highlightLink}
                             showUrlPreview={this.props.showUrlPreview}
-                            onWidgetLoad={this.props.onWidgetLoad} />
+                            onWidgetLoad={this.props.onWidgetLoad} 
+                            chatWidth={this.props.chatWidth}
+                        />
                         { editButton }
                     </div>
                 </div>


### PR DESCRIPTION
Calculates the width of the timeline panel based on which panels are collapsed and the width of the window, rather than measuring it in the DOM after rendering. This width is then used to work out what height image thumbnails should be. This hopefully helps with: https://github.com/vector-im/riot-web/issues/2646