### PR TITLE
Track decryption success/failure rate with piwik

### DIFF
--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -56,7 +56,7 @@ export default class DecryptionFailureTracker {
     }
 
     loadTrackedEventHashMap() {
-        this.trackedEventHashMap = JSON.parse(localStorage.getItem('mx-decryption-failure-event-id-hashes'));
+        this.trackedEventHashMap = JSON.parse(localStorage.getItem('mx-decryption-failure-event-id-hashes')) || {};
     }
 
     saveTrackedEventHashMap() {

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+class DecryptionFailure {
+    constructor(failedEventId) {
+        this.failedEventId = failedEventId;
+        this.ts = Date.now();
+    }
+}
+
+export default class DecryptionFailureTracker {
+    // Array of items of type DecryptionFailure. Every `CHECK_INTERVAL_MS`, this list
+    // is checked for failures that happened > `GRACE_PERIOD_MS` ago. Those that did
+    // are added to `failuresToTrack`.
+    failures = [];
+
+    // Every TRACK_INTERVAL_MS (so as to spread the number of hits done on Analytics),
+    // one DecryptionFailure of this FIFO is removed and tracked.
+    failuresToTrack = [];
+
+    // Spread the load on `Analytics` by sending at most 1 event per
+    // `TRACK_INTERVAL_MS`.
+    static TRACK_INTERVAL_MS = 1000;
+
+    // Call `checkFailures` every `CHECK_INTERVAL_MS`.
+    static CHECK_INTERVAL_MS = 5000;
+
+    // Give events a chance to be decrypted by waiting `GRACE_PERIOD_MS` before moving
+    // the failure to `failuresToTrack`.
+    static GRACE_PERIOD_MS = 5000;
+
+    constructor(fn) {
+        if (!fn || typeof fn !== 'function') {
+            throw new Error('DecryptionFailureTracker requires tracking function');
+        }
+
+        this.trackDecryptionFailure = fn;
+    }
+
+    eventDecrypted(e) {
+        if (e.isDecryptionFailure()) {
+            this.addDecryptionFailureForEvent(e);
+        } else {
+            // Could be an event in the failures, remove it
+            this.removeDecryptionFailuresForEvent(e);
+        }
+    }
+
+    addDecryptionFailureForEvent(e) {
+        this.failures.push(new DecryptionFailure(e.getId()));
+    }
+
+    removeDecryptionFailuresForEvent(e) {
+        this.failures = this.failures.filter((f) => f.failedEventId !== e.getId());
+    }
+
+    /**
+     * Start checking for and tracking failures.
+     * @return {function} a function that clears state and causes DFT to stop checking for
+     * and tracking failures.
+     */
+    start() {
+        const checkInterval = setInterval(
+            () => this.checkFailures(Date.now()),
+            DecryptionFailureTracker.CHECK_INTERVAL_MS,
+        );
+
+        const trackInterval = setInterval(
+            () => this.trackFailure(),
+            DecryptionFailureTracker.TRACK_INTERVAL_MS,
+        );
+
+        return () => {
+            clearInterval(checkInterval);
+            clearInterval(trackInterval);
+
+            this.failures = [];
+            this.failuresToTrack = [];
+        };
+    }
+
+    /**
+     * Mark failures that occured before nowTs - GRACE_PERIOD_MS as failures that should be
+     * tracked. Only mark one failure per event ID.
+     * @param {number} nowTs the timestamp that represents the time now.
+     */
+    checkFailures(nowTs) {
+        const failuresGivenGrace = this.failures.filter(
+            (f) => nowTs > f.ts + DecryptionFailureTracker.GRACE_PERIOD_MS,
+        );
+
+        // Only track one failure per event
+        const dedupedFailuresMap = failuresGivenGrace.reduce(
+            (result, failure) => ({...result, [failure.failedEventId]: failure}),
+            {},
+        );
+        const dedupedFailures = Object.keys(dedupedFailuresMap).map((k) => dedupedFailuresMap[k]);
+
+        this.failuresToTrack = [...this.failuresToTrack, ...dedupedFailures];
+    }
+
+    /**
+     * If there is a failure that should be tracked, call the given trackDecryptionFailure
+     * function with the first failure in the FIFO of failures that should be tracked.
+     */
+    trackFailure() {
+        if (this.failuresToTrack.length > 0) {
+            this.trackDecryptionFailure(this.failuresToTrack.shift());
+        }
+    }
+}

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -21,10 +21,6 @@ class DecryptionFailure {
     }
 }
 
