### PR TITLE
Separate sender profile into elements with classes

### DIFF
--- a/src/components/views/messages/SenderProfile.js
+++ b/src/components/views/messages/SenderProfile.js
@@ -32,9 +32,9 @@ export default function SenderProfile(props) {
 
     return (
         <div className="mx_SenderProfile" dir="auto" onClick={props.onClick}>
-            <EmojiText>{name || ''}</EmojiText>
+            <EmojiText className="mx_SenderProfile_name">{name || ''}</EmojiText>
             {props.enableFlair ? <Flair userId={mxEvent.getSender()} /> : null}
-            {props.aux ? <EmojiText> {props.aux}</EmojiText> : null}
+            {props.aux ? <EmojiText className="mx_SenderProfile_aux"> {props.aux}</EmojiText> : null}
         </div>
     );
 }


### PR DESCRIPTION
For separate CSS manipulation so that we can vary opacity independently for flair/name/aux

codep https://github.com/vector-im/riot-web/pull/5085

