### PR TITLE
Fix ability to invite users with caps in their user IDs

### DIFF
--- a/src/components/views/dialogs/ChatInviteDialog.js
+++ b/src/components/views/dialogs/ChatInviteDialog.js
@@ -178,7 +178,7 @@ module.exports = React.createClass({
     },
 
     onQueryChanged: function(ev) {
-        const query = ev.target.value.toLowerCase();
+        const query = ev.target.value;
         if (this.queryChangedDebouncer) {
             clearTimeout(this.queryChangedDebouncer);
         }
@@ -271,10 +271,11 @@ module.exports = React.createClass({
             query,
             searchError: null,
         });
+        const queryLowercase = query.toLowerCase();
         const results = [];
         MatrixClientPeg.get().getUsers().forEach((user) => {
-            if (user.userId.toLowerCase().indexOf(query) === -1 &&
-                user.displayName.toLowerCase().indexOf(query) === -1
+            if (user.userId.toLowerCase().indexOf(queryLowercase) === -1 &&
+                user.displayName.toLowerCase().indexOf(queryLowercase) === -1
             ) {
                 return;
             }


### PR DESCRIPTION
By lowercasing only when testing against local user IDs/display names. The user_directory shouldn't care. And when we make the placeholder "We didn't get any results, but here's the user with the exact mxid you typed in", use the original query.

Fixes https://github.com/vector-im/riot-web/issues/4310