### PR TITLE
Implement message-hiding

### DIFF
--- a/src/components/views/messages/MessageEvent.js
+++ b/src/components/views/messages/MessageEvent.js
@@ -18,9 +18,16 @@ limitations under the License.
 
 const React = require('react');
 const sdk = require('../../../index');
+import { _t } from '../../../languageHandler';
 
 module.exports = React.createClass({
     displayName: 'MessageEvent',
+
+    getInitialState: function() {
+        return {
+            bodyHidden: false,
+        };
+    },
 
     propTypes: {
         /* the MatrixEvent to show */
@@ -43,7 +50,17 @@ module.exports = React.createClass({
     },
 
     getEventTileOps: function() {
-        return this.refs.body && this.refs.body.getEventTileOps ? this.refs.body.getEventTileOps() : null;
+        const eventTileOps = this.refs.body && this.refs.body.getEventTileOps ? this.refs.body.getEventTileOps() : {};
+
+        eventTileOps.isBodyHidden = () => {
+            return this.state.bodyHidden;
+        };
+
+        eventTileOps.toggleBodyHidden = () => {
+            this.state.bodyHidden = !this.state.bodyHidden;
+        };
+
+        return eventTileOps;
     },
 
     render: function() {
@@ -69,10 +86,16 @@ module.exports = React.createClass({
             BodyType = bodyTypes['m.file'];
         }
 
-        return <BodyType ref="body" mxEvent={this.props.mxEvent} highlights={this.props.highlights}
-                    highlightLink={this.props.highlightLink}
-                    showUrlPreview={this.props.showUrlPreview}
-                    tileShape={this.props.tileShape}
-                    onWidgetLoad={this.props.onWidgetLoad} />;
+        if (this.state.bodyHidden) {
+            const tooltip = _t("You have hidden this message.");
+            return <span className="mx_HiddenBody" title={tooltip}>
+                   </span>;
+        } else {
+            return <BodyType ref="body" mxEvent={this.props.mxEvent} highlights={this.props.highlights}
+                        highlightLink={this.props.highlightLink}
+                        showUrlPreview={this.props.showUrlPreview}
+                        tileShape={this.props.tileShape}
+                        onWidgetLoad={this.props.onWidgetLoad} />;
+        }
     },
 });

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -472,6 +472,7 @@
     "Image '%(Body)s' cannot be displayed.": "Image '%(Body)s' cannot be displayed.",
     "This image cannot be displayed.": "This image cannot be displayed.",
     "Error decrypting video": "Error decrypting video",
+    "You have hidden this message.": "You have hidden this message.",
     "%(senderDisplayName)s changed the avatar for %(roomName)s": "%(senderDisplayName)s changed the avatar for %(roomName)s",
     "%(senderDisplayName)s removed the room avatar.": "%(senderDisplayName)s removed the room avatar.",
     "%(senderDisplayName)s changed the room avatar to <img/>": "%(senderDisplayName)s changed the room avatar to <img/>",


### PR DESCRIPTION
Add a "Hide"/"Unhide" item to the message context menu which hides the event
body for message events.  The placeholder text for hidden messages is easily
mistaken for an actual message body, so this needs to be changed next.

Addresses vector-im/riot-web#5649.

Goes with PR vector-im/riot-web#5798