### PR TITLE
Fix npm@5 bug when doing npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint": "eslint src/",
     "lintall": "eslint src/ test/",
     "clean": "rimraf lib",
-    "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt",
+    "prepare": "npm run build && git rev-parse HEAD > git-revision.txt",
     "test": "karma start $KARMAFLAGS --browsers PhantomJS",
     "test-multi": "karma start $KARMAFLAGS --single-run=false"
   },


### PR DESCRIPTION
NPM@5.x droped support of prepublish for npm install. prepare replaces prepublish. See https://github.com/npm/npm/issues/10074