### PR TITLE
Fall back to another store if indexeddb start fails

### DIFF
--- a/src/utils/createMatrixClient.js
+++ b/src/utils/createMatrixClient.js
@@ -32,13 +32,18 @@ try {
  * @param {Object} opts  options to pass to Matrix.createClient. This will be
  *    extended with `sessionStore` and `store` members.
  *
+ * @param {bool} useIndexedDb True to attempt to use indexeddb, or false to force
+ *     use of the memory store. Default: true.
+ *
  * @property {string} indexedDbWorkerScript  Optional URL for a web worker script
  *    for IndexedDB store operations. By default, indexeddb ops are done on
  *    the main thread.
  *
  * @returns {MatrixClient} the newly-created MatrixClient
  */
-export default function createMatrixClient(opts) {
+export default function createMatrixClient(opts, useIndexedDb) {
+    if (useIndexedDb === undefined) useIndexedDb = true;
+
     const storeOpts = {
         useAuthorizationHeader: true,
     };
@@ -47,7 +52,7 @@ export default function createMatrixClient(opts) {
         storeOpts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
     }
 
-    if (indexedDB && localStorage) {
+    if (indexedDB && localStorage && useIndexedDb) {
         storeOpts.store = new Matrix.IndexedDBStore({
             indexedDB: indexedDB,
             dbName: "riot-web-sync",


### PR DESCRIPTION
If we can't start indexeddb, fall back to a different store.

Previously we just ignored the exception and ploughed on anyway, on
the assumption that startup() was just for the indexeddb store to
load data anyway, and if that failed it would just do an initial
/sync instead (and also we'd keep trying to save the sync back which
would fail...). Then, in the previous release we started pulling
the settings out of the store on startup, making the assumpton that
the store actually worked, so the read obviously failed and the app
failed to start up.

This makes Riot work in Tor browser / firefox in daft mode again.