### PR TITLE
Ignore unrecognised login flows

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -862,7 +862,7 @@
     "Error: Problem communicating with the given homeserver.": "Error: Problem communicating with the given homeserver.",
     "Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar. Either use HTTPS or <a>enable unsafe scripts</a>.": "Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar. Either use HTTPS or <a>enable unsafe scripts</a>.",
     "Can't connect to homeserver - please check your connectivity, ensure your <a>homeserver's SSL certificate</a> is trusted, and that a browser extension is not blocking requests.": "Can't connect to homeserver - please check your connectivity, ensure your <a>homeserver's SSL certificate</a> is trusted, and that a browser extension is not blocking requests.",
-    "Sorry, this homeserver is using a login which is not recognised ": "Sorry, this homeserver is using a login which is not recognised ",
+    "This homeserver doesn't offer any login flows which are supported by this client.": "This homeserver doesn't offer any login flows which are supported by this client.",
     "Login as guest": "Login as guest",
     "Return to app": "Return to app",
     "Failed to fetch avatar URL": "Failed to fetch avatar URL",


### PR DESCRIPTION
Update the Login component so that if it sees an unrecognised login flow, it just ignores it and uses another one, so that riot can still be used with homeservers supporting custom login types.

NB this PR is against ~~*master*~~ release-v0.11-patches