### PR TITLE
Slate Fixes 42?

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1544,18 +1544,6 @@ export default class MessageComposerInput extends React.Component {
         this.handleKeyCommand('toggle-mode');
     };
 
-    onBlur = (e) => {
-        this.selection = this.state.editorState.selection;
-    };
-
-    onFocus = (e) => {
-        if (this.selection) {
-            const change = this.state.editorState.change().select(this.selection);
-            this.onChange(change);
-            delete this.selection;
-        }
-    };
-
     focusComposer = () => {
         this.refs.editor.focus();
     };
@@ -1601,8 +1589,6 @@ export default class MessageComposerInput extends React.Component {
                             onChange={this.onChange}
                             onKeyDown={this.onKeyDown}
                             onPaste={this.onPaste}
-                            onBlur={this.onBlur}
-                            onFocus={this.onFocus}
                             renderNode={this.renderNode}
                             renderMark={this.renderMark}
                             // disable spell check for the placeholder because browsers don't like "unencrypted"

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1255,16 +1255,14 @@ export default class MessageComposerInput extends React.Component {
 
         let editorState;
         const historyItem = this.historyManager.getItem(delta);
-        if (historyItem) {
-            if (historyItem.format === 'rich' && !this.state.isRichTextEnabled) {
-                editorState = this.richToMdEditorState(historyItem.value);
-            }
-            else if (historyItem.format === 'markdown' && this.state.isRichTextEnabled) {
-                editorState = this.mdToRichEditorState(historyItem.value);
-            }
-            else {
-                editorState = historyItem.value;
-            }
+        if (!historyItem) return;
+
+        if (historyItem.format === 'rich' && !this.state.isRichTextEnabled) {
+            editorState = this.richToMdEditorState(historyItem.value);
+        } else if (historyItem.format === 'markdown' && this.state.isRichTextEnabled) {
+            editorState = this.mdToRichEditorState(historyItem.value);
+        } else {
+            editorState = historyItem.value;
         }
 
         // Move selection to the end of the selected history


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

### remove faulty onBlur/onFocus code which caused selection to rollback

After a ***LOT*** of debugging I found the bit which caused the reset of the selection to be the `onFocus` handler, setting the selection to something that did not match the document and thus it caused a reset back to `[0, 0]`

I am not *100%* on what this code intends to do as the focus/blur behaviour seems identical without it.
Pinging @ara4n for insight on why this code segment was added


*Should fix* https://github.com/vector-im/riot-web/issues/7080