### PR TITLE
Fix some react warnings in GroupMemberList

### DIFF
--- a/src/components/views/groups/GroupMemberList.js
+++ b/src/components/views/groups/GroupMemberList.js
@@ -106,12 +106,11 @@ export default withMatrixClient(React.createClass({
             });
         }
 
-        memberList = memberList.map((m, index) => {
-            return (
-                <GroupMemberTile key={index} groupId={this.props.groupId} member={m} />
-            );
+        const uniqueMembers = {};
+        memberList.forEach((m) => {
+            if (!uniqueMembers[m.userId]) uniqueMembers[m.userId] = m;
         });
-
+        memberList = Object.keys(uniqueMembers).map((userId) => uniqueMembers[userId]);
         memberList.sort((a, b) => {
             // TODO: should put admins at the top: we don't yet have that info
             if (a < b) {
@@ -123,10 +122,16 @@ export default withMatrixClient(React.createClass({
             }
         });
 
+        const memberTiles = memberList.map((m) => {
+            return (
+                <GroupMemberTile key={m.userId} groupId={this.props.groupId} member={m} />
+            );
+        });
+
         return <TruncatedList className="mx_MemberList_wrapper" truncateAt={this.state.truncateAt}
             createOverflowElement={this._createOverflowTile}
         >
-            { memberList }
+            { memberTiles }
         </TruncatedList>;
     },
 

--- a/src/components/views/groups/GroupMemberList.js
+++ b/src/components/views/groups/GroupMemberList.js
@@ -59,6 +59,7 @@ export default withMatrixClient(React.createClass({
     },
 
     _fetchMembers: function() {
+        if (this._unmounted) return;
         this.setState({
             members: this._groupStore.getGroupMembers(),
             invitedMembers: this._groupStore.getGroupInvitedMembers(),
@@ -105,9 +106,9 @@ export default withMatrixClient(React.createClass({
             });
         }
 
-        memberList = memberList.map((m) => {
+        memberList = memberList.map((m, index) => {
             return (
-                <GroupMemberTile key={m.userId} groupId={this.props.groupId} member={m} />
+                <GroupMemberTile key={index} groupId={this.props.groupId} member={m} />
             );
         });
 


### PR DESCRIPTION
 - If the list contains two users twice, react would warn about duplicate keys. Use `index` instead.
 - Check if unmounted before setting state after fetching members.