### PR TITLE
Remove `disableMarkdown` setting

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -90,10 +90,6 @@ const SETTINGS_LABELS = [
         label: 'Hide removed messages',
     },
     {
-        id: 'disableMarkdown',
-        label: 'Disable markdown formatting',
-    },
-    {
         id: 'enableSyntaxHighlightLanguageDetection',
         label: 'Enable automatic language detection for syntax highlighting',
     },


### PR DESCRIPTION
This was used by the old composer to control whether to interpret text as markdown prior to sending.

The new setting is `MessageComposerInput.isRichTextEnabled`.