### PR TITLE
Update roomlist when an event is decrypted

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -87,6 +87,7 @@ module.exports = React.createClass({
         cli.on("Room.receipt", this.onRoomReceipt);
         cli.on("RoomState.events", this.onRoomStateEvents);
         cli.on("RoomMember.name", this.onRoomMemberName);
+        cli.on("Event.decrypted", this.onEventDecrypted);
         cli.on("accountData", this.onAccountData);
 
         this.refreshRoomList();
@@ -154,6 +155,7 @@ module.exports = React.createClass({
             MatrixClientPeg.get().removeListener("Room.receipt", this.onRoomReceipt);
             MatrixClientPeg.get().removeListener("RoomState.events", this.onRoomStateEvents);
             MatrixClientPeg.get().removeListener("RoomMember.name", this.onRoomMemberName);
+            MatrixClientPeg.get().removeListener("Event.decrypted", this.onEventDecrypted);
             MatrixClientPeg.get().removeListener("accountData", this.onAccountData);
         }
         // cancel any pending calls to the rate_limited_funcs
@@ -220,6 +222,11 @@ module.exports = React.createClass({
     },
 
     onRoomMemberName: function(ev, member) {
+        this._delayedRefreshRoomList();
+    },
+
+    onEventDecrypted: function(ev) {
+        // An event being decrypted may mean we need to re-order the room list
         this._delayedRefreshRoomList();
     },
 


### PR DESCRIPTION
Events are now decrypted asynchronously, so are not decrypted
at the time of the Room.timeline which is when our RoomList
got the chance to update. It needs to update once the event has
been decrypted.

Ideally we would not update the whole room list order, but this is
how all the room list re-ordering happens right now, so staying
consistent with this.

Fixes https://github.com/vector-im/riot-web/issues/5020