### PR TITLE
Revert "Don't rely on room members to query power levels"

### DIFF
--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -309,8 +309,8 @@ export default class MessageComposer extends React.Component {
                 </div>;
         }
 
-        const canSendMessages = !this.state.tombstone &&
-            this.props.room.maySendMessage();
+        const canSendMessages = !this.state.tombstone && this.props.room.currentState.maySendMessage(
+            MatrixClientPeg.get().credentials.userId);
 
         if (canSendMessages) {
             // This also currently includes the call buttons. Really we should


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#2145

as we're reverting the js-sdk PR it requires