### PR TITLE
Work around draft-js-export-html#62 by post-processing <br>\n

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -84,7 +84,13 @@ export function charactersToImageNode(alt, useSvg, ...unicode) {
 }
 
 
-export function stripParagraphs(html: string): string {
+export function processHtmlForSending(html: string): string {
+    // Replace "<br>\n" with "<br>" because the \n is redundant and causes an
+    // extra newline per line within `<pre>` tags.
+    // This is a workaround for a bug in draft-js-export-html:
+    //   https://github.com/sstur/draft-js-export-html/issues/62
+    html = html.replace(/\<br\>\n/g, '<br>');
+
     const contentDiv = document.createElement('div');
     contentDiv.innerHTML = html;
 

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -99,9 +99,8 @@ export function processHtmlForSending(html: string): string {
         if (element.tagName.toLowerCase() === 'p') {
             contentHTML += element.innerHTML + '<br />';
         } else if (element.tagName.toLowerCase() === 'pre') {
-            // Replace "<br>\n" with "<br>" because the \n is redundant and causes an
-            // extra newline per line within `<pre>` tags.
-            // This is a workaround for a bug in draft-js-export-html:
+            // Replace "<br>\n" with "\n" within `<pre>` tags because the <br> is
+            // redundant. This is a workaround for a bug in draft-js-export-html:
             //   https://github.com/sstur/draft-js-export-html/issues/62
             contentHTML += '<pre>' +
                 element.innerHTML.replace(/<br>\n/g, '\n').trim() +

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -85,11 +85,6 @@ export function charactersToImageNode(alt, useSvg, ...unicode) {
 
 
 export function processHtmlForSending(html: string): string {
-    // Replace "<br>\n" with "<br>" because the \n is redundant and causes an
-    // extra newline per line within `<pre>` tags.
-    // This is a workaround for a bug in draft-js-export-html:
-    //   https://github.com/sstur/draft-js-export-html/issues/62
-    html = html.replace(/\<br\>\n/g, '<br>');
 
     const contentDiv = document.createElement('div');
     contentDiv.innerHTML = html;
@@ -103,6 +98,14 @@ export function processHtmlForSending(html: string): string {
         const element = contentDiv.children[i];
         if (element.tagName.toLowerCase() === 'p') {
             contentHTML += element.innerHTML + '<br />';
+        } else if (element.tagName.toLowerCase() === 'pre') {
+            // Replace "<br>\n" with "<br>" because the \n is redundant and causes an
+            // extra newline per line within `<pre>` tags.
+            // This is a workaround for a bug in draft-js-export-html:
+            //   https://github.com/sstur/draft-js-export-html/issues/62
+            contentHTML += '<pre>' +
+                element.innerHTML.replace(/<br>\n/g, '\n').trim() +
+                '</pre>';
         } else {
             const temp = document.createElement('div');
             temp.appendChild(element.cloneNode(true));

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -507,9 +507,9 @@ export default class MessageComposerInput extends React.Component {
         }
 
         if (this.state.isRichtextEnabled) {
-            contentHTML = HtmlUtils.stripParagraphs(
+            contentHTML = HtmlUtils.processHtmlForSending(
                 RichText.contentStateToHTML(contentState),
-            ).replace(/\<br\>\n/g, '<br>');
+            );
         } else {
             const md = new Markdown(contentText);
             if (md.isPlainText()) {

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -509,7 +509,7 @@ export default class MessageComposerInput extends React.Component {
         if (this.state.isRichtextEnabled) {
             contentHTML = HtmlUtils.stripParagraphs(
                 RichText.contentStateToHTML(contentState),
-            );
+            ).replace(/\<br\>\n/g, '<br>');
         } else {
             const md = new Markdown(contentText);
             if (md.isPlainText()) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4446 by post-processing the output HTML from draft-js-export-html by replacing `<br>\n` with `<br>`. This works for content within or outside of `<pre>`. If we replace with `\n` instead, the newlines only apply in `<pre>` tags so we use `<br>`.