### PR TITLE
Remove unnecessary 'load' on notif audio element

### DIFF
--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -96,7 +96,6 @@ const Notifier = {
     _playAudioNotification: function(ev, room) {
         const e = document.getElementById("messageAudio");
         if (e) {
-            e.load();
             e.play();
         }
     },


### PR DESCRIPTION
It's not necessary to explicitly load and it throws an exception
if you call it while the element is playing, so better to just
remove it.