### PR TITLE
Use the web worker when clearing js-sdk stores

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -48,7 +48,6 @@ class MatrixClientPeg {
         this.opts = {
             initialSyncLimit: 20,
         };
-        this.indexedDbWorkerScript = null;
     }
 
     /**
@@ -59,7 +58,7 @@ class MatrixClientPeg {
      * @param {string} script href to the script to be passed to the web worker
      */
     setIndexedDbWorkerScript(script) {
-        this.indexedDbWorkerScript = script;
+        createMatrixClient.indexedDbWorkerScript = script;
     }
 
     get(): MatrixClient {

--- a/src/utils/createMatrixClient.js
+++ b/src/utils/createMatrixClient.js
@@ -25,13 +25,13 @@ const localStorage = window.localStorage;
  * @param {Object} opts  options to pass to Matrix.createClient. This will be
  *    extended with `sessionStore` and `store` members.
  *
- * @param {string} indexedDbWorkerScript  Optional URL for a web worker script
- *    for IndexedDB store operations. If not given, indexeddb ops are done on
+ * @property {string} indexedDbWorkerScript  Optional URL for a web worker script
+ *    for IndexedDB store operations. By default, indexeddb ops are done on
  *    the main thread.
  *
  * @returns {MatrixClient} the newly-created MatrixClient
  */
-export default function createMatrixClient(opts, indexedDbWorkerScript) {
+export default function createMatrixClient(opts) {
     const storeOpts = {};
 
     if (localStorage) {
@@ -45,7 +45,7 @@ export default function createMatrixClient(opts, indexedDbWorkerScript) {
             indexedDB: window.indexedDB,
             dbName: "riot-web-sync",
             localStorage: localStorage,
-            workerScript: indexedDbWorkerScript,
+            workerScript: createMatrixClient.indexedDbWorkerScript,
         });
     }
 
@@ -53,3 +53,5 @@ export default function createMatrixClient(opts, indexedDbWorkerScript) {
 
     return Matrix.createClient(opts);
 }
+
+createMatrixClient.indexedDbWorkerScript = null;


### PR DESCRIPTION
It turns out that Firefox doesn't let you use indexeddb from private tabs,
*unless* you are *also* in a webworker. We need to either consistently use it
or not use it - so let's use it.