### PR TITLE
Add option to also output untranslated string

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -23,6 +23,10 @@ import SettingsStore, {SettingLevel} from "./settings/SettingsStore";
 
 const i18nFolder = 'i18n/';
 
+// Control whether to also return original, untranslated strings
+// Useful for debugging and testing
+const ANNOTATE_STRINGS = false;
+
 // We use english strings as keys, some of which contain full stops
 counterpart.setSeparator('|');
 // Fall back to English
@@ -84,7 +88,21 @@ export function _t(text, variables, tags) {
     // The translation returns text so there's no XSS vector here (no unsafe HTML, no code execution)
     const translated = safeCounterpartTranslate(text, args);
 
-    return substitute(translated, variables, tags);
+    let substituted = substitute(translated, variables, tags);
+
+    // For development/testing purposes it is useful to also output the original string
+    // Don't do that for release versions
+    if (ANNOTATE_STRINGS) {
+        if (typeof substituted === 'string') {
+            return `@@${text}##${substituted}@@`
+        }
+        else {
+            return <span className='translated-string' data-orig-string={text}>{substituted}</span>;
+        }
+    }
+    else {
+        return substituted;
+    }
 }
 
 /*


### PR DESCRIPTION
Option to have the translation function also output the untransatated string in a special format. These strings can then later be found and analyzed in order to aid testing and debugging. E.g. in https://gitlab.com/saparvia/riot-selenium-tests the string-marking feature relies on special output.