### PR TITLE
CreateRoomDialog is rendered before getting the config default_federate 

### DIFF
--- a/src/components/views/dialogs/CreateRoomDialog.js
+++ b/src/components/views/dialogs/CreateRoomDialog.js
@@ -26,7 +26,7 @@ export default React.createClass({
         onFinished: PropTypes.func.isRequired,
     },
 
-    componentDidMount: function() {
+    componentWillMount: function() {
         const config = SdkConfig.get();
         // Dialog shows inverse of m.federate (noFederate) strict false check to skip undefined check (default = true)
         this.defaultNoFederate = config.default_federate === false;


### PR DESCRIPTION
CreateRoomDialog is rendered before get the config default_federate value
    
In React the order of the execution of mount and render functions is: `componentWillMount --> render --> componentDidMount`
(Ref: https://stackoverflow.com/questions/45337165/react-render-is-being-called-before-componentdidmount and https://developmentarc.gitbooks.io/react-indepth/content/life_cycle/birth/premounting_with_componentwillmount.html )

The `CreateRoomDialog` `render()` function is executed before than  the `componentDidMount()` function so the
    
      `this.defaultNoFederate = config.default_federate === false;`
    
; instruction which is executed in the `componentDidMount` function (in `CreateRoomDialog`) is evaluated always after than the rendering of the page.
    
Therefore, the obvious issue is that the values obtained from the  `SdkConfig.get()` function (`config.default_federate`) are obtained    later than their usage on `render()`.
    
On other hand, if the `render()` method depends on some other data a part of props, you need tell React that the component needs    re-rendering by calling setState(). This is need to say React that    the status of the checkbox was toggled.
    
(Ref: https://reactjs.org/docs/react-component.html#setstate)
    
This patch made those changes to fix the described issues:
    
* componentWillMount instead of componentDidMount
* add toggleDefaultNoFederate to keep synced the status of the property
    
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
