### PR TITLE
Option to suggest a username from the URL

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -52,6 +52,8 @@ export default React.createClass({
 
         teamToken: React.PropTypes.string,
 
+        suggestedUsername: React.PropTypes.string,
+
         // and lots and lots of other stuff.
     },
 
@@ -242,6 +244,7 @@ export default React.createClass({
                         opacity={this.props.middleOpacity}
                         collapsedRhs={this.props.collapseRhs}
                         ConferenceHandler={this.props.ConferenceHandler}
+                        suggestedUsername={this.props.suggestedUsername}
                     />;
                 if (!this.props.collapseRhs) right_panel = <RightPanel roomId={this.props.currentRoomId} opacity={this.props.rightOpacity} />;
                 break;

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -161,6 +161,8 @@ module.exports = React.createClass({
             register_hs_url: null,
             register_is_url: null,
             register_id_sid: null,
+
+            username_template: null,
         };
         return s;
     },
@@ -172,6 +174,18 @@ module.exports = React.createClass({
             config: {},
             onTokenLoginCompleted: () => {},
         };
+    },
+
+    getSuggestedUsername: function() {
+        if (!this.state.username_template) return "";
+
+        const replaceChar = "."; // arbitrary choice from web IRC clients
+        let username = this.state.username_template;
+        while (username.includes(replaceChar)) {
+            username = username.replace(replaceChar, Math.floor(Math.random() * 10)); // 0-9
+        }
+
+        return username;
     },
 
     getCurrentHsUrl: function() {
@@ -265,6 +279,15 @@ module.exports = React.createClass({
             console.log('Setting register_hs_url ', paramHs);
             this.setState({
                 register_hs_url: paramHs,
+            });
+        }
+
+        // Grab a username template from the query string
+        const usernameTemplate = this.props.startingFragmentQueryParams.username_template;
+        if (usernameTemplate) {
+            console.log('Setting username_template ' + usernameTemplate);
+            this.setState({
+                username_template: usernameTemplate,
             });
         }
 
@@ -722,6 +745,7 @@ module.exports = React.createClass({
     _setMxId: function(payload) {
         const SetMxIdDialog = sdk.getComponent('views.dialogs.SetMxIdDialog');
         const close = Modal.createTrackedDialog('Set MXID', '', SetMxIdDialog, {
+            suggestedUsername: this.getSuggestedUsername(),
             homeserverUrl: MatrixClientPeg.get().getHomeserverUrl(),
             onFinished: (submitted, credentials) => {
                 if (!submitted) {
@@ -1438,6 +1462,7 @@ module.exports = React.createClass({
                         onRegistered={this.onRegistered}
                         currentRoomId={this.state.currentRoomId}
                         teamToken={this._teamToken}
+                        suggestedUsername={this.getSuggestedUsername()}
                         {...this.props}
                         {...this.state}
                     />
@@ -1465,6 +1490,7 @@ module.exports = React.createClass({
                     idSid={this.state.register_id_sid}
                     email={this.props.startingFragmentQueryParams.email}
                     referrer={this.props.startingFragmentQueryParams.referrer}
+                    suggestedUsername={this.getSuggestedUsername()}
                     defaultHsUrl={this.getDefaultHsUrl()}
                     defaultIsUrl={this.getDefaultIsUrl()}
                     brand={this.props.config.brand}

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -88,6 +88,8 @@ module.exports = React.createClass({
 
         // is the RightPanel collapsed?
         collapsedRhs: React.PropTypes.bool,
+
+        suggestedUsername: React.PropTypes.string,
     },
 
     getInitialState: function() {
@@ -837,6 +839,7 @@ module.exports = React.createClass({
 
             const SetMxIdDialog = sdk.getComponent('views.dialogs.SetMxIdDialog');
             const close = Modal.createTrackedDialog('Set MXID', '', SetMxIdDialog, {
+                suggestedUsername: this.props.suggestedUsername,
                 homeserverUrl: cli.getHomeserverUrl(),
                 onFinished: (submitted, credentials) => {
                     if (submitted) {

--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -38,6 +38,7 @@ module.exports = React.createClass({
         sessionId: React.PropTypes.string,
         makeRegistrationUrl: React.PropTypes.func.isRequired,
         idSid: React.PropTypes.string,
+        suggestedUsername: React.PropTypes.string,
         customHsUrl: React.PropTypes.string,
         customIsUrl: React.PropTypes.string,
         defaultHsUrl: React.PropTypes.string,
@@ -73,6 +74,7 @@ module.exports = React.createClass({
             // them in this component's state since this component
             // persist for the duration of the registration process.
             formVals: {
+                username: this.props.suggestedUsername,
                 email: this.props.email,
             },
             // true if we're waiting for the user to complete

--- a/src/components/views/dialogs/SetMxIdDialog.js
+++ b/src/components/views/dialogs/SetMxIdDialog.js
@@ -35,6 +35,8 @@ const USERNAME_CHECK_DEBOUNCE_MS = 250;
 export default React.createClass({
     displayName: 'SetMxIdDialog',
     propTypes: {
+        suggestedUsername: React.PropTypes.string,
+
         onFinished: React.PropTypes.func.isRequired,
         // Called when the user requests to register with a different homeserver
         onDifferentServerClicked: React.PropTypes.func.isRequired,
@@ -45,7 +47,7 @@ export default React.createClass({
     getInitialState: function() {
         return {
             // The entered username
-            username: '',
+            username: this.props.suggestedUsername || '',
             // Indicate ongoing work on the username
             usernameBusy: false,
             // Indicate error with username


### PR DESCRIPTION
Useful for sites that want to put in an easy link for their chat, similar to IRC webclients. Adds vector-im/riot-web#1549

Example: `https://riot.im/develop/#/register?username_template=MyPrefix...`
Periods become numbers (0-9) like most IRC web clients.

Works with ILAG (which is why the suggested username is thrown around so much).