### PR TITLE
move css rule to be more generic; remove overriden rule

### DIFF
--- a/res/css/views/messages/_MTextBody.scss
+++ b/res/css/views/messages/_MTextBody.scss
@@ -17,8 +17,3 @@ limitations under the License.
 .mx_MTextBody {
     white-space: pre-wrap;
 }
-
-.mx_MTextBody pre{
-  overflow-y: auto;
-  max-height: 30vh;
-}

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -391,6 +391,7 @@ limitations under the License.
 .mx_EventTile_content .markdown-body pre {
     overflow-x: overlay;
     overflow-y: visible;
+    max-height: 30vh;
 }
 
 .mx_EventTile_content .markdown-body code {


### PR DESCRIPTION
Fixes codeblocks in `m.notice` events being infinite height by moving `max-height` to all `pre` blocks from html events rather than just `m.text` ones
`visible` was applied and `auto` discarded due to order

![image](https://user-images.githubusercontent.com/2403652/41369652-63d28918-6f3d-11e8-9b39-367b62cae606.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>