### PR TITLE
Pin lolex at 2.3.2 to avoid bug causing tests to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "isomorphic-fetch": "^2.2.1",
     "linkifyjs": "^2.1.3",
     "lodash": "^4.13.1",
-    "lolex": "^2.3.2",
+    "lolex": "2.3.2",
     "matrix-js-sdk": "0.10.1",
     "optimist": "^0.6.1",
     "pako": "^1.0.5",


### PR DESCRIPTION
See https://github.com/sinonjs/lolex/issues/170