### PR TITLE
fix e2ee file/media stuff

### DIFF
--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -243,7 +243,7 @@ function uploadFile(matrixClient, roomId, file, progressHandler) {
             const blob = new Blob([encryptResult.data]);
             return matrixClient.uploadContent(blob, {
                 progressHandler: progressHandler,
-                omitFilename: true,
+                includeFilename: false,
             }).then(function(url) {
                 // If the attachment is encrypted then bundle the URL along
                 // with the information needed to decrypt the attachment and

--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -243,6 +243,7 @@ function uploadFile(matrixClient, roomId, file, progressHandler) {
             const blob = new Blob([encryptResult.data]);
             return matrixClient.uploadContent(blob, {
                 progressHandler: progressHandler,
+                omitFilename: true,
             }).then(function(url) {
                 // If the attachment is encrypted then bundle the URL along
                 // with the information needed to decrypt the attachment and

--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -327,6 +327,7 @@ module.exports = React.createClass({
                     // will have the correct name when the user tries to download it.
                     // We can't provide a Content-Disposition header like we would for HTTP.
                     download: fileName,
+                    rel: "noopener",
                     target: "_blank",
                     textContent: _t("Download %(text)s", { text: text }),
                 }, "*");


### PR DESCRIPTION
+ cross-origin loader had `rel="undefined"` due to a missing value, fix to `noopener`
+ pass `omitFilename` to explicitly prevent `filename=undefined`

### ~~Depends on https://github.com/matrix-org/matrix-js-sdk/pull/659~~