### PR TITLE
hide some commands after space as they have special semantics

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -26,11 +26,12 @@ import SettingsStore, {SettingLevel} from './settings/SettingsStore';
 
 
 class Command {
-    constructor({name, args='', description, runFn}) {
+    constructor({name, args='', description, runFn, hideCompletionAfterSpace=false}) {
         this.command = '/' + name;
         this.args = args;
         this.description = description;
         this.runFn = runFn;
+        this.hideCompletionAfterSpace = hideCompletionAfterSpace;
     }
 
     getCommand() {
@@ -78,6 +79,7 @@ export const CommandMap = {
             });
             return success();
         },
+        hideCompletionAfterSpace: true,
     }),
 
     nick: new Command({
@@ -466,6 +468,7 @@ export const CommandMap = {
         name: 'me',
         args: '<message>',
         description: _td('Displays action'),
+        hideCompletionAfterSpace: true,
     }),
 };
 /* eslint-enable babel/no-invalid-this */

--- a/src/autocomplete/CommandProvider.js
+++ b/src/autocomplete/CommandProvider.js
@@ -46,6 +46,8 @@ export default class CommandProvider extends AutocompleteProvider {
             // The input looks like a command with arguments, perform exact match
             const name = command[1].substr(1); // strip leading `/`
             if (CommandMap[name]) {
+                // some commands, namely `me` and `ddg` don't suit having the usage shown whilst typing their arguments
+                if (!CommandMap[name].hideCompletionAfterSpace) return [];
                 matches = [CommandMap[name]];
             }
         } else {


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/7008 and https://github.com/vector-im/riot-web/issues/7051

ddg gets its own Autocomplete pane so it looks silly:
![image](https://user-images.githubusercontent.com/2403652/42888720-bd1f636e-8aa0-11e8-9492-fb96875628d2.png)

me is:
> anyone who is techie enough to know what /me is doesn't need to be told it each and every time for the duration of them typing a /me command. at the least we could hide it after the first word has been typed




Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>