### PR TITLE
Implement button to remove a room from a group

### DIFF
--- a/src/components/views/groups/GroupRoomTile.js
+++ b/src/components/views/groups/GroupRoomTile.js
@@ -67,9 +67,11 @@ const GroupRoomTile = React.createClass({
         e.stopPropagation();
         const groupId = this.props.groupId;
         const roomName = this.state.name;
+        const roomId = this.props.groupRoom.roomId;
         this.context.matrixClient
-            .removeRoomFromGroup(groupId, this.props.groupRoom.roomId)
+            .removeRoomFromGroup(groupId, roomId)
             .catch((err) => {
+                console.error(`Error whilst removing ${roomId} from ${groupId}`, err);
                 const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
                 Modal.createTrackedDialog('Failed to remove room from group', '', ErrorDialog, {
                     title: _t("Failed to remove room from group"),

--- a/src/components/views/groups/GroupRoomTile.js
+++ b/src/components/views/groups/GroupRoomTile.js
@@ -49,6 +49,13 @@ const GroupRoomTile = React.createClass({
         });
     },
 
+    onDeleteClick: function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.context.matrixClient
+            .removeRoomFromGroup(this.props.groupId, this.props.groupRoom.roomId);
+    },
+
     render: function() {
         const BaseAvatar = sdk.getComponent('avatars.BaseAvatar');
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
@@ -76,6 +83,9 @@ const GroupRoomTile = React.createClass({
                 <div className="mx_GroupRoomTile_name">
                     { name }
                 </div>
+                <AccessibleButton className="mx_GroupRoomTile_delete" onClick={this.onDeleteClick}>
+                    <img src="img/cancel-small.svg" />
+                </AccessibleButton>
             </AccessibleButton>
         );
     },

--- a/src/groups.js
+++ b/src/groups.js
@@ -24,8 +24,7 @@ export const GroupMemberType = PropTypes.shape({
 
 export const GroupRoomType = PropTypes.shape({
     name: PropTypes.string,
-    // TODO: API doesn't return this yet
-    // roomId: PropTypes.string.isRequired,
+    roomId: PropTypes.string.isRequired,
     canonicalAlias: PropTypes.string,
     avatarUrl: PropTypes.string,
 });
@@ -41,6 +40,7 @@ export function groupMemberFromApiObject(apiObject) {
 export function groupRoomFromApiObject(apiObject) {
     return {
         name: apiObject.name,
+        roomId: apiObject.room_id,
         canonicalAlias: apiObject.canonical_alias,
         avatarUrl: apiObject.avatar_url,
     };

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -895,5 +895,7 @@
     "Matrix Room ID": "Matrix Room ID",
     "email address": "email address",
     "Try using one of the following valid address types: %(validTypesList)s.": "Try using one of the following valid address types: %(validTypesList)s.",
-    "You have entered an invalid address.": "You have entered an invalid address."
+    "You have entered an invalid address.": "You have entered an invalid address.",
+    "Failed to remove room from group": "Failed to remove room from group",
+    "Failed to remove '%(roomName)s' from %(groupId)s": "Failed to remove '%(roomName)s' from %(groupId)s"
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -897,5 +897,7 @@
     "Try using one of the following valid address types: %(validTypesList)s.": "Try using one of the following valid address types: %(validTypesList)s.",
     "You have entered an invalid address.": "You have entered an invalid address.",
     "Failed to remove room from group": "Failed to remove room from group",
-    "Failed to remove '%(roomName)s' from %(groupId)s": "Failed to remove '%(roomName)s' from %(groupId)s"
+    "Failed to remove '%(roomName)s' from %(groupId)s": "Failed to remove '%(roomName)s' from %(groupId)s",
+    "Are you sure you want to remove '%(roomName)s' from %(groupId)s?": "Are you sure you want to remove '%(roomName)s' from %(groupId)s?",
+    "Removing a room from the group will also remove it from the group page.": "Removing a room from the group will also remove it from the group page."
 }


### PR DESCRIPTION
NB: This doesn't provide any feedback to the user. We should use a GroupSummaryStore-style component to refresh the view after a successful hit to the API. This could affect the summary view as well, because when rooms are removed from a group, they are also removed from the summary (if necessary).

CSS at https://github.com/vector-im/riot-web/pull/5141