### PR TITLE
Only apply room pills to matrix.to room links, exclude event links

### DIFF
--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -25,8 +25,8 @@ import { getDisplayAliasForRoom } from '../../../Rooms';
 const REGEX_MATRIXTO = new RegExp(MATRIXTO_URL_PATTERN);
 
 // For URLs of matrix.to links in the timeline which have been reformatted by
-// HttpUtils transformTags to relative links
-const REGEX_LOCAL_MATRIXTO = /^#\/(?:user|room)\/(([\#\!\@\+]).*)$/;
+// HttpUtils transformTags to relative links. This excludes event URLs (with `[^\/]*`)
+const REGEX_LOCAL_MATRIXTO = /^#\/(?:user|room)\/(([\#\!\@\+])[^\/]*)$/;
 
 const Pill = React.createClass({
     statics: {


### PR DESCRIPTION
This fixes vector-im/riot-web#4680
and fixes vector-im/riot-web#4670