### PR TITLE
don't set the displayname on registration as Synapse now does it

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1143,11 +1143,6 @@ export default React.createClass({
         } else if (this._is_registered) {
             this._is_registered = false;
 
-            // Set the display name = user ID localpart
-            MatrixClientPeg.get().setDisplayName(
-                MatrixClientPeg.get().getUserIdLocalpart(),
-            );
-
             if (this.props.config.welcomeUserId && getCurrentLanguage().startsWith("en")) {
                 createRoom({
                     dmUserId: this.props.config.welcomeUserId,


### PR DESCRIPTION
# Fixes https://github.com/vector-im/riot-web/issues/5484

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>