### PR TITLE
Fix custom tags not being ordered manually

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -160,32 +160,26 @@ class RoomListStore extends Store {
         });
 
         const listOrders = {
-            "manual": [
-                "m.favourite",
-            ],
-            "recent": [
-                "im.vector.fake.invite",
-                "im.vector.fake.recent",
-                "im.vector.fake.direct",
-                "m.lowpriority",
-                "im.vector.fake.archived",
-            ],
+            "m.favourite": "manual",
+            "im.vector.fake.invite": "recent",
+            "im.vector.fake.recent": "recent",
+            "im.vector.fake.direct": "recent",
+            "m.lowpriority": "recent",
+            "im.vector.fake.archived": "recent",
         };
 
-        Object.keys(listOrders).forEach((order) => {
-            listOrders[order].forEach((listKey) => {
-                let comparator;
-                switch (order) {
-                    case "recent":
-                        comparator = this._recentsComparator;
-                        break;
-                    case "manual":
-                    default:
-                        comparator = this._getManualComparator(listKey, optimisticRequest);
-                        break;
-                }
-                lists[listKey].sort(comparator);
-            });
+        Object.keys(lists).forEach((listKey) => {
+            let comparator;
+            switch (listOrders[listKey]) {
+                case "recent":
+                    comparator = this._recentsComparator;
+                    break;
+                case "manual":
+                default:
+                    comparator = this._getManualComparator(listKey, optimisticRequest);
+                    break;
+            }
+            lists[listKey].sort(comparator);
         });
 
         this._setState({


### PR DESCRIPTION
Actually fixes vector-im/riot-web#6135 unlike #1748, which
incorrectly assumed that custom tags would be included in
listOrders.

This fix makes sure that the `default` case in the `switch`
is actually used.

Replaces #1749