### PR TITLE
Fix an incorrect console error

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -330,7 +330,7 @@ module.exports = React.createClass({
                     defaultDeviceDisplayName: this.props.defaultDeviceDisplayName,
                 });
             }).catch((e) => {
-                console.error(`Error attempting to load session from token params: ${e}`);
+                console.error(`Error attempting to load session: ${e}`);
                 return false;
             }).then((loadedSession) => {
                 if (!loadedSession) {


### PR DESCRIPTION
... this error is thrown when registering as guest or loading from
localstorage, not when using tokenparams.