### PR TITLE
Enable autocompletion for non-English languages.

### DIFF
--- a/src/autocomplete/UserProvider.js
+++ b/src/autocomplete/UserProvider.js
@@ -44,6 +44,7 @@ export default class UserProvider extends AutocompleteProvider {
         this.matcher = new FuzzyMatcher([], {
             keys: ['name', 'userId'],
             shouldMatchPrefix: true,
+            shouldMatchWordsOnly: false
         });
 
         this._onRoomTimelineBound = this._onRoomTimeline.bind(this);


### PR DESCRIPTION
Hello all.

I noticed that autocompletion works for MXID and only English nicknames. This change enables autocompletion for nicknames on other languages.
Also this fixes the https://github.com/vector-im/riot-web/issues/4868

Signed-off-by: Anatoly Sablin <sablintolya@gmail.com>