### PR TITLE
Do not truncate autocompleted users in composer

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -158,7 +158,7 @@ export default class UserProvider extends AutocompleteProvider {
     }
 
     renderCompletions(completions: [React.Component]): ?React.Component {
-        return <div className="mx_Autocomplete_Completion_container_pill mx_Autocomplete_Completion_container_truncate">
+        return <div className="mx_Autocomplete_Completion_container_pill">
             { completions }
         </div>;
     }


### PR DESCRIPTION
so that disambiguation is possible at a glance.

Fixes https://github.com/vector-im/riot-web/issues/6024