### PR TITLE
Remove tag panel feature flag

### DIFF
--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -88,12 +88,6 @@ export const SETTINGS = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
-    "feature_tag_panel": {
-        isFeature: true,
-        displayName: _td("Tag Panel"),
-        supportedLevels: LEVELS_FEATURE,
-        default: false,
-    },
     "MessageComposerInput.dontSuggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Disable Emoji suggestions while typing'),


### PR DESCRIPTION
We forgot to remove this when taking tagpanel out of labs, so now
this flag just does nothing.