### PR TITLE
Improve tracking of UISIs

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -199,9 +199,9 @@ class Analytics {
         this._paq.push(['trackPageView']);
     }
 
-    trackEvent(category, action, name) {
+    trackEvent(category, action, name, value) {
         if (this.disabled) return;
-        this._paq.push(['trackEvent', category, action, name]);
+        this._paq.push(['trackEvent', category, action, name, value]);
     }
 
     logout() {

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -157,12 +157,15 @@ export default class DecryptionFailureTracker {
     }
 
     /**
-     * If there is a failure that should be tracked, call the given trackDecryptionFailure
-     * function with the first failure in the FIFO of failures that should be tracked.
+     * If there are failures that should be tracked, call the given trackDecryptionFailure
+     * function with the number of failures that should be tracked.
      */
     trackFailure() {
         if (this.failuresToTrack.length > 0) {
-            // Remove all failures, and expose the number of failures
+            // Remove all failures, and expose the number of failures for now.
+            //
+            // TODO: Track a histogram of error types to cardinailty to allow for
+            // aggregation by error type.
             this.trackDecryptionFailure(this.failuresToTrack.splice(0).length);
         }
     }

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -40,9 +40,8 @@ export default class DecryptionFailureTracker {
     checkInterval = null;
     trackInterval = null;
 
-    // Spread the load on `Analytics` by sending at most 1 event per
-    // `TRACK_INTERVAL_MS`.
-    static TRACK_INTERVAL_MS = 1000;
+    // Spread the load on `Analytics` by tracking at a low frequency, `TRACK_INTERVAL_MS`.
+    static TRACK_INTERVAL_MS = 60000;
 
     // Call `checkFailures` every `CHECK_INTERVAL_MS`.
     static CHECK_INTERVAL_MS = 5000;
@@ -163,7 +162,8 @@ export default class DecryptionFailureTracker {
      */
     trackFailure() {
         if (this.failuresToTrack.length > 0) {
-            this.trackDecryptionFailure(this.failuresToTrack.shift());
+            // Remove all failures, and expose the number of failures
+            this.trackDecryptionFailure(this.failuresToTrack.splice(0).length);
         }
     }
 }

--- a/src/DecryptionFailureTracker.js
+++ b/src/DecryptionFailureTracker.js
@@ -48,7 +48,7 @@ export default class DecryptionFailureTracker {
 
     // Give events a chance to be decrypted by waiting `GRACE_PERIOD_MS` before moving
     // the failure to `failuresToTrack`.
-    static GRACE_PERIOD_MS = 5000;
+    static GRACE_PERIOD_MS = 60000;
 
     constructor(fn) {
         if (!fn || typeof fn !== 'function') {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1304,9 +1304,9 @@ export default React.createClass({
             }
         });
 
-        const dft = new DecryptionFailureTracker((failure) => {
+        const dft = new DecryptionFailureTracker((total) => {
             // TODO: Pass reason for failure as third argument to trackEvent
-            Analytics.trackEvent('E2E', 'Decryption failure');
+            Analytics.trackEvent('E2E', 'Decryption failure', null, total);
         });
 
         // Shelved for later date when we have time to think about persisting history of


### PR DESCRIPTION
 - Track UISIs in bulk, using piwik event value
 - Increase the grace period given to allow events to be decrypted before counting them as failures. This allows more time for key requests and the like.