### PR TITLE
Display whether the group summary/room list is loading

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -407,6 +407,10 @@ export default React.createClass({
     getInitialState: function() {
         return {
             summary: null,
+            isGroupPublicised: null,
+            isUserPrivileged: null,
+            groupRooms: null,
+            groupRoomsLoading: null,
             error: null,
             editing: false,
             saving: false,
@@ -458,8 +462,11 @@ export default React.createClass({
             }
             this.setState({
                 summary,
+                summaryLoading: !this._groupStore.isStateReady('GroupStore.Summary'),
                 isGroupPublicised: this._groupStore.getGroupPublicity(),
                 isUserPrivileged: this._groupStore.isUserPrivileged(),
+                groupRooms: this._groupStore.getGroupRooms(),
+                groupRoomsLoading: !this._groupStore.isStateReady('GroupStore.GroupRooms'),
                 error: null,
             });
         });
@@ -667,7 +674,7 @@ export default React.createClass({
                 <h3>{ _t('Rooms') }</h3>
                 { addRoomRow }
             </div>
-            <RoomDetailList rooms={this._groupStore.getGroupRooms()} />
+            <RoomDetailList rooms={this.state.groupRooms} loading={this.state.groupRoomsLoading} />
         </div>;
     },
 
@@ -863,7 +870,7 @@ export default React.createClass({
         const Spinner = sdk.getComponent("elements.Spinner");
         const TintableSvg = sdk.getComponent("elements.TintableSvg");
 
-        if (this.state.summary === null && this.state.error === null || this.state.saving) {
+        if (this.state.summaryLoading && this.state.error === null || this.state.saving) {
             return <Spinner />;
         } else if (this.state.summary) {
             const summary = this.state.summary;

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -462,11 +462,11 @@ export default React.createClass({
             }
             this.setState({
                 summary,
-                summaryLoading: !this._groupStore.isStateReady('GroupStore.Summary'),
+                summaryLoading: !this._groupStore.isStateReady(GroupStore.STATE_KEY.Summary),
                 isGroupPublicised: this._groupStore.getGroupPublicity(),
                 isUserPrivileged: this._groupStore.isUserPrivileged(),
                 groupRooms: this._groupStore.getGroupRooms(),
-                groupRoomsLoading: !this._groupStore.isStateReady('GroupStore.GroupRooms'),
+                groupRoomsLoading: !this._groupStore.isStateReady(GroupStore.STATE_KEY.GroupRooms),
                 isUserMember: this._groupStore.getGroupMembers().some(
                     (m) => m.userId === MatrixClientPeg.get().credentials.userId,
                 ),

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -657,6 +657,7 @@ export default React.createClass({
         const RoomDetailList = sdk.getComponent('rooms.RoomDetailList');
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
         const TintableSvg = sdk.getComponent('elements.TintableSvg');
+        const Spinner = sdk.getComponent('elements.Spinner');
 
         const addRoomRow = this.state.editing ?
             (<AccessibleButton className="mx_GroupView_rooms_header_addRow"
@@ -674,7 +675,10 @@ export default React.createClass({
                 <h3>{ _t('Rooms') }</h3>
                 { addRoomRow }
             </div>
-            <RoomDetailList rooms={this.state.groupRooms} loading={this.state.groupRoomsLoading} />
+            { this.state.groupRoomsLoading ?
+                <Spinner /> :
+                <RoomDetailList rooms={this.state.groupRooms} />
+            }
         </div>;
     },
 

--- a/src/components/views/rooms/RoomDetailList.js
+++ b/src/components/views/rooms/RoomDetailList.js
@@ -113,8 +113,6 @@ export default React.createClass({
 
             worldReadable: PropTypes.bool,
             guestCanJoin: PropTypes.bool,
-
-            loading: PropTypes.bool,
         })),
     },
 
@@ -126,10 +124,6 @@ export default React.createClass({
     },
 
     render() {
-        const Spinner = sdk.getComponent('elements.Spinner');
-        if (this.props.loading) {
-            return <Spinner />;
-        }
         const rows = this.getRows();
         let rooms;
         if (rows.length == 0) {

--- a/src/components/views/rooms/RoomDetailList.js
+++ b/src/components/views/rooms/RoomDetailList.js
@@ -113,6 +113,8 @@ export default React.createClass({
 
             worldReadable: PropTypes.bool,
             guestCanJoin: PropTypes.bool,
+
+            loading: PropTypes.bool,
         })),
     },
 
@@ -124,6 +126,10 @@ export default React.createClass({
     },
 
     render() {
+        const Spinner = sdk.getComponent('elements.Spinner');
+        if (this.props.loading) {
+            return <Spinner />;
+        }
         const rows = this.getRows();
         let rooms;
         if (rows.length == 0) {

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -23,6 +23,14 @@ import FlairStore from './FlairStore';
  * other useful group APIs that may have an effect on the group summary.
  */
 export default class GroupStore extends EventEmitter {
+
+    static STATE_KEY = {
+        GroupMembers: 'GroupMembers',
+        GroupInvitedMembers: 'GroupInvitedMembers',
+        Summary: 'Summary',
+        GroupRooms: 'GroupRooms',
+    };
+
     constructor(matrixClient, groupId) {
         super();
         this.groupId = groupId;
@@ -43,7 +51,7 @@ export default class GroupStore extends EventEmitter {
             this._members = result.chunk.map((apiMember) => {
                 return groupMemberFromApiObject(apiMember);
             });
-            this._ready['GroupStore.GroupMembers'] = true;
+            this._ready[GroupStore.STATE_KEY.GroupMembers] = true;
             this._notifyListeners();
         }).catch((err) => {
             console.error("Failed to get group member list: " + err);
@@ -54,7 +62,7 @@ export default class GroupStore extends EventEmitter {
             this._invitedMembers = result.chunk.map((apiMember) => {
                 return groupMemberFromApiObject(apiMember);
             });
-            this._ready['GroupStore.GroupInvitedMembers'] = true;
+            this._ready[GroupStore.STATE_KEY.GroupInvitedMembers] = true;
             this._notifyListeners();
         }).catch((err) => {
             // Invited users not visible to non-members
@@ -69,7 +77,7 @@ export default class GroupStore extends EventEmitter {
     _fetchSummary() {
         this._matrixClient.getGroupSummary(this.groupId).then((resp) => {
             this._summary = resp;
-            this._ready['GroupStore.Summary'] = true;
+            this._ready[GroupStore.STATE_KEY.Summary] = true;
             this._notifyListeners();
         }).catch((err) => {
             this.emit('error', err);
@@ -81,7 +89,7 @@ export default class GroupStore extends EventEmitter {
             this._rooms = resp.chunk.map((apiRoom) => {
                 return groupRoomFromApiObject(apiRoom);
             });
-            this._ready['GroupStore.GroupRooms'] = true;
+            this._ready[GroupStore.STATE_KEY.GroupRooms] = true;
             this._notifyListeners();
         }).catch((err) => {
             this.emit('error', err);


### PR DESCRIPTION
This uses a `ready` flag assigned to each fetching API used by the GroupServer. I've avoided making this generic for now for want of not doing so early.

fixes https://github.com/vector-im/riot-web/issues/5457