### PR TITLE
Match by emoji ascii regex first before shorthand

### DIFF
--- a/src/autocomplete/EmojiProvider.js
+++ b/src/autocomplete/EmojiProvider.js
@@ -41,7 +41,7 @@ const CATEGORY_ORDER = [
 ];
 
 // Match for ":wink:" or ascii-style ";-)" provided by emojione
-const EMOJI_REGEX = new RegExp('(:\\w*:?|' + asciiRegexp + ')', 'g');
+const EMOJI_REGEX = new RegExp('(' + asciiRegexp + '|:\\w*:?)', 'g');
 const EMOJI_SHORTNAMES = Object.keys(EmojiData).map((key) => EmojiData[key]).sort(
     (a, b) => {
         if (a.category === b.category) {


### PR DESCRIPTION
Plaintext emojis that start with ":" will also match against the shorthand regex but the match won't include the important part of the plaintext emoji. This means some emoji like ":)" won't be matched.

To fix this, put the ascii emoji regex first so that the match will be plaintext or otherwise it will fall through to the shorthand match (if there is one).

Fixes https://github.com/vector-im/riot-web/issues/4467