### PR TITLE
Don't allow UserSettings to render if !MatrixClientPeg.get()

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -276,6 +276,16 @@ module.exports = React.createClass({
         }
     },
 
+    // `UserSettings` assumes that the client peg will not be null, so give it some
+    // sort of assurance here by only allowing a re-render if the client is truthy.
+    //
+    // This is required because `UserSettings` maintains its own state and if this state
+    // updates (e.g. during _setStateFromSessionStore) after the client peg has been made
+    // null (during logout), then it will attempt to re-render and throw errors.
+    shouldComponentUpdate: function() {
+        return Boolean(MatrixClientPeg.get());
+    },
+
     _setStateFromSessionStore: function() {
         this.setState({
             userHasGeneratedPassword: Boolean(this._sessionStore.getCachedPassword()),


### PR DESCRIPTION
Now that it has state that updates following the nulling of the MCP (userHasGeneratedPassword) we need to stop it from rendering if the MCP is null.

Fixes https://github.com/vector-im/riot-web/issues/4319