### PR TITLE
Get Group profile from TagTile instead of TagPanel

### DIFF
--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -18,7 +18,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { MatrixClient } from 'matrix-js-sdk';
 import FilterStore from '../../stores/FilterStore';
-import FlairStore from '../../stores/FlairStore';
 import TagOrderStore from '../../stores/TagOrderStore';
 
 import GroupActions from '../../actions/GroupActions';
@@ -36,17 +35,7 @@ const TagPanel = React.createClass({
 
     getInitialState() {
         return {
-            // A list of group profiles for tags that are group IDs. The intention in future
-            // is to allow arbitrary tags to be selected in the TagPanel, not just groups.
-            // For now, it suffices to maintain a list of ordered group profiles.
-            orderedGroupTagProfiles: [
-            // {
-            //     groupId: '+awesome:foo.bar',{
-            //     name: 'My Awesome Community',
-            //     avatarUrl: 'mxc://...',
-            //     shortDescription: 'Some description...',
-            // },
-            ],
+            orderedTags: [],
             selectedTags: [],
         };
     },
@@ -67,15 +56,8 @@ const TagPanel = React.createClass({
             if (this.unmounted) {
                 return;
             }
-
-            const orderedTags = TagOrderStore.getOrderedTags() || [];
-            const orderedGroupTags = orderedTags.filter((t) => t[0] === '+');
-            // XXX: One profile lookup failing will bring the whole lot down
-            Promise.all(orderedGroupTags.map(
-                (groupId) => FlairStore.getGroupProfileCached(this.context.matrixClient, groupId),
-            )).then((orderedGroupTagProfiles) => {
-                if (this.unmounted) return;
-                this.setState({orderedGroupTagProfiles});
+            this.setState({
+                orderedTags: TagOrderStore.getOrderedTags() || [],
             });
         });
         // This could be done by anything with a matrix client
@@ -113,11 +95,11 @@ const TagPanel = React.createClass({
         const TintableSvg = sdk.getComponent('elements.TintableSvg');
         const DNDTagTile = sdk.getComponent('elements.DNDTagTile');
 
-        const tags = this.state.orderedGroupTagProfiles.map((groupProfile, index) => {
+        const tags = this.state.orderedTags.map((tag, index) => {
             return <DNDTagTile
-                key={groupProfile.groupId + '_' + index}
-                groupProfile={groupProfile}
-                selected={this.state.selectedTags.includes(groupProfile.groupId)}
+                key={tag + '_' + index}
+                tag={tag}
+                selected={this.state.selectedTags.includes(tag)}
                 onEndDrag={this.onTagTileEndDrag}
             />;
         });

--- a/src/components/views/elements/DNDTagTile.js
+++ b/src/components/views/elements/DNDTagTile.js
@@ -29,7 +29,7 @@ const tagTileSource = {
     beginDrag: function(props) {
         // Return the data describing the dragged item
         return {
-            tag: props.groupProfile.groupId,
+            tag: props.tag,
         };
     },
 
@@ -55,7 +55,7 @@ const tagTileTarget = {
         dis.dispatch({
             action: 'order_tag',
             tag: monitor.getItem().tag,
-            targetTag: props.groupProfile.groupId,
+            targetTag: props.tag,
             // Note: we indicate that the tag should be after the target when
             // it's being dragged over the top half of the target.
             after: draggedY < targetY,
@@ -65,7 +65,7 @@ const tagTileTarget = {
     drop(props) {
         // Return the data to be returned by getDropResult
         return {
-            tag: props.groupProfile.groupId,
+            tag: props.tag,
         };
     },
 };

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -58,6 +58,8 @@ export default React.createClass({
             ).then((profile) => {
                 if (this.unmounted) return;
                 this.setState({profile});
+            }).catch((err) => {
+                console.warn('Could not fetch group profile for ' + this.props.tag, err);
             });
         }
     },

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -42,6 +42,12 @@ export default React.createClass({
         matrixClient: React.PropTypes.instanceOf(MatrixClient).isRequired,
     },
 
+    getInitialState() {
+        return {
+            hover: false,
+        };
+    },
+
     componentWillMount() {
         this.unmounted = false;
         if (this.props.tag[0] === '+') {
@@ -57,12 +63,6 @@ export default React.createClass({
 
     componentWillUnmount() {
         this.unmounted = true;
-    },
-
-    getInitialState() {
-        return {
-            hover: false,
-        };
     },
 
     onClick: function(e) {

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -24,11 +24,17 @@ import { isOnlyCtrlOrCmdKeyEvent } from '../../../Keyboard';
 
 import FlairStore from '../../../stores/FlairStore';
 
+// A class for a child of TagPanel (possibly wrapped in a DNDTagTile) that represents
+// a thing to click on for the user to filter the visible rooms in the RoomList to:
+//  - Rooms that are part of the group
+//  - Direct messages with members of the group
+// with the intention that this could be expanded to arbitrary tags in future.
 export default React.createClass({
     displayName: 'TagTile',
 
     propTypes: {
         // A string tag such as "m.favourite" or a group ID such as "+groupid:domain.bla"
+        // For now, only group IDs are handled.
         tag: PropTypes.string,
     },
 

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -28,6 +28,7 @@ export default React.createClass({
     displayName: 'TagTile',
 
     propTypes: {
+        // A string tag such as "m.favourite" or a group ID such as "+groupid:domain.bla"
         tag: PropTypes.string,
     },
 

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -45,6 +45,7 @@ export default React.createClass({
     getInitialState() {
         return {
             hover: false,
+            profile: null,
         };
     },
 

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -44,7 +44,9 @@ export default React.createClass({
 
     getInitialState() {
         return {
+            // Whether the mouse is over the tile
             hover: false,
+            // The profile data of the group if this.props.tag is a group ID
             profile: null,
         };
     },


### PR DESCRIPTION
So that instead of getting all group profiles everytime the tags
change order, get them when the TagTile mounts for a group tag.