### PR TITLE
Fix incorrect variable in string

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -877,7 +877,7 @@
     "Room name or alias": "Room name or alias",
     "You are an administrator of this group": "You are an administrator of this group",
     "Failed to remove the room from the summary of %(groupId)s": "Failed to remove the room from the summary of %(groupId)s",
-    "The room '%(roomName)' could not be removed from the summary.": "The room '%(roomName)' could not be removed from the summary.",
+    "The room '%(roomName)s' could not be removed from the summary.": "The room '%(roomName)s' could not be removed from the summary.",
     "Failed to remove a user from the summary of %(groupId)s": "Failed to remove a user from the summary of %(groupId)s",
     "The user '%(displayName)s' could not be removed from the summary.": "The user '%(displayName)s' could not be removed from the summary."
 }


### PR DESCRIPTION
A variable in a translatable string seems to be missing a final "s" to make it work (and match what is in the source code).