### PR TITLE
AppsDrawer: Remove unnecessary bind

### DIFF
--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -64,7 +64,7 @@ module.exports = React.createClass({
             });
         }
 
-        this.dispatcherRef = dis.register(this.onAction.bind(this));
+        this.dispatcherRef = dis.register(this.onAction);
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
When using `React.createClass()`, class methods are automatically bound to the instance.