### PR TITLE
show warning when LL is disabled but was enabled before

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -250,6 +250,19 @@ function _handleLoadSessionFailure(e) {
                             onFinished: resolve,
                         });
                     });
+                } else {
+                    // show warning about simultaneous use
+                    // between LL/non-LL version on same host.
+                    // as disabling LL when previously enabled
+                    // is a strong indicator of this (/develop & /app)
+                    const LazyLoadingDisabledDialog =
+                        sdk.getComponent("views.dialogs.LazyLoadingDisabledDialog");
+                    return new Promise((resolve) => {
+                        Modal.createDialog(LazyLoadingDisabledDialog, {
+                            onFinished: resolve,
+                            host: window.location.host,
+                        });
+                    });
                 }
             }).then(() => {
                 return MatrixClientPeg.get().store.deleteAllData();

--- a/src/components/views/dialogs/LazyLoadingDisabledDialog.js
+++ b/src/components/views/dialogs/LazyLoadingDisabledDialog.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import QuestionDialog from './QuestionDialog';
+import { _t } from '../../../languageHandler';
+
+export default (props) => {
+    const description1 =
+        _t("You've previously used Riot on %(host)s with lazy loading of members enabled. " +
+            "In this version lazy loading is disabled. " +
+            "As the local cache is not compatible between these two settings, " +
+            "Riot needs to resync your account.",
+            {host: props.host});
+    const description2 = _t("If the other version of Riot is still open in another tab, " +
+            "please close it as using Riot on the same host with both " +
+            "lazy loading enabled and disabled simultaneously will cause issues.");
+
+    return (<QuestionDialog
+        hasCancelButton={false}
+        title={_t("Incompatible local cache")}
+        description={<div><p>{description1}</p><p>{description2}</p></div>}
+        button={_t("Clear cache and resync")}
+        onFinished={props.onFinished}
+    />);
+};

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1261,5 +1261,9 @@
     "Import": "Import",
     "Failed to set direct chat tag": "Failed to set direct chat tag",
     "Failed to remove tag %(tagName)s from room": "Failed to remove tag %(tagName)s from room",
-    "Failed to add tag %(tagName)s to room": "Failed to add tag %(tagName)s to room"
+    "Failed to add tag %(tagName)s to room": "Failed to add tag %(tagName)s to room",
+    "You've previously used Riot on %(host)s with lazy loading of members enabled. In this version lazy loading is disabled. As the local cache is not compatible between these two settings, Riot needs to resync your account.": "You've previously used Riot on %(host)s with lazy loading of members enabled. In this version lazy loading is disabled. As the local cache is not compatible between these two settings, Riot needs to resync your account.",
+    "If the other version of Riot is still open in another tab, please close it as using Riot on the same host with both lazy loading enabled and disabled simultaneously will cause issues.": "If the other version of Riot is still open in another tab, please close it as using Riot on the same host with both lazy loading enabled and disabled simultaneously will cause issues.",
+    "Incompatible local cache": "Incompatible local cache",
+    "Clear cache and resync": "Clear cache and resync"
 }


### PR DESCRIPTION
Addresses https://github.com/vector-im/riot-web/issues/7432 by showing a dialog if you're using /app & /develop together, as we can't support this well with LL.

Not including the idb version downgrade stuff in this for now as this needs to go into the release today, and want to push as little untested changes to /app as possible. #2199 is about just that, and should not go into the release.

![lldisableddialog](https://user-images.githubusercontent.com/274386/46611893-638e0580-cb0f-11e8-9ed2-a2df57cba693.png)