-function eventIdHash(eventId) {
-    return crypto.subtle.digest('SHA-256', eventId);
-}
-
 export default class DecryptionFailureTracker {
     // Array of items of type DecryptionFailure. Every `CHECK_INTERVAL_MS`, this list
     // is checked for failures that happened > `GRACE_PERIOD_MS` ago. Those that did
@@ -37,7 +33,7 @@ export default class DecryptionFailureTracker {
 
     // Event IDs of failures that were tracked previously
     trackedEventHashMap = {
-        // [eventIdHash(eventId)]: true
+        // [eventId]: true
     };
 
     // Spread the load on `Analytics` by sending at most 1 event per
@@ -130,7 +126,7 @@ export default class DecryptionFailureTracker {
         // Only track one failure per event
         const dedupedFailuresMap = failuresGivenGrace.reduce(
             (map, failure) => {
-                if (!this.trackedEventHashMap[eventIdHash(failure.failedEventId)]) {
+                if (!this.trackedEventHashMap[failure.failedEventId]) {
                     return map.set(failure.failedEventId, failure);
                 } else {
                     return map;
@@ -143,7 +139,7 @@ export default class DecryptionFailureTracker {
         const trackedEventIds = [...dedupedFailuresMap.keys()];
 
         this.trackedEventHashMap = trackedEventIds.reduce(
-            (result, eventId) => ({...result, [eventIdHash(eventId)]: true}),
+            (result, eventId) => ({...result, [eventId]: true}),
             this.trackedEventHashMap,
         );
 

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -55,13 +55,13 @@ export default class DecryptionFailureTracker {
         this.trackDecryptionFailure = fn;
     }
 
-    loadTrackedEventHashMap() {
-        this.trackedEventHashMap = JSON.parse(localStorage.getItem('mx-decryption-failure-event-id-hashes')) || {};
-    }
+    // loadTrackedEventHashMap() {
+    //     this.trackedEventHashMap = JSON.parse(localStorage.getItem('mx-decryption-failure-event-id-hashes')) || {};
+    // }
 
-    saveTrackedEventHashMap() {
-        localStorage.setItem('mx-decryption-failure-event-id-hashes', JSON.stringify(this.trackedEventHashMap));
-    }
+    // saveTrackedEventHashMap() {
+    //     localStorage.setItem('mx-decryption-failure-event-id-hashes', JSON.stringify(this.trackedEventHashMap));
+    // }
 
     eventDecrypted(e) {
         if (e.isDecryptionFailure()) {
@@ -143,7 +143,9 @@ export default class DecryptionFailureTracker {
             this.trackedEventHashMap,
         );
 
-        this.saveTrackedEventHashMap();
+        // Commented out for now for expediency, we need to consider unbound nature of storing
+        // this in localStorage
+        // this.saveTrackedEventHashMap();
 
         const dedupedFailures = dedupedFailuresMap.values();
 

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -98,9 +98,17 @@ export default class DecryptionFailureTracker {
      * @param {number} nowTs the timestamp that represents the time now.
      */
     checkFailures(nowTs) {
-        const failuresGivenGrace = this.failures.filter(
-            (f) => nowTs > f.ts + DecryptionFailureTracker.GRACE_PERIOD_MS,
-        );
+        const failuresGivenGrace = [];
+        const failuresNotReady = [];
+        while (this.failures.length > 0) {
+            const f = this.failures.shift();
+            if (nowTs > f.ts + DecryptionFailureTracker.GRACE_PERIOD_MS) {
+                failuresGivenGrace.push(f);
+            } else {
+                failuresNotReady.push(f);
+            }
+        }
+        this.failures = failuresNotReady;
 
         // Only track one failure per event
         const dedupedFailuresMap = failuresGivenGrace.reduce(

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -36,6 +36,10 @@ export default class DecryptionFailureTracker {
         // [eventId]: true
     };
 
+    // Set to an interval ID when `start` is called
+    checkInterval = null;
+    trackInterval = null;
+
     // Spread the load on `Analytics` by sending at most 1 event per
     // `TRACK_INTERVAL_MS`.
     static TRACK_INTERVAL_MS = 1000;
@@ -82,27 +86,28 @@ export default class DecryptionFailureTracker {
 
     /**
      * Start checking for and tracking failures.
-     * @return {function} a function that clears state and causes DFT to stop checking for
-     * and tracking failures.
      */
     start() {
-        const checkInterval = setInterval(
+        this.checkInterval = setInterval(
             () => this.checkFailures(Date.now()),
             DecryptionFailureTracker.CHECK_INTERVAL_MS,
         );
 
-        const trackInterval = setInterval(
+        this.trackInterval = setInterval(
             () => this.trackFailure(),
             DecryptionFailureTracker.TRACK_INTERVAL_MS,
         );
+    }
 
-        return () => {
-            clearInterval(checkInterval);
-            clearInterval(trackInterval);
+    /**
+     * Clear state and stop checking for and tracking failures.
+     */
+    stop() {
+        clearInterval(this.checkInterval);
+        clearInterval(this.trackInterval);
 
-            this.failures = [];
-            this.failuresToTrack = [];
-        };
+        this.failures = [];
+        this.failuresToTrack = [];
     }
 
     /**

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -129,17 +129,18 @@ export default class DecryptionFailureTracker {
 
         // Only track one failure per event
         const dedupedFailuresMap = failuresGivenGrace.reduce(
-            (result, failure) => {
+            (map, failure) => {
                 if (!this.trackedEventHashMap[eventIdHash(failure.failedEventId)]) {
-                    return {...result, [failure.failedEventId]: failure};
+                    return map.set(failure.failedEventId, failure);
                 } else {
-                    return result;
+                    return map;
                 }
             },
-            {},
+            // Use a map to preseve key ordering
+            new Map(),
         );
 
-        const trackedEventIds = Object.keys(dedupedFailuresMap);
+        const trackedEventIds = [...dedupedFailuresMap.keys()];
 
         this.trackedEventHashMap = trackedEventIds.reduce(
             (result, eventId) => ({...result, [eventIdHash(eventId)]: true}),
@@ -148,7 +149,7 @@ export default class DecryptionFailureTracker {
 
         this.saveTrackedEventHashMap();
 
-        const dedupedFailures = trackedEventIds.map((k) => dedupedFailuresMap[k]);
+        const dedupedFailures = dedupedFailuresMap.values();
 
         this.failuresToTrack = [...this.failuresToTrack, ...dedupedFailures];
     }

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1313,6 +1313,7 @@ export default React.createClass({
             // TODO: Pass reason for failure as third argument to trackEvent
             Analytics.trackEvent('E2E', 'Decryption failure');
         });
+        dft.loadEventTrackedPreviously();
 
         const stopDft = dft.start();
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1309,6 +1309,7 @@ export default React.createClass({
         });
 
         // XXX: This will do a HTTP request for each Event.decrypted event
+        // if the decryption was a failure
         cli.on("Event.decrypted", (e) => {
             if (e.isDecryptionFailure()) {
                 Analytics.trackEvent('E2E', 'Decryption failure');

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1313,7 +1313,7 @@ export default React.createClass({
             // TODO: Pass reason for failure as third argument to trackEvent
             Analytics.trackEvent('E2E', 'Decryption failure');
         });
-        dft.loadEventTrackedPreviously();
+        dft.loadTrackedEventHashMap();
 
         const stopDft = dft.start();
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1311,9 +1311,7 @@ export default React.createClass({
         // XXX: This will do a HTTP request for each Event.decrypted event
         cli.on("Event.decrypted", (e) => {
             if (e.isDecryptionFailure()) {
-                Analytics.trackEvent('E2E', 'Decryption result', 'failure');
-            } else {
-                Analytics.trackEvent('E2E', 'Decryption result', 'success');
+                Analytics.trackEvent('E2E', 'Decryption failure');
             }
         });
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1312,7 +1312,7 @@ export default React.createClass({
         // if the decryption was a failure
         cli.on("Event.decrypted", (e) => {
             if (e.isDecryptionFailure()) {
-                Analytics.trackEvent('E2E', 'Decryption failure');
+                Analytics.trackEvent('E2E', 'Decryption failure', 'ev.content.body: ' + e.getContent().body);
             }
         });
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1318,10 +1318,10 @@ export default React.createClass({
         // tracked events across sessions.
         // dft.loadTrackedEventHashMap();
 
-        const stopDft = dft.start();
+        dft.start();
 
         // When logging out, stop tracking failures and destroy state
-        cli.on("Session.logged_out", stopDft);
+        cli.on("Session.logged_out", () => dft.stop());
         cli.on("Event.decrypted", (e) => dft.eventDecrypted(e));
 
         const krh = new KeyRequestHandler(cli);

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1313,7 +1313,10 @@ export default React.createClass({
             // TODO: Pass reason for failure as third argument to trackEvent
             Analytics.trackEvent('E2E', 'Decryption failure');
         });
-        dft.loadTrackedEventHashMap();
+
+        // Shelved for later date when we have time to think about persisting history of
+        // tracked events across sessions.
+        // dft.loadTrackedEventHashMap();
 
         const stopDft = dft.start();
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1318,7 +1318,7 @@ export default React.createClass({
 
         // When logging out, stop tracking failures and destroy state
         cli.on("Session.logged_out", stopDft);
-        cli.on("Event.decrypted", dft.eventDecrypted);
+        cli.on("Event.decrypted", (e) => dft.eventDecrypted(e));
 
         const krh = new KeyRequestHandler(cli);
         cli.on("crypto.roomKeyRequest", (req) => {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1308,6 +1308,15 @@ export default React.createClass({
             }
         });
 
+        // XXX: This will do a HTTP request for each Event.decrypted event
+        cli.on("Event.decrypted", (e) => {
+            if (e.isDecryptionFailure()) {
+                Analytics.trackEvent('E2E', 'Decryption result', 'failure');
+            } else {
+                Analytics.trackEvent('E2E', 'Decryption result', 'success');
+            }
+        });
+
         const krh = new KeyRequestHandler(cli);
         cli.on("crypto.roomKeyRequest", (req) => {
             krh.handleKeyRequest(req);

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -120,6 +120,7 @@ describe.only('DecryptionFailureTracker', function() {
         tracker.trackFailure();
         tracker.trackFailure();
 
+        expect(failures.length).toBe(2, 'expected 2 failures to be tracked, got ' + failures.length);
         expect(failures[0].failedEventId).toBe(decryptedEvent.getId(), 'the first failure should be tracked first');
         expect(failures[1].failedEventId).toBe(decryptedEvent2.getId(), 'the second failure should be tracked second');
 

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -151,7 +151,7 @@ describe('DecryptionFailureTracker', function() {
         done();
     });
 
-    it('should not track a failure for an event that was tracked in a previous session', (done) => {
+    xit('should not track a failure for an event that was tracked in a previous session', (done) => {
         // This test uses localStorage, clear it beforehand
         localStorage.clear();
 
@@ -171,7 +171,9 @@ describe('DecryptionFailureTracker', function() {
 
         // Simulate the browser refreshing by destroying tracker and creating a new tracker
         const secondTracker = new DecryptionFailureTracker((failure) => failures.push(failure));
-        secondTracker.loadTrackedEventHashMap();
+
+        //secondTracker.loadTrackedEventHashMap();
+
         secondTracker.eventDecrypted(decryptedEvent);
         secondTracker.checkFailures(Infinity);
         secondTracker.trackFailure();

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -30,7 +30,7 @@ function createFailedDecryptionEvent() {
     return event;
 }
 
-describe.only('DecryptionFailureTracker', function() {
+describe('DecryptionFailureTracker', function() {
     it('tracks a failed decryption', function(done) {
         const failedDecryptionEvent = createFailedDecryptionEvent();
         let trackedFailure = null;

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -125,4 +125,28 @@ describe.only('DecryptionFailureTracker', function() {
 
         done();
     });
+
+    it('should not track a failure for an event that was tracked previously', (done) => {
+        const decryptedEvent = createFailedDecryptionEvent();
+
+        const failures = [];
+        const tracker = new DecryptionFailureTracker((failure) => failures.push(failure));
+
+        // Indicate decryption
+        tracker.eventDecrypted(decryptedEvent);
+
+        // Pretend "now" is Infinity
+        tracker.checkFailures(Infinity);
+
+        tracker.trackFailure();
+
+        // Indicate a second decryption, after having tracked the failure
+        tracker.eventDecrypted(decryptedEvent);
+
+        tracker.trackFailure();
+
+        expect(failures.length).toBe(1, 'should only track a single failure per event');
+
+        done();
+    });
 });

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -1,0 +1,128 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import expect from 'expect';
+
+import DecryptionFailureTracker from '../src/DecryptionFailureTracker';
+
+import { MatrixEvent } from 'matrix-js-sdk';
+
+function createFailedDecryptionEvent() {
+    const event = new MatrixEvent({
+        event_id: "event-id-" + Math.random().toString(16).slice(2),
+    });
+    event._setClearData(
+        event._badEncryptedMessage(":("),
+    );
+    return event;
+}
+
+describe.only('DecryptionFailureTracker', function() {
+    it('tracks a failed decryption', function(done) {
+        const failedDecryptionEvent = createFailedDecryptionEvent();
+        let trackedFailure = null;
+        const tracker = new DecryptionFailureTracker((failure) => {
+            trackedFailure = failure;
+        });
+
+        tracker.eventDecrypted(failedDecryptionEvent);
+
+        // Pretend "now" is Infinity
+        tracker.checkFailures(Infinity);
+
+        // Immediately track the newest failure, if there is one
+        tracker.trackFailure();
+
+        expect(trackedFailure).toNotBe(null, 'should track a failure for an event that failed decryption');
+
+        done();
+    });
+
+    it('does not track a failed decryption where the event is subsequently successfully decrypted', (done) => {
+        const decryptedEvent = createFailedDecryptionEvent();
+        const tracker = new DecryptionFailureTracker((failure) => {
+            expect(true).toBe(false, 'should not track an event that has since been decrypted correctly');
+        });
+
+        tracker.eventDecrypted(decryptedEvent);
+
+        // Indicate successful decryption: clear data can be anything where the msgtype is not m.bad.encrypted
+        decryptedEvent._setClearData({});
+        tracker.eventDecrypted(decryptedEvent);
+
+        // Pretend "now" is Infinity
+        tracker.checkFailures(Infinity);
+
+        // Immediately track the newest failure, if there is one
+        tracker.trackFailure();
+        done();
+    });
+
+    it('only tracks a single failure per event, despite multiple failed decryptions for multiple events', (done) => {
+        const decryptedEvent = createFailedDecryptionEvent();
+        const decryptedEvent2 = createFailedDecryptionEvent();
+
+        let count = 0;
+        const tracker = new DecryptionFailureTracker((failure) => count++);
+
+        // Arbitrary number of failed decryptions for both events
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent2);
+        tracker.eventDecrypted(decryptedEvent2);
+        tracker.eventDecrypted(decryptedEvent2);
+
+        // Pretend "now" is Infinity
+        tracker.checkFailures(Infinity);
+
+        // Simulated polling of `trackFailure`, an arbitrary number ( > 2 ) times
+        tracker.trackFailure();
+        tracker.trackFailure();
+        tracker.trackFailure();
+        tracker.trackFailure();
+
+        expect(count).toBe(2, count + ' failures tracked, should only track a single failure per event');
+
+        done();
+    });
+
+    it('track failures in the order they occured', (done) => {
+        const decryptedEvent = createFailedDecryptionEvent();
+        const decryptedEvent2 = createFailedDecryptionEvent();
+
+        const failures = [];
+        const tracker = new DecryptionFailureTracker((failure) => failures.push(failure));
+
+        // Indicate decryption
+        tracker.eventDecrypted(decryptedEvent);
+        tracker.eventDecrypted(decryptedEvent2);
+
+        // Pretend "now" is Infinity
+        tracker.checkFailures(Infinity);
+
+        // Simulated polling of `trackFailure`, an arbitrary number ( > 2 ) times
+        tracker.trackFailure();
+        tracker.trackFailure();
+
+        expect(failures[0].failedEventId).toBe(decryptedEvent.getId(), 'the first failure should be tracked first');
+        expect(failures[1].failedEventId).toBe(decryptedEvent2.getId(), 'the second failure should be tracked second');
+
+        done();
+    });
+});


### PR DESCRIPTION
Emit a piwik event when a decryption occurs in the category "E2E" with
the action "Decryption result" and the name either "failure" or
"success".

NB: This will cause Riot to a lot of networking when decrypting many
events. One HTTP request per decrypted event should be expected.