### PR TITLE
use constants everywhere to avoid typos like `im.vector.settings` :D

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -29,7 +29,7 @@ import sdk from '../../index';
 import dis from '../../dispatcher';
 import sessionStore from '../../stores/SessionStore';
 import MatrixClientPeg from '../../MatrixClientPeg';
-import SettingsStore from "../../settings/SettingsStore";
+import SettingsStore, {SettingEventType} from "../../settings/SettingsStore";
 
 import TagOrderActions from '../../actions/TagOrderActions';
 import RoomListActions from '../../actions/RoomListActions';
@@ -132,7 +132,7 @@ const LoggedInView = React.createClass({
     },
 
     onAccountData: function(event) {
-        if (event.getType() === "im.vector.web.settings") {
+        if (event.getType() === SettingEventType) {
             this.setState({
                 useCompactLayout: event.getContent().useCompactLayout,
             });

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -44,7 +44,7 @@ import PageTypes from '../../PageTypes';
 import createRoom from "../../createRoom";
 import KeyRequestHandler from '../../KeyRequestHandler';
 import { _t, getCurrentLanguage } from '../../languageHandler';
-import SettingsStore, {SettingLevel} from "../../settings/SettingsStore";
+import SettingsStore, {SettingLevel, SettingEventType} from "../../settings/SettingsStore";
 
 /** constants for MatrixChat.state.view */
 const VIEWS = {
@@ -1294,7 +1294,7 @@ export default React.createClass({
         });
 
         cli.on("accountData", function(ev) {
-            if (ev.getType() === 'im.vector.web.settings') {
+            if (ev.getType() === SettingEventType) {
                 if (ev.getContent() && ev.getContent().theme) {
                     dis.dispatch({
                         action: 'set_theme',

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -45,7 +45,7 @@ import { KeyCode, isOnlyCtrlOrCmdKeyEvent } from '../../Keyboard';
 
 import RoomViewStore from '../../stores/RoomViewStore';
 import RoomScrollStateStore from '../../stores/RoomScrollStateStore';
-import SettingsStore, {SettingLevel} from "../../settings/SettingsStore";
+import SettingsStore, {SettingLevel, SettingEventType} from "../../settings/SettingsStore";
 import WidgetUtils from '../../utils/WidgetUtils';
 
 const DEBUG = false;
@@ -643,7 +643,7 @@ module.exports = React.createClass({
 
     onAccountData: function(event) {
         const type = event.getType();
-        if ((type === "org.matrix.preview_urls" || type === "im.vector.web.settings") && this.state.room) {
+        if ((type === "org.matrix.preview_urls" || type === SettingEventType) && this.state.room) {
             // non-e2ee url previews are stored in legacy event type `org.matrix.room.preview_urls`
             this._updatePreviewUrlVisibility(this.state.room);
         }
@@ -657,7 +657,7 @@ module.exports = React.createClass({
                 // XXX: we should validate the event
                 console.log("Tinter.tint from onRoomAccountData");
                 Tinter.tint(color_scheme.primary_color, color_scheme.secondary_color);
-            } else if (type === "org.matrix.room.preview_urls" || type === "im.vector.web.settings") {
+            } else if (type === "org.matrix.room.preview_urls" || type === SettingEventType) {
                 // non-e2ee url previews are stored in legacy event type `org.matrix.room.preview_urls`
                 this._updatePreviewUrlVisibility(room);
             }

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -21,15 +21,16 @@ import {
     NotificationBodyEnabledController,
     NotificationsEnabledController,
 } from "./controllers/NotificationControllers";
-
+import {SettingLevel} from './SettingsStore';
+const {DEVICE, ROOM_DEVICE, ROOM_ACCOUNT, ACCOUNT, ROOM, CONFIG, DEFAULT} = SettingLevel;
 
 // These are just a bunch of helper arrays to avoid copy/pasting a bunch of times
-const LEVELS_ROOM_SETTINGS = ['device', 'room-device', 'room-account', 'account', 'config'];
-const LEVELS_ROOM_SETTINGS_WITH_ROOM = ['device', 'room-device', 'room-account', 'account', 'config', 'room'];
-const LEVELS_ACCOUNT_SETTINGS = ['device', 'account', 'config'];
-const LEVELS_FEATURE = ['device', 'config'];
-const LEVELS_DEVICE_ONLY_SETTINGS = ['device'];
-const LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG = ['device', 'config'];
+const LEVELS_ROOM_SETTINGS = [DEVICE, ROOM_DEVICE, ROOM_ACCOUNT, ACCOUNT, CONFIG];
+const LEVELS_ROOM_SETTINGS_WITH_ROOM = [DEVICE, ROOM_DEVICE, ROOM_ACCOUNT, ACCOUNT, CONFIG, ROOM];
+const LEVELS_ACCOUNT_SETTINGS = [DEVICE, ACCOUNT, CONFIG];
+const LEVELS_FEATURE = [DEVICE, CONFIG];
+const LEVELS_DEVICE_ONLY_SETTINGS = [DEVICE];
+const LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG = [DEVICE, CONFIG];
 
 export const SETTINGS = {
     // EXAMPLE SETTING:
@@ -42,9 +43,9 @@ export const SETTINGS = {
     //
     //     // Display name can also be an object for different levels.
     //     //displayName: {
-    //     //    "device": _td("Name for when the setting is used at 'device'"),
-    //     //    "room": _td("Name for when the setting is used at 'room'"),
-    //     //    "default": _td("The name for all other levels"),
+    //     //    [DEVICE]: _td("Name for when the setting is used at DEVICE"),
+    //     //    [ROOM]: _td("Name for when the setting is used at ROOM"),
+    //     //    [DEFAULT]: _td("The name for all other levels"),
     //     //}
     //
     //     // The supported levels are required. Preferably, use the preset arrays
@@ -52,14 +53,14 @@ export const SETTINGS = {
     //     supportedLevels: [
     //         // The order does not matter.
     //
-    //         "device",        // Affects the current device only
-    //         "room-device",   // Affects the current room on the current device
-    //         "room-account",  // Affects the current room for the current account
-    //         "account",       // Affects the current account
-    //         "room",          // Affects the current room (controlled by room admins)
-    //         "config",        // Affects the current application
+    //         DEVICE,        // Affects the current device only
+    //         ROOM_DEVICE,   // Affects the current room on the current device
+    //         ROOM_ACCOUNT,  // Affects the current room for the current account
+    //         ACCOUNT,       // Affects the current account
+    //         ROOM,          // Affects the current room (controlled by room admins)
+    //         CONFIG,        // Affects the current application
     //
-    //         // "default" is always supported and does not get listed here.
+    //         // DEFAULT is always supported and does not get listed here.
     //     ],
     //
     //     // Required. Can be any data type. The value specified here should match
@@ -228,27 +229,27 @@ export const SETTINGS = {
     "blacklistUnverifiedDevices": {
         // We specifically want to have room-device > device so that users may set a device default
         // with a per-room override.
-        supportedLevels: ['room-device', 'device'],
+        supportedLevels: [ROOM_DEVICE, DEVICE],
         supportedLevelsAreOrdered: true,
         displayName: {
-            "default": _td('Never send encrypted messages to unverified devices from this device'),
-            "room-device": _td('Never send encrypted messages to unverified devices in this room from this device'),
+            [DEFAULT]: _td('Never send encrypted messages to unverified devices from this device'),
+            [ROOM_DEVICE]: _td('Never send encrypted messages to unverified devices in this room from this device'),
         },
         default: false,
     },
     "urlPreviewsEnabled": {
         supportedLevels: LEVELS_ROOM_SETTINGS_WITH_ROOM,
         displayName: {
-            "default": _td('Enable inline URL previews by default'),
-            "room-account": _td("Enable URL previews for this room (only affects you)"),
-            "room": _td("Enable URL previews by default for participants in this room"),
+            [DEFAULT]: _td('Enable inline URL previews by default'),
+            [ROOM_ACCOUNT]: _td("Enable URL previews for this room (only affects you)"),
+            [ROOM]: _td("Enable URL previews by default for participants in this room"),
         },
         default: true,
     },
     "urlPreviewsEnabled_e2ee": {
-        supportedLevels: ['room-device', 'room-account'],
+        supportedLevels: [ROOM_DEVICE, ROOM_ACCOUNT],
         displayName: {
-            "room-account": _td("Enable URL previews for this room (only affects you)"),
+            [ROOM_ACCOUNT]: _td("Enable URL previews for this room (only affects you)"),
         },
         default: false,
     },
@@ -281,7 +282,7 @@ export const SETTINGS = {
         default: false,
     },
     "PinnedEvents.isOpen": {
-        supportedLevels: ['room-device'],
+        supportedLevels: [ROOM_DEVICE],
         default: false,
     },
 };

--- a/src/settings/SettingsStore.js
+++ b/src/settings/SettingsStore.js
@@ -40,6 +40,10 @@ export const SettingLevel = {
     CONFIG: "config",
     DEFAULT: "default",
 };
+const {DEVICE, ROOM_DEVICE, ROOM_ACCOUNT, ACCOUNT, ROOM, CONFIG, DEFAULT} = SettingLevel;
+
+export const SettingEventType = 'im.vector.web.settings';
+
 
 // Convert the settings to easier to manage objects for the handlers
 const defaultSettings = {};
@@ -50,13 +54,13 @@ for (const key of Object.keys(SETTINGS)) {
 }
 
 const LEVEL_HANDLERS = {
-    "device": new DeviceSettingsHandler(featureNames),
-    "room-device": new RoomDeviceSettingsHandler(),
-    "room-account": new RoomAccountSettingsHandler(),
-    "account": new AccountSettingsHandler(),
-    "room": new RoomSettingsHandler(),
-    "config": new ConfigSettingsHandler(),
-    "default": new DefaultSettingsHandler(defaultSettings),
+    [DEVICE]: new DeviceSettingsHandler(featureNames),
+    [ROOM_DEVICE]: new RoomDeviceSettingsHandler(),
+    [ROOM_ACCOUNT]: new RoomAccountSettingsHandler(),
+    [ACCOUNT]: new AccountSettingsHandler(),
+    [ROOM]: new RoomSettingsHandler(),
+    [CONFIG]: new ConfigSettingsHandler(),
+    [DEFAULT]: new DefaultSettingsHandler(defaultSettings),
 };
 
 // Wrap all the handlers with local echo
@@ -65,7 +69,7 @@ for (const key of Object.keys(LEVEL_HANDLERS)) {
 }
 
 const LEVEL_ORDER = [
-    'device', 'room-device', 'room-account', 'account', 'room', 'config', 'default',
+    DEVICE, ROOM_DEVICE, ROOM_ACCOUNT, DEVICE, ACCOUNT, ROOM, CONFIG, DEFAULT,
 ];
 
 /**
@@ -99,13 +103,13 @@ export default class SettingsStore {
      * The level to get the display name for; Defaults to 'default'.
      * @return {String} The display name for the setting, or null if not found.
      */
-    static getDisplayName(settingName, atLevel = "default") {
+    static getDisplayName(settingName, atLevel = DEFAULT) {
         if (!SETTINGS[settingName] || !SETTINGS[settingName].displayName) return null;
 
         let displayName = SETTINGS[settingName].displayName;
         if (displayName instanceof Object) {
             if (displayName[atLevel]) displayName = displayName[atLevel];
-            else displayName = displayName["default"];
+            else displayName = displayName[DEFAULT];
         }
 
         return _t(displayName);
@@ -164,7 +168,7 @@ export default class SettingsStore {
             throw new Error("Setting " + settingName + " is not a feature");
         }
 
-        return SettingsStore.setValue(settingName, null, "device", value);
+        return SettingsStore.setValue(settingName, null, DEVICE, value);
     }
 
     /**
@@ -206,7 +210,7 @@ export default class SettingsStore {
 
         const setting = SETTINGS[settingName];
         const levelOrder = (setting.supportedLevelsAreOrdered ? setting.supportedLevels : LEVEL_ORDER);
-        if (!levelOrder.includes("default")) levelOrder.push("default"); // always include default
+        if (!levelOrder.includes(DEFAULT)) levelOrder.push(DEFAULT); // always include default
 
         const minIndex = levelOrder.indexOf(level);
         if (minIndex === -1) throw new Error("Level " + level + " is not prioritized");
@@ -230,7 +234,7 @@ export default class SettingsStore {
         for (let i = minIndex; i < levelOrder.length; i++) {
             const handler = handlers[levelOrder[i]];
             if (!handler) continue;
-            if (excludeDefault && levelOrder[i] === "default") continue;
+            if (excludeDefault && levelOrder[i] === DEFAULT) continue;
 
             const value = handler.getValue(settingName, roomId);
             if (value === null || value === undefined) continue;
@@ -330,7 +334,7 @@ export default class SettingsStore {
         }
 
         // Always support 'default'
-        if (!handlers['default']) handlers['default'] = LEVEL_HANDLERS['default'];
+        if (!handlers[DEFAULT]) handlers[DEFAULT] = LEVEL_HANDLERS[DEFAULT];
 
         return handlers;
     }

--- a/src/settings/handlers/AccountSettingsHandler.js
+++ b/src/settings/handlers/AccountSettingsHandler.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {SettingEventType} from '../SettingsStore';
 import SettingsHandler from "./SettingsHandler";
 import MatrixClientPeg from '../../MatrixClientPeg';
 
@@ -55,7 +56,7 @@ export default class AccountSettingHandler extends SettingsHandler {
 
         const content = this._getSettings() || {};
         content[settingName] = newValue;
-        return MatrixClientPeg.get().setAccountData("im.vector.web.settings", content);
+        return MatrixClientPeg.get().setAccountData(SettingEventType, content);
     }
 
     canSetValue(settingName, roomId) {
@@ -67,7 +68,7 @@ export default class AccountSettingHandler extends SettingsHandler {
         return cli !== undefined && cli !== null;
     }
 
-    _getSettings(eventType = "im.vector.web.settings") {
+    _getSettings(eventType = SettingEventType) {
         const cli = MatrixClientPeg.get();
         if (!cli) return null;
 

--- a/src/settings/handlers/RoomAccountSettingsHandler.js
+++ b/src/settings/handlers/RoomAccountSettingsHandler.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {SettingEventType} from '../SettingsStore';
 import SettingsHandler from "./SettingsHandler";
 import MatrixClientPeg from '../../MatrixClientPeg';
 
@@ -59,7 +60,7 @@ export default class RoomAccountSettingsHandler extends SettingsHandler {
 
         const content = this._getSettings(roomId) || {};
         content[settingName] = newValue;
-        return MatrixClientPeg.get().setRoomAccountData(roomId, "im.vector.web.settings", content);
+        return MatrixClientPeg.get().setRoomAccountData(roomId, SettingEventType, content);
     }
 
     canSetValue(settingName, roomId) {
@@ -74,7 +75,7 @@ export default class RoomAccountSettingsHandler extends SettingsHandler {
         return cli !== undefined && cli !== null;
     }
 
-    _getSettings(roomId, eventType = "im.vector.web.settings") {
+    _getSettings(roomId, eventType = SettingEventType) {
         const room = MatrixClientPeg.get().getRoom(roomId);
         if (!room) return null;
 

--- a/src/settings/handlers/RoomSettingsHandler.js
+++ b/src/settings/handlers/RoomSettingsHandler.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {SettingEventType} from '../SettingsStore';
 import SettingsHandler from "./SettingsHandler";
 import MatrixClientPeg from '../../MatrixClientPeg';
 
@@ -45,14 +46,14 @@ export default class RoomSettingsHandler extends SettingsHandler {
 
         const content = this._getSettings(roomId) || {};
         content[settingName] = newValue;
-        return MatrixClientPeg.get().sendStateEvent(roomId, "im.vector.web.settings", content, "");
+        return MatrixClientPeg.get().sendStateEvent(roomId, SettingEventType, content, "");
     }
 
     canSetValue(settingName, roomId) {
         const cli = MatrixClientPeg.get();
         const room = cli.getRoom(roomId);
 
-        let eventType = "im.vector.web.settings";
+        let eventType = SettingEventType;
         if (settingName === "urlPreviewsEnabled") eventType = "org.matrix.room.preview_urls";
 
         if (!room) return false;
@@ -64,7 +65,7 @@ export default class RoomSettingsHandler extends SettingsHandler {
         return cli !== undefined && cli !== null;
     }
 
-    _getSettings(roomId, eventType = "im.vector.web.settings") {
+    _getSettings(roomId, eventType = SettingEventType) {
         const room = MatrixClientPeg.get().getRoom(roomId);
         if (!room) return null;
 


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

just a little bit of maintenance after finding the string typo bug which broke room-account settings previously.