### PR TITLE
When sorting completions, use matched string, not entire query

### DIFF
--- a/src/autocomplete/EmojiProvider.js
+++ b/src/autocomplete/EmojiProvider.js
@@ -115,12 +115,12 @@ export default class EmojiProvider extends AutocompleteProvider {
             completions = completions.concat(this.nameMatcher.match(matchedString));
 
             const sorters = [];
-            // First, sort by score (Infinity if query not in shortname)
-            sorters.push((c) => score(query, c.shortname));
-            // If the query is not empty, sort by length of shortname. Example:
-            //  query = ":bookmark"
+            // First, sort by score (Infinity if matchedString not in shortname)
+            sorters.push((c) => score(matchedString, c.shortname));
+            // If the matchedString is not empty, sort by length of shortname. Example:
+            //  matchedString = ":bookmark"
             //  completions = [":bookmark:", ":bookmark_tabs:", ...]
-            if (query.length > 1) {
+            if (matchedString.length > 1) {
                 sorters.push((c) => c.shortname.length);
             }
             // Finally, sort by original ordering

--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -63,9 +63,10 @@ export default class RoomProvider extends AutocompleteProvider {
                     displayedAlias: getDisplayAliasForRoom(room),
                 };
             }));
-            completions = this.matcher.match(command[0]);
+            const matchedString = command[0];
+            completions = this.matcher.match(matchedString);
             completions = _sortBy(completions, [
-                (c) => score(query, c.displayedAlias),
+                (c) => score(matchedString, c.displayedAlias),
                 (c) => c.displayedAlias.length,
             ]).map((room) => {
                 const displayAlias = getDisplayAliasForRoom(room.room) || room.roomId;


### PR DESCRIPTION
Otherwise the results vary depending on where you start autocompleting in your message. We only care about the matched string.