### PR TITLE
Implement TextualEvent tiles for im.vector.modular.widgets

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -250,8 +250,8 @@ function textForPowerEvent(event) {
 
 function textForWidgetEvent(event) {
     const senderName = event.sender ? event.sender.name : event.getSender();
-    const previousContent = event.getPrevContent() ? event.getPrevContent() : {};
-    const {name, type, url} = event.getContent() ? event.getContent() : {};
+    const previousContent = event.getPrevContent() || {};
+    const {name, type, url} = event.getContent() || {};
     let widgetName = widgetName || name || type || previousContent.type || '';
 
     // Apply sentence case

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -248,6 +248,26 @@ function textForPowerEvent(event) {
     });
 }
 
+function textForWidgetEvent(event) {
+    const senderName = event.sender ? event.sender.name : event.getSender();
+    const previousContent = event.getPrevContent() ? event.getPrevContent() : {};
+    const {name, type} = event.getContent() ? event.getContent() : {};
+    let widgetName = widgetName || name || type || previousContent.type || '';
+
+    // Apply sentence case
+    widgetName = widgetName ? widgetName[0].toUpperCase() + widgetName.slice(1).toLowerCase() + ' ' : '';
+
+    if (event.getContent().url) {
+        return _t('%(senderName)s added a %(widgetName)swidget', {
+            senderName, widgetName,
+        });
+    } else {
+        return _t('%(senderName)s removed a %(widgetName)swidget', {
+            senderName, widgetName,
+        });
+    }
+}
+
 var handlers = {
     'm.room.message': textForMessageEvent,
     'm.room.name':    textForRoomNameEvent,
@@ -260,6 +280,8 @@ var handlers = {
     'm.room.history_visibility': textForHistoryVisibilityEvent,
     'm.room.encryption': textForEncryptionEvent,
     'm.room.power_levels': textForPowerEvent,
+
+    'im.vector.modular.widgets': textForWidgetEvent,
 };
 
 module.exports = {

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -251,13 +251,13 @@ function textForPowerEvent(event) {
 function textForWidgetEvent(event) {
     const senderName = event.sender ? event.sender.name : event.getSender();
     const previousContent = event.getPrevContent() ? event.getPrevContent() : {};
-    const {name, type} = event.getContent() ? event.getContent() : {};
+    const {name, type, url} = event.getContent() ? event.getContent() : {};
     let widgetName = widgetName || name || type || previousContent.type || '';
 
     // Apply sentence case
     widgetName = widgetName ? widgetName[0].toUpperCase() + widgetName.slice(1).toLowerCase() + ' ' : '';
 
-    if (event.getContent().url) {
+    if (url) {
         return _t('%(senderName)s added a %(widgetName)swidget', {
             senderName, widgetName,
         });

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -257,6 +257,8 @@ function textForWidgetEvent(event) {
     // Apply sentence case
     widgetName = widgetName ? widgetName[0].toUpperCase() + widgetName.slice(1).toLowerCase() + ' ' : '';
 
+    // If the widget was removed, its content should be {}, but this is sufficiently
+    // equivalent to that condition.
     if (url) {
         return _t('%(senderName)s added a %(widgetName)swidget', {
             senderName, widgetName,

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -44,6 +44,8 @@ var eventTileTypes = {
     'm.room.history_visibility' : 'messages.TextualEvent',
     'm.room.encryption' : 'messages.TextualEvent',
     'm.room.power_levels' : 'messages.TextualEvent',
+
+    'im.vector.modular.widgets': 'messages.TextualEvent',
 };
 
 var MAX_READ_AVATARS = 5;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -969,5 +969,7 @@
     "Automatically replace plain text Emoji": "Automatically replace plain text Emoji",
     "Failed to upload image": "Failed to upload image",
     "Failed to update group": "Failed to update group",
-    "Hide avatars in user and room mentions": "Hide avatars in user and room mentions"
+    "Hide avatars in user and room mentions": "Hide avatars in user and room mentions",
+    "%(senderName)s added a %(widgetName)swidget": "%(senderName)s added a %(widgetName)swidget",
+    "%(senderName)s removed a %(widgetName)swidget": "%(senderName)s removed a %(widgetName)swidget"
 }


### PR DESCRIPTION
E.g. "Bob added a Acme widget", "Susan removed a Giraffe widget"  The name is calculated by taking the `name` in the event content, falling back on the `type`, falling back on the previous content `type`. This is then capitalised.

Should be squash merged.
