### PR TITLE
Only match users by matchgin displayname or user ID prefixes

### DIFF
--- a/src/autocomplete/QueryMatcher.js
+++ b/src/autocomplete/QueryMatcher.js
@@ -69,6 +69,12 @@ export default class QueryMatcher {
         if (this.options.shouldMatchWordsOnly === undefined) {
             this.options.shouldMatchWordsOnly = true;
         }
+
+        // By default, match anywhere in the string being searched. If enabled, only return
+        // matches that are prefixed with the query.
+        if (this.options.shouldMatchPrefix === undefined) {
+            this.options.shouldMatchPrefix = false;
+        }
     }
 
     setObjects(objects: Array<Object>) {
@@ -87,7 +93,7 @@ export default class QueryMatcher {
                 resultKey = resultKey.replace(/[^\w]/g, '');
             }
             const index = resultKey.indexOf(query);
-            if (index !== -1) {
+            if (index !== -1 && (!this.options.shouldMatchPrefix || index === 0)) {
                 results.push({key, index});
             }
         });

--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -37,10 +37,11 @@ export default class UserProvider extends AutocompleteProvider {
 
     constructor() {
         super(USER_REGEX, {
-            keys: ['name', 'userId'],
+            keys: ['name'],
         });
         this.matcher = new FuzzyMatcher([], {
-            keys: ['name', 'userId'],
+            keys: ['name'],
+            shouldMatchPrefix: true,
         });
     }
 


### PR DESCRIPTION
Because tab completing "k" probably shouldn't give you "luke"

Fixes https://github.com/vector-im/riot-web/issues/4495