### PR TITLE
improve origin check of ScalarMessaging postmessage API.

### DIFF
--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -563,7 +563,7 @@ const onMessage = function(event) {
     const url = SdkConfig.get().integrations_ui_url;
     if (
         event.origin.length === 0 ||
-        !url.startsWith(event.origin) ||
+        !url.startsWith(event.origin + '/') ||
         !event.data.action ||
         event.data.api // Ignore messages with specific API set
     ) {


### PR DESCRIPTION
ensures that https://scalar.ve can't access the API.
many thanks to @rugk for pointing out the potential vuln.
cc @rxl881 in case this bug has been transplanted elsewhere.