### PR TITLE
Fix accepting invites

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -91,8 +91,8 @@ export default class UserProvider extends AutocompleteProvider {
             if (member.userId !== currentUserId) return true;
         });
 
-        this.users = _sortBy(this.users, (completion) =>
-            1E20 - lastSpoken[completion.user.userId] || 1E20,
+        this.users = _sortBy(this.users, (member) =>
+            1E20 - lastSpoken[member.userId] || 1E20,
         );
 
         this.matcher.setObjects(this.users);


### PR DESCRIPTION
Accepting an invite would cause a room to arrive via /sync only for it to throw an error in the auto complete code and cause the client to go wibbly (infinite spinner or preview bar).

The logs that lead to the debugging of this are https://github.com/matrix-org/riot-web-rageshakes/issues/239

Hopefully the error being throw isn't totally unrelated but looking at the sync handling for inviteRooms in sync.js, new rooms are stored and _then_ the Room event is emitted. The Room event could trigger setUserListFromRoom, which is where the bug was. So the room should have been stored regardless of this bug and the client should have been recoverable by swapping away and viewing the room again.