### PR TITLE
add null-guard for stickerpickerWidget in StickerPicker

### DIFF
--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -166,6 +166,7 @@ export default class Stickerpicker extends React.Component {
     }
 
     _sendVisibilityToWidget(visible) {
+        if (!this.state.stickerpickerWidget) return;
         const widgetMessaging = ActiveWidgetStore.getWidgetMessaging(this.state.stickerpickerWidget.id);
         if (widgetMessaging && visible !== this._prevSentVisibility) {
             widgetMessaging.sendVisibility(visible);


### PR DESCRIPTION
Should fix
```
Stickerpicker.js:169 Uncaught TypeError: Cannot read property 'id' of undefined
    at Stickerpicker._sendVisibilityToWidget (Stickerpicker.js:169)
    at Stickerpicker.componentDidUpdate (Stickerpicker.js:113)
    at measureLifeCyclePerf (ReactCompositeComponent.js:73)
    at ReactCompositeComponent.js:726
    at CallbackQueue.notifyAll (CallbackQueue.js:74)
    at ReactReconcileTransaction.close (ReactReconcileTransaction.js:78)
    at ReactReconcileTransaction.closeAll (Transaction.js:207)
    at ReactReconcileTransaction.perform (Transaction.js:154)
    at ReactUpdatesFlushTransaction.perform (Transaction.js:141)
    at ReactUpdatesFlushTransaction.perform (ReactUpdates.js:87)
    at Object.flushBatchedUpdates (ReactUpdates.js:170)
    at ReactDefaultBatchingStrategyTransaction.closeAll (Transaction.js:207)
    at ReactDefaultBatchingStrategyTransaction.perform (Transaction.js:154)
    at Object.batchedUpdates (ReactDefaultBatchingStrategy.js:60)
    at Object.enqueueUpdate (ReactUpdates.js:198)
    at enqueueUpdate (ReactUpdateQueue.js:22)
    at Object.enqueueSetState (ReactUpdateQueue.js:216)
    at Object.ReactComponent.setState (ReactBaseClasses.js:62)
    at Object.onResize (RoomView.js:1362)
```

which Erik has found to prevent syncing and cause critical breakage