### PR TITLE
Don't try to match with an empty query string

### DIFF
--- a/src/autocomplete/QueryMatcher.js
+++ b/src/autocomplete/QueryMatcher.js
@@ -86,6 +86,9 @@ export default class QueryMatcher {
         if (this.options.shouldMatchWordsOnly) {
             query = query.replace(/[^\w]/g, '');
         }
+        if (query.length === 0) {
+            return [];
+        }
         const results = [];
         this.keyMap.keys.forEach((key) => {
             let resultKey = key.toLowerCase();


### PR DESCRIPTION
This was causing UserProvider to give results because every string happens to start with empty string and its regex also accepts the empty string.