### PR TITLE
Add sensible missing entry generator for MELS tests

### DIFF
--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -88,6 +88,9 @@ describe('MemberEventListSummary', function() {
         sandbox = testUtils.stubClient();
 
         languageHandler.setLanguage('en').done(done);
+        languageHandler.setMissingEntryGenerator(function(key) {
+            return key.split('|', 2)[1];
+        });
     });
 
     afterEach(function() {


### PR DESCRIPTION
Fixes vector-im/riot-web#5426 (because we don't test plurals anywhere else)