### PR TITLE
Show connection error message immediately, also during reconnect

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -300,7 +300,8 @@ module.exports = React.createClass({
             this.state.syncStateData.error &&
             this.state.syncStateData.error.errcode === 'M_RESOURCE_LIMIT_EXCEEDED'
         );
-        return this.state.syncState === "ERROR" && !errorIsMauError;
+        return this.state.syncState == "RECONNECTING" ||
+            (this.state.syncState === "ERROR" && !errorIsMauError);
     },
 
     _getUnsentMessageContent: function() {


### PR DESCRIPTION
As catchup sync can take quite some time (maybe temporarily even slower with LL)
it can be confusing when you come back to riot after a couple of days and you only see old messages while the first sync is running. If riot didn't get the time to fail /sync 3 times (like when sleeping your laptop), it won't show you anything to indicate your timeline is behind and its reconnecting.

This is probably not the best way to deal with this, as in the laptop wakeup scenario, you might as well have 0 failed syncs but still catchup takes minutes. Looking at how much time there was between the last and new sync might be better, but this sort of does the job for now

Addresses item 6 (We no longer show a spinner when recovering after losing connectivity) of https://github.com/vector-im/riot-web/issues/7182