### PR TITLE
improve linkifier AGAIN

### DIFF
--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -41,6 +41,7 @@ function matrixLinkify(linkify) {
     const S_HASH_NAME_COLON_DOMAIN = new linkify.parser.State();
     const S_HASH_NAME_COLON_DOMAIN_DOT = new linkify.parser.State();
     const S_ROOMALIAS = new linkify.parser.State(ROOMALIAS);
+    const S_ROOMALIAS_COLON = new linkify.parser.State();
 
     const roomname_tokens = [
         TT.DOT,
@@ -72,6 +73,8 @@ function matrixLinkify(linkify) {
     S_HASH_NAME_COLON_DOMAIN_DOT.on(TT.TLD, S_ROOMALIAS);
 
     S_ROOMALIAS.on(TT.DOT, S_HASH_NAME_COLON_DOMAIN_DOT); // accept repeated TLDs (e.g .org.uk)
+    S_ROOMALIAS.on(TT.COLON, S_ROOMALIAS_COLON); // do not accept trailing `:`
+    S_ROOMALIAS_COLON.on(TT.NUM, S_ROOMALIAS); // but do accept :NUM (port specifier)
 
 
     const USERID = function(value) {
@@ -87,6 +90,7 @@ function matrixLinkify(linkify) {
     const S_AT_NAME_COLON_DOMAIN = new linkify.parser.State();
     const S_AT_NAME_COLON_DOMAIN_DOT = new linkify.parser.State();
     const S_USERID = new linkify.parser.State(USERID);
+    const S_USERID_COLON = new linkify.parser.State();
 
     const username_tokens = [
         TT.DOT,
@@ -116,6 +120,8 @@ function matrixLinkify(linkify) {
     S_AT_NAME_COLON_DOMAIN_DOT.on(TT.TLD, S_USERID);
 
     S_USERID.on(TT.DOT, S_AT_NAME_COLON_DOMAIN_DOT); // accept repeated TLDs (e.g .org.uk)
+    S_USERID.on(TT.COLON, S_USERID_COLON); // do not accept trailing `:`
+    S_USERID_COLON.on(TT.NUM, S_USERID); // but do accept :NUM (port specifier)
 
 
     const GROUPID = function(value) {
@@ -131,6 +137,7 @@ function matrixLinkify(linkify) {
     const S_PLUS_NAME_COLON_DOMAIN = new linkify.parser.State();
     const S_PLUS_NAME_COLON_DOMAIN_DOT = new linkify.parser.State();
     const S_GROUPID = new linkify.parser.State(GROUPID);
+    const S_GROUPID_COLON = new linkify.parser.State();
 
     const groupid_tokens = [
         TT.DOT,
@@ -160,6 +167,8 @@ function matrixLinkify(linkify) {
     S_PLUS_NAME_COLON_DOMAIN_DOT.on(TT.TLD, S_GROUPID);
 
     S_GROUPID.on(TT.DOT, S_PLUS_NAME_COLON_DOMAIN_DOT); // accept repeated TLDs (e.g .org.uk)
+    S_GROUPID.on(TT.COLON, S_GROUPID_COLON); // do not accept trailing `:`
+    S_GROUPID_COLON.on(TT.NUM, S_GROUPID); // but do accept :NUM (port specifier)
 }
 
 // stubs, overwritten in MatrixChat's componentDidMount

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -35,7 +35,7 @@ function matrixLinkify(linkify) {
     };
     ROOMALIAS.prototype = new MultiToken();
 
-    const S_HASH = new linkify.parser.State();
+    const S_HASH = S_START.jump(TT.POUND);
     const S_HASH_NAME = new linkify.parser.State();
     const S_HASH_NAME_COLON = new linkify.parser.State();
     const S_HASH_NAME_COLON_DOMAIN = new linkify.parser.State();
@@ -56,8 +56,6 @@ function matrixLinkify(linkify) {
         // usernames @localhost:foo.com are otherwise not matched!
         TT.LOCALHOST,
     ];
-
-    S_START.on(TT.POUND, S_HASH);
 
     S_HASH.on(roomname_tokens, S_HASH_NAME);
     S_HASH_NAME.on(roomname_tokens, S_HASH_NAME);
@@ -84,7 +82,7 @@ function matrixLinkify(linkify) {
     };
     USERID.prototype = new MultiToken();
 
-    const S_AT = new linkify.parser.State();
+    const S_AT = S_START.jump(TT.AT);
     const S_AT_NAME = new linkify.parser.State();
     const S_AT_NAME_COLON = new linkify.parser.State();
     const S_AT_NAME_COLON_DOMAIN = new linkify.parser.State();
@@ -103,8 +101,6 @@ function matrixLinkify(linkify) {
         // as in roomname_tokens
         TT.LOCALHOST,
     ];
-
-    S_START.on(TT.AT, S_AT);
 
     S_AT.on(username_tokens, S_AT_NAME);
     S_AT_NAME.on(username_tokens, S_AT_NAME);
@@ -131,7 +127,7 @@ function matrixLinkify(linkify) {
     };
     GROUPID.prototype = new MultiToken();
 
-    const S_PLUS = new linkify.parser.State();
+    const S_PLUS = S_START.jump(TT.PLUS);
     const S_PLUS_NAME = new linkify.parser.State();
     const S_PLUS_NAME_COLON = new linkify.parser.State();
     const S_PLUS_NAME_COLON_DOMAIN = new linkify.parser.State();
@@ -150,8 +146,6 @@ function matrixLinkify(linkify) {
         // as in roomname_tokens
         TT.LOCALHOST,
     ];
-
-    S_START.on(TT.PLUS, S_PLUS);
 
     S_PLUS.on(groupid_tokens, S_PLUS_NAME);
     S_PLUS_NAME.on(groupid_tokens, S_PLUS_NAME);


### PR DESCRIPTION
+ adds support for ports in server_name, as per  [spec](https://matrix.org/speculator/spec/HEAD/appendices.html#server-name). Fixes https://github.com/vector-im/riot-web/issues/6949
+ removes intermediary state so might be a tiny fraction more efficient, copies style/design pattern from the official 3 plugins for the library.