### PR TITLE
Reduce save-restore window in ScrollPanel to reduce scrolling jumps

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -160,6 +160,10 @@ module.exports = React.createClass({
         this.checkFillState();
     },
 
+    componentWillUpdate: function(nextProps, nextState) {
+        this._saveScrollState();
+    },
+
     componentDidUpdate: function() {
         // after adding event tiles, we may need to tweak the scroll (either to
         // keep at the bottom of the timeline, or to maintain the view after


### PR DESCRIPTION
Hopefully improves: https://github.com/vector-im/riot-web/issues/2646