### PR TITLE
improve sanitization of img tags

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -145,7 +145,7 @@ const sanitizeHtmlParams = {
         font: ['color', 'data-mx-bg-color', 'data-mx-color', 'style'], // custom to matrix
         span: ['data-mx-bg-color', 'data-mx-color', 'style'], // custom to matrix
         a: ['href', 'name', 'target', 'rel'], // remote target: custom to matrix
-        img: ['src'],
+        img: ['src', 'width', 'height', 'alt', 'title'],
         ol: ['start'],
         code: ['class'], // We don't actually allow all classes, we filter them in transformTags
     },
@@ -191,7 +191,11 @@ const sanitizeHtmlParams = {
             // because transformTags is used _before_ we filter by allowedSchemesByTag and
             // we don't want to allow images with `https?` `src`s.
             if (!attribs.src.startsWith('mxc://')) {
-                return { tagName, attribs: {}};
+                if (attribs.alt || attribs.title) {
+                    return { tagName: 'span', text: attribs.alt || attribs.title, attribs: {} };
+                } else {
+                    return { tagName, attribs: {}};
+                }
             }
             attribs.src = MatrixClientPeg.get().mxcUrlToHttp(
                 attribs.src,


### PR DESCRIPTION
- allow width, height, alt, title attributes in img (fixes vector-im/riot-web#4646)
- replace disallowed URL schemes with the alt or title attribute (fixes vector-im/riot-web#4044)

If you want me to split these into two PRs, I can, but I figured that since they're both small, and related, I would put them together.