### PR TITLE
Fix another race with first-sync

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -942,10 +942,6 @@ module.exports = React.createClass({
             dis.dispatch({action: 'view_home_page'});
         } else if (this._is_registered) {
             this._is_registered = false;
-            // reset the 'have completed first sync' flag,
-            // since we've just logged in and will be about to sync
-            this.firstSyncComplete = false;
-            this.firstSyncPromise = q.defer();
 
             // Set the display name = user ID localpart
             MatrixClientPeg.get().setDisplayName(
@@ -1015,6 +1011,12 @@ module.exports = React.createClass({
         // Set ready to false now, then it'll be set to true when the sync
         // listener we set below fires.
         this.setState({ready: false});
+
+        // reset the 'have completed first sync' flag,
+        // since we're about to start the client and therefore about
+        // to do the first sync
+        this.firstSyncComplete = false;
+        this.firstSyncPromise = q.defer();
         const cli = MatrixClientPeg.get();
 
         // Allow the JS SDK to reap timeline events. This reduces the amount of


### PR DESCRIPTION
Set the first sync variables in onWillStartClient, as they race if
set on logged in (similar fix to https://github.com/matrix-org/matrix-react-sdk/pull/1124)