### PR TITLE
Insert MD links when autocompleting in MD mode

### DIFF
--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -55,13 +55,8 @@ export default class RoomProvider extends AutocompleteProvider {
                 const displayAlias = getDisplayAliasForRoom(room.room) || room.roomId;
                 return {
                     completion: displayAlias,
-                    entity: {
-                        type: 'LINK',
-                        mutability: 'IMMUTABLE',
-                        data: {
-                            url: 'https://matrix.to/#/' + displayAlias,
-                        },
-                    },
+                    suffix: ' ',
+                    href: 'https://matrix.to/#/' + displayAlias,
                     component: (
                         <PillCompletion initialComponent={<RoomAvatar width={24} height={24} room={room.room} />} title={room.name} description={displayAlias} />
                     ),

--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -56,13 +56,7 @@ export default class UserProvider extends AutocompleteProvider {
                 return {
                     completion: displayName,
                     suffix: range.start === 0 ? ': ' : ' ',
-                    entity: {
-                        type: 'LINK',
-                        mutability: 'IMMUTABLE',
-                        data: {
-                            url: 'https://matrix.to/#/' + user.userId,
-                        },
-                    },
+                    href: 'https://matrix.to/#/' + user.userId,
                     component: (
                         <PillCompletion
                             initialComponent={<MemberAvatar member={user} width={24} height={24}/>}

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -43,6 +43,7 @@ import {Completion} from "../../../autocomplete/Autocompleter";
 import Markdown from '../../../Markdown';
 import ComposerHistoryManager from '../../../ComposerHistoryManager';
 import MessageComposerStore from '../../../stores/MessageComposerStore';
+import { getDisplayAliasForRoom } from '../../../Rooms';
 
 import {MATRIXTO_URL_PATTERN} from '../../../linkify-matrix';
 const REGEX_MATRIXTO = new RegExp(MATRIXTO_URL_PATTERN);
@@ -225,7 +226,7 @@ export default class MessageComposerInput extends React.Component {
                             return r.getCanonicalAlias() === resource;
                         }) : MatrixClientPeg.get().getRoom(resource);
 
-                    linkText = room.getCanonicalAlias();
+                    linkText = getDisplayAliasForRoom(room) || resource;
 
                     avatar = room ? <RoomAvatar room={room} width={16} height={16}/> : null;
                 }


### PR DESCRIPTION
These will appear decorated because they are inserted as entities. It was necessary to modify pills to have an explicit linkText that is derived from the `href` being pillified (and is thus no longer the inserted completion but rather the display name (or user ID) or room alias.