### PR TITLE
 Adjust eventTriggersUnreadCount to include m.room.encrypted

### DIFF
--- a/src/Unread.js
+++ b/src/Unread.js
@@ -30,7 +30,7 @@ module.exports = {
             return false;
         } else if (ev.getType() == 'm.call.answer' || ev.getType() == 'm.call.hangup') {
             return false;
-        } else if (ev.getType == 'm.room.message' && ev.getContent().msgtype == 'm.notify') {
+        } else if (ev.getType() == 'm.room.message' && ev.getContent().msgtype == 'm.notify') {
             return false;
         }
         const EventTile = sdk.getComponent('rooms.EventTile');

--- a/src/Unread.js
+++ b/src/Unread.js
@@ -32,6 +32,8 @@ module.exports = {
             return false;
         } else if (ev.getType() == 'm.room.message' && ev.getContent().msgtype == 'm.notify') {
             return false;
+        } else if (ev.getType() == 'm.room.encrypted') {
+            return true;
         }
         const EventTile = sdk.getComponent('rooms.EventTile');
         return EventTile.haveTileForEvent(ev);


### PR DESCRIPTION
Because encrypted events should trigger unread counts. This does
mean that they are not decrypted at the point the count changes,
but also means we don't have to have a RoomList that is aware of
event decryption.

Fixes vector-im/riot-web#6132