### PR TITLE
Track duration of page changes

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -148,6 +148,9 @@ class Analytics {
     }
 
     trackPageChange(generationTimeMs) {
+        if (typeof generationTimeMs !== 'number') {
+            throw new Error('Analytics.trackPageChange: expected generationTimeMs to be a number');
+        }
         if (this.disabled) return;
         if (this.firstPage) {
             // De-duplicate first page
@@ -156,9 +159,7 @@ class Analytics {
             return;
         }
         this._paq.push(['setCustomUrl', getRedactedUrl()]);
-        if (typeof generationTimeMs === 'number') {
-            this._paq.push(['setGenerationTimeMs', generationTimeMs]);
-        }
+        this._paq.push(['setGenerationTimeMs', generationTimeMs]);
         this._paq.push(['trackPageView']);
     }
 

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -148,24 +148,7 @@ class Analytics {
         return true;
     }
 
-    startPageChangeTimer() {
-        performance.clearMarks('riot_page_change_start');
-        performance.mark('riot_page_change_start');
-    }
-
-    stopPageChangeTimer() {
-        performance.mark('riot_page_change_stop');
-        performance.measure(
-            'riot_page_change_delta',
-            'riot_page_change_start',
-            'riot_page_change_stop',
-        );
-
-        const measurement = performance.getEntriesByName('riot_page_change_delta').pop();
-        this.generationTimeMs = measurement.duration;
-    }
-
-    trackPageChange() {
+    trackPageChange(generationTimeMs) {
         if (this.disabled) return;
         if (this.firstPage) {
             // De-duplicate first page
@@ -174,8 +157,8 @@ class Analytics {
             return;
         }
         this._paq.push(['setCustomUrl', getRedactedUrl()]);
-        if (typeof this.generationTimeMs === 'number') {
-            this._paq.push(['setGenerationTimeMs', this.generationTimeMs]);
+        if (typeof generationTimeMs === 'number') {
+            this._paq.push(['setGenerationTimeMs', generationTimeMs]);
         }
         this._paq.push(['trackPageView']);
     }

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -74,7 +74,6 @@ class Analytics {
         this._paq = null;
         this.disabled = true;
         this.firstPage = true;
-        this.generationTimeMs = null;
     }
 
     /**

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -74,6 +74,7 @@ class Analytics {
         this._paq = null;
         this.disabled = true;
         this.firstPage = true;
+        this.generationTimeMs = null;
     }
 
     /**
@@ -147,6 +148,23 @@ class Analytics {
         return true;
     }
 
+    startPageChangeTimer() {
+        performance.clearMarks('riot_page_change_start');
+        performance.mark('riot_page_change_start');
+    }
+
+    stopPageChangeTimer() {
+        performance.mark('riot_page_change_stop');
+        performance.measure(
+            'riot_page_change_delta',
+            'riot_page_change_start',
+            'riot_page_change_stop',
+        );
+
+        const measurement = performance.getEntriesByName('riot_page_change_delta').pop();
+        this.generationTimeMs = measurement.duration;
+    }
+
     trackPageChange() {
         if (this.disabled) return;
         if (this.firstPage) {
@@ -156,6 +174,9 @@ class Analytics {
             return;
         }
         this._paq.push(['setCustomUrl', getRedactedUrl()]);
+        if (typeof this.generationTimeMs === 'number') {
+            this._paq.push(['setGenerationTimeMs', this.generationTimeMs]);
+        }
         this._paq.push(['trackPageView']);
     }
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -291,6 +291,8 @@ export default React.createClass({
         this.handleResize();
         window.addEventListener('resize', this.handleResize);
 
+        this._pageChanging = false;
+
         // check we have the right tint applied for this theme.
         // N.B. we don't call the whole of setTheme() here as we may be
         // racing with the theme CSS download finishing from index.js

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -368,11 +368,27 @@ export default React.createClass({
         window.removeEventListener('resize', this.handleResize);
     },
 
-    componentDidUpdate: function() {
+    componentWillUpdate: function(props, state) {
+        if (this.shouldTrackPageChange(this.state, state)) {
+            Analytics.startPageChangeTimer();
+        }
+    },
+
+    componentDidUpdate: function(prevProps, prevState) {
+        if (this.shouldTrackPageChange(prevState, this.state)) {
+            Analytics.stopPageChangeTimer();
+            Analytics.trackPageChange();
+        }
         if (this.focusComposer) {
             dis.dispatch({action: 'focus_composer'});
             this.focusComposer = false;
         }
+    },
+
+    shouldTrackPageChange(prevState, state) {
+        return prevState.currentRoomId !== state.currentRoomId ||
+            prevState.view !== state.view ||
+            prevState.page_type !== state.page_type;
     },
 
     setStateForNewView: function(state) {
@@ -1341,7 +1357,6 @@ export default React.createClass({
         if (this.props.onNewScreen) {
             this.props.onNewScreen(screen);
         }
-        Analytics.trackPageChange();
     },
 
     onAliasClick: function(event, alias) {


### PR DESCRIPTION
The duration measured is between
 - componentWillUpdate of MatrixChat and
 - componentDidUpdate of MatrixChat.

This does not account for *all* changes to the view that occur
when a room switch happens, for example. But it does at least
capture the difference between switching to a "big" room and
switching to a small test room.

(as per https://matomo.org/blog/2017/02/how-to-track-single-page-websites-using-piwik-analytics/ - thanks @michaelkaye for finding that!)

Fixes https://github.com/vector-im/riot-web/issues/6325