### PR TITLE
Perform substitution on all parts, not just the last one

### DIFF
--- a/test/i18n-test/languageHandler-test.js
+++ b/test/i18n-test/languageHandler-test.js
@@ -65,4 +65,9 @@ describe('languageHandler', function() {
         expect(languageHandler._t(text, {}, { 'StartChatButton': () => <i>foo</i> }))
             .toEqual(<span>Press <i>foo</i> to start a chat with someone</span>);
     });
+
+    it('replacements in the wrong order', function() {
+        const text = '%(var1)s %(var2)s';
+        expect(languageHandler._t(text, { var2: 'val2', var1: 'val1' })).toBe('val1 val2');
+    });
 });


### PR DESCRIPTION
Signed-off-by: Stefan Parviainen <pafcu@iki.fi>

This way the substitutions don't need to appear in the same order in the
translated string.