### PR TITLE
Move cursor to end of editor when quoting

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -229,7 +229,8 @@ export default class MessageComposerInput extends React.Component {
                     if (this.state.isRichtextEnabled) {
                         contentState = Modifier.setBlockType(contentState, startSelection, 'blockquote');
                     }
-                    const editorState = EditorState.push(this.state.editorState, contentState, 'insert-characters');
+                    let editorState = EditorState.push(this.state.editorState, contentState, 'insert-characters');
+                    editorState = EditorState.moveSelectionToEnd(editorState);
                     this.onEditorContentChanged(editorState);
                     editor.focus();
                 }


### PR DESCRIPTION
When quoting a message, move the selection to the end of the input box. Fixes https://github.com/vector-im/riot-web/issues/2336