### PR TITLE
Only submit phone number when phone loginType is selected

### DIFF
--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -69,10 +69,19 @@ class PasswordLogin extends React.Component {
 
     onSubmitForm(ev) {
         ev.preventDefault();
+        if (this.state.loginType === PasswordLogin.LOGIN_FIELD_PHONE) {
+            this.props.onSubmit(
+                this.state.username,
+                this.state.phoneCountry,
+                this.state.phoneNumber,
+                this.state.password,
+            );
+            return;
+        }
         this.props.onSubmit(
             this.state.username,
-            this.state.phoneCountry,
-            this.state.phoneNumber,
+            null,
+            null,
             this.state.password,
         );
     }

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -71,7 +71,7 @@ class PasswordLogin extends React.Component {
         ev.preventDefault();
         if (this.state.loginType === PasswordLogin.LOGIN_FIELD_PHONE) {
             this.props.onSubmit(
-                '',
+                '', // XXX: Synapse breaks if you send null here:
                 this.state.phoneCountry,
                 this.state.phoneNumber,
                 this.state.password,

--- a/src/components/views/login/PasswordLogin.js
+++ b/src/components/views/login/PasswordLogin.js
@@ -71,7 +71,7 @@ class PasswordLogin extends React.Component {
         ev.preventDefault();
         if (this.state.loginType === PasswordLogin.LOGIN_FIELD_PHONE) {
             this.props.onSubmit(
-                this.state.username,
+                '',
                 this.state.phoneCountry,
                 this.state.phoneNumber,
                 this.state.password,


### PR DESCRIPTION
Otherwise submit a phoneNumber and phoneCountry of `null` (when logging in with email or username).

Fixes https://github.com/vector-im/riot-web/issues/4000