### PR TITLE
Hide status bar on visible->hidden transition

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -169,8 +169,10 @@ module.exports = React.createClass({
 
     // Check whether current size is greater than 0, if yes call props.onVisible
     _checkSize: function() {
-        if (this.props.onVisible && this._getSize()) {
-            this.props.onVisible();
+        if (this._getSize()) {
+            if (this.props.onVisible) this.props.onVisible();
+        } else {
+            if (this.props.onHidden) this.props.onHidden();
         }
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1347,7 +1347,7 @@ module.exports = React.createClass({
     },
 
     onStatusBarHidden: function() {
-        // This is currently nor desired as it is annoying if it keeps expanding and collapsing
+        // This is currently not desired as it is annoying if it keeps expanding and collapsing
         // TODO: Find a less annoying way of hiding the status bar
         /*if (this.unmounted) return;
         this.setState({

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1347,10 +1347,12 @@ module.exports = React.createClass({
     },
 
     onStatusBarHidden: function() {
-        if (this.unmounted) return;
+        // This is currently nor desired as it is annoying if it keeps expanding and collapsing
+        // TODO: Find a less annoying way of hiding the status bar
+        /*if (this.unmounted) return;
         this.setState({
             statusBarVisible: false,
-        });
+        });*/
     },
 
     showSettings: function(show) {


### PR DESCRIPTION
`RoomStatusBar` takes an `onHidden` prop yet never uses it...until now

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>