### PR TITLE
Users should always be able to edit their user/non-room  widgets

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -274,6 +274,11 @@ export default class AppTile extends React.Component {
     }
 
     _canUserModify() {
+        // User widgets should always be modifiable by their creator
+        if (this.props.userWidget && MatrixClientPeg.get().credentials.userId === this.props.creatorUserId) {
+            return true;
+        }
+        // Check if the current user can modify widgets in the current room
         return WidgetUtils.canUserModifyWidgets(this.props.room.roomId);
     }
 
@@ -698,6 +703,8 @@ AppTile.propTypes = {
     // Optional function to be called on widget capability request
     // Called with an array of the requested capabilities
     onCapabilityRequest: PropTypes.func,
+    // Is this an instance of a user widget
+    userWidget: PropTypes.bool,
 };
 
 AppTile.defaultProps = {
@@ -710,4 +717,5 @@ AppTile.defaultProps = {
     showPopout: true,
     handleMinimisePointerEvents: false,
     whitelistCapabilities: [],
+    userWidget: false,
 };

--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -164,8 +164,8 @@ export default class Stickerpicker extends React.Component {
                             room={this.props.room}
                             type={stickerpickerWidget.content.type}
                             fullWidth={true}
-                            userId={stickerpickerWidget.sender || MatrixClientPeg.get().credentials.userId}
-                            creatorUserId={MatrixClientPeg.get().credentials.userId}
+                            userId={MatrixClientPeg.get().credentials.userId}
+                            creatorUserId={stickerpickerWidget.sender || MatrixClientPeg.get().credentials.userId}
                             waitForIframeLoad={true}
                             show={true}
                             showMenubar={true}

--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -178,6 +178,7 @@ export default class Stickerpicker extends React.Component {
                             onMinimiseClick={this._onHideStickersClick}
                             handleMinimisePointerEvents={true}
                             whitelistCapabilities={['m.sticker']}
+                            userWidget={true}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
"User widgets" such as sticker pickers should always be editable by their owner (regardless of the room that they are currently viewing).