### PR TITLE
Allow translation tags object to be a variable

### DIFF
--- a/scripts/gen-i18n.js
+++ b/scripts/gen-i18n.js
@@ -143,7 +143,7 @@ function getTranslationsJs(file) {
                         // Validate tag replacements
                         if (node.arguments.length > 2) {
                             const tagMap = node.arguments[2];
-                            for (const prop of tagMap.properties) {
+                            for (const prop of tagMap.properties || []) {
                                 if (prop.key.type === 'Literal') {
                                     const tag = prop.key.value;
                                     // RegExp same as in src/languageHandler.js


### PR DESCRIPTION
Don't try to validate the translation tags if it's not an object literal.