### PR TITLE
When hitting "tab" use an autocompleteDelay of 0

### DIFF
--- a/src/components/views/rooms/Autocomplete.js
+++ b/src/components/views/rooms/Autocomplete.js
@@ -68,7 +68,7 @@ export default class Autocomplete extends React.Component {
         let autocompleteDelay = UserSettingsStore.getLocalSetting('autocompleteDelay', 200);
 
         // Don't debounce if we are already showing completions
-        if (this.state.completions.length > 0) {
+        if (this.state.completions.length > 0 || this.state.forceComplete) {
             autocompleteDelay = 0;
         }
 


### PR DESCRIPTION
So that there's no delay when tab completing. Fixes https://github.com/vector-im/riot-web/issues/4497