### PR TITLE
Add null-guard to prevent RoomAvatar NPE when room is null

### DIFF
--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -66,7 +66,8 @@ module.exports = React.createClass({
     },
 
     onRoomStateEvents: function(ev) {
-        if (ev.getRoomId() !== this.props.room.roomId ||
+        if (!this.props.room ||
+            ev.getRoomId() !== this.props.room.roomId ||
             ev.getType() !== 'm.room.avatar'
         ) return;
 


### PR DESCRIPTION
which may have been occuring when peeking into a room that the
client hasn't got a Room object for.

Fixes https://github.com/vector-im/riot-web/issues/6432