### PR TITLE
Don't show labs features by default

### DIFF
--- a/src/UserSettingsStore.js
+++ b/src/UserSettingsStore.js
@@ -38,7 +38,8 @@ export default {
 
         return FEATURES.filter((f) => {
             const sdkConfigValue = featuresConfig[f.id];
-            if (!['enable', 'disable'].includes(sdkConfigValue)) {
+
+            if (sdkConfigValue === 'labs') {
                 return true;
             }
         }).map((f) => {


### PR DESCRIPTION
Previous PR disabled them but still showed the (broken) option