### PR TITLE
Provide more helpful errors when i18n generation fails

### DIFF
--- a/scripts/gen-i18n.js
+++ b/scripts/gen-i18n.js
@@ -158,6 +158,7 @@ function getTranslationsJs(file) {
                     } catch (e) {
                         console.log();
                         console.error(`ERROR: ${file}:${node.loc.start.line} ${tKey}`);
+                        console.error(e);
                         process.exit(1);
                     }
                 }

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -228,14 +228,12 @@ function textForRoomAliasesEvent(ev) {
             removedAddresses: removedAliases.join(', '),
         });
     } else {
-        const args = {
-            senderName: senderName,
-            addedAddresses: addedAliases.join(', '),
-            removedAddresses: removedAliases.join(', '),
-        };
         return _t(
-            '%(senderName)s added %(addedAddresses)s and removed %(removedAddresses)s as addresses for this room.',
-            args,
+            '%(senderName)s added %(addedAddresses)s and removed %(removedAddresses)s as addresses for this room.', {
+                senderName: senderName,
+                addedAddresses: addedAliases.join(', '),
+                removedAddresses: removedAliases.join(', '),
+            },
         );
     }
 }


### PR DESCRIPTION
Also fix TextForEvent.js so it doesn't break the script. Using a variable here is not recognized, so the object has been moved inline instead.