### PR TITLE
Disable widgets prior to release

### DIFF
--- a/src/UserSettingsStore.js
+++ b/src/UserSettingsStore.js
@@ -190,7 +190,7 @@ export default {
 
         const feature = this.getFeatureById(featureId);
         if (!feature) {
-            console.warn('Unknown feature');
+            console.warn(`Unknown feature "${featureId}"`);
             return false;
         }
         // Return the default if this feature has an override to be the default value or

--- a/src/UserSettingsStore.js
+++ b/src/UserSettingsStore.js
@@ -171,22 +171,36 @@ export default {
         localStorage.setItem('mx_local_settings', JSON.stringify(settings));
     },
 
-    isFeatureEnabled: function(feature: string): boolean {
+    getFeatureById(feature: string) {
+        for (let i = 0; i < this.LABS_FEATURES.length; i++) {
+            const f = this.LABS_FEATURES[i];
+            if (f.id === feature) {
+                return f;
+            }
+        }
+        return null;
+    },
+
+    isFeatureEnabled: function(featureId: string): boolean {
         // Disable labs for guests.
         if (MatrixClientPeg.get().isGuest()) return false;
 
-        if (localStorage.getItem(`mx_labs_feature_${feature}`) === null) {
-            for (let i = 0; i < this.LABS_FEATURES.length; i++) {
-                const f = this.LABS_FEATURES[i];
-                if (f.id === feature) {
-                    return f.default;
-                }
-            }
+        const feature = this.getFeatureById(featureId);
+        if (!feature) {
+            console.warn('Unknown feature');
+            return false;
         }
-        return localStorage.getItem(`mx_labs_feature_${feature}`) === 'true';
+        // Return the default if this feature has an override to be the default value or
+        // if the feature has never been toggled and is therefore not in localStorage
+        if (Object.keys(feature).includes('override') ||
+            localStorage.getItem(`mx_labs_feature_${featureId}`) === null
+        ) {
+            return feature.default;
+        }
+        return localStorage.getItem(`mx_labs_feature_${featureId}`) === 'true';
     },
 
-    setFeatureEnabled: function(feature: string, enabled: boolean) {
-        localStorage.setItem(`mx_labs_feature_${feature}`, enabled);
+    setFeatureEnabled: function(featureId: string, enabled: boolean) {
+        localStorage.setItem(`mx_labs_feature_${featureId}`, enabled);
     },
 };

--- a/src/UserSettingsStore.js
+++ b/src/UserSettingsStore.js
@@ -29,6 +29,9 @@ export default {
             name: "-",
             id: 'matrix_apps',
             default: false,
+
+            // XXX: Always use default, ignore localStorage and remove from labs
+            override: true,
         },
     ],
 

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -859,7 +859,13 @@ module.exports = React.createClass({
         if (this.props.enableLabs === false) return null;
         UserSettingsStore.doTranslations();
 
-        const features = UserSettingsStore.LABS_FEATURES.map((feature) => {
+        const features = [];
+        UserSettingsStore.LABS_FEATURES.forEach((feature) => {
+            // This feature has an override and will be set to the default, so do not
+            // show it here.
+            if (feature.override) {
+                return;
+            }
             // TODO: this ought to be a separate component so that we don't need
             // to rebind the onChange each time we render
             const onChange = (e) => {
@@ -867,7 +873,7 @@ module.exports = React.createClass({
                 this.forceUpdate();
             };
 
-            return (
+            features.push(
                 <div key={feature.id} className="mx_UserSettings_toggle">
                     <input
                         type="checkbox"
@@ -880,6 +886,12 @@ module.exports = React.createClass({
                 </div>
             );
         });
+
+        // No labs section when there are no features in labs
+        if (features.length === 0) {
+            return null;
+        }
+
         return (
             <div>
                 <h3>{ _t("Labs") }</h3>

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -883,8 +883,7 @@ module.exports = React.createClass({
                         onChange={ onChange }
                     />
                     <label htmlFor={feature.id}>{feature.name}</label>
-                </div>
-            );
+                </div>);
         });
 
         // No labs section when there are no features in labs


### PR DESCRIPTION
Widgets aren't _quite_ ready for prime-time so this disables them so that we can get RTE etc. out the door.