### PR TITLE
Fix group membership publicity

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -597,9 +597,7 @@ export default React.createClass({
         this.setState({
             publicityBusy: true,
         });
-        MatrixClientPeg.get().setGroupPublicity(this.props.groupId, publicity).then(() => {
-            this._loadGroupFromServer(this.props.groupId);
-        }).then(() => {
+        this._groupSummaryStore.setGroupPublicity(publicity).then(() => {
             this.setState({
                 publicityBusy: false,
             });
@@ -730,16 +728,16 @@ export default React.createClass({
             }
 
             let publicisedSection;
-            if (this.state.summary.user && this.state.summary.user.is_public) {
+            if (this.state.summary.user && this.state.summary.user.is_publicised) {
                 if (!this.state.publicityBusy) {
                     publicisedButton = <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
                             onClick={this._onPubliciseOffClick}
                         >
-                            {_t("Make private")}
+                            {_t("Unpublish")}
                         </AccessibleButton>;
                 }
                 publicisedSection = <div className="mx_GroupView_membershipSubSection">
-                    {_t("Your membership of this group is public")}
+                    {_t("This group is published on your profile")}
                     <div className="mx_GroupView_membership_buttonContainer">
                         {publicisedButton}
                     </div>
@@ -749,11 +747,11 @@ export default React.createClass({
                     publicisedButton = <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
                         onClick={this._onPubliciseOnClick}
                     >
-                        {_t("Make public")}
+                        {_t("Publish")}
                     </AccessibleButton>;
                 }
                 publicisedSection = <div className="mx_GroupView_membershipSubSection">
-                    {_t("Your membership of this group is private")}
+                    {_t("This group is not published on your profile")}
                     <div className="mx_GroupView_membership_buttonContainer">
                         {publicisedButton}
                     </div>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -883,8 +883,8 @@
     "The user '%(displayName)s' could not be removed from the summary.": "The user '%(displayName)s' could not be removed from the summary.",
     "Failed to add the following rooms to the summary of %(groupId)s:": "Failed to add the following rooms to the summary of %(groupId)s:",
     "The room '%(roomName)s' could not be removed from the summary.": "The room '%(roomName)s' could not be removed from the summary.",
-    "Your membership of this group is public": "Your membership of this group is public",
-    "Your membership of this group is private": "Your membership of this group is private",
-    "Make private": "Make private",
-    "Make public": "Make public"
+    "Unpublish": "Unpublish",
+    "This group is published on your profile": "This group is published on your profile",
+    "Publish": "Publish",
+    "This group is not published on your profile": "This group is not published on your profile"
 }

--- a/src/stores/GroupSummaryStore.js
+++ b/src/stores/GroupSummaryStore.js
@@ -69,9 +69,9 @@ export default class GroupSummaryStore extends EventEmitter {
             .then(this._fetchSummary.bind(this));
     }
 
-    setGroupPublicity(is_published) {
+    setGroupPublicity(isPublished) {
         return this._matrixClient
-            .setGroupPublicity(this._groupId, is_published)
+            .setGroupPublicity(this._groupId, isPublished)
             .then(this._fetchSummary.bind(this));
     }
 }

--- a/src/stores/GroupSummaryStore.js
+++ b/src/stores/GroupSummaryStore.js
@@ -68,4 +68,10 @@ export default class GroupSummaryStore extends EventEmitter {
             .removeUserFromGroupSummary(this._groupId, userId)
             .then(this._fetchSummary.bind(this));
     }
+
+    setGroupPublicity(is_published) {
+        return this._matrixClient
+            .setGroupPublicity(this._groupId, is_published)
+            .then(this._fetchSummary.bind(this));
+    }
 }


### PR DESCRIPTION
* Read the new flag in the summary API (the one we were reading
   was actually whether the group server listed you as a member to
   non-members).
 * Remove call to now-dead _loadGroupFromServer andf use the store
   instead