### PR TITLE
Make /join join again

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -672,7 +672,6 @@ module.exports = React.createClass({
             page_type: PageTypes.RoomView,
             thirdPartyInvite: roomInfo.third_party_invite,
             roomOobData: roomInfo.oob_data,
-            autoJoin: roomInfo.auto_join,
         };
 
         if (roomInfo.room_alias) {

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -134,6 +134,10 @@ class RoomViewStore extends Store {
             }
 
             this._setState(newState);
+
+            if (payload.auto_join) {
+                this._joinRoom(payload);
+            }
         } else if (payload.room_alias) {
             // Resolve the alias and then do a second dispatch with the room ID acquired
             this._setState({
@@ -153,6 +157,7 @@ class RoomViewStore extends Store {
                     event_id: payload.event_id,
                     highlighted: payload.highlighted,
                     room_alias: payload.room_alias,
+                    auto_join: payload.auto_join,
                 });
             }, (err) => {
                 dis.dispatch({


### PR DESCRIPTION
The auto_join parameter to view_room got broken at some point so
/join took you to the room and then sat there like a lemon.

Fixes https://github.com/vector-im/riot-web/issues/5029