### PR TITLE
Fix not stopping to peek when navigating away from peeked room

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -299,11 +299,11 @@ module.exports = React.createClass({
                         throw err;
                     }
                 });
+            } else if (room) {
+                // Stop peeking because we have joined this room previously
+                MatrixClientPeg.get().stopPeeking();
+                this.setState({isPeeking: false});
             }
-        } else if (room) {
-            // Stop peeking because we have joined this room previously
-            MatrixClientPeg.get().stopPeeking();
-            this.setState({isPeeking: false});
         }
     },
 


### PR DESCRIPTION
stopPeeking is currently not called when navigating to a joined room
after having peeked a room. This causes the /events endpoint for the
peeked room to be called until peeking another room, even when not
viewing the peeked room anymore.

The current code would only stop peeking if you joining were true (note the nesting),
e.g. when waiting for your join to be confirmed by /sync.

This change might make stopPeeking called also when not needed but there is a guard in
that method to do nothing if not currently peeking.

Came across this while testing the lazy load changes.