### PR TITLE
Fix ability to invite existing mx users

### DIFF
--- a/src/RoomInvite.js
+++ b/src/RoomInvite.js
@@ -28,7 +28,7 @@ export function inviteToRoom(roomId, addr) {
 
     if (addrType == 'email') {
         return MatrixClientPeg.get().inviteByEmail(roomId, addr);
-    } else if (addrType == 'mx') {
+    } else if (addrType == 'mx-user-id') {
         return MatrixClientPeg.get().invite(roomId, addr);
     } else {
         throw new Error('Unsupported address');


### PR DESCRIPTION
Bug introduced by https://github.com/matrix-org/matrix-react-sdk/pull/1432

We should really not be using string constant literals all over the place. 
We'd be less likely to run into this sort of bug these address types weren't copied literals.