### PR TITLE
Revert "UnknownDeviceDialog: get devices from SDK"

### DIFF
--- a/src/UnknownDeviceErrorHandler.js
+++ b/src/UnknownDeviceErrorHandler.js
@@ -25,6 +25,7 @@ const onAction = function(payload) {
         const UnknownDeviceDialog = sdk.getComponent('dialogs.UnknownDeviceDialog');
         isDialogOpen = true;
         Modal.createTrackedDialog('Unknown Device Error', '', UnknownDeviceDialog, {
+            devices: payload.err.devices,
             room: payload.room,
             onFinished: (r) => {
                 isDialogOpen = false;

--- a/src/components/views/dialogs/UnknownDeviceDialog.js
+++ b/src/components/views/dialogs/UnknownDeviceDialog.js
@@ -48,9 +48,8 @@ function UserUnknownDeviceList(props) {
     const {userId, userDevices} = props;
 
     const deviceListEntries = Object.keys(userDevices).map((deviceId) =>
-        <DeviceListEntry key={deviceId} userId={userId}
-            device={userDevices[deviceId]}
-        />,
+       <DeviceListEntry key={deviceId} userId={userId}
+           device={userDevices[deviceId]} />,
     );
 
     return (
@@ -93,60 +92,26 @@ export default React.createClass({
     propTypes: {
         room: React.PropTypes.object.isRequired,
 
+        // map from userid -> deviceid -> deviceinfo
+        devices: React.PropTypes.object.isRequired,
         onFinished: React.PropTypes.func.isRequired,
     },
 
-    componentWillMount: function() {
-        this._unmounted = false;
-
-        const roomMembers = this.props.room.getJoinedMembers().map((m) => {
-            return m.userId;
-        });
-
-        this.setState({
-            // map from userid -> deviceid -> deviceinfo
-            devices: null,
-        });
-        MatrixClientPeg.get().downloadKeys(roomMembers, false).then((devices) => {
-            if (this._unmounted) return;
-
-            const unknownDevices = {};
-            // This is all devices in this room, so find the unknown ones.
-            Object.keys(devices).forEach((userId) => {
-                Object.keys(devices[userId]).map((deviceId) => {
-                    const device = devices[userId][deviceId];
-
-                    if (device.isUnverified() && !device.isKnown()) {
-                        if (unknownDevices[userId] === undefined) {
-                            unknownDevices[userId] = {};
-                        }
-                        unknownDevices[userId][deviceId] = device;
-                    }
-
-                    // Given we've now shown the user the unknown device, it is no longer
-                    // unknown to them. Therefore mark it as 'known'.
-                    if (!device.isKnown()) {
-                        MatrixClientPeg.get().setDeviceKnown(userId, deviceId, true);
-                    }
-                });
-            });
-
-            this.setState({
-                devices: unknownDevices,
+    componentDidMount: function() {
+        // Given we've now shown the user the unknown device, it is no longer
+        // unknown to them. Therefore mark it as 'known'.
+        Object.keys(this.props.devices).forEach((userId) => {
+            Object.keys(this.props.devices[userId]).map((deviceId) => {
+                MatrixClientPeg.get().setDeviceKnown(userId, deviceId, true);
             });
         });
-    },
 
-    componentWillUnmount: function() {
-        this._unmounted = true;
+        // XXX: temporary logging to try to diagnose
+        // https://github.com/vector-im/riot-web/issues/3148
+        console.log('Opening UnknownDeviceDialog');
     },
 
     render: function() {
-        if (this.state.devices === null) {
-            const Spinner = sdk.getComponent("elements.Spinner");
-            return <Spinner />;
-        }
-
         const client = MatrixClientPeg.get();
         const blacklistUnverified = client.getGlobalBlacklistUnverifiedDevices() ||
               this.props.room.getBlacklistUnverifiedDevices();
@@ -189,7 +154,7 @@ export default React.createClass({
                     { warning }
                     { _t("Unknown devices") }:
 
-                    <UnknownDeviceList devices={this.state.devices} />
+                    <UnknownDeviceList devices={this.props.devices} />
                 </GeminiScrollbar>
                 <div className="mx_Dialog_buttons">
                     <button className="mx_Dialog_primary" autoFocus={true}


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#1584

Reverting because verifying a device pops up a new dialog meaning the UDD gets reinstantiated once you're done verifying the device, so this code causes the unknown devices to be re-fetched, at which point there are none because they were all marked as known when the dialog was first displayed.