### PR TITLE
Make clicking on side panels close settings (mk 3)

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -259,16 +259,15 @@ const LoggedInView = React.createClass({
         // When the panels are disabled, clicking on them results in a mouse event
         // which bubbles to certain elements in the tree. When this happens, close
         // any settings page that is currently open (user/room/group).
-        const targetClasses = new Set(ev.target.className.split(' '));
-        if (this.props.leftDisabled &&
-            this.props.rightDisabled &&
-            (
+        if (this.props.leftDisabled && this.props.rightDisabled) {
+            const targetClasses = new Set(ev.target.className.split(' '));
+            if (
                 targetClasses.has('mx_MatrixChat') ||
                 targetClasses.has('mx_MatrixChat_middlePanel') ||
                 targetClasses.has('mx_RoomView')
-            )
-        ) {
-            dis.dispatch({ action: 'close_settings' });
+            ) {
+                dis.dispatch({ action: 'close_settings' });
+            }
         }
     },
 

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -259,12 +259,13 @@ const LoggedInView = React.createClass({
         // When the panels are disabled, clicking on them results in a mouse event
         // which bubbles to certain elements in the tree. When this happens, close
         // any settings page that is currently open (user/room/group).
+        const targetClasses = new Set(ev.target.className.split(' '));
         if (this.props.leftDisabled &&
             this.props.rightDisabled &&
             (
-                ev.target.className === 'mx_MatrixChat' ||
-                ev.target.className === 'mx_MatrixChat_middlePanel' ||
-                ev.target.className === 'mx_RoomView'
+                targetClasses.has('mx_MatrixChat') ||
+                targetClasses.has('mx_MatrixChat_middlePanel') ||
+                targetClasses.has('mx_RoomView')
             )
         ) {
             dis.dispatch({ action: 'close_settings' });


### PR DESCRIPTION
Just do it by fixing the somewhat hacky logic to not break if the
target elements also have additional classes, like they do if the
toolbar is showing (I think it turns out this bug is only that it
doesn't work with the toolbar showing...)

Fixes https://github.com/vector-im/riot-web/issues/5658