### PR TITLE
Always store sent MD messages as MD in history

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -556,9 +556,15 @@ export default class MessageComposerInput extends React.Component {
             sendTextFn = this.client.sendEmoteMessage;
         }
 
-        this.historyManager.addItem(
-            contentHTML ? contentHTML : contentText,
-            contentHTML ? 'html' : 'markdown');
+        if (this.state.isRichtextEnabled) {
+            this.historyManager.addItem(
+                contentHTML ? contentHTML : contentText,
+                contentHTML ? 'html' : 'markdown',
+            );
+        } else {
+            // Always store MD input as input history
+            this.historyManager.addItem(contentText, 'markdown');
+        }
 
         let sendMessagePromise;
         if (contentHTML) {


### PR DESCRIPTION
Because converting them to HTML when they got sent as HTML seems a bit pointless when they're just going to get transformed back again when retrieved from history.

Fixes regression https://github.com/vector-im/riot-web/issues/4465