### PR TITLE
Revert "Take TagPanel out of labs"

### DIFF
--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -94,6 +94,12 @@ export const SETTINGS = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
+    "feature_tag_panel": {
+        isFeature: true,
+        displayName: _td("Tag Panel"),
+        supportedLevels: LEVELS_FEATURE,
+        default: false,
+    },
     "MessageComposerInput.dontSuggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Disable Emoji suggestions while typing'),


### PR DESCRIPTION
This reverts commit 1b28ab136b0b12fd4851b3440bd6664b3e75f849.

Codep https://github.com/vector-im/riot-web/pull/6375