### PR TITLE
[POC] trust in chrome to do scroll anchoring

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -650,7 +650,9 @@ module.exports = React.createClass({
                 "mx_MessagePanel_alwaysShowTimestamps": this.props.alwaysShowTimestamps,
             },
         );
+                // { topSpinner }
 
+                // { bottomSpinner }
         return (
             <ScrollPanel ref="scrollPanel" className={className}
                     onScroll={this.props.onScroll}
@@ -659,9 +661,7 @@ module.exports = React.createClass({
                     onUnfillRequest={this.props.onUnfillRequest}
                     style={style}
                     stickyBottom={this.props.stickyBottom}>
-                { topSpinner }
                 { this._getEventTiles() }
-                { bottomSpinner }
             </ScrollPanel>
         );
     },

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -636,7 +636,7 @@ module.exports = React.createClass({
         const prevScroll = scrollNode.scrollTop;
 
         // FF ignores attempts to set scrollTop to very large numbers
-        scrollNode.scrollTop = Math.min(scrollTop, scrollNode.scrollHeight);
+        // scrollNode.scrollTop = Math.min(scrollTop, scrollNode.scrollHeight);
 
         // If this change generates a scroll event, we should not update the
         // saved scroll state on it. See the comments in onScroll.


### PR DESCRIPTION
This does not exactly work because it fails when we're at the very top of the page and back paginating. It does however work very very well when paginating whilst the viewport is half-way down the timeline window or whilst at the very bottom.

Removing spinners doesn't seem to have any effect.

In theory the anchor selection algorithm chrome uses is selecting an element that React decides to turn into a totally new element. There is currently no planned mechanism to prevent some elements from being used as anchors.

Chome is also the only browser to support this

See https://drafts.csswg.org/css-scroll-anchoring/