### PR TITLE
Upgrade draft-js from 0.9.1 to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "classnames": "^2.1.2",
     "commonmark": "^0.27.0",
     "counterpart": "^0.18.0",
-    "draft-js": "^0.9.1",
+    "draft-js": "^0.10.1",
     "draft-js-export-html": "^0.5.0",
     "draft-js-export-markdown": "^0.2.0",
     "emojione": "2.2.7",


### PR DESCRIPTION
This fixes vector-im/riot-web#4675

Some APIs have become deprecated in this version but are still usable ( see https://draftjs.org/docs/v0-10-api-migration.html )