### PR TITLE
Make stickers/messages continuations of each other

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -447,10 +447,18 @@ module.exports = React.createClass({
         // is this a continuation of the previous message?
         let continuation = false;
 
+        // Some events should appear as continuations from previous events of
+        // different types.
+        const continuedTypes = ['m.sticker', 'm.room.message'];
+        const eventTypeContinues =
+            prevEvent !== null &&
+            continuedTypes.includes(mxEv.getType()) &&
+            continuedTypes.includes(prevEvent.getType());
+
         if (prevEvent !== null
                 && prevEvent.sender && mxEv.sender
                 && mxEv.sender.userId === prevEvent.sender.userId
-                && mxEv.getType() == prevEvent.getType()) {
+                && (mxEv.getType() == prevEvent.getType() || eventTypeContinues)) {
             continuation = true;
         }
 

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -450,12 +450,7 @@ module.exports = React.createClass({
         if (prevEvent !== null
                 && prevEvent.sender && mxEv.sender
                 && mxEv.sender.userId === prevEvent.sender.userId
-                // The preferred way of checking for 'continuation messages' is by
-                // checking whether subsiquent messages from the same user have a
-                // message body. This is because all messages intended to be displayed
-                // should have a 'body' whereas some (non-m.room) messages (such as
-                // m.sticker) may not have a message 'type'.
-                && Boolean(mxEv.getContent().body) == Boolean(prevEvent.getContent().body)) {
+                && mxEv.getType() == prevEvent.getType()) {
             continuation = true;
         }
 

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -471,8 +471,7 @@ module.exports = withMatrixClient(React.createClass({
         const eventType = this.props.mxEvent.getType();
 
         // Info messages are basically information about commands processed on a room
-        // For now assume that anything that doesn't have a content body is an isInfoMessage
-        const isInfoMessage = !content.body; // Boolean comparison of non-boolean content body
+        const isInfoMessage = (eventType !== 'm.room.message' && eventType !== 'm.room.sticker');
 
         const EventTileType = sdk.getComponent(getHandlerTile(this.props.mxEvent));
         // This shouldn't happen: the caller should check we support this type

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -471,7 +471,7 @@ module.exports = withMatrixClient(React.createClass({
         const eventType = this.props.mxEvent.getType();
 
         // Info messages are basically information about commands processed on a room
-        const isInfoMessage = (eventType !== 'm.room.message' && eventType !== 'm.room.sticker');
+        const isInfoMessage = (eventType !== 'm.room.message' && eventType !== 'm.sticker');
 
         const EventTileType = sdk.getComponent(getHandlerTile(this.props.mxEvent));
         // This shouldn't happen: the caller should check we support this type


### PR DESCRIPTION
This reverts the previous implementation of this because it introduced sender avatars (of the original sender) appearing next to redacted events.