### PR TITLE
Show who redacted an event on hover

### DIFF
--- a/src/components/views/messages/UnknownBody.js
+++ b/src/components/views/messages/UnknownBody.js
@@ -23,9 +23,14 @@ module.exports = React.createClass({
     displayName: 'UnknownBody',
 
     render: function() {
+        let tooltip = _t("Removed or unknown message type");
+        if (this.props.mxEvent.isRedacted()) {
+            tooltip = _t("Message removed by %(userId)s", {userId: this.props.mxEvent.getSender()});
+        }
+
         const text = this.props.mxEvent.getContent().body;
         return (
-            <span className="mx_UnknownBody" title={_t("Removed or unknown message type")}>
+            <span className="mx_UnknownBody" title={tooltip}>
                 {text}
             </span>
         );

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -827,6 +827,7 @@
     "Autocomplete Delay (ms):": "Autocomplete Delay (ms):",
     "This Home server does not support groups": "This Home server does not support groups",
     "Loading device info...": "Loading device info...",
+    "Message removed by %(userId)s": "Message removed by %(userId)s",
     "Groups": "Groups",
     "Create a new group": "Create a new group",
     "Create Group": "Create Group",

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -838,6 +838,7 @@
     "Autocomplete Delay (ms):": "Autocomplete Delay (ms):",
     "This Home server does not support groups": "This Home server does not support groups",
     "Loading device info...": "Loading device info...",
+    "Message removed by %(userId)s": "Message removed by %(userId)s",
     "Groups": "Groups",
     "Create a new group": "Create a new group",
     "Create Group": "Create Group",


### PR DESCRIPTION
This should fix https://github.com/vector-im/riot-web/issues/3931 although it's not obvious who actually performed the redaction.

Note: Putting the "Message redacted by whoever" in the body just doesn't look very good. This is why the I went with the tooltip.

This PR does not consider collapsing redactions: this feels like a different concern. 

Suggestions welcome on alternatives for displaying this information.