### PR TITLE
Align encrypted event buttons in Safari

### DIFF
--- a/res/css/views/dialogs/_EncryptedEventDialog.scss
+++ b/res/css/views/dialogs/_EncryptedEventDialog.scss
@@ -24,5 +24,8 @@ limitations under the License.
     @mixin mx_DialogButton;
     background-color: $primary-bg-color;
     color: $accent-color;
+}
+
+.mx_EncryptedEventDialog button {
     margin-top: 0px;
 }


### PR DESCRIPTION
Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>

## Browser comparison with guide line shown

### Safari

<img width="342" alt="safari-align-eed" src="https://user-images.githubusercontent.com/279572/48223151-b40ab400-e396-11e8-924d-60a3574f0181.png">

### Firefox

<img width="367" alt="firefox-align-eed" src="https://user-images.githubusercontent.com/279572/48223129-9ccbc680-e396-11e8-8e84-20e1c9f797df.png">

### Chrome

<img width="365" alt="chrome-align-eed" src="https://user-images.githubusercontent.com/279572/48223134-a2291100-e396-11e8-8622-5283b710df58.png">

### Edge

<img width="322" alt="edge-align-eed" src="https://user-images.githubusercontent.com/279572/48223164-bc62ef00-e396-11e8-8fe0-3b47d0e6fe3a.png">