### PR TITLE
s/DidMount/WillMount/ in MessageComposerInput

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -336,7 +336,7 @@ export default class MessageComposerInput extends React.Component {
         }
     }
 
-    componentDidMount() {
+    componentWillMount() {
         this.dispatcherRef = dis.register(this.onAction);
         this.historyManager = new ComposerHistoryManager(this.props.room.roomId, 'mx_slate_composer_history_');
     }


### PR DESCRIPTION
This fixes the tests that broke with https://github.com/matrix-org/matrix-js-sdk/pull/717

This is because of https://github.com/vector-im/riot-web/blob/master/test/app-tests/joining.js#L63
which prevents the DOM nodes from actually ending up in the DOM, even though the react components
get rendered. This means that WillMount and WillUnmount are called, but not DidMount.

Using WillMount is more symmertrical anyway since the resulting teardown code must be in
WillUnmount (since there is no DidUnmount).