### PR TITLE
preventDefault when moving autocomplete selection with vertical arrow

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -890,6 +890,7 @@ export default class MessageComposerInput extends React.Component {
             }
         } else {
             this.moveAutocompleteSelection(up);
+            e.preventDefault();
         }
     };
 


### PR DESCRIPTION
Otherwise the composer selection updates, in turn hiding the autocomplete box - fixes vector-im/riot-web#4790