### PR TITLE
Fix room topics/names resetting when UserSetting re-renders

### DIFF
--- a/src/components/views/elements/EditableItemList.js
+++ b/src/components/views/elements/EditableItemList.js
@@ -139,8 +139,11 @@ module.exports = React.createClass({
             </div>
             { editableItems }
             { this.props.canEdit ?
+                // This is slightly evil; we want a new instance of
+                // EditableItem when the list grows. To make sure it's
+                // reset to its initial state.
                 <EditableItem
-                    key={-1}
+                    key={editableItems.length}
                     initialValue={this.props.newItem}
                     onAdd={this.onItemAdded}
                     onChange={this.onNewItemChanged}

--- a/src/components/views/elements/EditableText.js
+++ b/src/components/views/elements/EditableText.js
@@ -61,7 +61,7 @@ module.exports = React.createClass({
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (nextProps.initialValue !== this.props.initialValue || nextProps.initialValue !== this.value) {
+        if (nextProps.initialValue !== this.props.initialValue) {
             this.value = nextProps.initialValue;
             if (this.refs.editable_div) {
                 this.showPlaceholder(!this.value);


### PR DESCRIPTION
This reverts a fix to EditableText introduced in
    https://github.com/matrix-org/matrix-react-sdk/pull/1445
which introduced a bug that causes room name and topic to
reset when UserSettings is rerendered because
    `initialValue != this.value`

This also fixes the same bug originally fixed by #1445:
 >fix entering the same thing twice (which had the bug of not
 >emptying the "new" field)

which, in other words meant that clicking "+" when adding a room
alias would not reset the contents of the bottom-most alias in the
list.

The fix is to increment the `key` of the element, causing a new
instance to be mounted instead of passing new props to the existing
one.

Fixes https://github.com/vector-im/riot-web/issues/6019