### PR TITLE
use npm scripts arg passing instead of $KARMAFLAGS to make cross-compat

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-export KARMAFLAGS="--no-colors"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 nvm use 4
@@ -16,7 +15,7 @@ npm install
 (cd node_modules/matrix-js-sdk && npm install)
 
 # run the mocha tests
-npm run test
+npm run test -- --no-colors
 
 # run eslint
 npm run lintall -- -f checkstyle -o eslint.xml || true

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "lintall": "eslint src/ test/",
     "clean": "rimraf lib",
     "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt",
-    "test": "karma start $KARMAFLAGS --single-run=true --browsers ChromeHeadless",
-    "test-multi": "karma start $KARMAFLAGS"
+    "test": "karma start --single-run=true --browsers ChromeHeadless",
+    "test-multi": "karma start"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",


### PR DESCRIPTION
this way `npm run test` will work on Windows, most of the work was @richvdh changing us over to Chrome from PhantomJS