### PR TITLE
Potentially fix a memory leak in FlairStore

### DIFF
--- a/src/stores/FlairStore.js
+++ b/src/stores/FlairStore.js
@@ -160,7 +160,7 @@ class FlairStore extends EventEmitter {
                 await this._groupProfilesPromise[groupId];
             } catch (e) {
                 // Don't log the error; this is done below
-                return undefined;
+                return null;
             }
             return this._groupProfiles[groupId];
         }
@@ -176,7 +176,7 @@ class FlairStore extends EventEmitter {
             console.log('FlairStore: Failed to get group profile for ' + groupId, e);
             // Don't retry, but allow a retry when the profile is next requested
             delete this._groupProfilesPromise[groupId];
-            return;
+            return null;
         }
 
         this._groupProfiles[groupId] = {

--- a/src/stores/FlairStore.js
+++ b/src/stores/FlairStore.js
@@ -167,7 +167,7 @@ class FlairStore extends EventEmitter {
 
         // No request yet, start one
         console.log('FlairStore: Request group profile of ' + groupId);
-        this._groupProfilesPromise[groupId] = matrixClient.getGroupProfile(groupId).delay(5000);
+        this._groupProfilesPromise[groupId] = matrixClient.getGroupProfile(groupId);
 
         let profile;
         try {

--- a/src/stores/FlairStore.js
+++ b/src/stores/FlairStore.js
@@ -154,16 +154,26 @@ class FlairStore extends EventEmitter {
             return this._groupProfiles[groupId];
         }
 
-        // No request yet, start one
-        if (!this._groupProfilesPromise[groupId]) {
-            this._groupProfilesPromise[groupId] = matrixClient.getGroupProfile(groupId);
+        // A request is ongoing, wait for it to complete and return the group profile.
+        if (this._groupProfilesPromise[groupId]) {
+            try {
+                await this._groupProfilesPromise[groupId];
+            } catch (e) {
+                // Don't log the error; this is done below
+                return undefined;
+            }
+            return this._groupProfiles[groupId];
         }
+
+        // No request yet, start one
+        console.log('FlairStore: Request group profile of ' + groupId);
+        this._groupProfilesPromise[groupId] = matrixClient.getGroupProfile(groupId).delay(5000);
 
         let profile;
         try {
             profile = await this._groupProfilesPromise[groupId];
         } catch (e) {
-            console.log('Failed to get group profile for ' + groupId, e);
+            console.log('FlairStore: Failed to get group profile for ' + groupId, e);
             // Don't retry, but allow a retry when the profile is next requested
             delete this._groupProfilesPromise[groupId];
             return;
@@ -179,6 +189,7 @@ class FlairStore extends EventEmitter {
 
         /// XXX: This is verging on recreating a third "Flux"-looking Store. We really
         /// should replace FlairStore with a Flux store and some async actions.
+        console.log('FlairStore: Emit updateGroupProfile for ' + groupId);
         this.emit('updateGroupProfile');
 
         setTimeout(() => {


### PR DESCRIPTION
For each successful request of a group profile, we previously
emitted an `updateGroupProfile` event per caller of
`getGroupProfileCached`. This is sub-optimal because only a single
event emit is required to update the views listening.

It's possible that this was enabling some race to cause a memory
leak but this is not certain, hence the extra logging for future
debugging.