### PR TITLE
Factor-out GroupStore and create GroupStoreCache

### DIFF
--- a/src/GroupAddressPicker.js
+++ b/src/GroupAddressPicker.js
@@ -19,6 +19,7 @@ import sdk from './';
 import MultiInviter from './utils/MultiInviter';
 import { _t } from './languageHandler';
 import MatrixClientPeg from './MatrixClientPeg';
+import GroupStoreCache from './stores/GroupStoreCache';
 
 export function showGroupInviteDialog(groupId) {
     const AddressPickerDialog = sdk.getComponent("dialogs.AddressPickerDialog");
@@ -86,10 +87,11 @@ function _onGroupInviteFinished(groupId, addrs) {
 }
 
 function _onGroupAddRoomFinished(groupId, addrs) {
+    const groupStore = GroupStoreCache.getGroupStore(MatrixClientPeg.get(), groupId);
     const errorList = [];
     return Promise.all(addrs.map((addr) => {
-        return MatrixClientPeg.get()
-            .addRoomToGroup(groupId, addr.address)
+        return groupStore
+            .addRoomToGroup(addr.address)
             .catch(() => { errorList.push(addr.address); })
             .reflect();
     })).then(() => {

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -18,7 +18,7 @@ import EventEmitter from 'events';
 
 /**
  * Stores the group summary for a room and provides an API to change it and
- * other useful group APIs may have an effect on the group summary.
+ * other useful group APIs that may have an effect on the group summary.
  */
 export default class GroupStore extends EventEmitter {
     constructor(matrixClient, groupId) {

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -17,9 +17,10 @@ limitations under the License.
 import EventEmitter from 'events';
 
 /**
- * Stores the group summary for a room and provides an API to change it
+ * Stores the group summary for a room and provides an API to change it and
+ * other useful group APIs may have an effect on the group summary.
  */
-export default class GroupSummaryStore extends EventEmitter {
+export default class GroupStore extends EventEmitter {
     constructor(matrixClient, groupId) {
         super();
         this._groupId = groupId;
@@ -43,6 +44,11 @@ export default class GroupSummaryStore extends EventEmitter {
 
     getSummary() {
         return this._summary;
+    }
+
+    addRoomToGroup(roomId) {
+        return this._matrixClient
+            .addRoomToGroup(this._groupId, roomId);
     }
 
     addRoomToGroupSummary(roomId, categoryId) {

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -23,14 +23,14 @@ import EventEmitter from 'events';
 export default class GroupStore extends EventEmitter {
     constructor(matrixClient, groupId) {
         super();
-        this._groupId = groupId;
+        this.groupId = groupId;
         this._matrixClient = matrixClient;
         this._summary = {};
         this._fetchSummary();
     }
 
     _fetchSummary() {
-        this._matrixClient.getGroupSummary(this._groupId).then((resp) => {
+        this._matrixClient.getGroupSummary(this.groupId).then((resp) => {
             this._summary = resp;
             this._notifyListeners();
         }).catch((err) => {
@@ -48,36 +48,36 @@ export default class GroupStore extends EventEmitter {
 
     addRoomToGroup(roomId) {
         return this._matrixClient
-            .addRoomToGroup(this._groupId, roomId);
+            .addRoomToGroup(this.groupId, roomId);
     }
 
     addRoomToGroupSummary(roomId, categoryId) {
         return this._matrixClient
-            .addRoomToGroupSummary(this._groupId, roomId, categoryId)
+            .addRoomToGroupSummary(this.groupId, roomId, categoryId)
             .then(this._fetchSummary.bind(this));
     }
 
     addUserToGroupSummary(userId, roleId) {
         return this._matrixClient
-            .addUserToGroupSummary(this._groupId, userId, roleId)
+            .addUserToGroupSummary(this.groupId, userId, roleId)
             .then(this._fetchSummary.bind(this));
     }
 
     removeRoomFromGroupSummary(roomId) {
         return this._matrixClient
-            .removeRoomFromGroupSummary(this._groupId, roomId)
+            .removeRoomFromGroupSummary(this.groupId, roomId)
             .then(this._fetchSummary.bind(this));
     }
 
     removeUserFromGroupSummary(userId) {
         return this._matrixClient
-            .removeUserFromGroupSummary(this._groupId, userId)
+            .removeUserFromGroupSummary(this.groupId, userId)
             .then(this._fetchSummary.bind(this));
     }
 
     setGroupPublicity(isPublished) {
         return this._matrixClient
-            .setGroupPublicity(this._groupId, isPublished)
+            .setGroupPublicity(this.groupId, isPublished)
             .then(this._fetchSummary.bind(this));
     }
 }

--- a/src/stores/GroupStoreCache.js
+++ b/src/stores/GroupStoreCache.js
@@ -22,7 +22,7 @@ class GroupStoreCache {
     }
 
     getGroupStore(matrixClient, groupId) {
-        if (!this.groupStore || this.groupStore._groupId !== groupId) {
+        if (!this.groupStore || this.groupStore.groupId !== groupId) {
             // This effectively throws away the reference to any previous GroupStore,
             // allowing it to be GCd once the components referencing it have stopped
             // referencing it.

--- a/src/stores/GroupStoreCache.js
+++ b/src/stores/GroupStoreCache.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import GroupStore from './GroupStore';
+
+class GroupStoreCache {
+    constructor() {
+        this.groupStores = {};
+    }
+
+    getGroupStore(matrixClient, groupId) {
+        if (!this.groupStores[groupId]) {
+            this.groupStores[groupId] = new GroupStore(matrixClient, groupId);
+        }
+        return this.groupStores[groupId];
+    }
+}
+
+
+let singletonGroupStoreCache = null;
+if (!singletonGroupStoreCache) {
+    singletonGroupStoreCache = new GroupStoreCache();
+}
+module.exports = singletonGroupStoreCache;

--- a/src/stores/GroupStoreCache.js
+++ b/src/stores/GroupStoreCache.js
@@ -18,17 +18,19 @@ import GroupStore from './GroupStore';
 
 class GroupStoreCache {
     constructor() {
-        this.groupStores = {};
+        this.groupStore = null;
     }
 
     getGroupStore(matrixClient, groupId) {
-        if (!this.groupStores[groupId]) {
-            this.groupStores[groupId] = new GroupStore(matrixClient, groupId);
+        if (!this.groupStore || this.groupStore._groupId !== groupId) {
+            // This effectively throws away the reference to any previous GroupStore,
+            // allowing it to be GCd once the components referencing it have stopped
+            // referencing it.
+            this.groupStore = new GroupStore(matrixClient, groupId);
         }
-        return this.groupStores[groupId];
+        return this.groupStore;
     }
 }
-
 
 let singletonGroupStoreCache = null;
 if (!singletonGroupStoreCache) {


### PR DESCRIPTION
In order to provide feedback when adding a room to a group, the group summarry store needs to be extended to store the list of rooms in a group. This commit is the first step required.

The next step is to get the GroupRoomList listening to updates from GroupStore and expose the list of rooms from GroupStore.

(We're running out of words to describe the hierachy of things that store things)