### PR TITLE
don't fire share dialog when clicking timestamp of event,

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -439,17 +439,6 @@ module.exports = withMatrixClient(React.createClass({
         });
     },
 
-    onPermalinkShareClicked: function(e) {
-        // These permalinks are like above, can be opened in new tab/window to matrix.to
-        // but otherwise fire the ShareDialog as it makes little sense to click permalink
-        // whilst it is in the current room
-        e.preventDefault();
-        const ShareDialog = sdk.getComponent("dialogs.ShareDialog");
-        Modal.createTrackedDialog('share room event dialog', '', ShareDialog, {
-            target: this.props.mxEvent,
-        });
-    },
-
     _renderE2EPadlock: function() {
         const ev = this.props.mxEvent;
         const props = {onClick: this.onCryptoClicked};
@@ -680,7 +669,7 @@ module.exports = withMatrixClient(React.createClass({
                         { avatar }
                         { sender }
                         <div className="mx_EventTile_reply">
-                            <a href={permalink} onClick={this.onPermalinkShareClicked}>
+                            <a href={permalink} onClick={this.onPermalinkClicked}>
                                 { timestamp }
                             </a>
                             { this._renderE2EPadlock() }
@@ -707,7 +696,7 @@ module.exports = withMatrixClient(React.createClass({
                         { avatar }
                         { sender }
                         <div className="mx_EventTile_line">
-                            <a href={permalink} onClick={this.onPermalinkShareClicked}>
+                            <a href={permalink} onClick={this.onPermalinkClicked}>
                                 { timestamp }
                             </a>
                             { this._renderE2EPadlock() }


### PR DESCRIPTION
it was tripping people up and broke search permalinks

this was me being a little trigger happy and not noticing that Search doesn't have its own `tileShape`

### Fixes https://github.com/vector-im/riot-web/issues/6940

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>