### PR TITLE
affix copyButton so that it doesn't get scrolled horizontally

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -392,6 +392,7 @@ limitations under the License.
     overflow-x: overlay;
     overflow-y: visible;
     max-height: 30vh;
+    position: static;
 }
 
 .mx_EventTile_content .markdown-body code {
@@ -406,7 +407,7 @@ limitations under the License.
     visibility: hidden;
     cursor: pointer;
     top: 6px;
-    right: 6px;
+    right: 36px;
     width: 19px;
     height: 19px;
     background-image: url($copy-button-url);


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/4341
![image](https://user-images.githubusercontent.com/2403652/41497599-114fac06-7150-11e8-9972-d5323d0ef966.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>