### PR TITLE
Fix TextualBody.js to remove NodeList.forEach()

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -337,7 +337,7 @@ module.exports = React.createClass({
 
     _addCodeCopyButton() {
         // Add 'copy' buttons to pre blocks
-        ReactDOM.findDOMNode(this).querySelectorAll('.mx_EventTile_body pre').forEach((p) => {
+        Array.from(ReactDOM.findDOMNode(this).querySelectorAll('.mx_EventTile_body pre')).forEach((p) => {
             const button = document.createElement("span");
             button.className = "mx_EventTile_copyButton";
             button.onclick = (e) => {


### PR DESCRIPTION
Not all browsers support forEach() on NodeList objects. This causes crashes on some browsers, such as IE and FF<50.

Signed-off-by: Adrian Hossu <adrian@freetrainers.com>