### PR TITLE
Account for `\n` after each block

### DIFF
--- a/src/RichText.js
+++ b/src/RichText.js
@@ -201,10 +201,8 @@ export function selectionStateToTextOffsets(selectionState: SelectionState,
 export function textOffsetsToSelectionState({start, end}: SelectionRange,
                                             contentBlocks: Array<ContentBlock>): SelectionState {
     let selectionState = SelectionState.createEmpty();
-
-    for (let block of contentBlocks) {
-        let blockLength = block.getLength();
-
+    for (const block of contentBlocks) {
+        const blockLength = block.getLength();
         if (start !== -1 && start < blockLength) {
             selectionState = selectionState.merge({
                 anchorKey: block.getKey(),
@@ -212,9 +210,8 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
             });
             start = -1;
         } else {
-            start -= blockLength;
+            start -= blockLength + 1;
         }
-
         if (end !== -1 && end <= blockLength) {
             selectionState = selectionState.merge({
                 focusKey: block.getKey(),
@@ -222,10 +219,9 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
             });
             end = -1;
         } else {
-            end -= blockLength;
+            end -= blockLength + 1;
         }
     }
-
     return selectionState;
 }
 

--- a/src/RichText.js
+++ b/src/RichText.js
@@ -210,7 +210,7 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
             });
             start = -1;
         } else {
-            start -= blockLength + 1;
+            start -= blockLength + 1; // +1 to account for newline between blocks
         }
         if (end !== -1 && end <= blockLength) {
             selectionState = selectionState.merge({
@@ -219,7 +219,7 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
             });
             end = -1;
         } else {
-            end -= blockLength + 1;
+            end -= blockLength + 1; // +1 to account for newline between blocks
         }
     }
     return selectionState;


### PR DESCRIPTION
when converting from text offsets to selection state.

fixes vector-im/riot-web#4728