### PR TITLE
Fix issue with preview of phone number on register and waiting for sms code confirmation code

### DIFF
--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -374,7 +374,7 @@ export const MsisdnAuthEntry = React.createClass({
             return (
                 <div>
                     <p>{ _t("A text message has been sent to %(msisdn)s",
-                        { msisdn: <i>this._msisdn</i> },
+                        { msisdn: <i> { this._msisdn }</i> },
                     ) }
                     </p>
                     <p>{ _t("Please enter the code it contains:") }</p>

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -374,7 +374,7 @@ export const MsisdnAuthEntry = React.createClass({
             return (
                 <div>
                     <p>{ _t("A text message has been sent to %(msisdn)s",
-                        { msisdn: <i> { this._msisdn }</i> },
+                        { msisdn: <i>{ this._msisdn }</i> },
                     ) }
                     </p>
                     <p>{ _t("Please enter the code it contains:") }</p>


### PR DESCRIPTION
Hi.

Today I was trying to sign in in riot-web in my local dev machine. On registration it would require to type mobile number then it started to show the confirmation code box and no phone number, instead it was showing `this._msisdn`.

Fixed it by wrapping js code to evaluate it on render.

Signed-off-by: Alexandr Korsak <alex.korsak@gmail.com>