### PR TITLE
Use the rawDisplayName for the user provider completion

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -54,7 +54,9 @@ export default class UserProvider extends AutocompleteProvider {
             completions = this.matcher.match(command[0]).map((user) => {
                 const displayName = (user.name || user.userId || '').replace(' (IRC)', ''); // FIXME when groups are done
                 return {
-                    completion: displayName,
+                    // Length of completion should equal length of text in decorator. draft-js
+                    // relies on the length of the entity === length of the text in the decoration.
+                    completion: user.rawDisplayName,
                     suffix: range.start === 0 ? ': ' : ' ',
                     href: 'https://matrix.to/#/' + user.userId,
                     component: (


### PR DESCRIPTION
to make sure that the length of text in the decoration (See `<Pill>`) is equal to the length of text in the completion (underlying text range that the Entity covers).

fixes vector-im/riot-web#4751