### PR TITLE
Bind onImageError in constructor

### DIFF
--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -49,6 +49,7 @@ export default class extends React.Component {
         super(props);
 
         this.onAction = this.onAction.bind(this);
+        this.onImageError = this.onImageError.bind(this);
         this.onImageEnter = this.onImageEnter.bind(this);
         this.onImageLeave = this.onImageLeave.bind(this);
         this.onClientSync = this.onClientSync.bind(this);


### PR DESCRIPTION
Tt uses `this` but wasn't bound anywhere so the error handler was
just throwing an exception.