### PR TITLE
Only move through history if caret at start or end of line

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -640,17 +640,16 @@ export default class MessageComposerInput extends React.Component {
             const firstBlock = this.state.editorState.getCurrentContent().getFirstBlock();
             const lastBlock = this.state.editorState.getCurrentContent().getLastBlock();
 
-            const selectionOffset = selection.getAnchorOffset();
             let canMoveUp = false;
             let canMoveDown = false;
             if (blockKey === firstBlock.getKey()) {
-                const textBeforeCursor = firstBlock.getText().slice(0, selectionOffset);
-                canMoveUp = textBeforeCursor.indexOf('\n') === -1;
+                canMoveUp = selection.getStartOffset() === selection.getEndOffset() &&
+                    selection.getStartOffset() === 0;
             }
 
             if (blockKey === lastBlock.getKey()) {
-                const textAfterCursor = lastBlock.getText().slice(selectionOffset);
-                canMoveDown = textAfterCursor.indexOf('\n') === -1;
+                canMoveDown = selection.getStartOffset() === selection.getEndOffset() &&
+                    selection.getStartOffset() === lastBlock.getText().length;
             }
 
             if ((up && !canMoveUp) || (!up && !canMoveDown)) return;


### PR DESCRIPTION
As suggested by @dbkr (because this is what we do for the old composer), only move through history when the caret is that the beginning of the first line (block) or end of the last.

This has the nice property of being able to move the caret up to a really long message: fixes https://github.com/vector-im/riot-web/issues/4471