### PR TITLE
Fix bugs in textOffsetsToSelectionState

### DIFF
--- a/src/RichText.js
+++ b/src/RichText.js
@@ -204,24 +204,26 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
     let selectionState = SelectionState.createEmpty();
     for (const block of contentBlocks) {
         const blockLength = block.getLength();
+        // -1 indicating that the position start position has been found
         if (start !== -1) {
             if (start < blockLength + 1) {
                 selectionState = selectionState.merge({
                     anchorKey: block.getKey(),
                     anchorOffset: start,
                 });
-                start = -1;
+                start = -1; // selection state for the start calculated
             } else {
                 start -= blockLength + 1; // +1 to account for newline between blocks
             }
         }
+        // -1 indicating that the position end position has been found
         if (end !== -1) {
             if (end < blockLength + 1) {
                 selectionState = selectionState.merge({
                     focusKey: block.getKey(),
                     focusOffset: end,
                 });
-                end = -1;
+                end = -1; // selection state for the start calculated
             } else {
                 end -= blockLength + 1; // +1 to account for newline between blocks
             }

--- a/src/RichText.js
+++ b/src/RichText.js
@@ -204,23 +204,27 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
     let selectionState = SelectionState.createEmpty();
     for (const block of contentBlocks) {
         const blockLength = block.getLength();
-        if (start !== -1 && start < blockLength) {
-            selectionState = selectionState.merge({
-                anchorKey: block.getKey(),
-                anchorOffset: start,
-            });
-            start = -1;
-        } else {
-            start -= blockLength + 1; // +1 to account for newline between blocks
+        if (start !== -1) {
+            if (start < blockLength + 1) {
+                selectionState = selectionState.merge({
+                    anchorKey: block.getKey(),
+                    anchorOffset: start,
+                });
+                start = -1;
+            } else {
+                start -= blockLength + 1; // +1 to account for newline between blocks
+            }
         }
-        if (end !== -1 && end <= blockLength) {
-            selectionState = selectionState.merge({
-                focusKey: block.getKey(),
-                focusOffset: end,
-            });
-            end = -1;
-        } else {
-            end -= blockLength + 1; // +1 to account for newline between blocks
+        if (end !== -1) {
+            if (end < blockLength + 1) {
+                selectionState = selectionState.merge({
+                    focusKey: block.getKey(),
+                    focusOffset: end,
+                });
+                end = -1;
+            } else {
+                end -= blockLength + 1; // +1 to account for newline between blocks
+            }
         }
     }
     return selectionState;

--- a/src/RichText.js
+++ b/src/RichText.js
@@ -202,6 +202,9 @@ export function selectionStateToTextOffsets(selectionState: SelectionState,
 export function textOffsetsToSelectionState({start, end}: SelectionRange,
                                             contentBlocks: Array<ContentBlock>): SelectionState {
     let selectionState = SelectionState.createEmpty();
+    // Subtract block lengths from `start` and `end` until they are less than the current
+    // block length (accounting for the NL at the end of each block). Set them to -1 to
+    // indicate that the corresponding selection state has been determined.
     for (const block of contentBlocks) {
         const blockLength = block.getLength();
         // -1 indicating that the position start position has been found
@@ -223,7 +226,7 @@ export function textOffsetsToSelectionState({start, end}: SelectionRange,
                     focusKey: block.getKey(),
                     focusOffset: end,
                 });
-                end = -1; // selection state for the start calculated
+                end = -1; // selection state for the end calculated
             } else {
                 end -= blockLength + 1; // +1 to account for newline between blocks
             }


### PR DESCRIPTION
This just had some thinkos in it. Namely the conditionals were slightly wrong and this lead to negative offset selection state being returned, causing vector-im/riot-web#4792

fixes vector-im/riot-web#4792