### PR TITLE
Don't notify for bad encrypted messages

### DIFF
--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -256,6 +256,10 @@ const Notifier = {
     },
 
     onEventDecrypted: function(ev) {
+        // 'decrypted' means the decryption process has finished: it may have failed,
+        // in which case it might decrypt soon if the keys arrive
+        if (ev.isDecryptionFailure()) return;
+
         const idx = this.pendingEncryptedEventIds.indexOf(ev.getId());
         if (idx === -1) return;
 


### PR DESCRIPTION
Continue to wait for decryption if the decryption process failed.
Because we weren't doing this, the first message in a megolm session
was generally failing to decrypt the first time because the keys often
arrive after the message.

Fixes https://github.com/vector-im/riot-web/issues/6284

This is is small & safe enough that we may want to consider
putting it in 0.14 if we're cutting another RC.

@lukebarnard1 I've assigned this to you but feel free to punt it to Rich if you don't feel like you have enough context