### PR TITLE
Allow HTML input

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -152,7 +152,7 @@ export function sanitizedHtmlNode(insaneHtml) {
     return <div dangerouslySetInnerHTML={{ __html: saneHtml }} dir="auto" />;
 }
 
-const sanitizeHtmlParams = {
+export const sanitizeHtmlParams = {
     allowedTags: [
         'font', // custom to matrix for IRC-style font coloring
         'del', // for markdown

--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -16,8 +16,9 @@ limitations under the License.
 
 import commonmark from 'commonmark';
 import escape from 'lodash/escape';
+import {sanitizeHtmlParams} from './HtmlUtils';
 
-const ALLOWED_HTML_TAGS = ['sub', 'sup', 'del', 'u'];
+const ALLOWED_HTML_TAGS = sanitizeHtmlParams.allowedTags;
 
 // These types of node are definitely text
 const TEXT_NODES = ['text', 'softbreak', 'linebreak', 'paragraph', 'document'];


### PR DESCRIPTION
and not just in part, its weird we only allow `<del>`, `<sup>`, `<sub>`, `<u>`, might as well let people use any html thats whitelisted anyway
its how github does it and it just feels right

For https://github.com/vector-im/riot-web/issues/5466