### PR TITLE
on HTML Imgs copy alt to title if there is no title to provide tooltip

### DIFF
--- a/.eslintignore.errorfiles
+++ b/.eslintignore.errorfiles
@@ -92,7 +92,6 @@ src/components/views/settings/DevicesPanel.js
 src/components/views/settings/IntegrationsManager.js
 src/components/views/settings/Notifications.js
 src/ContentMessages.js
-src/HtmlUtils.js
 src/ImageUtils.js
 src/languageHandler.js
 src/linkify-matrix.js

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -240,6 +240,11 @@ const sanitizeHtmlParams = {
                 attribs.width || 800,
                 attribs.height || 600,
             );
+
+            if (!attribs.title && attribs.alt) {
+                attribs.title = attribs.alt;
+            }
+
             return { tagName: tagName, attribs: attribs };
         },
         'code': function(tagName, attribs) {

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -377,36 +377,6 @@ class HtmlHighlighter extends BaseHighlighter {
     }
 }
 
-class TextHighlighter extends BaseHighlighter {
-    constructor(highlightClass, highlightLink) {
-        super(highlightClass, highlightLink);
-        this._key = 0;
-    }
-
-    /* create a <span> node to hold the given content
-     *
-     * snippet: content of the span
-     * highlight: true to highlight as a search match
-     *
-     * returns a React node
-     */
-    _processSnippet(snippet, highlight) {
-        const key = this._key++;
-
-        let node =
-            <span key={key} className={highlight ? this.highlightClass : null}>
-                { snippet }
-            </span>;
-
-        if (highlight && this.highlightLink) {
-            node = <a key={key} href={this.highlightLink}>{ node }</a>;
-        }
-
-        return node;
-    }
-}
-
-
 /* turn a matrix event body into html
  *
  * content: 'content' of the MatrixEvent


### PR DESCRIPTION
Especially helpful when someone's using a client capable of custom emojis which may or may not be unclear:
![image](https://user-images.githubusercontent.com/2403652/41765687-b9836eb6-75fc-11e8-9435-797e88284f2a.png)
which currently have no hover tooltip because they only provide an alt
so now they magically will show a tooltip

### Fixes https://github.com/vector-im/riot-web/issues/6917