### PR TITLE
Give BaseAvatar a shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "querystring": "^0.2.0",
     "react": "^15.4.0",
     "react-addons-css-transition-group": "15.3.2",
+    "react-addons-shallow-compare": "^15.6.2",
     "react-beautiful-dnd": "^4.0.0",
     "react-dom": "^15.4.0",
     "react-gemini-scrollbar": "matrix-org/react-gemini-scrollbar#5e97aef",

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -22,6 +22,8 @@ import AvatarLogic from '../../../Avatar';
 import sdk from '../../../index';
 import AccessibleButton from '../elements/AccessibleButton';
 
+import shallowCompare from 'react-addons-shallow-compare';
+
 module.exports = React.createClass({
     displayName: 'BaseAvatar',
 
@@ -81,6 +83,21 @@ module.exports = React.createClass({
                 }
             }
         }
+    },
+
+    shouldComponentUpdate(nextProps, nextState) {
+        // There's a list of URLs in both props ('urls') and state ('imageUrls').
+        // state.imageUrls is derived from props.urls (for better or worse) in
+        // componentWillReceiveProps so we only need to compare each URL in state.imageUrls
+        if (this.state.imageUrls && nextState.imageUrls) {
+            if (this.state.imageUrls.length !== nextState.imageUrls.length) return true;
+            for (let i = 0; i < this.state.imageUrls.length; ++i) {
+                if (this.state.imageUrls[i] !== nextState.imageUrls[i]) return true;
+            }
+        }
+
+        // otherwise, defer to shallow comparison
+        return shallowCompare(this, nextProps, nextState);
     },
 
     onClientSync: function(syncState, prevState) {


### PR DESCRIPTION
Pulls in react-addons-shallow-compare to do the shallow props/state
comparison, although it's now deprecated in favour of
React.PureComponent, but that doesn't actually implement
shouldComponentUpdate so you can't defer to a superclass method
like this.