### PR TITLE
Fix e2e icons floating above jitsi

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -288,7 +288,6 @@ limitations under the License.
     position: absolute;
     top: 9px;
     left: 46px;
-    z-index: 2;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Remove another seemingly redundant z-index

Fixes https://github.com/vector-im/riot-web/issues/7056