### PR TITLE
dont keep the spinner in the memberlist when fetching /members fails

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -91,7 +91,9 @@ module.exports = React.createClass({
         const cli = MatrixClientPeg.get();
         const room = cli.getRoom(this.props.roomId);
         if (room) {
-            await room.loadMembersIfNeeded();
+            try {
+                await room.loadMembersIfNeeded();
+            } catch(ex) {/* already logged in RoomView */}
         }
     },
 


### PR DESCRIPTION
if loadMembersIfNeeded fails, remove the spinner and show the members known so far.
Should we also show this in somewhere in the UI and maybe even a retry button?