### PR TITLE
Implement old composer feature that inserts ': ' or ' '

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -55,6 +55,7 @@ export default class UserProvider extends AutocompleteProvider {
                 const displayName = (user.name || user.userId || '').replace(' (IRC)', ''); // FIXME when groups are done
                 return {
                     completion: displayName,
+                    suffix: range.start === 0 ? ': ' : ' ',
                     entity: {
                         type: 'LINK',
                         mutability: 'IMMUTABLE',

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -928,7 +928,7 @@ export default class MessageComposerInput extends React.Component {
             return false;
         }
 
-        const {range = {}, completion = '', entity = null} = displayedCompletion;
+        const {range = {}, completion = '', entity = null, suffix = ''} = displayedCompletion;
         let entityKey;
         if (entity) {
             entityKey = Entity.create(
@@ -938,7 +938,7 @@ export default class MessageComposerInput extends React.Component {
             );
         }
 
-        const contentState = Modifier.replaceText(
+        let contentState = Modifier.replaceText(
             activeEditorState.getCurrentContent(),
             RichText.textOffsetsToSelectionState(
                 range, activeEditorState.getCurrentContent().getBlocksAsArray(),
@@ -947,6 +947,12 @@ export default class MessageComposerInput extends React.Component {
             null,
             entityKey,
         );
+
+        // Move the selection to the end of the block
+        const afterSelection = contentState.getSelectionAfter();
+        if (suffix) {
+            contentState = Modifier.replaceText(contentState, afterSelection, suffix);
+        }
 
         let editorState = EditorState.push(activeEditorState, contentState, 'insert-characters');
         editorState = EditorState.forceSelection(editorState, contentState.getSelectionAfter());


### PR DESCRIPTION
after a user completion