### PR TITLE
Remove the request-only stuff we don't need anymore

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -199,24 +199,11 @@ module.exports = function (config) {
 
                     'matrix-react-sdk': path.resolve('test/skinned-sdk.js'),
                     'sinon': 'sinon/pkg/sinon.js',
-
-                    // To make webpack happy
-                    // Related: https://github.com/request/request/issues/1529
-                    // (there's no mock available for fs, so we fake a mock by using
-                    // an in-memory version of fs)
-                    "fs": "memfs",
                 },
                 modules: [
                     path.resolve('./test'),
                     "node_modules"
                 ],
-            },
-            node: {
-                // Because webpack is made of fail
-                // https://github.com/request/request/issues/1529
-                // Note: 'mock' is the new 'empty'
-                net: 'mock',
-                tls: 'mock'
             },
             devtool: 'inline-source-map',
             externals: {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "lodash": "^4.13.1",
     "lolex": "2.3.2",
     "matrix-js-sdk": "matrix-org/matrix-js-sdk#develop",
-    "memfs": "^2.10.1",
     "optimist": "^0.6.1",
     "pako": "^1.0.5",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
Paired with (**please review all 3**):
* https://github.com/vector-im/riot-web/pull/7637
* https://github.com/matrix-org/matrix-js-sdk/pull/775

----

This was introduced in https://github.com/matrix-org/matrix-react-sdk/pull/2250 but can be pulled out due to https://github.com/matrix-org/matrix-js-sdk/pull/770. See https://github.com/vector-im/riot-web/issues/7634 for more information about the future.