### PR TITLE
Make clicking on side panels close settings (mk 2)

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -85,7 +85,6 @@ textarea {
 
 .mx_fadable.mx_fadable_faded {
     opacity: 0.3;
-    pointer-events: none;
 }
 
 /* XXX: critical hack to GeminiScrollbar to allow them to work in FF 42 and Chrome 48.

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -259,15 +259,9 @@ const LoggedInView = React.createClass({
         // When the panels are disabled, clicking on them results in a mouse event
         // which bubbles to certain elements in the tree. When this happens, close
         // any settings page that is currently open (user/room/group).
-        if (this.props.leftDisabled &&
-            this.props.rightDisabled &&
-            (
-                ev.target.className === 'mx_MatrixChat' ||
-                ev.target.className === 'mx_MatrixChat_middlePanel' ||
-                ev.target.className === 'mx_RoomView'
-            )
-        ) {
+        if (this.props.leftDisabled && this.props.rightDisabled) {
             dis.dispatch({ action: 'close_settings' });
+            ev.stopPropagation();
         }
     },
 
@@ -396,7 +390,7 @@ const LoggedInView = React.createClass({
         }
 
         return (
-            <div className='mx_MatrixChat_wrapper' aria-hidden={this.props.hideToSRUsers} onClick={this._onClick}>
+            <div className='mx_MatrixChat_wrapper' aria-hidden={this.props.hideToSRUsers} onClickCapture={this._onClick}>
                 { topBar }
                 <DragDropContext onDragEnd={this._onDragEnd}>
                     <div className={bodyClasses}>


### PR DESCRIPTION
Capture the clicks in LoggedInView and dismiss the settings view,
then discard the click event. Remove `pointer-events: none`
so we can capture the click.

Fixes https://github.com/vector-im/riot-web/issues/5658