### PR TITLE
Import react as React in src/components/views/elements/DNDTagTile.js

### DIFF
--- a/src/components/views/elements/DNDTagTile.js
+++ b/src/components/views/elements/DNDTagTile.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import TagTile from './TagTile';
 
+import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
 export default function DNDTagTile(props) {


### PR DESCRIPTION
I suspect it was not noticed because Riot exposes `React` as global for debugging purpose. However, it makes the SDK crash for other embedders.