### PR TITLE
only dispatch an action for self-membership

### DIFF
--- a/src/actions/MatrixActionCreators.js
+++ b/src/actions/MatrixActionCreators.js
@@ -163,6 +163,7 @@ function createSelfRoomMembershipAction(matrixClient, membershipEvent, member, o
     if (member.userId === matrixClient.getUserId()) {
         return { action: 'MatrixActions.Room.selfMembership', member };
     }
+    return null;
 }
 
 /**

--- a/src/actions/MatrixActionCreators.js
+++ b/src/actions/MatrixActionCreators.js
@@ -149,9 +149,9 @@ function createRoomTimelineAction(matrixClient, timelineEvent, room, toStartOfTi
  */
 
 /**
- * Create a MatrixActions.RoomMember.membership action that represents
- * a MatrixClient `RoomMember.membership` matrix event, emitted when a
- * member's membership is updated.
+ * Create a MatrixActions.Room.selfMembership action that represents
+ * a MatrixClient `RoomMember.membership` matrix event for the syncing user,
+ * emitted when the member's membership is updated.
  *
  * @param {MatrixClient} matrixClient the matrix client.
  * @param {MatrixEvent} membershipEvent the m.room.member event.
@@ -159,8 +159,10 @@ function createRoomTimelineAction(matrixClient, timelineEvent, room, toStartOfTi
  * @param {string} oldMembership the member's previous membership.
  * @returns {RoomMembershipAction} an action of type `MatrixActions.RoomMember.membership`.
  */
-function createRoomMembershipAction(matrixClient, membershipEvent, member, oldMembership) {
-    return { action: 'MatrixActions.RoomMember.membership', member };
+function createSelfRoomMembershipAction(matrixClient, membershipEvent, member, oldMembership) {
+    if (member.userId === matrixClient.getUserId()) {
+        return { action: 'MatrixActions.Room.selfMembership', member };
+    }
 }
 
 /**
@@ -202,7 +204,7 @@ export default {
         this._addMatrixClientListener(matrixClient, 'Room', createRoomAction);
         this._addMatrixClientListener(matrixClient, 'Room.tags', createRoomTagsAction);
         this._addMatrixClientListener(matrixClient, 'Room.timeline', createRoomTimelineAction);
-        this._addMatrixClientListener(matrixClient, 'RoomMember.membership', createRoomMembershipAction);
+        this._addMatrixClientListener(matrixClient, 'RoomMember.membership', createSelfRoomMembershipAction);
         this._addMatrixClientListener(matrixClient, 'Event.decrypted', createEventDecryptedAction);
     },
 
@@ -217,7 +219,10 @@ export default {
      */
     _addMatrixClientListener(matrixClient, eventName, actionCreator) {
         const listener = (...args) => {
-            dis.dispatch(actionCreator(matrixClient, ...args), true);
+            const payload = actionCreator(matrixClient, ...args);
+            if (payload) {
+                dis.dispatch(payload, true);
+            }
         };
         matrixClient.on(eventName, listener);
         this._matrixClientListenersStop.push(() => {

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -120,8 +120,7 @@ class RoomListStore extends Store {
                 this._generateRoomLists();
             }
             break;
-            case 'MatrixActions.RoomMember.membership': {
-                if (!this._matrixClient || payload.member.userId !== this._matrixClient.credentials.userId) break;
+            case 'MatrixActions.Room.selfMembership': {
                 this._generateRoomLists();
             }
             break;


### PR DESCRIPTION
as literally *everything* listens to the dispatcher, dispatching an action can be quite slow,
especially when only matched in one listener, and the rest all having to be called
to just say "no, thanks". This is especially the case for the RoomMember.membership
event being put on the dispatcher, as there can be thousands of these events
when the room members are loading.

Since the RoomMember.membership action is only used on one place,
and only for the syncing user, change it to just that and only dispatch
in that case. This saves 100-300ms when setting the OOB members in
a big room (7000k members)

Maybe later on we can back this by room.getMyMembership() and avoid the
listener even...