### PR TITLE
Update tab-complete state onRoom received after joining

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -234,8 +234,6 @@ module.exports = React.createClass({
         // making it impossible to indicate a newly joined room.
         const room = this.state.room;
         if (room) {
-            UserProvider.getInstance().setUserListFromRoom(room);
-            this.tabComplete.loadEntries(room);
             this.setState({
                 unsentMessageError: this._getUnsentMessageError(room),
             });
@@ -523,6 +521,8 @@ module.exports = React.createClass({
         this._warnAboutEncryption(room);
         this._calculatePeekRules(room);
         this._updatePreviewUrlVisibility(room);
+        this.tabComplete.loadEntries(room);
+        UserProvider.getInstance().setUserListFromRoom(room);
     },
 
     _warnAboutEncryption: function(room) {


### PR DESCRIPTION
As opposed to doing it when the component mounts.

Fixes vector-im/riot-web#3700 (hopefully)

land https://github.com/matrix-org/matrix-react-sdk/pull/1144 first