### PR TITLE
Update room tags behaviour to match spec more

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -37,6 +37,11 @@ import GroupStore from '../../../stores/GroupStore';
 const HIDE_CONFERENCE_CHANS = true;
 const STANDARD_TAGS_REGEX = /^(m\.(favourite|lowpriority)|im\.vector\.fake\.(invite|recent|direct|archived))$/;
 
+function labelForTagName(tagName) {
+    if (tagName.startsWith('u.')) return tagName.slice(2);
+    return tagName;
+}
+
 function phraseForSection(section) {
     switch (section) {
         case 'm.favourite':
@@ -690,7 +695,7 @@ module.exports = React.createClass({
                     if (!tagName.match(STANDARD_TAGS_REGEX)) {
                         return <RoomSubList list={self.state.lists[tagName]}
                              key={tagName}
-                             label={tagName}
+                             label={labelForTagName(tagName)}
                              tagName={tagName}
                              emptyContent={this._getEmptyContent(tagName)}
                              editable={true}

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -194,6 +194,11 @@ class RoomListStore extends Store {
                     }
                 }
 
+                // ignore any m. tag names we don't know about
+                tagNames = tagNames.filter((t) => {
+                    return !t.startsWith('m.') || lists[t] !== undefined;
+                });
+
                 if (tagNames.length) {
                     for (let i = 0; i < tagNames.length; i++) {
                         const tagName = tagNames[i];


### PR DESCRIPTION
Fix Riot's behaviour with room tags after my cleanup in
https://github.com/matrix-org/matrix-doc/pull/1457 . Although, reading
it again, it's not clear how you're supposed to tell the difference
between a reverse-dns tag name and a legacy freeform text tag
(contains a '.'?) - I've left it detecting these as freeform text
for now.