### PR TITLE
Improve group join/leave feedback

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -678,7 +678,7 @@ export default React.createClass({
 
     _onRejectInviteClick: function() {
         this.setState({membershipBusy: true});
-        this._matrixClient.leaveGroup(this.props.groupId).then(() => {
+        this._groupStore.leaveGroup().then(() => {
             // don't reset membershipBusy here: wait for the membership change to come down the sync
         }).catch((e) => {
             this.setState({membershipBusy: false});
@@ -692,7 +692,8 @@ export default React.createClass({
 
     _onJoinClick: function() {
         this.setState({membershipBusy: true});
-        this._matrixClient.joinGroup(this.props.groupId).then(() => {
+
+        this._groupStore.joinGroup().then(() => {
             // don't reset membershipBusy here: wait for the membership change to come down the sync
         }).catch((e) => {
             this.setState({membershipBusy: false});
@@ -715,7 +716,7 @@ export default React.createClass({
                 if (!confirmed) return;
 
                 this.setState({membershipBusy: true});
-                this._matrixClient.leaveGroup(this.props.groupId).then(() => {
+                this._groupStore.leaveGroup().then(() => {
                     // don't reset membershipBusy here: wait for the membership change to come down the sync
                 }).catch((e) => {
                     this.setState({membershipBusy: false});

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -994,8 +994,8 @@ export default React.createClass({
 
         return <div className={membershipContainerClasses}>
             <div className="mx_GroupView_membershipSubSection">
-                { /* Empty div for flex alignment */ }
-                <div />
+                { /* The <div /> is for flex alignment */ }
+                { this.state.membershipBusy ? <Spinner /> : <div /> }
                 <div className="mx_GroupView_membership_buttonContainer">
                     <AccessibleButton
                         className={membershipButtonClasses}

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -468,7 +468,7 @@ export default React.createClass({
 
         if (group.myMembership === 'leave') {
             // Leave settings - the user might have clicked the "Leave" button
-            this._onCancelClick();
+            this._closeSettings();
         }
         this.setState({membershipBusy: false});
     },
@@ -566,6 +566,10 @@ export default React.createClass({
     },
 
     _onCancelClick: function() {
+        this._closeSettings();
+    },
+
+    _closeSettings() {
         this.setState({
             editing: false,
             profileForm: null,

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -466,6 +466,10 @@ export default React.createClass({
     _onGroupMyMembership: function(group) {
         if (group.groupId !== this.props.groupId) return;
 
+        if (group.myMembership === 'leave') {
+            // Leave settings - the user might have clicked the "Leave" button
+            this._onCancelClick();
+        }
         this.setState({membershipBusy: false});
     },
 

--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -252,12 +252,36 @@ export default class GroupStore extends EventEmitter {
 
     acceptGroupInvite() {
         return MatrixClientPeg.get().acceptGroupInvite(this.groupId)
+            // The user should now be able to access (personal) group settings
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.Summary))
             // The user might be able to see more rooms now
             .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupRooms))
             // The user should now appear as a member
             .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupMembers))
             // The user should now not appear as an invited member
             .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupInvitedMembers));
+    }
+
+    joinGroup() {
+        return MatrixClientPeg.get().joinGroup(this.groupId)
+            // The user should now be able to access (personal) group settings
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.Summary))
+            // The user might be able to see more rooms now
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupRooms))
+            // The user should now appear as a member
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupMembers))
+            // The user should now not appear as an invited member
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupInvitedMembers));
+    }
+
+    leaveGroup() {
+        return MatrixClientPeg.get().leaveGroup(this.groupId)
+            // The user should now not be able to access group settings
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.Summary))
+            // The user might only be able to see a subset of rooms now
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupRooms))
+            // The user should now not appear as a member
+            .then(this._fetchResource.bind(this, GroupStore.STATE_KEY.GroupMembers));
     }
 
     addRoomToGroupSummary(roomId, categoryId) {


### PR DESCRIPTION
 - Display changes to memberlist, summary (for settings cog), rooms (some rooms might only be visible to joined users.
 - Leave settings page after clicking "Leave"
 - Show membership spinner next to "Leave"/"Join" button once clicked

Might fix https://github.com/vector-im/riot-web/issues/6475