### PR TITLE
Give the current theme to widgets and the integration manager

### DIFF
--- a/src/ScalarAuthClient.js
+++ b/src/ScalarAuthClient.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import Promise from 'bluebird';
+import SettingsStore from "./settings/SettingsStore";
 const request = require('browser-request');
 
 const SdkConfig = require('./SdkConfig');
@@ -109,6 +110,7 @@ class ScalarAuthClient {
         let url = SdkConfig.get().integrations_ui_url;
         url += "?scalar_token=" + encodeURIComponent(this.scalarToken);
         url += "&room_id=" + encodeURIComponent(roomId);
+        url += "&theme=" + encodeURIComponent(SettingsStore.getValue("theme"));
         if (id) {
             url += '&integ_id=' + encodeURIComponent(id);
         }

--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -27,6 +27,7 @@ import ScalarAuthClient from '../../../ScalarAuthClient';
 import ScalarMessaging from '../../../ScalarMessaging';
 import { _t } from '../../../languageHandler';
 import WidgetUtils from '../../../WidgetUtils';
+import SettingsStore from "../../../settings/SettingsStore";
 
 // The maximum number of widgets that can be added in a room
 const MAX_WIDGETS = 2;
@@ -131,6 +132,9 @@ module.exports = React.createClass({
             '$matrix_room_id': this.props.room.roomId,
             '$matrix_display_name': user ? user.displayName : this.props.userId,
             '$matrix_avatar_url': user ? MatrixClientPeg.get().mxcUrlToHttp(user.avatarUrl) : '',
+
+            // Namespaced for Riot
+            '$riot_theme': SettingsStore.getValue("theme"),
         };
 
         app.id = appId;

--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -133,8 +133,8 @@ module.exports = React.createClass({
             '$matrix_display_name': user ? user.displayName : this.props.userId,
             '$matrix_avatar_url': user ? MatrixClientPeg.get().mxcUrlToHttp(user.avatarUrl) : '',
 
-            // Namespaced for Riot
-            '$riot_theme': SettingsStore.getValue("theme"),
+            // TODO: Namespace themes through some standard
+            '$theme': SettingsStore.getValue("theme"),
         };
 
         app.id = appId;


### PR DESCRIPTION
For cases where the widgets and/or integration manager wish to look similar to Riot. This is kinda a step forward to the occasional complaint of Scalar not being dark-theme capable (I can't find the issue for this). Someone else would actually have to do the dark theme for Scalar, as I obviously don't have access.

The reason for namespacing the theme parameter in the widget URL is because other clients may not have the concept of themes, or may not agree on what their identifiers should be. For instance, another client may decide that their "light theme" is actually called "our_awesome_light_theme". Clients are recommended to document and support similar parameters, and widget writers are recommended to have per-client parameters in their widgets to check for the theme.