### PR TITLE
Invalidate the user's public groups cache when changing group publicity

### DIFF
--- a/src/stores/FlairStore.js
+++ b/src/stores/FlairStore.js
@@ -56,6 +56,10 @@ class FlairStore extends EventEmitter {
         return groupSupport;
     }
 
+    invalidatePublicisedGroups(userId) {
+        delete this._userGroups[userId];
+    }
+
     getPublicisedGroupsCached(matrixClient, userId) {
         if (this._userGroups[userId]) {
             return Promise.resolve(this._userGroups[userId]);

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import EventEmitter from 'events';
+import FlairStore from './FlairStore';
 
 /**
  * Stores the group summary for a room and provides an API to change it and
@@ -110,6 +111,7 @@ export default class GroupStore extends EventEmitter {
     setGroupPublicity(isPublished) {
         return this._matrixClient
             .setGroupPublicity(this.groupId, isPublished)
+            .then(() => { FlairStore.invalidatePublicisedGroups(this._matrixClient.credentials.userId); })
             .then(this._fetchSummary.bind(this));
     }
 }


### PR DESCRIPTION
This will make the changes to their Flair "live", but only from the user's own perspective.

Fixes vector-im/riot-web#5236 (for the user's own perspective).