### PR TITLE
DM guessing: prefer oldest joined member

### DIFF
--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -144,7 +144,18 @@ export function guessDMRoomTarget(room, me) {
     let oldestTs;
     let oldestUser;
 
-    // Pick the user who's been here longest (and isn't us)
+    // Pick the joined user who's been here longest (and isn't us),
+    for (const user of room.getJoinedMembers()) {
+        if (user.userId == me.userId) continue;
+
+        if (oldestTs === undefined || user.events.member.getTs() < oldestTs) {
+            oldestUser = user;
+            oldestTs = user.events.member.getTs();
+        }
+    }
+    if (oldestUser) return oldestUser;
+
+    // if there are no joined members other than us, use the oldest member
     for (const user of room.currentState.getMembers()) {
         if (user.userId == me.userId) continue;
 


### PR DESCRIPTION
In the DM guessing code, prefer the oldest joined member if there's
anyone in the rom other than us. Otherwise, fall back to the old
behaviour.

Fixes https://github.com/vector-im/riot-web/issues/4288