### PR TITLE
Show spinner in member list while loading members

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -43,19 +43,6 @@ module.exports = React.createClass({
         this.memberDict = this.getMemberDict();
         const members = this.roomMembers();
 
-        this.setState({
-            loading: false,
-            members: members,
-            filteredJoinedMembers: this._filterMembers(members, 'join'),
-            filteredInvitedMembers: this._filterMembers(members, 'invite'),
-
-            // ideally we'd size this to the page height, but
-            // in practice I find that a little constraining
-            truncateAtJoined: INITIAL_LOAD_NUM_MEMBERS,
-            truncateAtInvited: INITIAL_LOAD_NUM_INVITED,
-            searchQuery: "",
-        });
-
         const cli = MatrixClientPeg.get();
         cli.on("RoomState.members", this.onRoomStateMember);
         cli.on("RoomMember.name", this.onRoomMemberName);
@@ -74,6 +61,20 @@ module.exports = React.createClass({
         if (enablePresenceByHsUrl && enablePresenceByHsUrl[hsUrl] !== undefined) {
             this._showPresence = enablePresenceByHsUrl[hsUrl];
         }
+        // set the state after determining _showPresence to make sure it's
+        // taken into account while rerendering
+        this.setState({
+            loading: false,
+            members: members,
+            filteredJoinedMembers: this._filterMembers(members, 'join'),
+            filteredInvitedMembers: this._filterMembers(members, 'invite'),
+
+            // ideally we'd size this to the page height, but
+            // in practice I find that a little constraining
+            truncateAtJoined: INITIAL_LOAD_NUM_MEMBERS,
+            truncateAtInvited: INITIAL_LOAD_NUM_INVITED,
+            searchQuery: "",
+        });
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
Demo below:
 - load big room without having previously loaded it
 - switch to other room (and show other right panel tabs still work while loading)
 - switch back and room members appear straight away

![memberlist-spinner](https://user-images.githubusercontent.com/274386/44777977-30556f80-ab7c-11e8-997a-1448a15c7ed9.gif)

Addresses item 3 (We see a flicker of stale membership state in the membership list) of https://github.com/vector-im/riot-web/issues/7182

Requires: https://github.com/matrix-org/matrix-js-sdk/pull/714