### PR TITLE
relax lint for jsx-curly-spacing and arrow-parens

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,12 @@ module.exports = {
         // <Element prop={ consideredError} prop={notConsideredError} />
         //
         // https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-spacing.md
-        "react/jsx-curly-spacing": ["error", {"when": "never", "children": {"when": "always"}}],
+        //
+        // Disabled for now - if anything we'd like to *enforce* spacing in JSX
+        // curly brackets for legibility, but in practice it's not clear that the
+        // consistency particularly improves legibility here. --Matthew
+        //
+        // "react/jsx-curly-spacing": ["error", {"when": "never", "children": {"when": "always"}}],
 
         // Assert spacing before self-closing JSX tags, and no spacing before or
         // after the closing slash, and no spacing after the opening bracket of
@@ -88,7 +93,6 @@ module.exports = {
         "valid-jsdoc": ["warn"],
         "new-cap": ["warn"],
         "key-spacing": ["warn"],
-        "arrow-parens": ["warn"],
         "prefer-const": ["warn"],
 
         // crashes currently: https://github.com/eslint/eslint/issues/6274


### PR DESCRIPTION
As per discussion in #riot-dev (https://matrix.to/#/!DdJkzRliezrwpNebLk:matrix.org/$1525283868176414XGKPl:matrix.org), this relaxes two lint rules which are unnecessarily restrictive given the trade-off between hindering external (and internal) contributions versus the negligible impact on legibility or code quality.

If anything we should turn jsx-curly-spaces back on but mandating whitespace in future, but this will create needless noise right now, so let's just be relaxed given what a minor impact it makes on legibility.