### PR TITLE
check type before msgtype in the case of `m.sticker` with msgtype

### DIFF
--- a/src/components/views/messages/MessageEvent.js
+++ b/src/components/views/messages/MessageEvent.js
@@ -72,10 +72,10 @@ module.exports = React.createClass({
         let BodyType = UnknownBody;
         if (!this.props.mxEvent.isRedacted()) {
             // only resolve BodyType if event is not redacted
-            if (msgtype && bodyTypes[msgtype]) {
-                BodyType = bodyTypes[msgtype];
-            } else if (type && evTypes[type]) {
+            if (type && evTypes[type]) {
                 BodyType = evTypes[type];
+            } else if (msgtype && bodyTypes[msgtype]) {
+                BodyType = bodyTypes[msgtype];
             } else if (content.url) {
                 // Fallback to MFileBody if there's a content URL
                 BodyType = bodyTypes['m.file'];


### PR DESCRIPTION
riot-android correctly renders `m.sticker` with `content.msgtype` as sticker, riot-web renders it as whatever the msgtype says it is which is wrong.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>