### PR TITLE
fix missing date sep caused by hidden event at start of day

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -353,7 +353,7 @@ module.exports = React.createClass({
                     }
 
                     if (!isMembershipChange(collapsedMxEv) ||
-                        this._wantsDateSeparator(this.props.events[i], collapsedMxEv.getDate())) {
+                        this._wantsDateSeparator(mxEv, collapsedMxEv.getDate())) {
                         break;
                     }
 
@@ -376,9 +376,7 @@ module.exports = React.createClass({
                     // of MemberEventListSummary, render each member event as if the previous
                     // one was itself. This way, the timestamp of the previous event === the
                     // timestamp of the current event, and no DateSeperator is inserted.
-                    const ret = this._getTilesForEvent(e, e, e === lastShownEvent);
-                    prevEvent = e;
-                    return ret;
+                    return this._getTilesForEvent(e, e, e === lastShownEvent);
                 }).reduce((a, b) => a.concat(b));
 
                 if (eventTiles.length === 0) {
@@ -397,6 +395,7 @@ module.exports = React.createClass({
                     ret.push(this._getReadMarkerTile(visible));
                 }
 
+                prevEvent = mxEv;
                 continue;
             }
 


### PR DESCRIPTION
if first event in day was hidden, the date sep would go missing as the next event would compare its date to the hidden one instead of the one before it
due to naive N-1 check rather than a previous valid event comparison, now fixed by comparing date against the first event in MELS instead (MELS breaks apart into multiple MELSes on date changes so this is valid)

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>