### PR TITLE
apply roomlist searchFilter to aliases if it begins with a `#`

### DIFF
--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -105,8 +105,15 @@ var RoomSubList = React.createClass({
 
     applySearchFilter: function(list, filter) {
         if (filter === "") return list;
+        const lcFilter = filter.toLowerCase();
         return list.filter((room) => {
-            return room.name && room.name.toLowerCase().indexOf(filter.toLowerCase()) >= 0
+            if (room.name && room.name.toLowerCase().includes(lcFilter)) return true;
+            // only apply search filter to aliases if it looks like an alias (starts with `#`)
+            // to prevent loads of false positives with server names, e.g `matrix`
+            if (filter[0] === '#' && room.getAliases().some((alias) => {
+                return alias.toLowerCase().startsWith(lcFilter);
+            })) return true;
+            return false;
         });
     },
 

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -106,15 +106,10 @@ var RoomSubList = React.createClass({
     applySearchFilter: function(list, filter) {
         if (filter === "") return list;
         const lcFilter = filter.toLowerCase();
-        return list.filter((room) => {
-            if (room.name && room.name.toLowerCase().includes(lcFilter)) return true;
-            // only apply search filter to aliases if it looks like an alias (starts with `#`)
-            // to prevent loads of false positives with server names, e.g `matrix`
-            if (filter[0] === '#' && room.getAliases().some((alias) => {
-                return alias.toLowerCase().startsWith(lcFilter);
-            })) return true;
-            return false;
-        });
+        // case insensitive if room name includes filter,
+        // or if starts with `#` and one of room's aliases starts with filter
+        return list.filter((room) => (room.name && room.name.toLowerCase().includes(lcFilter)) ||
+            (filter[0] === '#' && room.getAliases().some((alias) => alias.toLowerCase().startsWith(lcFilter))));
     },
 
     // The header is collapsable if it is hidden or not stuck


### PR DESCRIPTION
# Fixes https://github.com/vector-im/riot-web/issues/5719

applies only if begins with a `#` otherwise yielded too many false positives when searching for `matrix`

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>