### PR TITLE
Give password confirmation correct title, description

### DIFF
--- a/src/components/views/dialogs/SetEmailDialog.js
+++ b/src/components/views/dialogs/SetEmailDialog.js
@@ -85,6 +85,10 @@ export default React.createClass({
         this.setState({emailBusy: true});
     },
 
+    onCancelled: function() {
+        this.props.onFinished(false);
+    },
+
     onEmailDialogFinished: function(ok) {
         if (ok) {
             this.verifyEmailAddress();
@@ -133,7 +137,7 @@ export default React.createClass({
 
         return (
             <BaseDialog className="mx_SetEmailDialog"
-                onFinished={this.props.onFinished}
+                onFinished={this.onCancelled}
                 title={this.props.title}
             >
                 <div className="mx_Dialog_content">


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4311

This was due to `BaseDialog` calling `onFinished` with a mouse event instead of `false` (and it was assumed to call with `true/false`, but doesn't)