### PR TITLE
Only set selected tags state when updating rooms

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -324,12 +324,7 @@ module.exports = React.createClass({
             // Show all rooms
             this._visibleRooms = MatrixClientPeg.get().getRooms();
         }
-
-        this.setState({
-            selectedTags,
-        }, () => {
-            this.refreshRoomList();
-        });
+        this._delayedRefreshRoomList();
     },
 
     refreshRoomList: function() {
@@ -345,6 +340,9 @@ module.exports = React.createClass({
         this.setState({
             lists: this.getRoomLists(),
             totalRoomCount: totalRooms,
+            // Do this here so as to not render every time the selected tags
+            // themselves change.
+            selectedTags: TagOrderStore.getSelectedTags(),
         });
 
         // this._lastRefreshRoomListTs = Date.now();


### PR DESCRIPTION
instead of every time we get an update from a GroupStore/otherwise.

This was leading to many setStates and renders at startup when we
receive many group /members /rooms etc. responses.

Also, use the rate limited version of refreshRoomList.