### PR TITLE
Display spinner not room preview after room create

### DIFF
--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -79,12 +79,6 @@ function createRoom(opts) {
     const modal = Modal.createDialog(Loader, null, 'mx_Dialog_spinner');
 
     let roomId;
-    if (opts.andView) {
-        // We will possibly have a successful join, indicate as such
-        dis.dispatch({
-            action: 'will_join',
-        });
-    }
     return client.createRoom(createOpts).finally(function() {
         modal.close();
     }).then(function(res) {
@@ -104,8 +98,10 @@ function createRoom(opts) {
                 action: 'view_room',
                 room_id: roomId,
                 should_peek: false,
-                // Creating a room will have joined us to the room
-                joined: true,
+                // Creating a room will have joined us to the room,
+                // so we are expecting the room to come down the sync
+                // stream, if it hasn't already.
+                joining: true,
             });
         }
         return roomId;

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -119,11 +119,9 @@ class RoomViewStore extends Store {
                 roomLoadError: null,
                 // should peek by default
                 shouldPeek: payload.should_peek === undefined ? true : payload.should_peek,
+                // have we sent a join request for this room and are waiting for a response?
+                joining: payload.joining || false,
             };
-
-            if (payload.joined) {
-                newState.joining = false;
-            }
 
             if (this._state.forwardingEvent) {
                 dis.dispatch({


### PR DESCRIPTION
After creating a room, display the activity spinner while we wait
for the room to come down the event stream.

This was the intention before but I can't see how it would have
worked: we were setting the 'joining' flag, but then resetting it
by claiming we were already joined in the view_room dispatch.

 * Send 'joining' instead of 'joined' in view_room dispatch, which
   will set the corresponding joining flag (ie. to indicate we've
   sent a request to join the room). Remove the 'joined' flag.
 * Reset 'joining' to false otherwise on a view_room dispatch to
   prevent it from leaking between rooms (this may have been the
   intention of the `if (payload.joined) newState.joining = false`?)

Fixes https://github.com/vector-im/riot-web/issues/4701