### PR TITLE
Luke/attempt fix peeking regression

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -170,6 +170,15 @@ module.exports = React.createClass({
             isInitialEventHighlighted: RoomViewStore.isInitialEventHighlighted(),
         };
 
+        // Temporary logging to diagnose https://github.com/vector-im/riot-web/issues/4307
+        console.log(
+            'RVS update:',
+            newState.roomId,
+            newState.roomAlias,
+            'loading?', newState.roomLoading,
+            'joining?', newState.joining,
+        );
+
         // NB: This does assume that the roomID will not change for the lifetime of
         // the RoomView instance
         if (initial) {

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -191,7 +191,9 @@ module.exports = React.createClass({
         this.setState(newState, () => {
             // At this point, this.state.roomId could be null (e.g. the alias might not
             // have been resolved yet) so anything called here must handle this case.
-            this._onHaveRoom();
+            if (initial) {
+                this._onHaveRoom();
+            }
         });
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -617,7 +617,7 @@ module.exports = React.createClass({
     },
 
     onRoom: function(room) {
-        if (!room || room.roomId !== this.state.roomId || !this.state.joining) {
+        if (!room || room.roomId !== this.state.roomId) {
             return;
         }
         this.setState({


### PR DESCRIPTION
Not convinced by this at all, but it follows more closely what RoomView did before, which was to only set the room object on component mount, when a peek is successful and when joining a room.