### PR TITLE
Don't reset the presence timer on every dispatch

### DIFF
--- a/src/Presence.js
+++ b/src/Presence.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ class Presence {
         this.running = true;
         if (undefined === this.state) {
             this._resetTimer();
-            this.dispatcherRef = dis.register(this._onUserActivity.bind(this));
+            this.dispatcherRef = dis.register(this._onAction.bind(this));
         }
     }
 
@@ -125,9 +126,10 @@ class Presence {
         this.setState("unavailable");
     }
 
-    _onUserActivity(payload) {
-        if (payload.action === "sync_state" || payload.action === "self_presence_updated") return;
-        this._resetTimer();
+    _onAction(payload) {
+        if (payload.action === "user_activity") {
+            this._resetTimer();
+        }
     }
 
     /**


### PR DESCRIPTION
Only on user activity (there's now a dispatch every time we set a
member event, ie. A LOT, hence this now being a problem)