### PR TITLE
Avoid getting stuck in a loop in CAS login

### DIFF
--- a/src/Login.js
+++ b/src/Login.js
@@ -178,11 +178,18 @@ export default class Login {
     }
 
     redirectToCas() {
-      var client = this._createTemporaryClient();
-      var parsedUrl = url.parse(window.location.href, true);
+      const client = this._createTemporaryClient();
+      const parsedUrl = url.parse(window.location.href, true);
+
+      // XXX: at this point, the fragment will always be #/login, which is no
+      // use to anyone. Ideally, we would get the intended fragment from
+      // MatrixChat.screenAfterLogin so that you could follow #/room links etc
+      // through a CAS login.
+      parsedUrl.hash = "";
+
       parsedUrl.query["homeserver"] = client.getHomeserverUrl();
       parsedUrl.query["identityServer"] = client.getIdentityServerUrl();
-      var casUrl = client.getCasLoginUrl(url.format(parsedUrl));
+      const casUrl = client.getCasLoginUrl(url.format(parsedUrl));
       window.location.href = casUrl;
     }
 }


### PR DESCRIPTION
498ea53 made it so that the #/login URL fragment was prioritised over the token
params in the query string; unfortunately that also means that CAS login gets
stuck in a loop where you always get redirected back to the login view.

Prioritising the URL fragment over the token params may or may not be the
correct thing to, but I also think it's incorrect that we ask the CAS server to
redirect us back to #/login. Accordingly, the easiest fix here is just to clear
the URL fragment before redirecting to CAS.