### PR TITLE
Use sandbox for preview iframe

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -335,7 +335,7 @@ module.exports = React.createClass({
                               */ }
                             <a ref="dummyLink" />
                         </div>
-                        <iframe src={renderer_url} onLoad={onIframeLoad} ref="iframe" />
+                        <iframe src={renderer_url} sandbox="allow-scripts" onLoad={onIframeLoad} ref="iframe" />
                     </div>
                 </span>
             );


### PR DESCRIPTION
We have to allow JS, of course, as that's what's needed for rendering.

Because even though it may be cross-origin, it could still do bad things.