### PR TITLE
Fix NPE in MemberList

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -18,12 +18,7 @@ limitations under the License.
 
 import React from 'react';
 import { _t } from '../../../languageHandler';
-import classNames from 'classnames';
-import Matrix from 'matrix-js-sdk';
-import Promise from 'bluebird';
 var MatrixClientPeg = require("../../../MatrixClientPeg");
-var Modal = require("../../../Modal");
-var Entities = require("../../../Entities");
 var sdk = require('../../../index');
 var GeminiScrollbar = require('react-gemini-scrollbar');
 var rate_limited_func = require('../../../ratelimitedfunc');
@@ -36,25 +31,20 @@ module.exports = React.createClass({
     displayName: 'MemberList',
 
     getInitialState: function() {
-        const state = {
-            members: [],
+        this.memberDict = this.getMemberDict();
+        const members = this.roomMembers();
+
+        return {
+            members: members,
+            filteredJoinedMembers: this._filterMembers(members, 'join'),
+            filteredInvitedMembers: this._filterMembers(members, 'invite'),
+
             // ideally we'd size this to the page height, but
             // in practice I find that a little constraining
             truncateAtJoined: INITIAL_LOAD_NUM_MEMBERS,
             truncateAtInvited: INITIAL_LOAD_NUM_INVITED,
             searchQuery: "",
         };
-        if (!this.props.roomId) return state;
-        var cli = MatrixClientPeg.get();
-        var room = cli.getRoom(this.props.roomId);
-        if (!room) return state;
-
-        this.memberDict = this.getMemberDict();
-
-        state.members = this.roomMembers();
-        state.filteredJoinedMembers = this._filterMembers(state.members, 'join');
-        state.filteredInvitedMembers = this._filterMembers(state.members, 'invite');
-        return state;
     },
 
     componentWillMount: function() {


### PR DESCRIPTION
_getChildCountInvited would throw an NPE if invoked before the js-sdk had found
the room. Make sure we initialise the state correctly.

(This seems to have been introduced by #1412)