### PR TITLE
Regenerate the room list when m.fully_read is issued

### DIFF
--- a/src/actions/MatrixActionCreators.js
+++ b/src/actions/MatrixActionCreators.js
@@ -79,7 +79,7 @@ function createAccountDataAction(matrixClient, accountDataEvent) {
  * @param {MatrixClient} matrixClient the matrix client.
  * @param {MatrixEvent} accountDataEvent the account data event.
  * @param {Room} room the room where account data was changed
- * @returns {RoomAccountDataAction} an action of type MatrixActions.accountData.
+ * @returns {RoomAccountDataAction} an action of type MatrixActions.Room.accountData.
  */
 function createRoomAccountDataAction(matrixClient, accountDataEvent, room) {
     return {

--- a/src/actions/MatrixActionCreators.js
+++ b/src/actions/MatrixActionCreators.js
@@ -63,6 +63,35 @@ function createAccountDataAction(matrixClient, accountDataEvent) {
 }
 
 /**
+ * @typedef RoomAccountDataAction
+ * @type {Object}
+ * @property {string} action 'MatrixActions.Room.accountData'.
+ * @property {MatrixEvent} event the MatrixEvent that triggered the dispatch.
+ * @property {string} event_type the type of the MatrixEvent, e.g. "m.direct".
+ * @property {Object} event_content the content of the MatrixEvent.
+ * @property {Room} room the room where the account data was changed.
+ */
+
+/**
+ * Create a MatrixActions.Room.accountData action that represents a MatrixClient `Room.accountData`
+ * matrix event.
+ *
+ * @param {MatrixClient} matrixClient the matrix client.
+ * @param {MatrixEvent} accountDataEvent the account data event.
+ * @param {Room} room the room where account data was changed
+ * @returns {RoomAccountDataAction} an action of type MatrixActions.accountData.
+ */
+function createRoomAccountDataAction(matrixClient, accountDataEvent, room) {
+    return {
+        action: 'MatrixActions.Room.accountData',
+        event: accountDataEvent,
+        event_type: accountDataEvent.getType(),
+        event_content: accountDataEvent.getContent(),
+        room: room,
+    };
+}
+
+/**
  * @typedef RoomAction
  * @type {Object}
  * @property {string} action 'MatrixActions.Room'.
@@ -201,6 +230,7 @@ export default {
     start(matrixClient) {
         this._addMatrixClientListener(matrixClient, 'sync', createSyncAction);
         this._addMatrixClientListener(matrixClient, 'accountData', createAccountDataAction);
+        this._addMatrixClientListener(matrixClient, 'Room.accountData', createRoomAccountDataAction);
         this._addMatrixClientListener(matrixClient, 'Room', createRoomAction);
         this._addMatrixClientListener(matrixClient, 'Room.tags', createRoomTagsAction);
         this._addMatrixClientListener(matrixClient, 'Room.timeline', createRoomTimelineAction);

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -142,6 +142,13 @@ class RoomListStore extends Store {
                 this._generateRoomLists();
             }
             break;
+            case 'MatrixActions.Room.accountData': {
+                if (payload.event_type === 'm.fully_read') {
+                    this._clearCachedRoomState(payload.room.roomId);
+                    this._generateRoomLists();
+                }
+            }
+            break;
             case 'MatrixActions.Room.myMembership': {
                 this._generateRoomLists();
             }


### PR DESCRIPTION
Not doing so results in the RoomListStore tracking stale data when the user reads messages on another device. The visual effect of this is rooms being incorrectly pinned in places they shouldn't be, such as the top of the list. This also fixes another visual bug where rooms don't move down once their timelines are read. This second issue is mot prominent when multiple rooms have been pinned to the top, and the middle one is read ahead of the others - it'll stick around until some other condition decides to wipe the room's cached state.

Fixes https://github.com/vector-im/riot-web/issues/7653