### PR TITLE
Attempt to fix a host of scroll jumps using ReactResizeDetector

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-addons-css-transition-group": "15.3.2",
     "react-dom": "^15.4.0",
     "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#5e97aef",
+    "react-resize-detector": "^1.1.0",
     "sanitize-html": "^1.14.1",
     "text-encoding-utf-8": "^1.0.1",
     "url": "^0.11.0",

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -17,6 +17,7 @@ limitations under the License.
 const React = require("react");
 const ReactDOM = require("react-dom");
 const GeminiScrollbar = require('react-gemini-scrollbar');
+import ReactResizeDetector from 'react-resize-detector';
 import Promise from 'bluebird';
 import { KeyCode } from '../../Keyboard';
 
@@ -221,9 +222,10 @@ module.exports = React.createClass({
     },
 
     onResize: function() {
+        if (!this._getScrollNode()) return;
         this.props.onResize();
         this.checkScroll();
-        this.refs.geminiPanel.forceUpdate();
+        if (this.refs.geminiPanel) this.refs.geminiPanel.forceUpdate();
     },
 
     // after an update to the contents of the panel, check that the scroll is
@@ -620,7 +622,6 @@ module.exports = React.createClass({
 
     _restoreSavedScrollState: function() {
         const scrollState = this.scrollState;
-        const scrollNode = this._getScrollNode();
 
         if (scrollState.stuckAtBottom) {
             this._setScrollTop(Number.MAX_VALUE);
@@ -664,6 +665,8 @@ module.exports = React.createClass({
             throw new Error("ScrollPanel._getScrollNode called when unmounted");
         }
 
+        if (!this.refs.geminiPanel) return;
+
         return this.refs.geminiPanel.scrollbar.getViewElement();
     },
 
@@ -678,6 +681,7 @@ module.exports = React.createClass({
                         <ol ref="itemlist" className="mx_RoomView_MessageList" aria-live="polite">
                             { this.props.children }
                         </ol>
+                        <ReactResizeDetector handleHeight onResize={this.onResize} />
                     </div>
                 </GeminiScrollbar>
                );

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -19,6 +19,7 @@ limitations under the License.
 
 const React = require('react');
 const classNames = require("classnames");
+import ReactResizeDetector from 'react-resize-detector';
 import { _t, _td } from '../../../languageHandler';
 const Modal = require('../../../Modal');
 
@@ -599,6 +600,7 @@ module.exports = withMatrixClient(React.createClass({
                             onWidgetLoad={this.props.onWidgetLoad} />
                         { editButton }
                     </div>
+                    <ReactResizeDetector handleHeight onResize={this.props.onWidgetLoad} />
                 </div>
             );
         }


### PR DESCRIPTION
Detect resizes within event tiles and within the main scroll panel
and restore scroll state when one of these happens.

This does not entirely fix the problem as we still could have a
scenario where the scroll state has been incorrectly saved to an
incorrect value, after which restoring will actually cause a scroll
jump.

In theory fixes https://github.com/vector-im/riot-web/issues/1770