### PR TITLE
Implement always-on-screen capability for widgets

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -31,7 +31,6 @@ limitations under the License.
     top: 14px;
     left: 8px;
     cursor: pointer;
-    z-index: 2;
 }
 
 .mx_EventTile.mx_EventTile_info .mx_EventTile_avatar {

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -444,7 +444,8 @@ function _startCallApp(roomId, type) {
         'email=$matrix_user_id',
     ].join('&');
     const widgetUrl = (
-        'https://scalar.vector.im/api/widgets' +
+        //'https://scalar.vector.im/api/widgets' +
+        'http://localhost:8620' +
         '/jitsi.html?' +
         queryString
     );

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -444,8 +444,7 @@ function _startCallApp(roomId, type) {
         'email=$matrix_user_id',
     ].join('&');
     const widgetUrl = (
-        //'https://scalar.vector.im/api/widgets' +
-        'http://localhost:8620' +
+        'https://scalar.vector.im/api/widgets' +
         '/jitsi.html?' +
         queryString
     );

--- a/src/FromWidgetPostMessageApi.js
+++ b/src/FromWidgetPostMessageApi.js
@@ -18,6 +18,7 @@ import URL from 'url';
 import dis from './dispatcher';
 import IntegrationManager from './IntegrationManager';
 import WidgetMessagingEndpoint from './WidgetMessagingEndpoint';
+import ActiveWidgetStore from './stores/ActiveWidgetStore';
 
 const WIDGET_API_VERSION = '0.0.1'; // Current API version
 const SUPPORTED_WIDGET_API_VERSIONS = [
@@ -155,6 +156,14 @@ export default class FromWidgetPostMessageApi {
             const integType = (data && data.integType) ? data.integType : null;
             const integId = (data && data.integId) ? data.integId : null;
             IntegrationManager.open(integType, integId);
+        } else if (action === 'set_always_on_screen') {
+            // This is a new message: there is no reason to support the deprecated widgetData here
+            const data = event.data.data;
+            const val = data.value;
+
+            if (ActiveWidgetStore.widgetHasCapability(widgetId, 'm.always_on_screen')) {
+                ActiveWidgetStore.setWidgetPersistence(widgetId, val);
+            }
         } else {
             console.warn('Widget postMessage event unhandled');
             this.sendError(event, {message: 'The postMessage was unhandled'});

--- a/src/components/views/elements/PersistedElement.js
+++ b/src/components/views/elements/PersistedElement.js
@@ -22,8 +22,12 @@ const PropTypes = require('prop-types');
 // of doing reusable widgets like dialog boxes & menus where we go and
 // pass in a custom control as the actual body.
 
+function getContainer(containerId) {
+    return document.getElementById(containerId);
+}
+
 function getOrCreateContainer(containerId) {
-    let container = document.getElementById(containerId);
+    let container = getContainer(containerId);
 
     if (!container) {
         container = document.createElement("div");
@@ -58,6 +62,24 @@ export default class PersistedElement extends React.Component {
         super();
         this.collectChildContainer = this.collectChildContainer.bind(this);
         this.collectChild = this.collectChild.bind(this);
+    }
+
+    /**
+     * Removes the DOM elements created when a PersistedElement with the given
+     * persistKey was mounted. The DOM elements will be re-added if another
+     * PeristedElement is mounted in the future.
+     *
+     * @param {string} persistKey Key used to uniquely identify this PersistedElement
+     */
+    static destroyElement(persistKey) {
+        const container = getContainer('mx_persistedElement_' + persistKey);
+        if (container) {
+            container.remove();
+        }
+    }
+
+    static isMounted(persistKey) {
+        return Boolean(getContainer('mx_persistedElement_' + persistKey));
     }
 
     collectChildContainer(ref) {

--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -214,24 +215,30 @@ module.exports = React.createClass({
     render: function() {
         const enableScreenshots = SettingsStore.getValue("enableWidgetScreenshots", this.props.room.room_id);
 
-        const apps = this.state.apps.map(
-            (app, index, arr) => {
-                return (<AppTile
-                    key={app.id}
-                    id={app.id}
-                    url={app.url}
-                    name={app.name}
-                    type={app.type}
-                    fullWidth={arr.length<2 ? true : false}
-                    room={this.props.room}
-                    userId={this.props.userId}
-                    show={this.props.showApps}
-                    creatorUserId={app.creatorUserId}
-                    widgetPageTitle={(app.data && app.data.title) ? app.data.title : ''}
-                    waitForIframeLoad={app.waitForIframeLoad}
-                    whitelistCapabilities={enableScreenshots ? ["m.capability.screenshot"] : []}
-                />);
-            });
+        const apps = this.state.apps.map((app, index, arr) => {
+            const capWhitelist = enableScreenshots ? ["m.capability.screenshot"] : [];
+
+            // Obviously anyone that can add a widget can claim it's a jitsi widget,
+            // so this doesn't really offer much over the set of domains we load
+            // widgets from at all, but it probably makes sense for sanity.
+            if (app.type == 'jitsi') capWhitelist.push("m.always_on_screen");
+
+            return (<AppTile
+                key={app.id}
+                id={app.id}
+                url={app.url}
+                name={app.name}
+                type={app.type}
+                fullWidth={arr.length<2 ? true : false}
+                room={this.props.room}
+                userId={this.props.userId}
+                show={this.props.showApps}
+                creatorUserId={app.creatorUserId}
+                widgetPageTitle={(app.data && app.data.title) ? app.data.title : ''}
+                waitForIframeLoad={app.waitForIframeLoad}
+                whitelistCapabilities={capWhitelist}
+            />);
+        });
 
         let addWidget;
         if (this.props.showApps &&

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -695,7 +695,6 @@ module.exports = withMatrixClient(React.createClass({
                         <div className="mx_EventTile_msgOption">
                             { readAvatars }
                         </div>
-                        { avatar }
                         { sender }
                         <div className="mx_EventTile_line">
                             <a href={permalink} onClick={this.onPermalinkClicked}>
@@ -712,6 +711,12 @@ module.exports = withMatrixClient(React.createClass({
                             { keyRequestInfo }
                             { editButton }
                         </div>
+                        {
+                            // The avatar goes after the event tile as it's absolutly positioned to be over the
+                            // event tile line, so needs to be later in the DOM so it appears on top (this avoids
+                            // the need for further z-indexing chaos)
+                        }
+                        { avatar }
                     </div>
                 );
             }

--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -24,6 +24,7 @@ import ScalarAuthClient from '../../../ScalarAuthClient';
 import dis from '../../../dispatcher';
 import AccessibleButton from '../elements/AccessibleButton';
 import WidgetUtils from '../../../utils/WidgetUtils';
+import ActiveWidgetStore from '../../../stores/ActiveWidgetStore';
 
 const widgetType = 'm.stickerpicker';
 
@@ -42,8 +43,6 @@ export default class Stickerpicker extends React.Component {
         this._onWidgetAction = this._onWidgetAction.bind(this);
         this._onResize = this._onResize.bind(this);
         this._onFinished = this._onFinished.bind(this);
-
-        this._collectWidgetMessaging = this._collectWidgetMessaging.bind(this);
 
         this.popoverWidth = 300;
         this.popoverHeight = 300;
@@ -166,17 +165,10 @@ export default class Stickerpicker extends React.Component {
         );
     }
 
-    _collectWidgetMessaging(widgetMessaging) {
-        this._appWidgetMessaging = widgetMessaging;
-
-        // Do this now instead of in componentDidMount because we might not have had the
-        // reference to widgetMessaging when mounting
-        this._sendVisibilityToWidget(true);
-    }
-
     _sendVisibilityToWidget(visible) {
-        if (this._appWidgetMessaging && visible !== this._prevSentVisibility) {
-            this._appWidgetMessaging.sendVisibility(visible);
+        const widgetMessaging = ActiveWidgetStore.getWidgetMessaging(this.state.stickerpickerWidget.id);
+        if (widgetMessaging && visible !== this._prevSentVisibility) {
+            widgetMessaging.sendVisibility(visible);
             this._prevSentVisibility = visible;
         }
     }
@@ -217,7 +209,6 @@ export default class Stickerpicker extends React.Component {
                     >
                     <PersistedElement containerId="mx_persisted_stickerPicker" style={{zIndex: STICKERPICKER_Z_INDEX}}>
                         <AppTile
-                            collectWidgetMessaging={this._collectWidgetMessaging}
                             id={stickerpickerWidget.id}
                             url={stickerpickerWidget.content.url}
                             name={stickerpickerWidget.content.name}

--- a/src/stores/ActiveWidgetStore.js
+++ b/src/stores/ActiveWidgetStore.js
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Stores information about the widgets active in the app right now:
+ *  * What widget is set to remain always-on-screen, if any
+ *    Only one widget may be 'always on screen' at any one time.
+ *  * Negotiated capabilities for active apps
+ */
+class ActiveWidgetStore {
+    constructor() {
+        this._persistentWidgetId = null;
+
+        // A list of negotiated capabilities for each widget, by ID
+        // {
+        //     widgetId: [caps...],
+        // }
+        this._capsByWidgetId = {};
+
+        // A WidgetMessaging instance for each widget ID
+        this._widgetMessagingByWidgetId = {};
+    }
+
+    setWidgetPersistence(widgetId, val) {
+        if (this._persistentWidgetId === widgetId && !val) {
+            this._persistentWidgetId = null;
+        } else if (this._persistentWidgetId !== widgetId && val) {
+            this._persistentWidgetId = widgetId;
+        }
+    }
+
+    getWidgetPersistence(widgetId) {
+        return this._persistentWidgetId === widgetId;
+    }
+
+    setWidgetCapabilities(widgetId, caps) {
+        this._capsByWidgetId[widgetId] = caps;
+    }
+
+    widgetHasCapability(widgetId, cap) {
+        return this._capsByWidgetId[widgetId] && this._capsByWidgetId[widgetId].includes(cap);
+    }
+
+    delWidgetCapabilities(widgetId) {
+        delete this._capsByWidgetId[widgetId];
+    }
+
+    setWidgetMessaging(widgetId, wm) {
+        this._widgetMessagingByWidgetId[widgetId] = wm;
+    }
+
+    getWidgetMessaging(widgetId) {
+        return this._widgetMessagingByWidgetId[widgetId];
+    }
+
+    delWidgetMessaging(widgetId) {
+        if (this._widgetMessagingByWidgetId[widgetId]) {
+            try {
+                this._widgetMessagingByWidgetId[widgetId].stop();
+            } catch (e) {
+                console.error('Failed to stop listening for widgetMessaging events', e.message);
+            }
+            delete this._widgetMessagingByWidgetId[widgetId];
+        }
+    }
+}
+
+if (global.singletonActiveWidgetStore === undefined) {
+    global.singletonActiveWidgetStore = new ActiveWidgetStore();
+}
+export default global.singletonActiveWidgetStore;


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-doc/issues/1354

This doesn't actually put the widget in the top left when you're in another room: for now it's off screen, but this can be done separately.

This is whitelisted to only jitsi widgets for now as per comment,
mostly because any widget that we may make always-on-screen we need
to preemptively put in a PersistedElement container, which is
unnecessary for any other widget.

Apologies that this does a bunch of refactoring which could have
been split out separately: I only discovered what needed to be
refactored in the process of doing this.

Fixes https://github.com/vector-im/riot-web/issues/6984