### PR TITLE
Allow guests to view individual groups

### DIFF
--- a/src/GroupAddressPicker.js
+++ b/src/GroupAddressPicker.js
@@ -114,7 +114,7 @@ function _onGroupInviteFinished(groupId, addrs) {
 
 function _onGroupAddRoomFinished(groupId, addrs, addRoomsPublicly) {
     const matrixClient = MatrixClientPeg.get();
-    const groupStore = GroupStoreCache.getGroupStore(matrixClient, groupId);
+    const groupStore = GroupStoreCache.getGroupStore(groupId);
     const errorList = [];
     return Promise.all(addrs.map((addr) => {
         return groupStore

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -495,7 +495,19 @@ export default React.createClass({
                 this._onEditClick();
             }
         });
+        let willDoOnboarding = false;
         this._groupStore.on('error', (err) => {
+            if (err.errcode === 'M_GUEST_ACCESS_FORBIDDEN' && !willDoOnboarding) {
+                dis.dispatch({
+                    action: 'do_after_sync_prepared',
+                    deferred_action: {
+                        action: 'view_group',
+                        group_id: groupId,
+                    },
+                });
+                dis.dispatch({action: 'view_set_mxid'});
+                willDoOnboarding = true;
+            }
             this.setState({
                 summary: null,
                 error: err,

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -469,7 +469,7 @@ export default React.createClass({
         if (group && group.inviter && group.inviter.userId) {
             this._fetchInviterProfile(group.inviter.userId);
         }
-        this._groupStore = GroupStoreCache.getGroupStore(this._matrixClient, groupId);
+        this._groupStore = GroupStoreCache.getGroupStore(groupId);
         this._groupStore.registerListener(() => {
             const summary = this._groupStore.getSummary();
             if (summary.profile) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -82,7 +82,6 @@ const ONBOARDING_FLOW_STARTERS = [
     'view_create_chat',
     'view_create_room',
     'view_my_groups',
-    'view_group',
 ];
 
 module.exports = React.createClass({

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -244,7 +244,7 @@ module.exports = React.createClass({
 
     _doNaiveGroupRoomSearch: function(query) {
         const lowerCaseQuery = query.toLowerCase();
-        const groupStore = GroupStoreCache.getGroupStore(MatrixClientPeg.get(), this.props.groupId);
+        const groupStore = GroupStoreCache.getGroupStore(this.props.groupId);
         const results = [];
         groupStore.getGroupRooms().forEach((r) => {
             const nameMatch = (r.name || '').toLowerCase().includes(lowerCaseQuery);

--- a/src/components/views/groups/GroupMemberInfo.js
+++ b/src/components/views/groups/GroupMemberInfo.js
@@ -59,9 +59,7 @@ module.exports = React.createClass({
     },
 
     _initGroupStore(groupId) {
-        this._groupStore = GroupStoreCache.getGroupStore(
-            this.context.matrixClient, this.props.groupId,
-        );
+        this._groupStore = GroupStoreCache.getGroupStore(this.props.groupId);
         this._groupStore.registerListener(this.onGroupStoreUpdated);
     },
 

--- a/src/components/views/groups/GroupMemberList.js
+++ b/src/components/views/groups/GroupMemberList.js
@@ -20,16 +20,11 @@ import sdk from '../../../index';
 import GroupStoreCache from '../../../stores/GroupStoreCache';
 import GeminiScrollbar from 'react-gemini-scrollbar';
 import PropTypes from 'prop-types';
-import withMatrixClient from '../../../wrappers/withMatrixClient';
 
 const INITIAL_LOAD_NUM_MEMBERS = 30;
 
-export default withMatrixClient(React.createClass({
+export default React.createClass({
     displayName: 'GroupMemberList',
-
-    contextTypes: {
-        matrixClient: PropTypes.object.isRequired,
-    },
 
     propTypes: {
         groupId: PropTypes.string.isRequired,
@@ -49,7 +44,7 @@ export default withMatrixClient(React.createClass({
     },
 
     _initGroupStore: function(groupId) {
-        this._groupStore = GroupStoreCache.getGroupStore(this.context.matrixClient, groupId);
+        this._groupStore = GroupStoreCache.getGroupStore(groupId);
         this._groupStore.registerListener(() => {
             this._fetchMembers();
         });
@@ -174,4 +169,4 @@ export default withMatrixClient(React.createClass({
             </div>
         );
     },
-}));
+});

--- a/src/components/views/groups/GroupPublicityToggle.js
+++ b/src/components/views/groups/GroupPublicityToggle.js
@@ -16,7 +16,6 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MatrixClient } from 'matrix-js-sdk';
 import sdk from '../../../index';
 import GroupStoreCache from '../../../stores/GroupStoreCache';
 import GroupStore from '../../../stores/GroupStore';
@@ -27,10 +26,6 @@ export default React.createClass({
 
     propTypes: {
         groupId: PropTypes.string.isRequired,
-    },
-
-    contextTypes: {
-        matrixClient: PropTypes.instanceOf(MatrixClient),
     },
 
     getInitialState() {
@@ -46,7 +41,7 @@ export default React.createClass({
     },
 
     _initGroupStore: function(groupId) {
-        this._groupStore = GroupStoreCache.getGroupStore(this.context.matrixClient, groupId);
+        this._groupStore = GroupStoreCache.getGroupStore(groupId);
         this._groupStore.registerListener(() => {
             this.setState({
                 isGroupPublicised: this._groupStore.getGroupPublicity(),

--- a/src/components/views/groups/GroupRoomInfo.js
+++ b/src/components/views/groups/GroupRoomInfo.js
@@ -61,9 +61,7 @@ module.exports = React.createClass({
     },
 
     _initGroupStore(groupId) {
-        this._groupStore = GroupStoreCache.getGroupStore(
-            this.context.matrixClient, this.props.groupId,
-        );
+        this._groupStore = GroupStoreCache.getGroupStore(this.props.groupId);
         this._groupStore.registerListener(this.onGroupStoreUpdated);
     },
 

--- a/src/components/views/groups/GroupRoomList.js
+++ b/src/components/views/groups/GroupRoomList.js
@@ -19,15 +19,10 @@ import sdk from '../../../index';
 import GroupStoreCache from '../../../stores/GroupStoreCache';
 import GeminiScrollbar from 'react-gemini-scrollbar';
 import PropTypes from 'prop-types';
-import {MatrixClient} from 'matrix-js-sdk';
 
 const INITIAL_LOAD_NUM_ROOMS = 30;
 
 export default React.createClass({
-    contextTypes: {
-        matrixClient: React.PropTypes.instanceOf(MatrixClient).isRequired,
-    },
-
     propTypes: {
         groupId: PropTypes.string.isRequired,
     },
@@ -46,7 +41,7 @@ export default React.createClass({
     },
 
     _initGroupStore: function(groupId) {
-        this._groupStore = GroupStoreCache.getGroupStore(this.context.matrixClient, groupId);
+        this._groupStore = GroupStoreCache.getGroupStore(groupId);
         this._groupStore.registerListener(() => {
             this._fetchRooms();
         });

--- a/src/stores/GroupStoreCache.js
+++ b/src/stores/GroupStoreCache.js
@@ -21,12 +21,12 @@ class GroupStoreCache {
         this.groupStore = null;
     }
 
-    getGroupStore(matrixClient, groupId) {
+    getGroupStore(groupId) {
         if (!this.groupStore || this.groupStore.groupId !== groupId) {
             // This effectively throws away the reference to any previous GroupStore,
             // allowing it to be GCd once the components referencing it have stopped
             // referencing it.
-            this.groupStore = new GroupStore(matrixClient, groupId);
+            this.groupStore = new GroupStore(groupId);
         }
         this.groupStore._fetchSummary();
         return this.groupStore;

--- a/src/utils/MultiInviter.js
+++ b/src/utils/MultiInviter.js
@@ -119,7 +119,7 @@ export default class MultiInviter {
         let doInvite;
         if (this.groupId !== null) {
             doInvite = GroupStoreCache
-                .getGroupStore(MatrixClientPeg.get(), this.groupId)
+                .getGroupStore(this.groupId)
                 .inviteUserToGroup(addr);
         } else {
             doInvite = inviteToRoom(this.roomId, addr);


### PR DESCRIPTION
If the server disallows guests from accessing them (if hasn't got https://github.com/matrix-org/synapse/pull/2715), start ILAG with an intention to return to the group.

Fixes https://github.com/vector-im/riot-web/issues/5650

Also, use MatrixClientPeg in the GroupStore to prevent weirdness when logging out/in - we don't want to cache old sessions. In my mind, this is a reason to either:
 1. Not use MatrixClient directly in the app
 1. Indicate logout by setting state within the matrixClient itself. 