### PR TITLE
Lazy load room members - Part I

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -34,6 +34,14 @@ interface MatrixClientCreds {
     guest: boolean,
 }
 
+const FILTER_CONTENT = {
+    room: {
+        state: {
+            lazy_load_members: true,
+        },
+    },
+};
+
 /**
  * Wrapper object for handling the js-sdk Matrix Client object in the react-sdk
  * Handles the creation/initialisation of client objects.
@@ -98,6 +106,8 @@ class MatrixClientPeg {
         const opts = utils.deepCopy(this.opts);
         // the react sdk doesn't work without this, so don't allow
         opts.pendingEventOrdering = "detached";
+
+        opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
 
         try {
             const promise = this.matrixClient.store.startup();

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -107,7 +107,9 @@ class MatrixClientPeg {
         // the react sdk doesn't work without this, so don't allow
         opts.pendingEventOrdering = "detached";
 
-        opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
+        if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
+            opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
+        }
 
         try {
             const promise = this.matrixClient.store.startup();

--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -81,8 +81,7 @@ export function isConfCallRoom(room, me, conferenceHandler) {
 }
 
 export function looksLikeDirectMessageRoom(room, me) {
-    if (me.membership == "join" || me.membership === "ban" ||
-        (me.membership === "leave" && me.events.member.getSender() !== me.events.member.getStateKey())) {
+    if (me.membership == "join" || me.membership === "ban" || me.isKicked()) {
         // Used to split rooms via tags
         const tagNames = Object.keys(room.tags);
         // Used for 1:1 direct chats

--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -166,7 +166,7 @@ export function guessDMRoomTarget(room, me) {
     for (const user of room.getJoinedMembers()) {
         if (user.userId == me.userId) continue;
 
-        if (oldestTs === undefined || user.events.member.getTs() < oldestTs) {
+        if (oldestTs === undefined || (user.events.member && user.events.member.getTs() < oldestTs)) {
             oldestUser = user;
             oldestTs = user.events.member.getTs();
         }
@@ -177,7 +177,7 @@ export function guessDMRoomTarget(room, me) {
     for (const user of room.currentState.getMembers()) {
         if (user.userId == me.userId) continue;
 
-        if (oldestTs === undefined || user.events.member.getTs() < oldestTs) {
+        if (oldestTs === undefined || (user.events.member && user.events.member.getTs() < oldestTs)) {
             oldestUser = user;
             oldestTs = user.events.member.getTs();
         }

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -749,21 +749,15 @@ module.exports = React.createClass({
     },
 
     _updateDMState() {
-        const me = this.state.room.getMember(MatrixClientPeg.get().credentials.userId);
+        const me = this.state.room.getMember(MatrixClientPeg.get().getUserId());
         if (!me || me.membership !== "join") {
             return;
         }
+        const roomId = this.state.room.roomId;
+        const dmInviter = me.getDirectChatInviter();
 
-        // The user may have accepted an invite with is_direct set
-        if (me.events.member.getPrevContent().membership === "invite" &&
-            me.events.member.getPrevContent().is_direct
-        ) {
-            // This is a DM with the sender of the invite event (which we assume
-            // preceded the join event)
-            Rooms.setDMRoom(
-                this.state.room.roomId,
-                me.events.member.getUnsigned().prev_sender,
-            );
+        if (dmInviter) {
+            Rooms.setDMRoom(roomId, dmInviter);
             return;
         }
 
@@ -777,11 +771,8 @@ module.exports = React.createClass({
 
         // The user may have sent an invite with is_direct sent
         const other = invitedMembers[0];
-        if (other &&
-            other.membership === "invite" &&
-            other.events.member.getContent().is_direct
-        ) {
-            Rooms.setDMRoom(this.state.room.roomId, other.userId);
+        if (other && !!other.getDirectChatInviter()) {
+            Rooms.setDMRoom(roomId, other.userId);
             return;
         }
     },

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -758,22 +758,6 @@ module.exports = React.createClass({
 
         if (dmInviter) {
             Rooms.setDMRoom(roomId, dmInviter);
-            return;
-        }
-
-        const invitedMembers = this.state.room.getMembersWithMembership("invite");
-        const joinedMembers = this.state.room.getMembersWithMembership("join");
-
-        // There must be one invited member and one joined member
-        if (invitedMembers.length !== 1 || joinedMembers.length !== 1) {
-            return;
-        }
-
-        // The user may have sent an invite with is_direct sent
-        const other = invitedMembers[0];
-        if (other && !!other.getDirectChatInviter()) {
-            Rooms.setDMRoom(roomId, other.userId);
-            return;
         }
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -754,7 +754,7 @@ module.exports = React.createClass({
             return;
         }
         const roomId = this.state.room.roomId;
-        const dmInviter = me.getDirectChatInviter();
+        const dmInviter = me.getDMInviter();
 
         if (dmInviter) {
             Rooms.setDMRoom(roomId, dmInviter);

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -314,7 +314,11 @@ module.exports = React.createClass({
                 this.setState({isPeeking: false});
 
                 //viewing a previously joined room, try to lazy load members
-                MatrixClientPeg.get().loadRoomMembersIfNeeded(room.roomId);
+
+                // lazy load members if enabled
+                if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
+                    MatrixClientPeg.get().loadRoomMembersIfNeeded(room.roomId);
+                }
             }
         }
     },

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -312,6 +312,9 @@ module.exports = React.createClass({
                 // Stop peeking because we have joined this room previously
                 MatrixClientPeg.get().stopPeeking();
                 this.setState({isPeeking: false});
+
+                //viewing a previously joined room, try to lazy load members
+                MatrixClientPeg.get().loadRoomMembersIfNeeded(room.roomId);
             }
         }
     },

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -317,7 +317,12 @@ module.exports = React.createClass({
 
                 // lazy load members if enabled
                 if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
-                    MatrixClientPeg.get().loadRoomMembersIfNeeded(room.roomId);
+                    MatrixClientPeg.get().loadRoomMembersIfNeeded(room.roomId).catch((err) => {
+                        const errorMessage = `Fetching room members for ${this.roomId} failed.` +
+                            " Room members will appear incomplete.";
+                        console.error(errorMessage);
+                        console.error(err);
+                    });
                 }
             }
         }

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -309,11 +309,11 @@ module.exports = React.createClass({
                     }
                 });
             } else if (room) {
+                //viewing a previously joined room, try to lazy load members
+                
                 // Stop peeking because we have joined this room previously
                 MatrixClientPeg.get().stopPeeking();
                 this.setState({isPeeking: false});
-
-                //viewing a previously joined room, try to lazy load members
 
                 // lazy load members if enabled
                 if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {

--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -598,7 +598,7 @@ module.exports = withMatrixClient(React.createClass({
 
     onMemberAvatarClick: function() {
         const member = this.props.member;
-        const avatarUrl = member.user ? member.user.avatarUrl : member.events.member.getContent().avatar_url;
+        const avatarUrl = member.getMxcAvatarUrl();
         if (!avatarUrl) return;
 
         const httpUrl = this.props.matrixClient.mxcUrlToHttp(avatarUrl);

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -342,8 +342,8 @@ module.exports = React.createClass({
                 if (!taggedRoom) {
                     return;
                 }
-                const me = taggedRoom.getMember(MatrixClientPeg.get().credentials.userId);
-                if (HIDE_CONFERENCE_CHANS && Rooms.isConfCallRoom(taggedRoom, me, this.props.ConferenceHandler)) {
+                const myUserId = MatrixClientPeg.get().getUserId();
+                if (HIDE_CONFERENCE_CHANS && Rooms.isConfCallRoom(taggedRoom, myUserId, this.props.ConferenceHandler)) {
                     return;
                 }
 

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -98,11 +98,11 @@ module.exports = React.createClass({
             </div>);
         }
 
-        const myMember = this.props.room ? this.props.room.currentState.members[
-            MatrixClientPeg.get().credentials.userId
-        ] : null;
-        const kicked = myMember.isKicked();
-        const banned = myMember && myMember.membership == 'ban';
+        const myMember = this.props.room ?
+            this.props.room.getMember(MatrixClientPeg.get().getUserId()) :
+            null;
+        const kicked = myMember && myMember.isKicked();
+        const banned = myMember && myMember && myMember.membership == 'ban';
 
         if (this.props.inviterName) {
             let emailMatchBlock;

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -101,11 +101,7 @@ module.exports = React.createClass({
         const myMember = this.props.room ? this.props.room.currentState.members[
             MatrixClientPeg.get().credentials.userId
         ] : null;
-        const kicked = (
-            myMember &&
-            myMember.membership == 'leave' &&
-            myMember.events.member.getSender() != MatrixClientPeg.get().credentials.userId
-        );
+        const kicked = myMember.isKicked();
         const banned = myMember && myMember.membership == 'ban';
 
         if (this.props.inviterName) {

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -83,6 +83,11 @@ export const SETTINGS = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
+    "feature_lazyloading": {
+        isFeature: true,
+        displayName: _td("Increase performance by loading room members on first view"),
+        supportedLevels: LEVELS_FEATURE,
+    },
     "MessageComposerInput.dontSuggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Disable Emoji suggestions while typing'),

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -173,8 +173,7 @@ class RoomListStore extends Store {
         if (!this._matrixClient) return;
 
         this._matrixClient.getRooms().forEach((room, index) => {
-            const me = room.getMember(this._matrixClient.credentials.userId);
-            const membership = me ? me.membership : room.getSyncedMembership();
+            const membership = room.getMyMembership(this._matrixClient.getUserId());
 
             if (membership == "invite") {
                 lists["im.vector.fake.invite"].push(room);

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -173,11 +173,13 @@ class RoomListStore extends Store {
         if (!this._matrixClient) return;
 
         this._matrixClient.getRooms().forEach((room, index) => {
-            const membership = room.getMyMembership(this._matrixClient.getUserId());
+            const myUserId = this._matrixClient.getUserId();
+            const membership = room.getMyMembership(myUserId);
+            const me = room.getMember(myUserId);
 
             if (membership == "invite") {
                 lists["im.vector.fake.invite"].push(room);
-            } else if (membership == "join" || membership === "ban" || me.isKicked()) {
+            } else if (membership == "join" || membership === "ban" || (me && me.isKicked())) {
                 // Used to split rooms via tags
                 let tagNames = Object.keys(room.tags);
 

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -178,8 +178,7 @@ class RoomListStore extends Store {
 
             if (me.membership == "invite") {
                 lists["im.vector.fake.invite"].push(room);
-            } else if (me.membership == "join" || me.membership === "ban" ||
-                     (me.membership === "leave" && me.events.member.getSender() !== me.events.member.getStateKey())) {
+            } else if (me.membership == "join" || me.membership === "ban" || me.isKicked()) {
                 // Used to split rooms via tags
                 let tagNames = Object.keys(room.tags);
 

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -174,11 +174,11 @@ class RoomListStore extends Store {
 
         this._matrixClient.getRooms().forEach((room, index) => {
             const me = room.getMember(this._matrixClient.credentials.userId);
-            if (!me) return;
+            const membership = me ? me.membership : room.getSyncedMembership();
 
-            if (me.membership == "invite") {
+            if (membership == "invite") {
                 lists["im.vector.fake.invite"].push(room);
-            } else if (me.membership == "join" || me.membership === "ban" || me.isKicked()) {
+            } else if (membership == "join" || membership === "ban" || me.isKicked()) {
                 // Used to split rooms via tags
                 let tagNames = Object.keys(room.tags);
 
@@ -205,10 +205,10 @@ class RoomListStore extends Store {
                 } else {
                     lists["im.vector.fake.recent"].push(room);
                 }
-            } else if (me.membership === "leave") {
+            } else if (membership === "leave") {
                 lists["im.vector.fake.archived"].push(room);
             } else {
-                console.error("unrecognised membership: " + me.membership + " - this should never happen");
+                console.error("unrecognised membership: " + membership + " - this should never happen");
             }
         });
 

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -133,6 +133,7 @@ class RoomViewStore extends Store {
 
     _viewRoom(payload) {
         if (payload.room_id) {
+            MatrixClientPeg.get().loadRoomMembersIfNeeded(payload.room_id);
             const newState = {
                 roomId: payload.room_id,
                 roomAlias: payload.room_alias,

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -133,7 +133,6 @@ class RoomViewStore extends Store {
 
     _viewRoom(payload) {
         if (payload.room_id) {
-            MatrixClientPeg.get().loadRoomMembersIfNeeded(payload.room_id);
             const newState = {
                 roomId: payload.room_id,
                 roomAlias: payload.room_alias,

--- a/src/utils/DMRoomMap.js
+++ b/src/utils/DMRoomMap.js
@@ -97,14 +97,8 @@ export default class DMRoomMap {
             // no entry? if the room is an invite, look for the is_direct hint.
             const room = this.matrixClient.getRoom(roomId);
             if (room) {
-                const me = room.getMember(this.matrixClient.credentials.userId);
-                if (me.membership == 'invite') {
-                    // The 'direct' hihnt is there, so declare that this is a DM room for
-                    // whoever invited us.
-                    if (me.events.member.getContent().is_direct) {
-                        return me.events.member.getSender();
-                    }
-                }
+                const me = room.getMember(this.matrixClient.getUserId());
+                return me.getDirectChatInviter();
             }
         }
         return this.roomToUser[roomId];

--- a/src/utils/DMRoomMap.js
+++ b/src/utils/DMRoomMap.js
@@ -96,9 +96,10 @@ export default class DMRoomMap {
         if (this.roomToUser[roomId] === undefined) {
             // no entry? if the room is an invite, look for the is_direct hint.
             const room = this.matrixClient.getRoom(roomId);
+            // TODO Use SUMMARYAPI to fix DM detection?
             if (room) {
                 const me = room.getMember(this.matrixClient.getUserId());
-                return me.getDMInviter();
+                return me && me.getDMInviter();
             }
         }
         return this.roomToUser[roomId];

--- a/src/utils/DMRoomMap.js
+++ b/src/utils/DMRoomMap.js
@@ -98,7 +98,7 @@ export default class DMRoomMap {
             const room = this.matrixClient.getRoom(roomId);
             if (room) {
                 const me = room.getMember(this.matrixClient.getUserId());
-                return me.getDirectChatInviter();
+                return me.getDMInviter();
             }
         }
         return this.roomToUser[roomId];

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -14,7 +14,7 @@ import dis from '../../../../src/dispatcher';
 import DMRoomMap from '../../../../src/utils/DMRoomMap.js';
 import GroupStore from '../../../../src/stores/GroupStore.js';
 
-import { Room, RoomMember } from 'matrix-js-sdk';
+import { MatrixClient, Room, RoomMember } from 'matrix-js-sdk';
 
 function generateRoomId() {
     return '!' + Math.random().toString().slice(2, 10) + ':domain';
@@ -48,6 +48,8 @@ describe('RoomList', () => {
         sandbox = TestUtils.stubClient(sandbox);
         client = MatrixClientPeg.get();
         client.credentials = {userId: myUserId};
+        //revert this to prototype method as the test-utils monkey-patches this to return a hardcoded value
+        client.getUserId = MatrixClient.prototype.getUserId;
 
         clock = lolex.install();
 


### PR DESCRIPTION
- [x] prototype lazy loading by calling /joined_members
- [x] detecting DMs should not assume there are member state events
- [x] sentinels should take lazily loaded members into account
- [x] avoid assuming there are member state events elsewhere
- [x] add feature flag

requires https://github.com/matrix-org/matrix-js-sdk/pull/667
