### PR TITLE
Lowercase all usernames

### DIFF
--- a/src/components/structures/login/Registration.js
+++ b/src/components/structures/login/Registration.js
@@ -302,7 +302,7 @@ module.exports = React.createClass({
         } : {};
 
         return this._matrixClient.register(
-            this.state.formVals.username,
+            this.state.formVals.username.toLowerCase(),
             this.state.formVals.password,
             undefined, // session id: included in the auth dict already
             auth,


### PR DESCRIPTION
As synapse doesn't accept usernames with capitals in them now

Fixes https://github.com/vector-im/riot-web/issues/5445