### PR TITLE
Lazy loading: enable newly introduced option

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -108,6 +108,7 @@ class MatrixClientPeg {
         opts.pendingEventOrdering = "detached";
 
         if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
+            opts.lazyLoadMembers = true;
             opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
         }
 


### PR DESCRIPTION
Option is needed to send lazy loading filters to all endpoints used (like /messages)

 - [ ] Need to cleanup: Right now we pass both the option and the filter in, because startClient is not async. It would be nicer of the filter was created inside of MatrixClient somehow and we only had to pass in the option, not the filter.