### PR TITLE
Don't pad 12h timestamps

### DIFF
--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -55,6 +55,7 @@ function twelveHourTime(date) {
     let hours = date.getHours() % 12;
     const minutes = pad(date.getMinutes());
     const ampm = date.getHours() >= 12 ? 'PM' : 'AM';
+    hours = hours ? hours : 12; // convert 0 -> 12
     return `${hours}:${minutes}${ampm}`;
 }
 

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -54,7 +54,7 @@ function pad(n) {
 function twelveHourTime(date) {
     let hours = date.getHours() % 12;
     const minutes = pad(date.getMinutes());
-    const ampm = date.getHours() >= 12 ? 'PM' : 'AM';
+    const ampm = date.getHours() >= 12 ? _t('PM') : _t('AM');
     hours = hours ? hours : 12; // convert 0 -> 12
     return `${hours}:${minutes}${ampm}`;
 }

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -55,7 +55,6 @@ function twelveHourTime(date) {
     let hours = date.getHours() % 12;
     const minutes = pad(date.getMinutes());
     const ampm = date.getHours() >= 12 ? 'PM' : 'AM';
-    hours = pad(hours ? hours : 12);
     return `${hours}:${minutes}${ampm}`;
 }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -421,6 +421,8 @@
     "Notifications": "Notifications",
     "(not supported by this browser)": "(not supported by this browser)",
     "<not supported>": "<not supported>",
+    "AM": "AM",
+    "PM": "PM",
     "NOT verified": "NOT verified",
     "No devices with registered encryption keys": "No devices with registered encryption keys",
     "No display name": "No display name",

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -120,6 +120,8 @@
     "zh-sg": "Chinese (Singapore)",
     "zh-tw": "Chinese (Taiwan)",
     "zu": "Zulu",
+    "AM": "AM",
+    "PM": "PM",
     "A text message has been sent to +%(msisdn)s. Please enter the verification code it contains": "A text message has been sent to +%(msisdn)s. Please enter the verification code it contains",
     "accept": "accept",
     "%(targetName)s accepted an invitation.": "%(targetName)s accepted an invitation.",


### PR DESCRIPTION
As per @lampholder's comment [here](https://github.com/vector-im/riot-web/issues/4393#issuecomment-312266849), this is the desirable behaviour.

Changes `03:00 PM` to be `3:00 PM`.