### PR TITLE
Track an event name when tracking a decryption failure

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1306,7 +1306,7 @@ export default React.createClass({
 
         const dft = new DecryptionFailureTracker((total) => {
             // TODO: Pass reason for failure as third argument to trackEvent
-            Analytics.trackEvent('E2E', 'Decryption failure', null, total);
+            Analytics.trackEvent('E2E', 'Decryption failure', 'unspecified_error', total);
         });
 
         // Shelved for later date when we have time to think about persisting history of


### PR DESCRIPTION
Otherwise piwik will not agregate the failures correctly for all views.