### PR TITLE
Send required properties when making requests to widgets over postMessage

### DIFF
--- a/src/FromWidgetPostMessageApi.js
+++ b/src/FromWidgetPostMessageApi.js
@@ -116,6 +116,12 @@ export default class FromWidgetPostMessageApi {
             return; // don't log this - debugging APIs like to spam postMessage which floods the log otherwise
         }
 
+        // Although the requestId is required, we don't use it. We'll be nice and process the message
+        // if the property is missing, but with a warning for widget developers.
+        if (!event.data.requestId) {
+            console.warn("fromWidget action '" + event.data.action + "' does not have a requestId");
+        }
+
         const action = event.data.action;
         const widgetId = event.data.widgetId;
         if (action === 'content_loaded') {

--- a/src/ToWidgetPostMessageApi.js
+++ b/src/ToWidgetPostMessageApi.js
@@ -51,11 +51,11 @@ export default class ToWidgetPostMessageApi {
         if (payload.response === undefined) {
             return;
         }
-        const promise = this._requestMap[payload._id];
+        const promise = this._requestMap[payload.requestId];
         if (!promise) {
             return;
         }
-        delete this._requestMap[payload._id];
+        delete this._requestMap[payload.requestId];
         promise.resolve(payload);
     }
 
@@ -64,21 +64,21 @@ export default class ToWidgetPostMessageApi {
         targetWindow = targetWindow || window.parent; // default to parent window
         targetOrigin = targetOrigin || "*";
         this._counter += 1;
-        action._id = Date.now() + "-" + Math.random().toString(36) + "-" + this._counter;
+        action.requestId = Date.now() + "-" + Math.random().toString(36) + "-" + this._counter;
 
         return new Promise((resolve, reject) => {
-            this._requestMap[action._id] = {resolve, reject};
+            this._requestMap[action.requestId] = {resolve, reject};
             targetWindow.postMessage(action, targetOrigin);
 
             if (this._timeoutMs > 0) {
                 setTimeout(() => {
-                    if (!this._requestMap[action._id]) {
+                    if (!this._requestMap[action.requestId]) {
                         return;
                     }
                     console.error("postMessage request timed out. Sent object: " + JSON.stringify(action),
                         this._requestMap);
-                    this._requestMap[action._id].reject(new Error("Timed out"));
-                    delete this._requestMap[action._id];
+                    this._requestMap[action.requestId].reject(new Error("Timed out"));
+                    delete this._requestMap[action.requestId];
                 }, this._timeoutMs);
             }
         });

--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -44,6 +44,8 @@ export default class WidgetMessaging {
     }
 
     messageToWidget(action) {
+        action.widgetId = this.widgetId; // Required to be sent for all outbound requests
+
         return this.toWidget.exec(action, this.target).then((data) => {
             // Check for errors and reject if found
             if (data.response === undefined) { // null is valid


### PR DESCRIPTION
The `requestId` and `widgetId` are required for all requests. For more information, see https://github.com/vector-im/riot-web/issues/6708