### PR TITLE
Fix ability to feature self in a group summary

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -239,6 +239,7 @@ const RoleUserList = React.createClass({
             button: _t("Add to summary"),
             validAddressTypes: ['mx'],
             groupId: this.props.groupId,
+            shouldOmitSelf: false,
             onFinished: (success, addrs) => {
                 if (!success) return;
                 const errorList = [];

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -41,7 +41,11 @@ module.exports = React.createClass({
         validAddressTypes: PropTypes.arrayOf(PropTypes.oneOf(addressTypes)),
         onFinished: PropTypes.func.isRequired,
         groupId: PropTypes.string,
+        // The type of entity to search for. Default: 'user'.
         pickerType: PropTypes.oneOf(['user', 'room']),
+        // Whether the current user should be omitted from the address returned. Only
+        // applicable when pickerType is `user`. Default: true.
+        shouldOmitSelf: PropTypes.bool,
     },
 
     getDefaultProps: function() {
@@ -50,6 +54,7 @@ module.exports = React.createClass({
             focus: true,
             validAddressTypes: addressTypes,
             pickerType: 'user',
+            shouldOmitSelf: true,
         };
     },
 
@@ -366,7 +371,9 @@ module.exports = React.createClass({
                 });
                 return;
             }
-            if (result.user_id === MatrixClientPeg.get().credentials.userId) {
+            if (this.props.shouldOmitSelf &&
+                result.user_id === MatrixClientPeg.get().credentials.userId
+            ) {
                 return;
             }
 

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -43,9 +43,9 @@ module.exports = React.createClass({
         groupId: PropTypes.string,
         // The type of entity to search for. Default: 'user'.
         pickerType: PropTypes.oneOf(['user', 'room']),
-        // Whether the current user should be omitted from the address returned. Only
-        // applicable when pickerType is `user`. Default: true.
-        shouldOmitSelf: PropTypes.bool,
+        // Whether the current user should be included in the addresses returned. Only
+        // applicable when pickerType is `user`. Default: false.
+        includeSelf: PropTypes.bool,
     },
 
     getDefaultProps: function() {
@@ -54,7 +54,7 @@ module.exports = React.createClass({
             focus: true,
             validAddressTypes: addressTypes,
             pickerType: 'user',
-            shouldOmitSelf: true,
+            includeSelf: false,
         };
     },
 
@@ -371,7 +371,7 @@ module.exports = React.createClass({
                 });
                 return;
             }
-            if (this.props.shouldOmitSelf &&
+            if (!this.props.includeSelf &&
                 result.user_id === MatrixClientPeg.get().credentials.userId
             ) {
                 return;


### PR DESCRIPTION
By default the AddressPicker would omit the currently logged-in user. This adds a property to override that to allow "self" to be picked.