### PR TITLE
Improve RTE HTML link handling

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -591,6 +591,14 @@ export default class MessageComposerInput extends React.Component {
                     }
                 });
             }
+            if (!shouldSendHTML) {
+                const hasAnEntity = blocks.some((block) => {
+                    return block.getCharacterList().filter((c) => {
+                        return c.getEntity();
+                    }).size > 0;
+                });
+                shouldSendHTML = hasAnEntity;
+            }
             if (shouldSendHTML) {
                 contentHTML = HtmlUtils.processHtmlForSending(
                     RichText.contentStateToHTML(contentState),

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -620,12 +620,13 @@ export default class MessageComposerInput extends React.Component {
                 });
             }
             if (!shouldSendHTML) {
-                const hasAnEntity = blocks.some((block) => {
+                const hasLink = blocks.some((block) => {
                     return block.getCharacterList().filter((c) => {
-                        return c.getEntity();
+                        const entityKey = c.getEntity();
+                        return entityKey && Entity.get(entityKey).getType() === 'LINK';
                     }).size > 0;
                 });
-                shouldSendHTML = hasAnEntity;
+                shouldSendHTML = hasLink;
             }
             if (shouldSendHTML) {
                 contentHTML = HtmlUtils.processHtmlForSending(

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -164,13 +164,13 @@ export default class MessageComposerInput extends React.Component {
         const decorators = richText ? RichText.getScopedRTDecorators(this.props) :
                 RichText.getScopedMDDecorators(this.props);
         decorators.push({
-          strategy: this.findLinkEntities.bind(this),
-          component: (props) => {
+            strategy: this.findLinkEntities.bind(this),
+            component: (props) => {
                 const {url} = Entity.get(props.entityKey).getData();
                 return (
-                  <a href={url}>
-                    {props.children}
-                  </a>
+                    <a href={url}>
+                        {props.children}
+                    </a>
                 );
             },
         });


### PR DESCRIPTION
Handle pasted `<a>` tags better by:
 - decorating them such that they look like links (fixes https://github.com/vector-im/riot-web/issues/4493)
 - sending HTML if there are any entities in the composer
 - allowing the user to stop editing the link text (fixes https://github.com/vector-im/riot-web/issues/3990)

