### PR TITLE
Fix RoomView stuck in 'accept invite' state

### DIFF
--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -249,11 +249,15 @@ class RoomViewStore extends Store {
     //
     // This flag remains true after the room has been sucessfully joined,
     // (this store doesn't listen for the appropriate member events)
-    // so you should always consider the room to be joined if the user's
-    // member events says they are joined.
+    // so you should always observe the joined state from the member event
+    // if a room object is present.
     // ie. The correct logic is:
-    // if (room && myMember.membership == 'joined') {
-    //     // user is joined to the room
+    // if (room) {
+    //     if (myMember.membership == 'joined') {
+    //         // user is joined to the room
+    //     } else {
+    //         // Not joined
+    //     }
     // } else {
     //     if (RoomViewStore.isJoining()) {
     //         // show spinner


### PR DESCRIPTION
After accepting a 3pid invite.

Rather than clear the joining flag when the join request completes,
leave it so the RoomView can see that we're expecting the user to
be joined in the various stages that might go through (waiting for
join request, waiting for room object, waiting for 'joined' member
event). The problem in this case was that we had to wait a bit for
the last one, and there was no bit of state to represent it.

This hopefully also makes the logic somewhat simpler.

Fixes https://github.com/vector-im/riot-web/issues/5041