### PR TITLE
while logging out ignore `Session.logged_out` as it is intentional

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -385,6 +385,8 @@ function _persistCredentialsToLocalStorage(credentials) {
     console.log(`Session persisted for ${credentials.userId}`);
 }
 
+let _isLoggingOut = false;
+
 /**
  * Logs the current session out and transitions to the logged-out state
  */
@@ -404,6 +406,7 @@ export function logout() {
         return;
     }
 
+    _isLoggingOut = true;
     MatrixClientPeg.get().logout().then(onLoggedOut,
         (err) => {
             // Just throwing an error here is going to be very unhelpful
@@ -417,6 +420,10 @@ export function logout() {
             onLoggedOut();
         },
     ).done();
+}
+
+export function isLoggingOut() {
+    return _isLoggingOut;
 }
 
 /**
@@ -449,6 +456,7 @@ async function startMatrixClient() {
  * storage. Used after a session has been logged out.
  */
 export function onLoggedOut() {
+    _isLoggingOut = false;
     stopMatrixClient();
     _clearStorage().done();
     dis.dispatch({action: 'on_logged_out'});

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1262,6 +1262,7 @@ export default React.createClass({
             }, true);
         });
         cli.on('Session.logged_out', function(call) {
+            if (Lifecycle.isLoggingOut()) return;
             const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
             Modal.createTrackedDialog('Signed out', '', ErrorDialog, {
                 title: _t('Signed Out'),


### PR DESCRIPTION
and sometimes the server sent us 0-N 403's which would each yield a Warning Dialog before the logout completed and everything was unmounted/reset

### Fixes https://github.com/vector-im/riot-web/issues/6911 and https://github.com/vector-im/riot-web/issues/5874

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>