### PR TITLE
Fix the avatar / room name in room preview

### DIFF
--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -153,6 +153,7 @@ class RoomViewStore extends Store {
                     event_id: payload.event_id,
                     highlighted: payload.highlighted,
                     room_alias: payload.room_alias,
+                    oob_data: payload.oob_data,
                 });
             }, (err) => {
                 dis.dispatch({


### PR DESCRIPTION
When clicking on rooms from the room directory. When RoomViewStore
resolved the room alias, it threw away the out-of-band data in the
process. This must have been broken as part of the ILAG /
RoomViewStore stuff.