### PR TITLE
suppressOnHover for member entity tiles which have no onClick

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -333,7 +333,7 @@ module.exports = React.createClass({
                         return;
                     }
                     memberList.push(
-                        <EntityTile key={e.getStateKey()} name={e.getContent().display_name} />
+                        <EntityTile key={e.getStateKey()} name={e.getContent().display_name} suppressOnHover={true} />
                     );
                 });
             }


### PR DESCRIPTION
so that the `>` is not shown on-hover if clicking is a no-op

Fixes https://github.com/vector-im/riot-web/issues/4667