### PR TITLE
Show correct text in set email password dialog (2)

### DIFF
--- a/src/components/views/dialogs/SetEmailDialog.js
+++ b/src/components/views/dialogs/SetEmailDialog.js
@@ -155,7 +155,7 @@ export default React.createClass({
                     <input
                         type="submit"
                         value={_t("Cancel")}
-                        onClick={this.props.onFinished}
+                        onClick={this.onCancelled}
                     />
                 </div>
             </BaseDialog>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4311

The cancel button onClick was hooked directly up to onFinished, so
the mouse event ended up as the boolean for whether an email had
been set.