### PR TITLE
Use mxid as sender name on set display name

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -58,7 +58,7 @@ function textForMemberEvent(ev) {
                     });
                 } else if (!prevContent.displayname && content.displayname) {
                     return _t('%(senderName)s set their display name to %(displayName)s.', {
-                        senderName,
+                        senderName: ev.getSender(),
                         displayName: content.displayname,
                     });
                 } else if (prevContent.displayname && !content.displayname) {


### PR DESCRIPTION
As it was, "<New name> set their display name to <New name>" which
is unhelpful because you never knew them as "<New name>" before.
They would previously have been displayed with their matrix ID, so
that's what should be here.