### PR TITLE
Lazy loading: Lazy load members while backpaginating

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -34,14 +34,6 @@ interface MatrixClientCreds {
     guest: boolean,
 }
 
-const FILTER_CONTENT = {
-    room: {
-        state: {
-            lazy_load_members: true,
-        },
-    },
-};
-
 /**
  * Wrapper object for handling the js-sdk Matrix Client object in the react-sdk
  * Handles the creation/initialisation of client objects.
@@ -109,7 +101,6 @@ class MatrixClientPeg {
 
         if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
             opts.lazyLoadMembers = true;
-            opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
         }
 
         try {
@@ -128,7 +119,7 @@ class MatrixClientPeg {
         MatrixActionCreators.start(this.matrixClient);
 
         console.log(`MatrixClientPeg: really starting MatrixClient`);
-        this.get().startClient(opts);
+        await this.get().startClient(opts);
         console.log(`MatrixClientPeg: MatrixClient started`);
     }
 

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -108,6 +108,7 @@ class MatrixClientPeg {
         opts.pendingEventOrdering = "detached";
 
         if (SettingsStore.isFeatureEnabled('feature_lazyloading')) {
+            opts.lazyLoadMembers = true;
             opts.filter = await this.matrixClient.createFilter(FILTER_CONTENT);
         }
 

--- a/src/RoomInvite.js
+++ b/src/RoomInvite.js
@@ -194,8 +194,7 @@ function _getDirectMessageRooms(addr) {
     const rooms = dmRooms.filter((dmRoom) => {
         const room = MatrixClientPeg.get().getRoom(dmRoom);
         if (room) {
-            const me = room.getMember(MatrixClientPeg.get().credentials.userId);
-            return me && me.membership == 'join';
+            return room.getMyMembership() === 'join';
         }
     });
     return rooms;

--- a/src/VectorConferenceHandler.js
+++ b/src/VectorConferenceHandler.js
@@ -84,7 +84,7 @@ ConferenceCall.prototype._getConferenceUserRoom = function() {
         preset: "private_chat",
         invite: [this.confUserId]
     }).then(function(res) {
-        return new Room(res.room_id);
+        return new Room(res.room_id, client.getUserId());
     });
 };
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -759,7 +759,8 @@ module.exports = React.createClass({
 
     _updateDMState() {
         const me = this.state.room.getMember(MatrixClientPeg.get().getUserId());
-        if (!me || me.membership !== "join") {
+        const room = this.state.room;
+        if (room.getMyMembership() != "join") {
             return;
         }
         const roomId = this.state.room.roomId;

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -758,16 +758,13 @@ module.exports = React.createClass({
     },
 
     _updateDMState() {
-        const me = this.state.room.getMember(MatrixClientPeg.get().getUserId());
         const room = this.state.room;
         if (room.getMyMembership() != "join") {
             return;
         }
-        const roomId = this.state.room.roomId;
-        const dmInviter = me.getDMInviter();
-
+        const dmInviter = room.getDMInviter();
         if (dmInviter) {
-            Rooms.setDMRoom(roomId, dmInviter);
+            Rooms.setDMRoom(room.roomId, dmInviter);
         }
     },
 

--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -54,8 +54,8 @@ export default class ChatCreateOrReuseDialog extends React.Component {
         for (const roomId of dmRooms) {
             const room = client.getRoom(roomId);
             if (room) {
-                const me = room.getMember(client.credentials.userId);
-                const highlight = room.getUnreadNotificationCount('highlight') > 0 || me.membership === "invite";
+                const isInvite = room.getMyMembership() === "invite";
+                const highlight = room.getUnreadNotificationCount('highlight') > 0 || isInvite;
                 tiles.push(
                     <RoomTile key={room.roomId} room={room}
                         transparent={true}
@@ -63,7 +63,7 @@ export default class ChatCreateOrReuseDialog extends React.Component {
                         selected={false}
                         unread={Unread.doesRoomHaveUnreadMessages(room)}
                         highlight={highlight}
-                        isInvite={me.membership === "invite"}
+                        isInvite={isInvite}
                         onClick={this.onRoomTileClick}
                     />,
                 );

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -189,7 +189,7 @@ const Pill = React.createClass({
                 },
                 getDirectionalContent: function() {
                     return this.getContent();
-                }
+                },
             };
             this.setState({member});
         }).catch((err) => {

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -187,6 +187,9 @@ const Pill = React.createClass({
                 getContent: () => {
                     return {avatar_url: resp.avatar_url};
                 },
+                getDirectionalContent: function() {
+                    return this.getContent();
+                }
             };
             this.setState({member});
         }).catch((err) => {

--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -774,15 +774,16 @@ module.exports = withMatrixClient(React.createClass({
             for (const roomId of dmRooms) {
                 const room = this.props.matrixClient.getRoom(roomId);
                 if (room) {
-                    const me = room.getMember(this.props.matrixClient.credentials.userId);
-
+                    const myMembership = room.getMyMembership();
+                    if (myMembership !== 'join') continue;
+                    
+                    const isInvite = myMembership === "invite";
                     // not a DM room if we have are not joined
-                    if (!me.membership || me.membership !== 'join') continue;
                     // not a DM room if they are not joined
                     const them = this.props.member;
                     if (!them.membership || them.membership !== 'join') continue;
 
-                    const highlight = room.getUnreadNotificationCount('highlight') > 0 || me.membership === 'invite';
+                    const highlight = room.getUnreadNotificationCount('highlight') > 0 || isInvite;
 
                     tiles.push(
                         <RoomTile key={room.roomId} room={room}
@@ -791,7 +792,7 @@ module.exports = withMatrixClient(React.createClass({
                             selected={false}
                             unread={Unread.doesRoomHaveUnreadMessages(room)}
                             highlight={highlight}
-                            isInvite={me.membership === "invite"}
+                            isInvite={isInvite}
                             onClick={this.onRoomTileClick}
                         />,
                     );

--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -775,15 +775,14 @@ module.exports = withMatrixClient(React.createClass({
                 const room = this.props.matrixClient.getRoom(roomId);
                 if (room) {
                     const myMembership = room.getMyMembership();
+                    // not a DM room if we have are not joined
                     if (myMembership !== 'join') continue;
                     
-                    const isInvite = myMembership === "invite";
-                    // not a DM room if we have are not joined
-                    // not a DM room if they are not joined
                     const them = this.props.member;
+                    // not a DM room if they are not joined
                     if (!them.membership || them.membership !== 'join') continue;
 
-                    const highlight = room.getUnreadNotificationCount('highlight') > 0 || isInvite;
+                    const highlight = room.getUnreadNotificationCount('highlight') > 0;
 
                     tiles.push(
                         <RoomTile key={room.roomId} room={room}
@@ -792,7 +791,7 @@ module.exports = withMatrixClient(React.createClass({
                             selected={false}
                             unread={Unread.doesRoomHaveUnreadMessages(room)}
                             highlight={highlight}
-                            isInvite={isInvite}
+                            isInvite={false}
                             onClick={this.onRoomTileClick}
                         />,
                     );

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -243,9 +243,7 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        const myUserId = MatrixClientPeg.get().credentials.userId;
-        const me = this.props.room.currentState.members[myUserId];
-
+        const isInvite = this.props.room.getMyMembership() === "invite";
         const notificationCount = this.state.notificationCount;
         // var highlightCount = this.props.room.getUnreadNotificationCount("highlight");
 
@@ -259,7 +257,7 @@ module.exports = React.createClass({
             'mx_RoomTile_unread': this.props.unread,
             'mx_RoomTile_unreadNotify': notifBadges,
             'mx_RoomTile_highlight': mentionBadges,
-            'mx_RoomTile_invited': (me && me.membership === 'invite'),
+            'mx_RoomTile_invited': isInvite,
             'mx_RoomTile_menuDisplayed': this.state.menuDisplayed,
             'mx_RoomTile_noBadges': !badges,
             'mx_RoomTile_transparent': this.props.transparent,

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -77,8 +77,7 @@ export default class WidgetUtils {
             return false;
         }
 
-        const member = room.getMember(me);
-        if (!member || member.membership !== "join") {
+        if (room.getMyMembership() !== "join") {
             console.warn(`User ${me} is not in room ${roomId}`);
             return false;
         }

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -20,15 +20,16 @@ function generateRoomId() {
     return '!' + Math.random().toString().slice(2, 10) + ':domain';
 }
 
-function createRoom(opts) {
-    const room = new Room(generateRoomId());
-    if (opts) {
-        Object.assign(room, opts);
-    }
-    return room;
-}
 
 describe('RoomList', () => {
+    function createRoom(opts) {
+        const room = new Room(generateRoomId(), client.getUserId());
+        if (opts) {
+            Object.assign(room, opts);
+        }
+        return room;
+    }
+
     let parentDiv = null;
     let sandbox = null;
     let client = null;


### PR DESCRIPTION
Based of #2102, depends on https://github.com/matrix-org/matrix-js-sdk/pull/676

Option is needed to send lazy loading filters to all endpoints used (like /messages)

 - [x] Need to cleanup: Right now we pass both the option and the filter in, because startClient is not async. It would be nicer of the filter was created inside of MatrixClient somehow and we only had to pass in the option, not the filter.