### PR TITLE
Offline mode

### DIFF
--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -61,7 +61,6 @@ const TagPanel = React.createClass({
 
     componentWillUnmount() {
         this.unmounted = true;
-        if (!this.context.matrixClient) return;
         this.context.matrixClient.removeListener("Group.myMembership", this._onGroupMyMembership);
         this.context.matrixClient.removeListener("sync", this.onClientSync);
         if (this._filterStoreToken) {
@@ -75,7 +74,6 @@ const TagPanel = React.createClass({
     },
 
     onClientSync(syncState, prevState) {
-        if (this.unmounted) return;
         // Consider the client reconnected if there is no error with syncing.
         // This means the state could be RECONNECTING, SYNCING or PREPARED.
         const reconnected = syncState !== "ERROR" && prevState !== syncState;

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -44,6 +44,7 @@ const TagPanel = React.createClass({
     componentWillMount: function() {
         this.unmounted = false;
         this.context.matrixClient.on("Group.myMembership", this._onGroupMyMembership);
+        this.context.matrixClient.on("sync", this.onClientSync);
 
         this._tagOrderStoreToken = TagOrderStore.addListener(() => {
             if (this.unmounted) {
@@ -61,6 +62,7 @@ const TagPanel = React.createClass({
     componentWillUnmount() {
         this.unmounted = true;
         this.context.matrixClient.removeListener("Group.myMembership", this._onGroupMyMembership);
+        this.context.matrixClient.removeListener("sync", this._onClientSync);
         if (this._filterStoreToken) {
             this._filterStoreToken.remove();
         }
@@ -69,6 +71,17 @@ const TagPanel = React.createClass({
     _onGroupMyMembership() {
         if (this.unmounted) return;
         dis.dispatch(GroupActions.fetchJoinedGroups(this.context.matrixClient));
+    },
+
+    onClientSync(syncState, prevState) {
+        if (this.unmounted) return;
+        // Consider the client reconnected if there is no error with syncing.
+        // This means the state could be RECONNECTING, SYNCING or PREPARED.
+        const reconnected = syncState !== "ERROR" && prevState !== syncState;
+        if (reconnected) {
+            // Load joined groups
+            dis.dispatch(GroupActions.fetchJoinedGroups(this.context.matrixClient));
+        }
     },
 
     onClick(e) {

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -61,6 +61,7 @@ const TagPanel = React.createClass({
 
     componentWillUnmount() {
         this.unmounted = true;
+        if (!this.context.matrixClient) return;
         this.context.matrixClient.removeListener("Group.myMembership", this._onGroupMyMembership);
         this.context.matrixClient.removeListener("sync", this._onClientSync);
         if (this._filterStoreToken) {

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -63,7 +63,7 @@ const TagPanel = React.createClass({
         this.unmounted = true;
         if (!this.context.matrixClient) return;
         this.context.matrixClient.removeListener("Group.myMembership", this._onGroupMyMembership);
-        this.context.matrixClient.removeListener("sync", this._onClientSync);
+        this.context.matrixClient.removeListener("sync", this.onClientSync);
         if (this._filterStoreToken) {
             this._filterStoreToken.remove();
         }

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -51,10 +51,12 @@ module.exports = React.createClass({
     },
 
     componentWillMount() {
+        this.unmounted = false;
         MatrixClientPeg.get().on('sync', this.onClientSync);
     },
 
     componentWillUnmount() {
+        this.unmounted = true;
         if (!MatrixClientPeg.get()) return;
         MatrixClientPeg.get().removeListener('sync', this.onClientSync);
     },
@@ -78,6 +80,8 @@ module.exports = React.createClass({
     },
 
     onClientSync(syncState, prevState) {
+        if (this.unmounted) return;
+
         // Consider the client reconnected if there is no error with syncing.
         // This means the state could be RECONNECTING, SYNCING or PREPARED.
         const reconnected = syncState !== "ERROR" && prevState !== syncState;

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import MatrixClientPeg from '../../../MatrixClientPeg';
+import { MatrixClient } from 'matrix-js-sdk';
 import AvatarLogic from '../../../Avatar';
 import sdk from '../../../index';
 import AccessibleButton from '../elements/AccessibleButton';
@@ -37,6 +37,10 @@ module.exports = React.createClass({
         defaultToInitialLetter: PropTypes.bool, // true to add default url
     },
 
+    contextTypes: {
+        matrixClient: PropTypes.instanceOf(MatrixClient),
+    },
+
     getDefaultProps: function() {
         return {
             width: 40,
@@ -52,13 +56,12 @@ module.exports = React.createClass({
 
     componentWillMount() {
         this.unmounted = false;
-        MatrixClientPeg.get().on('sync', this.onClientSync);
+        this.context.matrixClient.on('sync', this.onClientSync);
     },
 
     componentWillUnmount() {
         this.unmounted = true;
-        if (!MatrixClientPeg.get()) return;
-        MatrixClientPeg.get().removeListener('sync', this.onClientSync);
+        this.context.matrixClient.removeListener('sync', this.onClientSync);
     },
 
     componentWillReceiveProps: function(nextProps) {

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -55,6 +55,7 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount() {
+        if (!MatrixClientPeg.get()) return;
         MatrixClientPeg.get().removeListener('sync', this.onClientSync);
     },
 

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -17,7 +17,7 @@ import React from 'react';
 import sdk from '../../../index';
 import dis from '../../../dispatcher';
 import classNames from 'classnames';
-import { Room, RoomMember } from 'matrix-js-sdk';
+import { Room, RoomMember, MatrixClient } from 'matrix-js-sdk';
 import PropTypes from 'prop-types';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 import { MATRIXTO_URL_PATTERN } from '../../../linkify-matrix';
@@ -59,6 +59,17 @@ const Pill = React.createClass({
         room: PropTypes.instanceOf(Room),
         // Whether to include an avatar in the pill
         shouldShowPillAvatar: PropTypes.bool,
+    },
+
+
+    childContextTypes: {
+        matrixClient: PropTypes.instanceOf(MatrixClient),
+    },
+
+    getChildContext() {
+        return {
+            matrixClient: MatrixClientPeg.get(),
+        };
     },
 
     getInitialState() {

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -68,7 +68,7 @@ const Pill = React.createClass({
 
     getChildContext() {
         return {
-            matrixClient: MatrixClientPeg.get(),
+            matrixClient: this._matrixClient,
         };
     },
 
@@ -146,6 +146,7 @@ const Pill = React.createClass({
 
     componentWillMount() {
         this._unmounted = false;
+        this._matrixClient = MatrixClientPeg.get();
         this.componentWillReceiveProps(this.props);
     },
 

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -18,8 +18,9 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { MatrixClient } from 'matrix-js-sdk';
+
 import MFileBody from './MFileBody';
-import MatrixClientPeg from '../../../MatrixClientPeg';
 import ImageUtils from '../../../ImageUtils';
 import Modal from '../../../Modal';
 import sdk from '../../../index';
@@ -40,6 +41,10 @@ module.exports = React.createClass({
         onWidgetLoad: PropTypes.func.isRequired,
     },
 
+    contextTypes: {
+        matrixClient: PropTypes.instanceOf(MatrixClient),
+    },
+
     getInitialState: function() {
         return {
             decryptedUrl: null,
@@ -52,13 +57,12 @@ module.exports = React.createClass({
 
     componentWillMount() {
         this.unmounted = false;
-        MatrixClientPeg.get().on('sync', this.onClientSync);
+        this.context.matrixClient.on('sync', this.onClientSync);
     },
 
     componentWillUnmount() {
         this.unmounted = true;
-        if (!MatrixClientPeg.get()) return;
-        MatrixClientPeg.get().removeListener('sync', this.onClientSync);
+        this.context.matrixClient.removeListener('sync', this.onClientSync);
     },
 
     onClientSync(syncState, prevState) {
@@ -132,7 +136,7 @@ module.exports = React.createClass({
         if (content.file !== undefined) {
             return this.state.decryptedUrl;
         } else {
-            return MatrixClientPeg.get().mxcUrlToHttp(content.url);
+            return this.context.matrixClient.mxcUrlToHttp(content.url);
         }
     },
 
@@ -145,7 +149,7 @@ module.exports = React.createClass({
             }
             return this.state.decryptedUrl;
         } else {
-            return MatrixClientPeg.get().mxcUrlToHttp(content.url, 800, 600);
+            return this.context.matrixClient.mxcUrlToHttp(content.url, 800, 600);
         }
     },
 

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -51,15 +51,18 @@ module.exports = React.createClass({
     },
 
     componentWillMount() {
+        this.unmounted = false;
         MatrixClientPeg.get().on('sync', this.onClientSync);
     },
 
     componentWillUnmount() {
+        this.unmounted = true;
         if (!MatrixClientPeg.get()) return;
         MatrixClientPeg.get().removeListener('sync', this.onClientSync);
     },
 
     onClientSync(syncState, prevState) {
+        if (this.unmounted) return;
         // Consider the client reconnected if there is no error with syncing.
         // This means the state could be RECONNECTING, SYNCING or PREPARED.
         const reconnected = syncState !== "ERROR" && prevState !== syncState;

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -55,6 +55,7 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount() {
+        if (!MatrixClientPeg.get()) return;
         MatrixClientPeg.get().removeListener('sync', this.onClientSync);
     },
 

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -60,11 +60,6 @@ module.exports = React.createClass({
         this.context.matrixClient.on('sync', this.onClientSync);
     },
 
-    componentWillUnmount() {
-        this.unmounted = true;
-        this.context.matrixClient.removeListener('sync', this.onClientSync);
-    },
-
     onClientSync(syncState, prevState) {
         if (this.unmounted) return;
         // Consider the client reconnected if there is no error with syncing.
@@ -190,7 +185,9 @@ module.exports = React.createClass({
     },
 
     componentWillUnmount: function() {
+        this.unmounted = true;
         dis.unregister(this.dispatcherRef);
+        this.context.matrixClient.removeListener('sync', this.onClientSync);
     },
 
     onAction: function(payload) {

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -51,7 +51,7 @@ module.exports = React.createClass({
             decryptedThumbnailUrl: null,
             decryptedBlob: null,
             error: null,
-            imgError: null,
+            imgError: false,
         };
     },
 

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -117,7 +117,6 @@ describe('MemberEventListSummary', function() {
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 
-        expect(result.type).toBe('div');
         expect(result.props.children).toEqual([
           <div className="event_tile" key="event0">Expanded membership</div>,
         ]);
@@ -140,7 +139,6 @@ describe('MemberEventListSummary', function() {
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 
-        expect(result.type).toBe('div');
         expect(result.props.children).toEqual([
           <div className="event_tile" key="event0">Expanded membership</div>,
           <div className="event_tile" key="event1">Expanded membership</div>,

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
 import sdk from 'matrix-react-sdk';
 import * as languageHandler from '../../../../src/languageHandler';
-import peg from '../../../../src/MatrixClientPeg';
 import * as testUtils from '../../../test-utils';
 
 // Give MELS a matrixClient in its child context

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -6,6 +6,10 @@ import * as languageHandler from '../../../../src/languageHandler';
 import peg from '../../../../src/MatrixClientPeg';
 import * as testUtils from '../../../test-utils';
 
+// Give MELS a matrixClient in its child context
+const MemberEventListSummary = testUtils.wrapInMatrixClientContext(
+    sdk.getComponent('views.elements.MemberEventListSummary'),
+);
 
 describe('MemberEventListSummary', function() {
     let sandbox;

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -1,12 +1,12 @@
-const expect = require('expect');
-const React = require('react');
-const ReactDOM = require("react-dom");
-const ReactTestUtils = require('react-addons-test-utils');
-const sdk = require('matrix-react-sdk');
-const MemberEventListSummary = sdk.getComponent('views.elements.MemberEventListSummary');
+import expect from 'expect';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import sdk from 'matrix-react-sdk';
 import * as languageHandler from '../../../../src/languageHandler';
+import peg from '../../../../src/MatrixClientPeg';
+import * as testUtils from '../../../test-utils';
 
-const testUtils = require('../../../test-utils');
+
 describe('MemberEventListSummary', function() {
     let sandbox;
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -2,7 +2,8 @@
 
 import sinon from 'sinon';
 import Promise from 'bluebird';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import peg from '../src/MatrixClientPeg';
 import dis from '../src/dispatcher';
 import jssdk from 'matrix-js-sdk';
@@ -264,4 +265,27 @@ export function getDispatchForStore(store) {
         dis._callbacks[store._dispatchToken](payload);
         dis._isDispatching = false;
     };
+}
+
+export function wrapInMatrixClientContext(WrappedComponent) {
+    class Wrapper extends React.Component {
+        static childContextTypes = {
+            matrixClient: PropTypes.object,
+        }
+
+        getChildContext() {
+            return {
+                matrixClient: this._matrixClient,
+            };
+        }
+
+        componentWillMount() {
+            this._matrixClient = peg.get();
+        }
+
+        render() {
+            return <WrappedComponent {...this.props} />;
+        }
+    }
+    return Wrapper;
 }


### PR DESCRIPTION
Adds ability to use a logged-in client without having a connection to the HS.

These changes are mostly to recover from being offline - fetching avatars, thumbnails and joined groups.

Apart from this, the client can now run without pushRules (which it now assumes is OK, given that pushRules *will* be set if the client is successfully SYNCING). Otherwise, the client will load with the data stored in indexddb.

See https://github.com/matrix-org/matrix-js-sdk/pull/601