### PR TITLE
configurable Enter behaviour for ComposerInput

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -60,7 +60,7 @@ export const KeyCode = {
     KEY_Z: 90,
 };
 
-export function isOnlyCtrlOrCmdKeyEvent(ev) {
+export function isOnlyCtrlOrCmdKeyEvent(ev: KeyboardEvent) {
     const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
     if (isMac) {
         return ev.metaKey && !ev.altKey && !ev.ctrlKey && !ev.shiftKey;
@@ -69,7 +69,7 @@ export function isOnlyCtrlOrCmdKeyEvent(ev) {
     }
 }
 
-export function isOnlyCtrlOrCmdIgnoreShiftKeyEvent(ev) {
+export function isOnlyCtrlOrCmdIgnoreShiftKeyEvent(ev: KeyboardEvent) {
     const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
     if (isMac) {
         return ev.metaKey && !ev.altKey && !ev.ctrlKey;

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -76,6 +76,7 @@ const SIMPLE_SETTINGS = [
     { id: "enableSyntaxHighlightLanguageDetection" },
     { id: "MessageComposerInput.autoReplaceEmoji" },
     { id: "MessageComposerInput.dontSuggestEmoji" },
+    { id: "MessageComposerInput.enterSends" },
     { id: "Pill.shouldHidePillAvatar" },
     { id: "TextualBody.disableBigEmoji" },
     { id: "VideoView.flipVideoHorizontally" },

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -21,7 +21,7 @@ import type SyntheticKeyboardEvent from 'react/lib/SyntheticKeyboardEvent';
 
 import { Editor } from 'slate-react';
 import { getEventTransfer } from 'slate-react';
-import { Value, Document, Event, Block, Inline, Text, Range, Node } from 'slate';
+import { Value, Document, Block, Inline, Text, Range, Node, Change } from 'slate';
 
 import Html from 'slate-html-serializer';
 import Md from 'slate-md-serializer';
@@ -343,7 +343,7 @@ export default class MessageComposerInput extends React.Component {
                 // If so, what should be the format, and how do we differentiate it from replies?
 
                 const quote = Block.create('block-quote');
-                if (this.state.isRichTextEnabled) {    
+                if (this.state.isRichTextEnabled) {
                     let change = editorState.change();
                     if (editorState.anchorText.text === '' && editorState.anchorBlock.nodes.size === 1) {
                         // replace the current block rather than split the block
@@ -703,7 +703,7 @@ export default class MessageComposerInput extends React.Component {
         }
 
         // CTRL-ENTER is defined so don't bundle it in with this
-        if (isOnlyCtrlOrCmdKeyEvent(ev) && ev.keyCode !== KeyCode.ENTER) {
+        if (ev.keyCode !== KeyCode.ENTER && isOnlyCtrlOrCmdKeyEvent(ev)) {
             const ctrlCmdCommand = {
                 // C-m => Toggles between rich text and markdown modes
                 [KeyCode.KEY_M]: 'toggle-mode',
@@ -726,7 +726,7 @@ export default class MessageComposerInput extends React.Component {
                 // don't intercept SHIFT-ENTER, it should always newline
                 if (ev.shiftKey) return;
                 // CTRL-ENTER always sends message
-                if (ev.ctrlKey) this.handleReturn(ev, change);
+                if (isOnlyCtrlOrCmdKeyEvent(ev)) this.handleReturn(ev, change);
                 // ENTER on its own varies on setting
                 if (enterSends) {
                     return this.handleReturn(ev, change);

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -99,6 +99,11 @@ export const SETTINGS = {
         displayName: _td('Disable Emoji suggestions while typing'),
         default: false,
     },
+    "MessageComposerInput.enterSends": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td('Use Enter to send message'),
+        default: true,
+    },
     "useCompactLayout": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Use compact timeline layout'),


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/5006

### ~~Blocked on #1890~~

not yet i18n'd
allows users to choose Enter functionality




|                             | enterSends (default) | !enterSends |
|-----------------------------|----------------------|-------------|
| <kbd>⇧</kbd><kbd>⏎</kbd>    | newline              | newline     |
| <kbd>Ctrl/⌘</kbd><kbd>⏎</kbd> | send                 | send        |
| <kbd>⏎</kbd>                           | send                 | newline     |