### PR TITLE
fix membership list ordering when presence is disabled.

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -270,7 +270,7 @@ module.exports = React.createClass({
 
             // console.log("comparing " + this.memberString(memberA) + " and " + this.memberString(memberB));
 
-            if (userA.currentlyActive && userB.currentlyActive) {
+            if ((userA.currentlyActive && userB.currentlyActive) || !this._showPresence) {
                 // console.log(memberA.name + " and " + memberB.name + " are both active");
                 if (memberA.powerLevel === memberB.powerLevel) {
                     // console.log(memberA + " and " + memberB + " have same power level");


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/6643.

@lampholder we really need to find a way for P1 regressions to not hang around open for 23 days (for a regression introduced 66 days ago), especially when it's a oneliner to fix...