### PR TITLE
Fix bug that inserted emoji when typing

### DIFF
--- a/src/components/views/rooms/Autocomplete.js
+++ b/src/components/views/rooms/Autocomplete.js
@@ -233,7 +233,7 @@ export default class Autocomplete extends React.Component {
                 const componentPosition = position;
                 position++;
 
-                const onMouseOver = () => this.setSelection(componentPosition);
+                const onMouseMove = () => this.setSelection(componentPosition);
                 const onClick = () => {
                     this.setSelection(componentPosition);
                     this.onCompletionClicked();
@@ -243,7 +243,7 @@ export default class Autocomplete extends React.Component {
                     key: i,
                     ref: `completion${position - 1}`,
                     className,
-                    onMouseOver,
+                    onMouseMove,
                     onClick,
                 });
             });


### PR DESCRIPTION
This was quite simple in the end -- the mouse doens't move, but on some browsers, the autocomplete appearing beneath the mouse would cause the `onMouseOver`, which is not `onMouseMove`.

The fix was to use `onMouseMove`.

Fixes vector-im/riot-web#4974