### PR TITLE
Remove spurious cancel button

### DIFF
--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -56,7 +56,7 @@ module.exports = React.createClass({
             editing: false,
             inRoom: false,
             onSaveClick: function() {},
-            onCancelClick: function() {},
+            onCancelClick: null,
         };
     },
 


### PR DESCRIPTION
That appeared if you clicked on a room from the room directory
(it didn't do anything). It's only supposed to be shown when
editing room settings.