### PR TITLE
Fix one variant of a scroll jump that occurs when decrypting an m.text

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -215,6 +215,7 @@ module.exports = withMatrixClient(React.createClass({
         this.setState({
             verified: verified,
         });
+        this.props.onWidgetLoad();
     },
 
     _propsEqual: function(objA, objB) {

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -214,8 +214,10 @@ module.exports = withMatrixClient(React.createClass({
         const verified = await this.props.matrixClient.isEventSenderVerified(mxEvent);
         this.setState({
             verified: verified,
+        }, () => {
+            // Decryption may have caused a change in size
+            this.props.onWidgetLoad();
         });
-        this.props.onWidgetLoad();
     },
 
     _propsEqual: function(objA, objB) {

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -196,6 +196,8 @@ module.exports = withMatrixClient(React.createClass({
      */
     _onDecrypted: function() {
         // we need to re-verify the sending device.
+        // (we call onWidgetLoad in _verifyEvent to handle the case where decryption
+        // has caused a change in size of the event tile)
         this._verifyEvent(this.props.mxEvent);
         this.forceUpdate();
     },


### PR DESCRIPTION
This calls `onWidgetLoad` after an event has been decrypted or a device verification has changed. It isn't called after a `forceUpdate()` in `_onDecrypted` but empirically the change reduces scroll jumps in e2e rooms.