### PR TITLE
allow passing initial is_url like hs_url in query params

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -282,6 +282,14 @@ export default React.createClass({
                 register_hs_url: paramHs,
             });
         }
+        // Set a default IS with query param `is_url`
+        const paramIs = this.props.startingFragmentQueryParams.is_url;
+        if (paramIs) {
+            console.log('Setting register_is_url ', paramIs);
+            this.setState({
+                register_is_url: paramIs,
+            });
+        }
 
         // a thing to call showScreen with once login completes.  this is kept
         // outside this.state because updating it should never trigger a


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/6965

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>