### PR TITLE
Support third party integration managers in AppPermission

### DIFF
--- a/src/WidgetUtils.js
+++ b/src/WidgetUtils.js
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 import MatrixClientPeg from './MatrixClientPeg';
+import SdkConfig from "./SdkConfig";
+import * as url from "url";
 
 export default class WidgetUtils {
     /* Returns true if user is able to send state events to modify widgets in this room
@@ -54,5 +56,38 @@ export default class WidgetUtils {
         }
 
         return room.currentState.maySendStateEvent('im.vector.modular.widgets', me);
+    }
+
+    /**
+     * Returns true if specified url is a scalar URL, typically https://scalar.vector.im/api
+     * @param  {[type]}  testUrlString URL to check
+     * @return {Boolean} True if specified URL is a scalar URL
+     */
+    static isScalarUrl(testUrlString) {
+        if (!testUrlString) {
+            console.error('Scalar URL check failed. No URL specified');
+            return false;
+        }
+
+        const testUrl = url.parse(testUrlString);
+
+        let scalarUrls = SdkConfig.get().integrations_widgets_urls;
+        if (!scalarUrls || scalarUrls.length === 0) {
+            scalarUrls = [SdkConfig.get().integrations_rest_url];
+        }
+
+        for (let i = 0; i < scalarUrls.length; i++) {
+            const scalarUrl = url.parse(scalarUrls[i]);
+            if (testUrl && scalarUrl) {
+                if (
+                    testUrl.protocol === scalarUrl.protocol &&
+                    testUrl.host === scalarUrl.host &&
+                    testUrl.pathname.startsWith(scalarUrl.pathname)
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/components/views/elements/AppPermission.js
+++ b/src/components/views/elements/AppPermission.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import url from 'url';
 import { _t } from '../../../languageHandler';
+import SdkConfig from '../../../SdkConfig';
 
 export default class AppPermission extends React.Component {
     constructor(props) {
@@ -34,14 +35,21 @@ export default class AppPermission extends React.Component {
     }
 
     isScalarWurl(wurl) {
-        if (wurl && wurl.hostname && (
-            wurl.hostname === 'scalar.vector.im' ||
-            wurl.hostname === 'scalar-staging.riot.im' ||
-            wurl.hostname === 'scalar-develop.riot.im' ||
-            wurl.hostname === 'demo.riot.im' ||
-            wurl.hostname === 'localhost'
-        )) {
-            return true;
+        // Exit early if we've been given bad data
+        if (!wurl) {
+            return false;
+        }
+
+        let scalarUrls = SdkConfig.get().integrations_widgets_urls;
+        if (!scalarUrls || scalarUrls.length == 0) {
+            scalarUrls = [SdkConfig.get().integrations_rest_url];
+        }
+
+        const url = wurl.format();
+        for (const scalarUrl of scalarUrls) {
+            if (url.startsWith(scalarUrl)) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/components/views/elements/AppPermission.js
+++ b/src/components/views/elements/AppPermission.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import url from 'url';
 import { _t } from '../../../languageHandler';
 import SdkConfig from '../../../SdkConfig';
+import WidgetUtils from "../../../WidgetUtils";
 
 export default class AppPermission extends React.Component {
     constructor(props) {
@@ -20,7 +21,7 @@ export default class AppPermission extends React.Component {
 
         const searchParams = new URLSearchParams(wurl.search);
 
-        if (this.isScalarWurl(wurl) && searchParams && searchParams.get('url')) {
+        if (WidgetUtils.isScalarUrl(wurl) && searchParams && searchParams.get('url')) {
             curl = url.parse(searchParams.get('url'));
             if (curl) {
                 curl.search = curl.query = "";
@@ -32,26 +33,6 @@ export default class AppPermission extends React.Component {
             curlString = wurl.format();
         }
         return curlString;
-    }
-
-    isScalarWurl(wurl) {
-        // Exit early if we've been given bad data
-        if (!wurl) {
-            return false;
-        }
-
-        let scalarUrls = SdkConfig.get().integrations_widgets_urls;
-        if (!scalarUrls || scalarUrls.length == 0) {
-            scalarUrls = [SdkConfig.get().integrations_rest_url];
-        }
-
-        const url = wurl.format();
-        for (const scalarUrl of scalarUrls) {
-            if (url.startsWith(scalarUrl)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     render() {

--- a/src/components/views/elements/AppPermission.js
+++ b/src/components/views/elements/AppPermission.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import url from 'url';
 import { _t } from '../../../languageHandler';
-import SdkConfig from '../../../SdkConfig';
 import WidgetUtils from "../../../WidgetUtils";
 
 export default class AppPermission extends React.Component {

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -25,7 +25,6 @@ import PlatformPeg from '../../../PlatformPeg';
 import ScalarAuthClient from '../../../ScalarAuthClient';
 import WidgetMessaging from '../../../WidgetMessaging';
 import TintableSvgButton from './TintableSvgButton';
-import SdkConfig from '../../../SdkConfig';
 import Modal from '../../../Modal';
 import { _t, _td } from '../../../languageHandler';
 import sdk from '../../../index';

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -121,39 +121,6 @@ export default class AppTile extends React.Component {
         return u.format();
     }
 
-    /**
-     * Returns true if specified url is a scalar URL, typically https://scalar.vector.im/api
-     * @param  {[type]}  testUrlString URL to check
-     * @return {Boolean} True if specified URL is a scalar URL
-     */
-    isScalarUrl(testUrlString) {
-        if (!testUrlString) {
-            console.error('Scalar URL check failed. No URL specified');
-            return false;
-        }
-
-        const testUrl = url.parse(testUrlString);
-
-        let scalarUrls = SdkConfig.get().integrations_widgets_urls;
-        if (!scalarUrls || scalarUrls.length == 0) {
-            scalarUrls = [SdkConfig.get().integrations_rest_url];
-        }
-
-        for (let i = 0; i < scalarUrls.length; i++) {
-            const scalarUrl = url.parse(scalarUrls[i]);
-            if (testUrl && scalarUrl) {
-                if (
-                    testUrl.protocol === scalarUrl.protocol &&
-                    testUrl.host === scalarUrl.host &&
-                    testUrl.pathname.startsWith(scalarUrl.pathname)
-                ) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     isMixedContent() {
         const parentContentProtocol = window.location.protocol;
         const u = url.parse(this.props.url);
@@ -209,7 +176,7 @@ export default class AppTile extends React.Component {
     setScalarToken() {
         this.setState({initialising: true});
 
-        if (!this.isScalarUrl(this.props.url)) {
+        if (!WidgetUtils.isScalarUrl(this.props.url)) {
             console.warn('Non-scalar widget, not setting scalar token!', url);
             this.setState({
                 error: null,


### PR DESCRIPTION
3rd party integration managers should be able to have their widgets displayed in a friendly manner for clients that opt to use their interface. Currently, users are left in the dark if they decide to use a third party manager, as shown below. 
![image](https://user-images.githubusercontent.com/1190097/31364616-40550510-ad23-11e7-825e-c2c7e3dc285b.png)

Having the URLs hardcoded to Scalar URLs is a bit frustrating, as it goes completely against the logic in AppTile, which checks against the current configuration instead. The configuration check has been implemented here.