### PR TITLE
Fix exception when opening dev tools

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -244,12 +244,14 @@ export default class MessageComposerInput extends React.Component {
 
         let editorState = null;
         if (contentState) {
-            editorState = EditorState.createWithContent(contentState, compositeDecorator);
+            editorState = EditorState.moveFocusToEnd(
+                EditorState.createWithContent(contentState, compositeDecorator)
+            );
         } else {
             editorState = EditorState.createEmpty(compositeDecorator);
         }
 
-        return EditorState.moveFocusToEnd(editorState);
+        return editorState;
     }
 
     componentDidMount() {


### PR DESCRIPTION
Apparently draft sometimes gets unhappy when you try to move to the
end of an empty state, so only move to the end if we actually
created a non-empty state.

This will be irrelevant once https://github.com/matrix-org/matrix-react-sdk/pull/1890
is merged, but I have the fix now, and this is probably otherwise
going to annoy me now I'm doing things where devtools is very useful.

Fixes https://github.com/vector-im/riot-web/issues/6436