### PR TITLE
Fix GroupMemberList search for users without displayname

### DIFF
--- a/src/components/views/groups/GroupMemberList.js
+++ b/src/components/views/groups/GroupMemberList.js
@@ -92,7 +92,7 @@ export default withMatrixClient(React.createClass({
         query = (query || "").toLowerCase();
         if (query) {
             memberList = memberList.filter((m) => {
-                const matchesName = m.displayname.toLowerCase().indexOf(query) !== -1;
+                const matchesName = (m.displayname || "").toLowerCase().includes(query);
                 const matchesId = m.userId.toLowerCase().includes(query);
 
                 if (!matchesName && !matchesId) {


### PR DESCRIPTION
When there is a user in a group which has no displayname set
the search failed with "Cannot read property 'toLowerCase' of null"

Signed-Off-by: Matthias Kesler <krombel@krombel.de>