### PR TITLE
Consolidate the code copy button

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -393,7 +393,6 @@ export function bodyToHtml(content, highlights, opts) {
         }
         safeBody = sanitizeHtml(body, sanitizeHtmlParams);
         safeBody = unicodeToImage(safeBody);
-        if (isHtml) safeBody = addCodeCopyButton(safeBody);
     }
     finally {
         delete sanitizeHtmlParams.textFilter;
@@ -410,23 +409,6 @@ export function bodyToHtml(content, highlights, opts) {
         'markdown-body': isHtml,
     });
     return <span className={className} dangerouslySetInnerHTML={{ __html: safeBody }} dir="auto" />;
-}
-
-function addCodeCopyButton(safeBody) {
-    // Adds 'copy' buttons to pre blocks
-    // Note that this only manipulates the markup to add the buttons:
-    // we need to add the event handlers once the nodes are in the DOM
-    // since we can't save functions in the markup.
-    // This is done in TextualBody
-    const el = document.createElement("div");
-    el.innerHTML = safeBody;
-    const codeBlocks = Array.from(el.getElementsByTagName("pre"));
-    codeBlocks.forEach(p => {
-        const button = document.createElement("span");
-        button.className = "mx_EventTile_copyButton";
-        p.appendChild(button);
-    });
-    return el.innerHTML;
 }
 
 export function emojifyText(text) {

--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -113,14 +113,17 @@ module.exports = React.createClass({
                     }
                 }, 10);
             }
-            // add event handlers to the 'copy code' buttons
-            const buttons = ReactDOM.findDOMNode(this).getElementsByClassName("mx_EventTile_copyButton");
-            for (let i = 0; i < buttons.length; i++) {
-                buttons[i].onclick = (e) => {
-                    const copyCode = buttons[i].parentNode.getElementsByTagName("code")[0];
+
+            // Add 'copy' buttons to pre blocks
+            ReactDOM.findDOMNode(this).querySelectorAll('.mx_EventTile_body pre').forEach((p) => {
+                const button = document.createElement("span");
+                button.className = "mx_EventTile_copyButton";
+                button.onclick = (e) => {
+                    const copyCode = button.parentNode.getElementsByTagName("code")[0];
                     this.copyToClipboard(copyCode.textContent);
                 };
-            }
+                p.appendChild(button);
+            });
         }
     },
 

--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -114,16 +114,7 @@ module.exports = React.createClass({
                 }, 10);
             }
 
-            // Add 'copy' buttons to pre blocks
-            ReactDOM.findDOMNode(this).querySelectorAll('.mx_EventTile_body pre').forEach((p) => {
-                const button = document.createElement("span");
-                button.className = "mx_EventTile_copyButton";
-                button.onclick = (e) => {
-                    const copyCode = button.parentNode.getElementsByTagName("code")[0];
-                    this.copyToClipboard(copyCode.textContent);
-                };
-                p.appendChild(button);
-            });
+            this._addCodeCopyButton();
         }
     },
 
@@ -258,6 +249,19 @@ module.exports = React.createClass({
                 return true;
             }
         }
+    },
+
+    _addCodeCopyButton() {
+        // Add 'copy' buttons to pre blocks
+        ReactDOM.findDOMNode(this).querySelectorAll('.mx_EventTile_body pre').forEach((p) => {
+            const button = document.createElement("span");
+            button.className = "mx_EventTile_copyButton";
+            button.onclick = (e) => {
+                const copyCode = button.parentNode.getElementsByTagName("code")[0];
+                this.copyToClipboard(copyCode.textContent);
+            };
+            p.appendChild(button);
+        });
     },
 
     onCancelClick: function(event) {


### PR DESCRIPTION
Adding the code code button was done by manipulating the HTML of
the event body to add a span tag, then adding the onclick handler
after the thing was mounted. Apart from splitting the code between
two places, adding the span tag was, according to Chrome's
profiler, taking up quite a lot of CPU cycles (apparently as soon
as you set the innerHTML on a div). Instead, just build the whole
lot together after the component mounts.