### PR TITLE
Fix bug where a received message would remove completions for users

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -101,7 +101,8 @@ export default class UserProvider extends AutocompleteProvider {
     onUserSpoke(user: RoomMember) {
         if(user.userId === MatrixClientPeg.get().credentials.userId) return;
 
-        this.users = this.users.splice(
+        // Move the user that spoke to the front of the array
+        this.users.splice(
             this.users.findIndex((user2) => user2.userId === user.userId), 1);
         this.users = [user, ...this.users];
 


### PR DESCRIPTION
`Array.prototype.splice` will return the array of removed items, not a new array. The array operated on is actually modified in-place.

This was causing a few weird things to happen: https://github.com/vector-im/riot-web/issues/4511 and https://github.com/vector-im/riot-web/issues/4533. This should fix both of them but it is concerning that doing the tab completion is required to reproduce. Let's just see how this goes before closing the issues.

Thanks @turt2live for reproducing both bugs, giving enough information for a fix :)