### PR TITLE
Fix error handling on session restore

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -66,12 +66,13 @@ import sdk from './index';
  *     failed.
  */
 export function loadSession(opts) {
+    let enableGuest = opts.enableGuest || false;
+    const guestHsUrl = opts.guestHsUrl;
+    const guestIsUrl = opts.guestIsUrl;
+    const fragmentQueryParams = opts.fragmentQueryParams || {};
+    const defaultDeviceDisplayName = opts.defaultDeviceDisplayName;
+
     return new Promise.resolve().then(() => {
-        const fragmentQueryParams = opts.fragmentQueryParams || {};
-        let enableGuest = opts.enableGuest || false;
-        const guestHsUrl = opts.guestHsUrl;
-        const guestIsUrl = opts.guestIsUrl;
-        const defaultDeviceDisplayName = opts.defaultDeviceDisplayName;
 
         if (!guestHsUrl) {
             console.warn("Cannot enable guest access: can't determine HS URL to use");

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -215,18 +215,16 @@ function _restoreFromLocalStorage() {
 
     if (accessToken && userId && hsUrl) {
         console.log(`Restoring session for ${userId}`);
-        try {
-            return _doSetLoggedIn({
-                userId: userId,
-                deviceId: deviceId,
-                accessToken: accessToken,
-                homeserverUrl: hsUrl,
-                identityServerUrl: isUrl,
-                guest: isGuest,
-            }, false).then(() => true);
-        } catch (e) {
+        return _doSetLoggedIn({
+            userId: userId,
+            deviceId: deviceId,
+            accessToken: accessToken,
+            homeserverUrl: hsUrl,
+            identityServerUrl: isUrl,
+            guest: isGuest,
+        }, false).catch((e) => {
             return _handleRestoreFailure(e);
-        }
+        }).then(() => true);
     } else {
         console.log("No previous session found.");
         return Promise.resolve(false);

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -72,8 +72,7 @@ export function loadSession(opts) {
     const fragmentQueryParams = opts.fragmentQueryParams || {};
     const defaultDeviceDisplayName = opts.defaultDeviceDisplayName;
 
-    return new Promise.resolve().then(() => {
-
+    return Promise.resolve().then(() => {
         if (!guestHsUrl) {
             console.warn("Cannot enable guest access: can't determine HS URL to use");
             enableGuest = false;

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -360,7 +360,7 @@ export default React.createClass({
             // Note we don't catch errors from this: we catch everything within
             // loadSession as there's logic there to ask the user if they want
             // to try logging out.
-        }).done();
+        });
     },
 
     componentWillUnmount: function() {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
-Copyright 2017 New Vector Ltd
+Copyright 2017, 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -351,15 +351,15 @@ export default React.createClass({
                     guestIsUrl: this.getCurrentIsUrl(),
                     defaultDeviceDisplayName: this.props.defaultDeviceDisplayName,
                 });
-            }).catch((e) => {
-                console.error('Error attempting to load session', e);
-                return false;
             }).then((loadedSession) => {
                 if (!loadedSession) {
                     // fall back to showing the login screen
                     dis.dispatch({action: "start_login"});
                 }
             });
+            // Note we don't catch errors from this: we catch everything within
+            // loadSession as there's logic there to ask the user if they want
+            // to try logging out.
         }).done();
     },
 

--- a/src/components/views/dialogs/BaseDialog.js
+++ b/src/components/views/dialogs/BaseDialog.js
@@ -38,7 +38,7 @@ export default React.createClass({
         // onFinished callback to call when Escape is pressed
         // Take a boolean which is true if the dialog was dismissed
         // with a positive / confirm action or false if it was
-        // cancelled (from BaseDialog, this is always false).
+        // cancelled (BaseDialog itself only calls this with false).
         onFinished: PropTypes.func.isRequired,
 
         // called when a key is pressed

--- a/src/components/views/dialogs/BaseDialog.js
+++ b/src/components/views/dialogs/BaseDialog.js
@@ -36,7 +36,7 @@ export default React.createClass({
 
     propTypes: {
         // onFinished callback to call when Escape is pressed
-        // Take a boolean which is true is the dialog was dismissed
+        // Take a boolean which is true if the dialog was dismissed
         // with a positive / confirm action or false if it was
         // cancelled (from BaseDialog, this is always false).
         onFinished: PropTypes.func.isRequired,

--- a/src/components/views/dialogs/BaseDialog.js
+++ b/src/components/views/dialogs/BaseDialog.js
@@ -36,6 +36,9 @@ export default React.createClass({
 
     propTypes: {
         // onFinished callback to call when Escape is pressed
+        // Take a boolean which is true is the dialog was dismissed
+        // with a positive / confirm action or false if it was
+        // cancelled (from BaseDialog, this is always false).
         onFinished: PropTypes.func.isRequired,
 
         // called when a key is pressed
@@ -77,12 +80,12 @@ export default React.createClass({
         if (e.keyCode === KeyCode.ESCAPE) {
             e.stopPropagation();
             e.preventDefault();
-            this.props.onFinished();
+            this.props.onFinished(false);
         }
     },
 
     _onCancelClick: function(e) {
-        this.props.onFinished();
+        this.props.onFinished(false);
     },
 
     render: function() {

--- a/src/components/views/dialogs/SessionRestoreErrorDialog.js
+++ b/src/components/views/dialogs/SessionRestoreErrorDialog.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/views/dialogs/SessionRestoreErrorDialog.js
+++ b/src/components/views/dialogs/SessionRestoreErrorDialog.js
@@ -41,8 +41,12 @@ export default React.createClass({
         Modal.createTrackedDialog('Session Restore Error', 'Send Bug Report Dialog', BugReportDialog, {});
     },
 
-    _continueClicked: function() {
+    _onContinueClick: function() {
         this.props.onFinished(true);
+    },
+
+    _onCancelClick: function() {
+        this.props.onFinished(false);
     },
 
     render: function() {
@@ -81,8 +85,8 @@ export default React.createClass({
                     { bugreport }
                 </div>
                 <DialogButtons primaryButton={_t("Continue anyway")}
-                    onPrimaryButtonClick={this._continueClicked} focus={shouldFocusContinueButton}
-                    onCancel={this.props.onFinished} />
+                    onPrimaryButtonClick={this._onContinueClick} focus={shouldFocusContinueButton}
+                    onCancel={this._onCancelClick} />
             </BaseDialog>
         );
     },

--- a/src/components/views/elements/DialogButtons.js
+++ b/src/components/views/elements/DialogButtons.js
@@ -39,6 +39,10 @@ module.exports = React.createClass({
         focus: PropTypes.bool,
     },
 
+    _onCancelClick: function() {
+        this.props.onCancel();
+    },
+
     render: function() {
         let primaryButtonClassName = "mx_Dialog_primary";
         if (this.props.primaryButtonClass) {
@@ -53,7 +57,7 @@ module.exports = React.createClass({
                     { this.props.primaryButton }
                 </button>
                 { this.props.children }
-                <button onClick={this.props.onCancel}>
+                <button onClick={this._onCancelClick}>
                     { _t("Cancel") }
                 </button>
             </div>


### PR DESCRIPTION
Fix a number of failures that meant the excellent error handling
we had for failing to restore a session didn't work.

1. .catch on the promise rather than try/catch: it's async
2. Explicit cancel method in SessionRestoreErrorDialog that invokes
   onFinished with `false` because even with the catch fixed, this
   was getting the event as its first arg which is truthy, so
   clicking cancel still deleted your data.
3. DialogButtons: Don't pass onCancel straight into the button event
   handler as this leaks the MouseEvent through as an argument.
   Nothing is using it and it exacerbates failures like this
   because there are surprise arguments.

Lots of re-indenting has gone on too: reading commits individually may be useful.

Fixes https://github.com/vector-im/riot-web/issues/6616