### PR TITLE
Fix vector-im/riot-web#4526 by pretending to join when creating a room

### DIFF
--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -79,6 +79,12 @@ function createRoom(opts) {
     const modal = Modal.createDialog(Loader, null, 'mx_Dialog_spinner');
 
     let roomId;
+    if (opts.andView) {
+        // We will possibly have a successful join, indicate as such
+        dis.dispatch({
+            action: 'will_join',
+        });
+    }
     return client.createRoom(createOpts).finally(function() {
         modal.close();
     }).then(function(res) {
@@ -98,10 +104,16 @@ function createRoom(opts) {
                 action: 'view_room',
                 room_id: roomId,
                 should_peek: false,
+                // Creating a room will have joined us to the room
+                joined: true,
             });
         }
         return roomId;
     }, function(err) {
+        // We also failed to join the room (this sets joining to false in RoomViewStore)
+        dis.dispatch({
+            action: 'join_room_error',
+        });
         console.error("Failed to create room " + roomId + " " + err);
         Modal.createDialog(ErrorDialog, {
             title: _t("Failure to create room"),

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -141,6 +141,10 @@ class RoomViewStore extends Store {
                 shouldPeek: payload.should_peek === undefined ? true : payload.should_peek,
             };
 
+            if (payload.joined) {
+                newState.joining = false;
+            }
+
             // If an event ID wasn't specified, default to the one saved for this room
             // via update_scroll_state. Assume initialEventPixelOffset should be set.
             if (!newState.initialEventId) {


### PR DESCRIPTION
I thought about adding separate dispatches to prevent confusion but if anyone adds anything that listens to existing dispatches, they really ought to be grep-ing the world for said dispatch actions.