### PR TITLE
Make ratelimitedfunc time from the function's end

### DIFF
--- a/src/ratelimitedfunc.js
+++ b/src/ratelimitedfunc.js
@@ -35,13 +35,17 @@ module.exports = function(f, minIntervalMs) {
 
         if (self.lastCall < now - minIntervalMs) {
             f.apply(this);
-            self.lastCall = now;
+            // get the time again now the function has finished, so if it
+            // took longer than the delay time to execute, it doesn't
+            // immediately become eligible to run again.
+            self.lastCall = Date.now();
         } else if (self.scheduledCall === undefined) {
             self.scheduledCall = setTimeout(
                 () => {
                     self.scheduledCall = undefined;
                     f.apply(this);
-                    self.lastCall = now;
+                    // get time again as per above
+                    self.lastCall = Date.now();
                 },
                 (self.lastCall + minIntervalMs) - now,
             );


### PR DESCRIPTION
Otherwise any function tghat takes longer than the delay to execute
will become eligible for execution again immediately after
finishing and therefore be able to spin.

This should help with https://github.com/vector-im/riot-web/issues/6060
(at least in the respect that it makes ratelimitedfunc do its job)
even if it's not the reason Riot started getting wedged.