### PR TITLE
Restore `getValue()` on PowerSelector component

### DIFF
--- a/src/components/views/elements/PowerSelector.js
+++ b/src/components/views/elements/PowerSelector.js
@@ -98,6 +98,16 @@ module.exports = React.createClass({
         }
     },
 
+    getValue: function() {
+        if (this.refs.custom) {
+            return parseInt(this.refs.custom.value);
+        }
+        if (this.refs.select) {
+            return this.refs.select.value;
+        }
+        return undefined;
+    },
+
     render: function() {
         let customPicker;
         if (this.state.custom) {


### PR DESCRIPTION
Seems like it was removed in 3fa1bece0a8ad73ab91c297a17e6babdc4e7b6c6 by accident but it is still being used by the RoomSettings component.

This change fixes a `TypeError` that occurs when invoking `this.refs[key].getValue()` in RoomSettings.js: https://github.com/matrix-org/matrix-react-sdk/blob/4bf5e44b2043bbe95faa66943878acad23dfb823/src/components/views/rooms/RoomSettings.js#L404

This error prevents the room's power levels from being edited.