### PR TITLE
Only insert HTML into the composer in RTE mode

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -488,8 +488,7 @@ export default class MessageComposerInput extends React.Component {
         const currentContent = this.state.editorState.getCurrentContent();
 
         let contentState = null;
-
-        if (html) {
+        if (html && this.state.isRichtextEnabled) {
             contentState = Modifier.replaceWithFragment(
                 currentContent,
                 currentSelection,


### PR DESCRIPTION
If MD mode is enabled, paste the plaintext equivalent.

Fixes https://github.com/vector-im/riot-web/issues/4494