### PR TITLE
Fix room address picker tiles default name

### DIFF
--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -282,10 +282,15 @@ module.exports = React.createClass({
             }
             const avatarEvent = room.currentState.getStateEvents('m.room.avatar', '');
             const avatarUrl = avatarEvent ? avatarEvent.getContent().url : undefined;
+            const aliasEvents = room.currentState.getStateEvents('m.room.aliases');
+            const aliases = aliasEvents.map((ev) => ev.getContent().aliases).reduce((a, b) => {
+                return a.concat(b);
+            }, []);
+
             results.push({
                 room_id: room.roomId,
                 avatar_url: avatarUrl,
-                name: name || canonicalAlias,
+                name: name || canonicalAlias || aliases[0] || _t('Unnamed Room'),
             });
         });
         this._processResults(results, query);

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -272,20 +272,22 @@ module.exports = React.createClass({
             const topicEvent = room.currentState.getStateEvents('m.room.topic', '');
             const name = nameEvent ? nameEvent.getContent().name : '';
             const canonicalAlias = room.getCanonicalAlias();
+            const aliasEvents = room.currentState.getStateEvents('m.room.aliases');
+            const aliases = aliasEvents.map((ev) => ev.getContent().aliases).reduce((a, b) => {
+                return a.concat(b);
+            }, []);
             const topic = topicEvent ? topicEvent.getContent().topic : '';
 
             const nameMatch = (name || '').toLowerCase().includes(lowerCaseQuery);
-            const aliasMatch = (canonicalAlias || '').toLowerCase().includes(lowerCaseQuery);
+            const aliasMatch = aliases.some((alias) =>
+                (alias || '').toLowerCase().includes(lowerCaseQuery),
+            );
             const topicMatch = (topic || '').toLowerCase().includes(lowerCaseQuery);
             if (!(nameMatch || topicMatch || aliasMatch)) {
                 return;
             }
             const avatarEvent = room.currentState.getStateEvents('m.room.avatar', '');
             const avatarUrl = avatarEvent ? avatarEvent.getContent().url : undefined;
-            const aliasEvents = room.currentState.getStateEvents('m.room.aliases');
-            const aliases = aliasEvents.map((ev) => ev.getContent().aliases).reduce((a, b) => {
-                return a.concat(b);
-            }, []);
 
             results.push({
                 room_id: room.roomId,


### PR DESCRIPTION
 - If no canonical alias, use first alias (and fallback to Unnamed)
 - Match rooms on any aliases

fixes vector-im/riot-web#5414