### PR TITLE
Allow default for ctrl+shift+b, ctrl+shift+u in RTE

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -109,8 +109,7 @@ export default class MessageComposerInput extends React.Component {
         if ([KeyCode.KEY_B, KeyCode.KEY_I, KeyCode.KEY_U].includes(e.keyCode) &&
             e.shiftKey && e.ctrlKey
         ) {
-            // When null is returned, draft-js will NOT preventDefault, allowing dev tools
-            // to be toggled when the editor is focussed
+            // When null is returned, draft-js will NOT preventDefault
             return null;
         }
 

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -104,7 +104,11 @@ export default class MessageComposerInput extends React.Component {
         }
 
         // Allow opening of dev tools. getDefaultKeyBinding would be 'italic' for KEY_I
-        if (e.keyCode === KeyCode.KEY_I && e.shiftKey && e.ctrlKey) {
+        // Likewise protect bold and underline (in case some browsers use these as
+        // shortcuts for things).
+        if ([KeyCode.KEY_B, KeyCode.KEY_I, KeyCode.KEY_U].includes(e.keyCode) &&
+            e.shiftKey && e.ctrlKey
+        ) {
             // When null is returned, draft-js will NOT preventDefault, allowing dev tools
             // to be toggled when the editor is focussed
             return null;


### PR DESCRIPTION
fixes vector-im/riot-web#4750