### PR TITLE
RTE: Use <del> for strikeout

### DIFF
--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -62,6 +62,9 @@ function is_multi_line(node) {
  */
 export default class Markdown {
     constructor(input) {
+        // Support GH-style strikeout
+        input = input.replace(/~~(.*?)~~/g, '<del>$1</del>');
+
         this.input = input;
 
         const parser = new commonmark.Parser();

--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -62,9 +62,6 @@ function is_multi_line(node) {
  */
 export default class Markdown {
     constructor(input) {
-        // Support GH-style strikeout
-        input = input.replace(/~~(.*?)~~/g, '<del>$1</del>');
-
         this.input = input;
 
         const parser = new commonmark.Parser();

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -397,7 +397,7 @@ export default class MessageComposerInput extends React.Component {
                 'bold': (text) => `**${text}**`,
                 'italic': (text) => `*${text}*`,
                 'underline': (text) => `_${text}_`, // there's actually no valid underline in Markdown, but *shrug*
-                'strike': (text) => `~~${text}~~`,
+                'strike': (text) => `<del>${text}</del>`,
                 'code-block': (text) => `\`\`\`\n${text}\n\`\`\``,
                 'blockquote': (text) => text.split('\n').map((line) => `> ${line}\n`).join(''),
                 'unordered-list-item': (text) => text.split('\n').map((line) => `\n- ${line}`).join(''),


### PR DESCRIPTION
We've swapped to commonmark which uses <del> for strikeout, so make the RTE use that. 

As a bonus, interpret ~~ as <del>.

land https://github.com/matrix-org/matrix-react-sdk/pull/1144 first