### PR TITLE
Support data-mx-border-color on blockquotes

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -160,6 +160,7 @@ const sanitizeHtmlParams = {
         // custom ones first:
         font: ['color', 'data-mx-bg-color', 'data-mx-color', 'style'], // custom to matrix
         span: ['data-mx-bg-color', 'data-mx-color', 'style'], // custom to matrix
+        blockquote: ['data-mx-border-color', 'style'], // custom to matrix
         a: ['href', 'name', 'target', 'rel'], // remote target: custom to matrix
         img: ['src', 'width', 'height', 'alt', 'title'],
         ol: ['start'],
@@ -234,11 +235,11 @@ const sanitizeHtmlParams = {
             // because attributes are stripped after transforming
             delete attribs.style;
 
-            // Sanitise and transform data-mx-color and data-mx-bg-color to their CSS
-            // equivalents
+            // Sanitise and transform custom matrix attributes to their CSS equivalents
             const customCSSMapper = {
                 'data-mx-color': 'color',
                 'data-mx-bg-color': 'background-color',
+                'data-mx-border-color': 'border-color',
                 // $customAttributeKey: $cssAttributeKey
             };
 


### PR DESCRIPTION
This is useful for those looking to create warning, error, or otherwise slightly more colorful notices. 
![image](https://user-images.githubusercontent.com/1190097/30386256-9dd475bc-9866-11e7-8e8c-91434785b6bd.png)
