### PR TITLE
width and height must be int otherwise synapse cries

### DIFF
--- a/src/components/views/messages/RoomAvatarEvent.js
+++ b/src/components/views/messages/RoomAvatarEvent.js
@@ -62,8 +62,8 @@ module.exports = React.createClass({
         var url = ContentRepo.getHttpUriForMxc(
                     MatrixClientPeg.get().getHomeserverUrl(),
                     ev.getContent().url,
-                    14 * window.devicePixelRatio,
-                    14 * window.devicePixelRatio,
+                    Math.ceil(14 * window.devicePixelRatio),
+                    Math.ceil(14 * window.devicePixelRatio),
                     'crop'
                 );
 


### PR DESCRIPTION
```
{"errcode":"M_UNKNOWN","error":"Query parameter 'width' must be an integer"}
```

fixes vector-im/riot-web/issues/4268