### PR TITLE
Implement MessageComposerStore to persist composer state when room switching

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -132,7 +132,10 @@ export default class MessageComposerInput extends React.Component {
             isRichtextEnabled,
 
             // the currently displayed editor state (note: this is always what is modified on input)
-            editorState: null,
+            editorState: this.createEditorState(
+                isRichtextEnabled,
+                MessageComposerStore.getContentState(this.props.room.roomId),
+            ),
 
             // the original editor state, before we started tabbing through completions
             originalEditorState: null,
@@ -141,10 +144,6 @@ export default class MessageComposerInput extends React.Component {
             // we want to persist whilst browsing history
             currentlyComposedEditorState: null,
         };
-
-        // bit of a hack, but we need to do this here since createEditorState needs isRichtextEnabled
-        /* eslint react/no-direct-mutation-state:0 */
-        this.state.editorState = this.createEditorState();
 
         this.client = MatrixClientPeg.get();
     }
@@ -172,11 +171,6 @@ export default class MessageComposerInput extends React.Component {
     componentDidMount() {
         this.dispatcherRef = dis.register(this.onAction);
         this.historyManager = new ComposerHistoryManager(this.props.room.roomId);
-
-        // Reinstate the editor state for this room
-        this.setState({
-            editorState: MessageComposerStore.getEditorState(this.props.room.roomId),
-        });
     }
 
     componentWillUnmount() {
@@ -346,9 +340,9 @@ export default class MessageComposerInput extends React.Component {
             // Record the editor state for this room so that it can be retrieved after
             // switching to another room and back
             dis.dispatch({
-                action: 'editor_state',
+                action: 'content_state',
                 room_id: this.props.room.roomId,
-                editor_state: state.editorState,
+                content_state: state.editorState.getCurrentContent(),
             });
 
             if (!state.hasOwnProperty('originalEditorState')) {

--- a/src/stores/MessageComposerStore.js
+++ b/src/stores/MessageComposerStore.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import dis from '../dispatcher';
+import {Store} from 'flux/utils';
+
+const INITIAL_STATE = {
+    editorStateMap: {},
+};
+
+/**
+ * A class for storing application state to do with the message composer. This is a simple
+ * flux store that listens for actions and updates its state accordingly, informing any
+ * listeners (views) of state changes.
+ */
+class MessageComposerStore extends Store {
+    constructor() {
+        super(dis);
+
+        // Initialise state
+        this._state = INITIAL_STATE;
+    }
+
+    _setState(newState) {
+        this._state = Object.assign(this._state, newState);
+        this.__emitChange();
+    }
+
+    __onDispatch(payload) {
+        switch (payload.action) {
+            case 'editor_state':
+                this._editorState(payload);
+                break;
+            case 'on_logged_out':
+                this.reset();
+                break;
+        }
+    }
+
+    _editorState(payload) {
+        const editorStateMap = this._state.editorStateMap;
+        editorStateMap[payload.room_id] = payload.editor_state;
+        this._setState({
+            editorStateMap: editorStateMap,
+        });
+    }
+
+    getEditorState(roomId) {
+        return this._state.editorStateMap[roomId];
+    }
+
+    reset() {
+        this._state = Object.assign({}, INITIAL_STATE);
+    }
+}
+
+let singletonMessageComposerStore = null;
+if (!singletonMessageComposerStore) {
+    singletonMessageComposerStore = new MessageComposerStore();
+}
+module.exports = singletonMessageComposerStore;

--- a/src/stores/MessageComposerStore.js
+++ b/src/stores/MessageComposerStore.js
@@ -32,7 +32,7 @@ class MessageComposerStore extends Store {
         super(dis);
 
         // Initialise state
-        this._state = INITIAL_STATE;
+        this._state = Object.assign({}, INITIAL_STATE);
     }
 
     _setState(newState) {

--- a/src/stores/MessageComposerStore.js
+++ b/src/stores/MessageComposerStore.js
@@ -15,9 +15,11 @@ limitations under the License.
 */
 import dis from '../dispatcher';
 import {Store} from 'flux/utils';
+import {convertToRaw, convertFromRaw} from 'draft-js';
 
 const INITIAL_STATE = {
-    editorStateMap: {},
+    editorStateMap: localStorage.getItem('content_state') ?
+        JSON.parse(localStorage.getItem('content_state')) : {},
 };
 
 /**
@@ -40,8 +42,8 @@ class MessageComposerStore extends Store {
 
     __onDispatch(payload) {
         switch (payload.action) {
-            case 'editor_state':
-                this._editorState(payload);
+            case 'content_state':
+                this._contentState(payload);
                 break;
             case 'on_logged_out':
                 this.reset();
@@ -49,16 +51,19 @@ class MessageComposerStore extends Store {
         }
     }
 
-    _editorState(payload) {
+    _contentState(payload) {
         const editorStateMap = this._state.editorStateMap;
-        editorStateMap[payload.room_id] = payload.editor_state;
+        editorStateMap[payload.room_id] = convertToRaw(payload.content_state);
+        localStorage.setItem('content_state', JSON.stringify(editorStateMap));
+        console.info(localStorage.getItem('content_state'));
         this._setState({
             editorStateMap: editorStateMap,
         });
     }
 
-    getEditorState(roomId) {
-        return this._state.editorStateMap[roomId];
+    getContentState(roomId) {
+        return this._state.editorStateMap[roomId] ?
+            convertFromRaw(this._state.editorStateMap[roomId]) : null;
     }
 
     reset() {


### PR DESCRIPTION
This behaviour was present in the old composer but implemented using local storage. This is unecessary as we don't really care about our drafts across clients, the important thing is that our draft is kept when switching rooms.

As a bonus, ignore vertical arrow key presses when a modifier key is pressed so that the room switching keys (alt + up/down arrow) don't also cause history browsing (or autocomplete browsing).

Fixes https://github.com/vector-im/riot-web/issues/4507