### PR TITLE
only show m.room.message in FilePanel

### DIFF
--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -68,9 +68,8 @@ const FilePanel = React.createClass({
                     "room": {
                         "timeline": {
                             "contains_url": true,
-                            "not_types": [
-                                "m.room.avatar",
-                                "m.sticker",
+                            "types": [
+                                "m.room.message",
                             ],
                         },
                     },

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -69,6 +69,7 @@ const FilePanel = React.createClass({
                         "timeline": {
                             "contains_url": true,
                             "not_types": [
+                                "m.room.avatar",
                                 "m.sticker",
                             ],
                         },


### PR DESCRIPTION
instead of hiding
+ `m.sticker`
+ `m.room.avatar`
+ `m.room.widget`

### Fixes https://github.com/vector-im/riot-web/issues/5076
### FIxes https://github.com/vector-im/riot-web/issues/4480