### PR TITLE
Use, if possible, a room's canonical or first alias when viewing the …

### DIFF
--- a/src/components/views/rooms/RoomDetailList.js
+++ b/src/components/views/rooms/RoomDetailList.js
@@ -49,6 +49,7 @@ const RoomDetailRow = React.createClass({
         dis.dispatch({
             action: 'view_room',
             room_id: this.props.room.roomId,
+            room_alias: this.props.room.canonicalAlias || this.props.room.aliases[0],
         });
     },
 

--- a/src/components/views/rooms/RoomDetailList.js
+++ b/src/components/views/rooms/RoomDetailList.js
@@ -49,7 +49,7 @@ const RoomDetailRow = React.createClass({
         dis.dispatch({
             action: 'view_room',
             room_id: this.props.room.roomId,
-            room_alias: this.props.room.canonicalAlias || this.props.room.aliases[0],
+            room_alias: this.props.room.canonicalAlias || (this.props.room.aliases || [])[0],
         });
     },
 


### PR DESCRIPTION
…room

(Only affects rooms the user has never joined)

fixes https://github.com/vector-im/riot-web/issues/5500