### PR TITLE
route matrix.to/#/+... links internally (not just group ids)

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -36,6 +36,7 @@ import * as ContextualMenu from '../../structures/ContextualMenu';
 import SettingsStore from "../../../settings/SettingsStore";
 import PushProcessor from 'matrix-js-sdk/lib/pushprocessor';
 import ReplyThread from "../elements/ReplyThread";
+import {host as matrixtoHost} from '../../../matrix-to';
 
 linkifyMatrix(linkify);
 
@@ -304,7 +305,7 @@ module.exports = React.createClass({
             // never preview matrix.to links (if anything we should give a smart
             // preview of the room/user they point to: nobody needs to be reminded
             // what the matrix.to site looks like).
-            if (host == 'matrix.to') return false;
+            if (host === matrixtoHost) return false;
 
             if (node.textContent.toLowerCase().trim().startsWith(host.toLowerCase())) {
                 // it's a "foo.pl" style link

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -169,10 +169,17 @@ matrixLinkify.VECTOR_URL_PATTERN = "^(?:https?:\/\/)?(?:"
     + "(?:www\\.)?(?:riot|vector)\\.im/(?:app|beta|staging|develop)/"
     + ")(#.*)";
 
-matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/((#|@|!).*)";
+matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/([#@!+].*)";
 matrixLinkify.MATRIXTO_MD_LINK_PATTERN =
-    '\\[([^\\]]*)\\]\\((?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/((#|@|!)[^\\)]*)\\)';
+    '\\[([^\\]]*)\\]\\((?:https?:\/\/)?(?:www\\.)?matrix\\.to/#/([#@!+][^\\)]*)\\)';
 matrixLinkify.MATRIXTO_BASE_URL= baseUrl;
+
+const matrixToEntityMap = {
+    '@': '#/user/',
+    '#': '#/room/',
+    '!': '#/room/',
+    '+': '#/group/',
+};
 
 matrixLinkify.options = {
     events: function(href, type) {
@@ -204,24 +211,20 @@ matrixLinkify.options = {
             case 'userid':
             case 'groupid':
                 return matrixLinkify.MATRIXTO_BASE_URL + '/#/' + href;
-            default:
-                var m;
+            default: {
                 // FIXME: horrible duplication with HtmlUtils' transform tags
-                m = href.match(matrixLinkify.VECTOR_URL_PATTERN);
+                let m = href.match(matrixLinkify.VECTOR_URL_PATTERN);
                 if (m) {
                     return m[1];
                 }
                 m = href.match(matrixLinkify.MATRIXTO_URL_PATTERN);
                 if (m) {
                     const entity = m[1];
-                    if (entity[0] === '@') {
-                        return '#/user/' + entity;
-                    } else if (entity[0] === '#' || entity[0] === '!') {
-                        return '#/room/' + entity;
-                    }
+                    if (matrixToEntityMap[entity[0]]) return matrixToEntityMap[entity[0]] + entity;
                 }
 
                 return href;
+            }
         }
     },
 

--- a/src/matrix-to.js
+++ b/src/matrix-to.js
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const baseUrl = "https://matrix.to";
+export const host = "matrix.to";
+export const baseUrl = `https://${host}`;
 
 export function makeEventPermalink(roomId, eventId) {
     return `${baseUrl}/#/${roomId}/${eventId}`;


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/5614

and remove `matrix.to` literal and move into matrix-to to make it more generic, somewhat