### PR TITLE
Change OOO so that MELS generation will continue over hidden events

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -341,6 +341,10 @@ module.exports = React.createClass({
 
                     // Ignore redacted/hidden member events
                     if (!this._shouldShowEvent(collapsedMxEv)) {
+                        // If this hidden event is the RM and in or at end of a MELS put RM after MELS.
+                        if (collapsedMxEv.getId() === this.props.readMarkerEventId) {
+                            readMarkerInMels = true;
+                        }
                         continue;
                     }
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -339,6 +339,11 @@ module.exports = React.createClass({
                 for (;i + 1 < this.props.events.length; i++) {
                     const collapsedMxEv = this.props.events[i + 1];
 
+                    // Ignore redacted/hidden member events
+                    if (!this._shouldShowEvent(collapsedMxEv)) {
+                        continue;
+                    }
+
                     if (!isMembershipChange(collapsedMxEv) ||
                         this._wantsDateSeparator(this.props.events[i], collapsedMxEv.getDate())) {
                         break;
@@ -347,11 +352,6 @@ module.exports = React.createClass({
                     // If RM event is in MELS mark it as such and the RM will be appended after MELS.
                     if (collapsedMxEv.getId() === this.props.readMarkerEventId) {
                         readMarkerInMels = true;
-                    }
-
-                    // Ignore redacted/hidden member events
-                    if (!this._shouldShowEvent(collapsedMxEv)) {
-                        continue;
                     }
 
                     summarisedEvents.push(collapsedMxEv);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4716

this fixes the scenario of N Member events, then an invisible event e.g. (m.room.aliases) then more Member events not forming a MELS or forming one on either side of the invisible event.. Pre hide-join-parts this is how it worked.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>