### PR TITLE
Fix RoomSettings save

### DIFF
--- a/src/components/views/rooms/RoomSettings.js
+++ b/src/components/views/rooms/RoomSettings.js
@@ -298,7 +298,7 @@ module.exports = React.createClass({
         // color scheme
         var p;
         p = this.saveColor();
-        if (!Promise.isFulfilled(p)) {
+        if (!p.isFulfilled()) {
             promises.push(p);
         }
 
@@ -310,7 +310,7 @@ module.exports = React.createClass({
 
         // encryption
         p = this.saveEnableEncryption();
-        if (!Promise.isFulfilled(p)) {
+        if (!p.isFulfilled()) {
             promises.push(p);
         }
 


### PR DESCRIPTION
Looks like saving RoomSettings had been broken since 0d7cc59. `isFulfilled`
cannot be used as a static function.