### PR TITLE
Make devTools styling more consistent and easier to edit event data.

### DIFF
--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -14,8 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_DevTools_content {
+    margin: 10px 0;
+}
+
 .mx_DevTools_RoomStateExplorer_button, .mx_DevTools_RoomStateExplorer_query {
     margin-bottom: 10px;
+    max-width: 684px;
+    width: 100%;
+}
+
+.mx_DevTools_LabalCell {
+    font-weight: bold;
 }
 
 .mx_DevTools_label_left {
@@ -38,7 +48,6 @@ limitations under the License.
 
 .mx_DevTools_inputLabelCell
 {
-    padding-bottom: 21px;
     display: table-cell;
     font-weight: bold;
     padding-right: 24px;
@@ -46,7 +55,6 @@ limitations under the License.
 
 .mx_DevTools_inputCell {
     display: table-cell;
-    padding-bottom: 21px;
     width: 240px;
 }
 
@@ -60,6 +68,12 @@ limitations under the License.
     color: $input-fg-color;
     font-family: 'Open Sans', Helvetica, Arial, Sans-Serif;
     font-size: 16px;
+}
+
+.mx_DevTools_textarea {
+    font-size: 12px;
+    min-height: 250px;
+    width: 100%;
 }
 
 .mx_DevTools_tgl {

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -72,7 +72,9 @@ limitations under the License.
 
 .mx_DevTools_textarea {
     font-size: 12px;
+    max-width: 624px;
     min-height: 250px;
+    padding: 10px;
     width: 100%;
 }
 

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -20,7 +20,6 @@ limitations under the License.
 
 .mx_DevTools_RoomStateExplorer_button, .mx_DevTools_RoomStateExplorer_query {
     margin-bottom: 10px;
-    max-width: 684px;
     width: 100%;
 }
 

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -24,10 +24,6 @@ limitations under the License.
     width: 100%;
 }
 
-.mx_DevTools_LabalCell {
-    font-weight: bold;
-}
-
 .mx_DevTools_label_left {
     float: left;
 }

--- a/src/components/views/dialogs/DevtoolsDialog.js
+++ b/src/components/views/dialogs/DevtoolsDialog.js
@@ -138,7 +138,7 @@ class SendCustomEvent extends GenericEditor {
 
                 <br />
 
-                <div className="mx_DevTools_LabalCell">
+                <div className="mx_DevTools_inputLabelCell">
                     <label htmlFor="evContent"> { _t('Event Content') } </label>
                 </div>
                 <div>
@@ -219,11 +219,11 @@ class SendAccountData extends GenericEditor {
         }
 
         return <div>
-            <div className="mx_Dialog_content">
+            <div className="mx_DevTools_content">
                 { this.textInput('eventType', _t('Event Type')) }
                 <br />
 
-                <div className="mx_UserSettings_profileLabelCell">
+                <div className="mx_DevTools_inputLabelCell">
                     <label htmlFor="evContent"> { _t('Event Content') } </label>
                 </div>
                 <div>

--- a/src/components/views/dialogs/DevtoolsDialog.js
+++ b/src/components/views/dialogs/DevtoolsDialog.js
@@ -132,17 +132,17 @@ class SendCustomEvent extends GenericEditor {
         }
 
         return <div>
-            <div className="mx_Dialog_content">
+            <div className="mx_DevTools_content">
                 { this.textInput('eventType', _t('Event Type')) }
                 { this.state.isStateEvent && this.textInput('stateKey', _t('State Key')) }
 
                 <br />
 
-                <div className="mx_UserSettings_profileLabelCell">
+                <div className="mx_DevTools_LabalCell">
                     <label htmlFor="evContent"> { _t('Event Content') } </label>
                 </div>
                 <div>
-                    <textarea id="evContent" onChange={this._onChange} value={this.state.evContent} className="mx_TextInputDialog_input" cols="63" rows="5" />
+                    <textarea id="evContent" onChange={this._onChange} value={this.state.evContent} className="mx_DevTools_textarea" />
                 </div>
             </div>
             <div className="mx_Dialog_buttons">
@@ -227,7 +227,7 @@ class SendAccountData extends GenericEditor {
                     <label htmlFor="evContent"> { _t('Event Content') } </label>
                 </div>
                 <div>
-                    <textarea id="evContent" onChange={this._onChange} value={this.state.evContent} className="mx_TextInputDialog_input" cols="63" rows="5" />
+                    <textarea id="evContent" onChange={this._onChange} value={this.state.evContent} className="mx_DevTools_textarea" />
                 </div>
             </div>
             <div className="mx_Dialog_buttons">
@@ -485,7 +485,7 @@ class AccountDataExplorer extends DevtoolsComponent {
             }
 
             return <div className="mx_ViewSource">
-                <div className="mx_Dialog_content">
+                <div className="mx_DevTools_content">
                     <SyntaxHighlight className="json">
                         { JSON.stringify(this.state.event.event, null, 2) }
                     </SyntaxHighlight>


### PR DESCRIPTION
Currently there is inconsistent styling when viewing as opposed to editing room and account data (see screenshots). Before:

![screen shot 2018-05-23 at 17 41 50](https://user-images.githubusercontent.com/6763606/40438799-ee637454-5eb0-11e8-82df-4f4c5e96403c.png)
![screen shot 2018-05-23 at 17 42 16](https://user-images.githubusercontent.com/6763606/40438800-ee7e0486-5eb0-11e8-840b-1e0913ab4e57.png)

This PR adds styling for consistency between views and to make it easier to edit events (in the displayed modal).

After:

![screen shot 2018-05-23 at 17 45 42](https://user-images.githubusercontent.com/6763606/40438934-575b54a4-5eb1-11e8-8012-8a6c69d48f17.png)
![screen shot 2018-05-23 at 17 45 48](https://user-images.githubusercontent.com/6763606/40438935-5777e6dc-5eb1-11e8-867f-bca37918f05d.png)
