### PR TITLE
Persist contentState when sending SlashCommand via MessageComposerInput

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -723,6 +723,7 @@ export default class MessageComposerInput extends React.Component {
         const cmd = SlashCommands.processInput(this.props.room.roomId, commandText);
         if (cmd) {
             if (!cmd.error) {
+                this.historyManager.save(contentState, this.state.isRichtextEnabled ? 'html' : 'markdown');
                 this.setState({
                     editorState: this.createEditorState(),
                 });


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

Fixes vector-im/riot-web#5880