### PR TITLE
Fix room widget second load infini spinner

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -359,9 +359,6 @@ export default class AppTile extends React.Component {
         if (!this.widgetMessaging) {
             this._onInitialLoad();
         }
-        if (this._exposeWidgetMessaging) {
-            this._exposeWidgetMessaging(this.widgetMessaging);
-        }
     }
 
     /**

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -359,6 +359,7 @@ export default class AppTile extends React.Component {
         if (!this.widgetMessaging) {
             this._onInitialLoad();
         }
+        this.setState({loading: false});
     }
 
     /**
@@ -396,8 +397,6 @@ export default class AppTile extends React.Component {
         }).catch((err) => {
             console.log(`Failed to get capabilities for widget type ${this.props.type}`, this.props.id, err);
         });
-
-        this.setState({loading: false});
     }
 
     _onWidgetAction(payload) {


### PR DESCRIPTION
Fix regression where room widgets wouldn't open the second time they were expanded

Fixes https://github.com/vector-im/riot-web/issues/6707