### PR TITLE
fix radio for theme selection

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -729,6 +729,7 @@ module.exports = React.createClass({
         // to rebind the onChange each time we render
         const onChange = (e) => {
             if (e.target.checked) {
+                this._syncedSettings[setting.id] = setting.value;
                 UserSettingsStore.setSyncedSetting(setting.id, setting.value);
             }
             dis.dispatch({
@@ -741,7 +742,7 @@ module.exports = React.createClass({
                    type="radio"
                    name={ setting.id }
                    value={ setting.value }
-                   defaultChecked={ this._syncedSettings[setting.id] === setting.value }
+                   checked={ this._syncedSettings[setting.id] === setting.value }
                    onChange={ onChange }
             />
             <label htmlFor={ setting.id + "_" + setting.value }>


### PR DESCRIPTION
* Fixes https://github.com/vector-im/riot-web/issues/4700 *
* Should Fix https://github.com/vector-im/riot-web/issues/4964 *

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

https://github.com/facebook/react/pull/8575 broke it
normally input value/checked should be dumped to state and read from there but this works instead.

onChange now doesn't fire if you don't pass the value into the checked prop anymore.