### PR TITLE
Fix widget grant / revoke permission binding

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -52,6 +52,8 @@ export default class AppTile extends React.Component {
         this.onClickMenuBar = this.onClickMenuBar.bind(this);
         this._onMinimiseClick = this._onMinimiseClick.bind(this);
         this._onInitialLoad = this._onInitialLoad.bind(this);
+        this._grantWidgetPermission = this._grantWidgetPermission.bind(this);
+        this._revokeWidgetPermission = this._revokeWidgetPermission.bind(this);
     }
 
     /**


### PR DESCRIPTION
I'm not quite sure where this regression was introduced, but we're not correctly binding these functions at the moment (which is resulting in errors granting / removing widget permissions on /develop).