### PR TITLE
Clean on prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint src/",
     "lintall": "eslint src/ test/",
     "clean": "rimraf lib",
-    "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt",
+    "prepublish": "npm run clean && npm run build && git rev-parse HEAD > git-revision.txt",
     "test": "karma start --single-run=true --browsers ChromeHeadless",
     "test-multi": "karma start"
   },


### PR DESCRIPTION
To avoid any further problems where we ship build files with the
wrong capitalisation because npm is dumb