### PR TITLE
Use undocumented piwik cmd to disable heartbeattimer

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -92,6 +92,7 @@ class Analytics {
      */
     disable() {
         this.trackEvent('Analytics', 'opt-out');
+        this._paq.push(['disableHeartBeatTimer']);
         this.disabled = true;
     }
 

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -92,6 +92,9 @@ class Analytics {
      */
     disable() {
         this.trackEvent('Analytics', 'opt-out');
+        // disableHeartBeatTimer is undocumented but exists in the piwik code
+        // the _paq.push method will result in an error being printed in the console
+        // if an unknown method signature is passed
         this._paq.push(['disableHeartBeatTimer']);
         this.disabled = true;
     }


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

SHOULD FIX https://github.com/vector-im/riot-web/issues/6233

~[NEEDS TESTING]~