### PR TITLE
Allow autocompletion when typing user IDs

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -40,7 +40,7 @@ export default class UserProvider extends AutocompleteProvider {
             keys: ['name'],
         });
         this.matcher = new FuzzyMatcher([], {
-            keys: ['name'],
+            keys: ['name', 'userId'],
             shouldMatchPrefix: true,
         });
     }


### PR DESCRIPTION
Because we need to support tab completing `"@some_user"` if `@some_user` has a display name that is totally different and will therefore not match what the user typed in.

This does have the disadvantage of a display name appearing (the pill) that isn't at all what the user typed in, but the autocomplete box and the tooltip should give enough information to let the user know what's going on. (e.g. typing `@kyr*tab*` and getting `Remmy`).

This _does_ run contrary to vector-im/riot-web#4495

related to vector-im/riot-web#4794

cc @lampholder