### PR TITLE
only run e2e tests on PRs targeted on develop

### DIFF
--- a/.travis-test-riot.sh
+++ b/.travis-test-riot.sh
@@ -27,7 +27,7 @@ npm run build
 npm run test
 popd
 
-if [ "$TRAVIS_BRANCH" != "experimental" ]
+if [ "$TRAVIS_BRANCH" = "develop" ]
 then
     # run end to end tests
     git clone https://github.com/matrix-org/matrix-react-end-to-end-tests.git --branch master


### PR DESCRIPTION
Looking at `$TRAVIS_BRANCH` only works for the PR hook, not for push hook. But regardless it makes sense to only run the e2e tests once, for the PR hook. This will disable the e2e tests for the push hook because there `$TRAVIS_BRANCH` is the name of the branch the commit was pushed on.

See https://github.com/vector-im/riot-web/issues/7636