### PR TITLE
Revert "affix copyButton so that it doesn't get scrolled horizontally"

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -392,7 +392,6 @@ limitations under the License.
     overflow-x: overlay;
     overflow-y: visible;
     max-height: 30vh;
-    position: static;
 }
 
 .mx_EventTile_content .markdown-body code {
@@ -407,7 +406,7 @@ limitations under the License.
     visibility: hidden;
     cursor: pointer;
     top: 6px;
-    right: 36px;
+    right: 6px;
     width: 19px;
     height: 19px;
     background-image: url($copy-button-url);


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#1980
as it causes worse issue: https://github.com/vector-im/riot-web/issues/6934