### PR TITLE
Fix /join #alias command in markdown mode

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1003,7 +1003,6 @@ export default class MessageComposerInput extends React.Component {
 
     removeMDLinks(contentState: ContentState, prefixes: string[]) {
         const plaintext = contentState.getPlainText();
-        console.info('Removing MD', plaintext);
         if (!plaintext) return '';
         return plaintext.replace(REGEX_MATRIXTO_MARKDOWN_GLOBAL,
         (markdownLink, text, resource, prefix, offset) => {


### PR DESCRIPTION
Tab-completing a room alias inserts a markdown link, which is now stripped before a command is parsed. We also strip the MD links when doing the autocompletion itself (getAutocompleteQuery).

There is still an issue where `/invite` will not work at all with tab-completion - the text of a user Pill is not the userID but rather the display name, which cannot be used as an argument to the command.

fixes https://github.com/vector-im/riot-web/issues/4676