### PR TITLE
Fix brace style in TextForEvent.js

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -248,8 +248,7 @@ function textForCanonicalAliasEvent(ev) {
             senderName: senderName,
             address: ev.getContent().alias,
         });
-    }
-    else if (oldAlias) {
+    } else if (oldAlias) {
         return _t('%(senderName)s removed the main address for this room.', {
             senderName: senderName,
         });


### PR DESCRIPTION
Fixed lint warning I noticed on one of my other PR's builds
```
/home/travis/build/matrix-org/matrix-react-sdk/src/TextForEvent.js
  251:5  warning  Closing curly brace does not appear on the same line as the subsequent block  brace-style
```