### PR TITLE
Null check node before we pass it to velocity

### DIFF
--- a/src/Velociraptor.js
+++ b/src/Velociraptor.js
@@ -147,7 +147,7 @@ module.exports = React.createClass({
             // creating/destroying large numbers of elements"
             // (https://github.com/julianshapiro/velocity/issues/47)
             const domNode = ReactDom.findDOMNode(this.nodes[k]);
-            Velocity.Utilities.removeData(domNode);
+            if (domNode) Velocity.Utilities.removeData(domNode);
         }
         this.nodes[k] = node;
     },


### PR DESCRIPTION
As presumably sometimes the node wasn't actually in the DOM for
whatever reason, so don't propagate exceptions out into the app.

Should fix https://github.com/vector-im/riot-web/issues/6515