### PR TITLE
Correct false CSP statement

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -68,8 +68,9 @@ Tinter.registerTintable(updateTintedDownloadImage);
 // client. Otherwise those scripts written by remote users can read
 // the access token and end-to-end keys that are in local storage.
 //
-// For attachments downloaded directly from the homeserver we can use
-// Content-Security-Policy headers to disable script execution.
+// Attachments downloaded directly from the homeserver are embedded via
+// the src attribut of the img tag with plain-old http(s):// links.
+// Browsers make sure that usual images cannot execute JS.
 //
 // But attachments with end-to-end encryption are more difficult to handle.
 // We need to decrypt the attachment on the client and then display it.


### PR DESCRIPTION
CSPs **only apply** when you access the file directly. That means when you access `index.html` or, in this case, `/_matrix/media/v1/download/domain.com/dfsdf` the CSP is applied. When you fetch a `image.png` via `src` attribut or so there, it does not matter what CSP header that image loading itself sends.