### PR TITLE
Remove spurious console.trace

### DIFF
--- a/src/Tinter.js
+++ b/src/Tinter.js
@@ -252,7 +252,6 @@ class Tinter {
 
 
     setTheme(theme) {
-        console.trace("setTheme " + theme);
         this.theme = theme;
 
         // update keyRgb from the current theme CSS itself, if it defines it


### PR DESCRIPTION
There's no comment to say why this is here and the commit that
add it (e91e94fd4) doesn't mention it either, so it's presumably
unintentional.