### PR TITLE
Shuffle GroupView UI

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -739,20 +739,22 @@ export default React.createClass({
             }
 
             return <div className="mx_GroupView_membershipSection mx_GroupView_membershipSection_invited">
-                <div className="mx_GroupView_membershipSection_description">
-                    { _t("%(inviter)s has invited you to join this group", {inviter: group.inviter.userId}) }
-                </div>
-                <div className="mx_GroupView_membership_buttonContainer">
-                    <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
-                        onClick={this._onAcceptInviteClick}
-                    >
-                        { _t("Accept") }
-                    </AccessibleButton>
-                    <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
-                        onClick={this._onRejectInviteClick}
-                    >
-                        { _t("Decline") }
-                    </AccessibleButton>
+                <div className="mx_GroupView_membershipSubSection">
+                    <div className="mx_GroupView_membershipSection_description">
+                        { _t("%(inviter)s has invited you to join this group", {inviter: group.inviter.userId}) }
+                    </div>
+                    <div className="mx_GroupView_membership_buttonContainer">
+                        <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
+                            onClick={this._onAcceptInviteClick}
+                        >
+                            { _t("Accept") }
+                        </AccessibleButton>
+                        <AccessibleButton className="mx_GroupView_textButton mx_RoomHeader_textButton"
+                            onClick={this._onRejectInviteClick}
+                        >
+                            { _t("Decline") }
+                        </AccessibleButton>
+                    </div>
                 </div>
             </div>;
         } else if (group.myMembership === 'join') {

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -450,6 +450,8 @@ export default React.createClass({
         this._groupStore.on('update', () => {
             this.setState({
                 summary: this._groupStore.getSummary(),
+                isGroupPublicised: this._groupStore.getGroupPublicity(),
+                isUserPrivileged: this._groupStore.isUserPrivileged(),
                 error: null,
             });
         });

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -757,7 +757,7 @@ export default React.createClass({
                     </div>
                 </div>
             </div>;
-        } else if (group.myMembership === 'join') {
+        } else if (group.myMembership === 'join' && this.state.editing) {
             let youAreAMemberText = _t("You are a member of this group");
             if (this.state.summary.user && this.state.summary.user.is_privileged) {
                 youAreAMemberText = _t("You are an administrator of this group");

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -890,6 +890,7 @@ export default React.createClass({
                     </AccessibleButton>,
                 );
                 bodyNodes = [
+                    this._getMembershipSection(),
                     <textarea className="mx_GroupView_editLongDesc"
                         value={this.state.profileForm.long_description}
                         onChange={this._onLongDescChange}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -927,5 +927,9 @@
     "%(serverName)s Matrix ID": "%(serverName)s Matrix ID",
     "Add rooms to this group": "Add rooms to this group",
     "Invites sent": "Invites sent",
-    "Your group invitations have been sent.": "Your group invitations have been sent."
+    "Your group invitations have been sent.": "Your group invitations have been sent.",
+    "Publish this community on your profile": "Publish this community on your profile",
+    "Community Member Settings": "Community Member Settings",
+    "Long Description (HTML)": "Long Description (HTML)",
+    "Community Settings": "Community Settings"
 }

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -61,6 +61,14 @@ export default class GroupStore extends EventEmitter {
         return this._rooms;
     }
 
+    getGroupPublicity() {
+        return this._summary.user ? this._summary.user.is_publicised : null;
+    }
+
+    isUserPrivileged() {
+        return this._summary.user ? this._summary.user.is_privileged : null;
+    }
+
     addRoomToGroup(roomId) {
         return this._matrixClient
             .addRoomToGroup(this.groupId, roomId)


### PR DESCRIPTION
 - Put invite accept/decline buttons in correct div to align them to the right
 - Move membership section above long description textarea and only show membership settings when editing
 - Add useful functions to GroupView to inspect user flags
 - The "Leave" button is now in the top-right
 - The "Publish" button is not a checkbox

Fixes vector-im/riot-web#5304, vector-im/riot-web#5220, vector-im/riot-web#5210