### PR TITLE
fix styling of clearButton when its not there

### DIFF
--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -25,7 +25,7 @@ limitations under the License.
     justify-content: space-between;
 }
 
-.mx_TagPanel .mx_TagPanel_clearButton {
+.mx_TagPanel .mx_TagPanel_clearButton_container {
     /* Constant height within flex mx_TagPanel */
     height: 70px;
     width: 60px;

--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -17,12 +17,15 @@ limitations under the License.
 .mx_TagPanel {
     flex: 0 0 60px;
     background-color: $tertiary-accent-color;
-    cursor: pointer;
 
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
+}
+
+.mx_TagPanel_items_selected {
+    cursor: pointer;
 }
 
 .mx_TagPanel .mx_TagPanel_clearButton_container {

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -127,7 +127,9 @@ const TagPanel = React.createClass({
         }
 
         return <div className="mx_TagPanel">
-            { clearButton }
+            <div className="mx_TagPanel_clearButton_container">
+                { clearButton }
+            </div>
             <div className="mx_TagPanel_divider" />
             <GeminiScrollbarWrapper
                 className="mx_TagPanel_scroller"

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 New Vector Ltd.
+Copyright 2017, 2018 New Vector Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import dis from '../../dispatcher';
 import { _t } from '../../languageHandler';
 
 import { Droppable } from 'react-beautiful-dnd';
+import classNames from 'classnames';
 
 const TagPanel = React.createClass({
     displayName: 'TagPanel',
@@ -116,8 +117,10 @@ const TagPanel = React.createClass({
             />;
         });
 
+        const itemsSelected = this.state.selectedTags.length > 0;
+
         let clearButton;
-        if (this.state.selectedTags.length > 0) {
+        if (itemsSelected) {
             clearButton = <AccessibleButton className="mx_TagPanel_clearButton" onClick={this.onClearFilterClick}>
                 <TintableSvg src="img/icons-close.svg" width="24" height="24"
                              alt={_t("Clear filter")}
@@ -126,7 +129,11 @@ const TagPanel = React.createClass({
             </AccessibleButton>;
         }
 
-        return <div className="mx_TagPanel">
+        const classes = classNames('mx_TagPanel', {
+            mx_TagPanel_items_selected: itemsSelected,
+        });
+
+        return <div className={classes}>
             <div className="mx_TagPanel_clearButton_container">
                 { clearButton }
             </div>


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

broken by https://github.com/matrix-org/matrix-react-sdk/pull/1960
wrapping container added unconditionally to maintain static height, which was previously on the button itself which is a `<div role="button"/>` which is not a11y friendly if its there even if the button is unclickable

Also fixes clickable indication (pointer:cursor) even if clicking does nothing.