### PR TITLE
Fix stickers briefly being 2x the size

### DIFF
--- a/src/components/views/messages/MStickerBody.js
+++ b/src/components/views/messages/MStickerBody.js
@@ -107,6 +107,16 @@ export default class MStickerBody extends MImageBody {
             placeholderFixupHeight = content.info.h + 'px';
         }
 
+        // The pixel size of sticker images is generally larger than their intended display
+        // size so they render at native reolution on HiDPI displays. We therefore need to
+        // explicity set the size so they render at the intended size.
+        // XXX: This will be clobberred when we run fixupHeight(), but we need to do it
+        // here otherwise the stickers are momentarily displayed at the pixel size.
+        const imageStyle = {
+            height: content.info.h,
+            // leave the browser the calculate the width automatically
+        };
+
         placeholderSize = placeholderSize + 'px';
 
         // Body 'ref' required by MImageBody
@@ -132,6 +142,7 @@ export default class MStickerBody extends MImageBody {
                     <img
                         className={'mx_MStickerBody_image ' + this.state.imageClasses}
                         src={contentUrl}
+                        style={imageStyle}
                         ref='image'
                         alt={content.body}
                         onLoad={this._onImageLoad}


### PR DESCRIPTION
fixupHeight was the only thing actually fixing the size of the
sticker image to be the size we want it rather than the pixel size
of the image, and this was only getting run after the image loaded,
causing a flash of 2x image.