### PR TITLE
Remove margins when in a ReplyThread to stop them taking so much space

### DIFF
--- a/res/css/views/elements/_ReplyThread.scss
+++ b/res/css/views/elements/_ReplyThread.scss
@@ -14,8 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_ReplyThread {
+    margin-top: 0;
+}
+
 .mx_ReplyThread .mx_DateSeparator {
     font-size: 1em !important;
+    margin-top: 0;
     margin-bottom: 0;
     padding-bottom: 1px;
     bottom: -5px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/6683

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>