### PR TITLE
Run the riot-web tests against js-sdk develop

### DIFF
--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -22,8 +22,11 @@ git checkout "$curbranch" || git checkout develop
 mkdir node_modules
 npm install
 
-(cd node_modules/matrix-js-sdk && npm install)
+# use the version of js-sdk we just used in the react-sdk tests
+rm -r node_modules/matrix-js-sdk
+ln -s "$REACT_SDK_DIR/node_modules/matrix-js-sdk" node_modules/matrix-js-sdk
 
+# ... and, of course, the version of react-sdk we just built
 rm -r node_modules/matrix-react-sdk
 ln -s "$REACT_SDK_DIR" node_modules/matrix-react-sdk
 


### PR DESCRIPTION
When running the riot-web builds, use the develop version of js-sdk instead of
the latest release, to improve our chances of compatibility.