### PR TITLE
Replace (IRC) with flair

### DIFF
--- a/src/components/views/messages/SenderProfile.js
+++ b/src/components/views/messages/SenderProfile.js
@@ -105,11 +105,20 @@ export default React.createClass({
             return <span />; // emote message must include the name so don't duplicate it
         }
 
-        const displayedGroups = this._getDisplayedGroups(
-            this.state.userGroups, this.state.relatedGroups,
-        );
+        let flair = <div />;
+        if (this.props.enableFlair) {
+            const displayedGroups = this._getDisplayedGroups(
+                this.state.userGroups, this.state.relatedGroups,
+            );
 
-        name = displayedGroups.length > 0 ? name.replace(' (IRC)', '') : name;
+            // Backwards-compatible replacing of "(IRC)" with AS user flair
+            name = displayedGroups.length > 0 ? name.replace(' (IRC)', '') : name;
+
+            flair = <Flair key='flair'
+                userId={mxEvent.getSender()}
+                groups={displayedGroups}
+            />;
+        }
 
         const nameElem = <EmojiText key='name'>{ name || '' }</EmojiText>;
 
@@ -118,13 +127,7 @@ export default React.createClass({
             <span className="mx_SenderProfile_name">
                 { nameElem }
             </span>
-            { this.props.enableFlair ?
-                <Flair key='flair'
-                    userId={mxEvent.getSender()}
-                    groups={displayedGroups}
-                />
-                : null
-            }
+            { flair }
         </span>;
 
         const content = this.props.text ?

--- a/src/components/views/messages/SenderProfile.js
+++ b/src/components/views/messages/SenderProfile.js
@@ -38,7 +38,7 @@ export default React.createClass({
 
     getInitialState() {
         return {
-            groups: null,
+            userGroups: null,
             relatedGroups: [],
         };
     },
@@ -49,9 +49,9 @@ export default React.createClass({
 
         FlairStore.getPublicisedGroupsCached(
             this.context.matrixClient, this.props.mxEvent.getSender(),
-        ).then((groups) => {
+        ).then((userGroups) => {
             if (this.unmounted) return;
-            this.setState({groups});
+            this.setState({userGroups});
         });
 
         this.context.matrixClient.on('RoomState.events', this.onRoomStateEvents);
@@ -93,16 +93,16 @@ export default React.createClass({
             return <span />; // emote message must include the name so don't duplicate it
         }
 
-        let groups = this.state.groups || [];
+        let displayedGroups = this.state.userGroups || [];
         if (this.state.relatedGroups && this.state.relatedGroups.length > 0) {
-            groups = groups.filter((groupId) => {
+            displayedGroups = displayedGroups.filter((groupId) => {
                 return this.state.relatedGroups.includes(groupId);
             });
         } else {
-            groups = [];
+            displayedGroups = [];
         }
 
-        name = groups.length > 0 ? name.replace(' (IRC)', '') : name;
+        name = displayedGroups.length > 0 ? name.replace(' (IRC)', '') : name;
 
         const nameElem = <EmojiText key='name'>{ name || '' }</EmojiText>;
 
@@ -114,7 +114,7 @@ export default React.createClass({
             { this.props.enableFlair ?
                 <Flair key='flair'
                     userId={mxEvent.getSender()}
-                    groups={groups}
+                    groups={displayedGroups}
                 />
                 : null
             }

--- a/src/components/views/messages/SenderProfile.js
+++ b/src/components/views/messages/SenderProfile.js
@@ -83,6 +83,18 @@ export default React.createClass({
         });
     },
 
+    _getDisplayedGroups(userGroups, relatedGroups) {
+        let displayedGroups = userGroups || [];
+        if (relatedGroups && relatedGroups.length > 0) {
+            displayedGroups = displayedGroups.filter((groupId) => {
+                return relatedGroups.includes(groupId);
+            });
+        } else {
+            displayedGroups = [];
+        }
+        return displayedGroups;
+    },
+
     render() {
         const EmojiText = sdk.getComponent('elements.EmojiText');
         const {mxEvent} = this.props;
@@ -93,14 +105,9 @@ export default React.createClass({
             return <span />; // emote message must include the name so don't duplicate it
         }
 
-        let displayedGroups = this.state.userGroups || [];
-        if (this.state.relatedGroups && this.state.relatedGroups.length > 0) {
-            displayedGroups = displayedGroups.filter((groupId) => {
-                return this.state.relatedGroups.includes(groupId);
-            });
-        } else {
-            displayedGroups = [];
-        }
+        const displayedGroups = this._getDisplayedGroups(
+            this.state.userGroups, this.state.relatedGroups,
+        );
 
         name = displayedGroups.length > 0 ? name.replace(' (IRC)', '') : name;
 


### PR DESCRIPTION
If a user has public groups that are honoured in their flair, remove the (IRC) to give the appearance that the flair replaces it.

This required a total refactor of how <Flair/> is used. I think it makes sense to do the filtering outside of the component itself anyway, but it was necessary to do this so that SenderProfile could strip "(IRC)" accordingly.

Sadly, this meant SenderProfile became stateful. 