### PR TITLE
Strip MD user mentions from the `body` of sent messages

### DIFF
--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -92,7 +92,6 @@ export default React.createClass({
                 avatar = <RoomAvatar room={room} width={16} height={16}/>;
             }
         }
-
         const classes = classNames({
             "mx_UserPill": isUserPill,
             "mx_RoomPill": isRoomPill,

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -92,6 +92,7 @@ export default React.createClass({
                 avatar = <RoomAvatar room={room} width={16} height={16}/>;
             }
         }
+
         const classes = classNames({
             "mx_UserPill": isUserPill,
             "mx_RoomPill": isRoomPill,

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -732,7 +732,6 @@ export default class MessageComposerInput extends React.Component {
         }
 
         // Strip MD user mentions to preserve plaintext mention behaviour
-        // (MD links are very verbose and ugly)
         contentText = contentText.replace(REGEX_MATRIXTO_MARKDOWN_GLOBAL,
         (markdownLink, text, resource, prefix) => {
             return prefix === '@' ? text : markdownLink;

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -45,8 +45,9 @@ import ComposerHistoryManager from '../../../ComposerHistoryManager';
 import MessageComposerStore from '../../../stores/MessageComposerStore';
 import { getDisplayAliasForRoom } from '../../../Rooms';
 
-import {MATRIXTO_URL_PATTERN} from '../../../linkify-matrix';
+import {MATRIXTO_URL_PATTERN, MATRIXTO_MD_LINK_PATTERN} from '../../../linkify-matrix';
 const REGEX_MATRIXTO = new RegExp(MATRIXTO_URL_PATTERN);
+const REGEX_MATRIXTO_MARKDOWN_GLOBAL = new RegExp(MATRIXTO_MD_LINK_PATTERN, 'g');
 
 import {asciiRegexp, shortnameToUnicode, emojioneList, asciiList, mapUnicodeToShort} from 'emojione';
 const EMOJI_SHORTNAMES = Object.keys(emojioneList);
@@ -777,6 +778,13 @@ export default class MessageComposerInput extends React.Component {
             sendHtmlFn = this.client.sendHtmlEmote;
             sendTextFn = this.client.sendEmoteMessage;
         }
+
+        // Strip MD user mentions to preserve plaintext mention behaviour
+        // (MD links are very verbose and ugly)
+        contentText = contentText.replace(REGEX_MATRIXTO_MARKDOWN_GLOBAL,
+        (markdownLink, text, resource, prefix) => {
+            return prefix === '@' ? text : markdownLink;
+        });
 
         let sendMessagePromise;
         if (contentHTML) {

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -168,6 +168,8 @@ matrixLinkify.VECTOR_URL_PATTERN = "^(?:https?:\/\/)?(?:"
     + ")(#.*)";
 
 matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/((#|@|!).*)";
+matrixLinkify.MATRIXTO_MD_LINK_PATTERN =
+    '\\[([^\\]]*)\\]\\((?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/((#|@|!)[^\\)]*)\\)';
 matrixLinkify.MATRIXTO_BASE_URL= "https://matrix.to";
 
 matrixLinkify.options = {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -238,7 +238,12 @@ export function mkStubRoom(roomId = null) {
     return {
         roomId,
         getReceiptsForEvent: sinon.stub().returns([]),
-        getMember: sinon.stub().returns({}),
+        getMember: sinon.stub().returns({
+            userId: '@member:domain.bla',
+            name: 'Member',
+            roomId: roomId,
+            getAvatarUrl: () => 'mxc://avatar.url/image.png',
+        }),
         getJoinedMembers: sinon.stub().returns([]),
         getPendingEvents: () => [],
         getLiveTimeline: () => stubTimeline,


### PR DESCRIPTION
Because previously we just sent the display name and MD links are not very readable.

Fixes https://github.com/matrix-org/matrix-appservice-irc/issues/477