### PR TITLE
Ignore remote echos caused by this client

### DIFF
--- a/src/actions/TagOrderActions.js
+++ b/src/actions/TagOrderActions.js
@@ -42,9 +42,14 @@ TagOrderActions.moveTag = function(matrixClient, tag, destinationIx) {
     tags = tags.filter((t) => t !== tag);
     tags = [...tags.slice(0, destinationIx), tag, ...tags.slice(destinationIx)];
 
+    const storeId = TagOrderStore.getStoreId();
+
     return asyncAction('TagOrderActions.moveTag', () => {
         Analytics.trackEvent('TagOrderActions', 'commitTagOrdering');
-        return matrixClient.setAccountData('im.vector.web.tag_ordering', {tags});
+        return matrixClient.setAccountData(
+            'im.vector.web.tag_ordering',
+            {tags, _storeId: storeId},
+        );
     }, () => {
         // For an optimistic update
         return {tags};

--- a/src/stores/TagOrderStore.js
+++ b/src/stores/TagOrderStore.js
@@ -63,6 +63,11 @@ class TagOrderStore extends Store {
             // Get ordering from account data
             case 'MatrixActions.accountData': {
                 if (payload.event_type !== 'im.vector.web.tag_ordering') break;
+
+                // Ignore remote echos caused by this store so as to avoid setting
+                // state back to old state.
+                if (payload.event_content._storeId === this.getStoreId()) break;
+
                 this._setState({
                     orderedTagsAccountData: payload.event_content ? payload.event_content.tags : null,
                 });
@@ -174,6 +179,13 @@ class TagOrderStore extends Store {
 
     getOrderedTags() {
         return this._state.orderedTags;
+    }
+
+    getStoreId() {
+        // Generate a random ID to prevent this store from clobbering its
+        // state with redundant remote echos.
+        if (!this._id) this._id = Math.random().toString(16).slice(2, 10);
+        return this._id;
     }
 
     getSelectedTags() {


### PR DESCRIPTION
by sending each tag_ordering with a _storeId and ignoring accout data
that has a matching _storeId.

This will tend to become out of sync with the server over time if
requests continually fail, but subsequent successful requests will
rectify any differences.