### PR TITLE
Group create dialog: only enter localpart

### DIFF
--- a/src/components/views/dialogs/CreateGroupDialog.js
+++ b/src/components/views/dialogs/CreateGroupDialog.js
@@ -21,10 +21,6 @@ import dis from '../../../dispatcher';
 import { _t } from '../../../languageHandler';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 
-// We match fairly liberally and leave it up to the server to reject if
-// there are invalid characters etc.
-const GROUP_REGEX = /^\+(.*?):(.*)$/;
-
 export default React.createClass({
     displayName: 'CreateGroupDialog',
     propTypes: {
@@ -150,7 +146,7 @@ export default React.createClass({
                                     onBlur={this._onGroupIdBlur}
                                     value={this.state.groupId}
                                 />
-                                <span>:{MatrixClientPeg.get().getDomain()}</span>
+                                <span>:{ MatrixClientPeg.get().getDomain() }</span>
                             </div>
                         </div>
                         <div className="error">

--- a/src/components/views/dialogs/CreateGroupDialog.js
+++ b/src/components/views/dialogs/CreateGroupDialog.js
@@ -58,26 +58,9 @@ export default React.createClass({
     },
 
     _checkGroupId: function(e) {
-        const parsedGroupId = this._parseGroupId(this.state.groupId);
         let error = null;
-        if (parsedGroupId === null) {
-            error = _t(
-                "Community IDs must be of the form +localpart:%(domain)s",
-                {domain: MatrixClientPeg.get().getDomain()},
-            );
-        } else {
-            const groupId = parsedGroupId[0];
-            const domain = parsedGroupId[1];
-
-            if (!/^[a-zA-Z0-9]*$/.test(groupId)) {
-                error = _t("Community IDs may only contain alphanumeric characters");
-            } else if (domain !== MatrixClientPeg.get().getDomain()) {
-                error = _t(
-                    "It is currently only possible to create communities on your own home server: "+
-                    "use a community ID ending with %(domain)s",
-                    {domain: MatrixClientPeg.get().getDomain()},
-                );
-            }
+        if (!/^[a-zA-Z0-9]*$/.test(this.state.groupId)) {
+            error = _t("Community IDs may only contain alphanumeric characters");
         }
         this.setState({
             groupIdError: error,
@@ -90,14 +73,13 @@ export default React.createClass({
 
         if (this._checkGroupId()) return;
 
-        const parsedGroupId = this._parseGroupId(this.state.groupId);
         const profile = {};
         if (this.state.groupName !== '') {
             profile.name = this.state.groupName;
         }
         this.setState({creating: true});
         MatrixClientPeg.get().createGroup({
-            localpart: parsedGroupId[0],
+            localpart: this.state.groupId,
             profile: profile,
         }).then((result) => {
             dis.dispatch({
@@ -114,22 +96,6 @@ export default React.createClass({
 
     _onCancel: function() {
         this.props.onFinished(false);
-    },
-
-    /**
-     * Parse a string that may be a group ID
-     * If the string is a valid group ID, return a list of [localpart, domain],
-     * otherwise return null.
-     *
-     * @param {string} groupId The ID of the group
-     * @return {string[]} array of localpart, domain
-     */
-    _parseGroupId: function(groupId) {
-        const matches = GROUP_REGEX.exec(this.state.groupId);
-        if (!matches || matches.length < 3) {
-            return null;
-        }
-        return [matches[1], matches[2]];
     },
 
     render: function() {
@@ -176,13 +142,15 @@ export default React.createClass({
                                 <label htmlFor="groupid">{ _t('Community ID') }</label>
                             </div>
                             <div>
+                                <span>+</span>
                                 <input id="groupid" className="mx_CreateGroupDialog_input"
-                                    size="64"
-                                    placeholder={_t('+example:%(domain)s', {domain: MatrixClientPeg.get().getDomain()})}
+                                    size="32"
+                                    placeholder={_t('example')}
                                     onChange={this._onGroupIdChange}
                                     onBlur={this._onGroupIdBlur}
                                     value={this.state.groupId}
                                 />
+                                <span>:{MatrixClientPeg.get().getDomain()}</span>
                             </div>
                         </div>
                         <div className="error">

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -590,7 +590,7 @@
     "Community Name": "Community Name",
     "Example": "Example",
     "Community ID": "Community ID",
-    "+example:%(domain)s": "+example:%(domain)s",
+    "example": "example",
     "Create": "Create",
     "Create Room": "Create Room",
     "Room name (optional)": "Room name (optional)",


### PR DESCRIPTION
Since we currently can only create groups on the local server anyway,
there's no point making the user jump through the hoop of forming the
whole group ID and telling them off if they got the server name wrong.