### PR TITLE
Only add the code copy button for HTML messages

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -393,7 +393,7 @@ export function bodyToHtml(content, highlights, opts) {
         }
         safeBody = sanitizeHtml(body, sanitizeHtmlParams);
         safeBody = unicodeToImage(safeBody);
-        safeBody = addCodeCopyButton(safeBody);
+        if (isHtml) safeBody = addCodeCopyButton(safeBody);
     }
     finally {
         delete sanitizeHtmlParams.textFilter;


### PR DESCRIPTION
Trivial fast-path optimisation: plain text messages cannot possibly contain pre
blocks so there's no point in trying to parse them in order to add code copy
buttons.