### PR TITLE
Implement disabled-by-default setting for auto-replacement of plainte…

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -93,6 +93,10 @@ const SETTINGS_LABELS = [
         id: 'enableSyntaxHighlightLanguageDetection',
         label: 'Enable automatic language detection for syntax highlighting',
     },
+    {
+        id: 'MessageComposerInput.autoReplaceEmoji',
+        label: 'Automatically replace plain text Emoji',
+    },
 /*
     {
         id: 'useFixedWidthFont',

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -955,5 +955,6 @@
     "To join an exisitng group you'll have to know its group identifier; this will look something like <i>+example:matrix.org</i>.": "To join an exisitng group you'll have to know its group identifier; this will look something like <i>+example:matrix.org</i>.",
     "Featured Rooms:": "Featured Rooms:",
     "Error whilst fetching joined groups": "Error whilst fetching joined groups",
-    "Featured Users:": "Featured Users:"
+    "Featured Users:": "Featured Users:",
+    "Automatically replace plain text Emoji": "Automatically replace plain text Emoji"
 }


### PR DESCRIPTION
…xt emojis

FTR a list of plaintexts and their unicode equivalents can be found here - https://github.com/vector-im/riot-web/issues/4554#issuecomment-314374303

Pressing space after a matching emoji will replace the plaintext emoji with the equivalent unicode emoji.