### PR TITLE
Use createObjectURL instead of readAsDataURL for videos

### DIFF
--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -148,6 +148,8 @@ function infoForImageFile(matrixClient, roomId, imageFile) {
  * @return {Promise} A promise that resolves with the video image element.
  */
 function loadVideoElement(videoFile) {
+    const deferred = Promise.defer();
+
     // Load the file into an html element
     const video = document.createElement("video");
 

--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -153,7 +153,6 @@ function loadVideoElement(videoFile) {
     // Load the file into an html element
     const video = document.createElement("video");
 
-    // Once ready, returns its size
     // Wait until we have enough data to thumbnail the first frame.
     video.onloadeddata = function() {
         URL.revokeObjectURL(video.src);

--- a/src/ContentMessages.js
+++ b/src/ContentMessages.js
@@ -148,29 +148,21 @@ function infoForImageFile(matrixClient, roomId, imageFile) {
  * @return {Promise} A promise that resolves with the video image element.
  */
 function loadVideoElement(videoFile) {
-    const deferred = Promise.defer();
-
     // Load the file into an html element
     const video = document.createElement("video");
 
-    const reader = new FileReader();
-    reader.onload = function(e) {
-        video.src = e.target.result;
-
-        // Once ready, returns its size
-        // Wait until we have enough data to thumbnail the first frame.
-        video.onloadeddata = function() {
-            deferred.resolve(video);
-        };
-        video.onerror = function(e) {
-            deferred.reject(e);
-        };
+    // Once ready, returns its size
+    // Wait until we have enough data to thumbnail the first frame.
+    video.onloadeddata = function() {
+        URL.revokeObjectURL(video.src);
+        deferred.resolve(video);
     };
-    reader.onerror = function(e) {
+    video.onerror = function(e) {
         deferred.reject(e);
     };
-    reader.readAsDataURL(videoFile);
-
+    
+    // We don't use readAsDataURL because massive files and b64 don't mix.
+    video.src = URL.createObjectURL(videoFile);
     return deferred.promise;
 }
 


### PR DESCRIPTION
Fix for https://github.com/vector-im/riot-web/issues/4264