### PR TITLE
Improve terms auth flow

### DIFF
--- a/res/css/views/login/_InteractiveAuthEntryComponents.scss
+++ b/res/css/views/login/_InteractiveAuthEntryComponents.scss
@@ -30,13 +30,15 @@ limitations under the License.
     border: 1px solid $accent-color;
 }
 
-.mx_InteractiveAuthEntryComponents_msisdnSubmit {
+.mx_InteractiveAuthEntryComponents_msisdnSubmit,
+.mx_InteractiveAuthEntryComponents_termsSubmit {
     margin-top: 4px;
     margin-bottom: 5px;
 }
 
 // XXX: This should be a common button class
-.mx_InteractiveAuthEntryComponents_msisdnSubmit:disabled {
+.mx_InteractiveAuthEntryComponents_msisdnSubmit:disabled,
+.mx_InteractiveAuthEntryComponents_termsSubmit:disabled {
     background-color: $light-fg-color;
     cursor: default;
 }

--- a/res/css/views/login/_InteractiveAuthEntryComponents.scss
+++ b/res/css/views/login/_InteractiveAuthEntryComponents.scss
@@ -40,3 +40,7 @@ limitations under the License.
     background-color: $light-fg-color;
     cursor: default;
 }
+
+.mx_InteractiveAuthEntryComponents_termsPolicy {
+    display: block;
+}

--- a/res/css/views/login/_InteractiveAuthEntryComponents.scss
+++ b/res/css/views/login/_InteractiveAuthEntryComponents.scss
@@ -30,16 +30,26 @@ limitations under the License.
     border: 1px solid $accent-color;
 }
 
-.mx_InteractiveAuthEntryComponents_msisdnSubmit,
-.mx_InteractiveAuthEntryComponents_termsSubmit {
+.mx_InteractiveAuthEntryComponents_msisdnSubmit {
     margin-top: 4px;
     margin-bottom: 5px;
 }
 
+.mx_InteractiveAuthEntryComponents_termsSubmit {
+    margin-top: 20px;
+    margin-bottom: 5px;
+    display: block;
+    width: 100%;
+}
+
 // XXX: This should be a common button class
-.mx_InteractiveAuthEntryComponents_msisdnSubmit:disabled,
-.mx_InteractiveAuthEntryComponents_termsSubmit:disabled {
+.mx_InteractiveAuthEntryComponents_msisdnSubmit:disabled {
     background-color: $light-fg-color;
+    cursor: default;
+}
+
+.mx_InteractiveAuthEntryComponents_termsSubmit:disabled {
+    background-color: $accent-color-50pct;
     cursor: default;
 }
 

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -12,6 +12,7 @@ $light-fg-color: #747474;
 // button UI (white-on-green in light skin)
 $accent-fg-color: $primary-bg-color;
 $accent-color: #76CFA6;
+$accent-color-50pct: #76CFA67F;
 
 $selection-fg-color: $primary-fg-color;
 

--- a/res/themes/light/css/_base.scss
+++ b/res/themes/light/css/_base.scss
@@ -18,6 +18,7 @@ $focus-bg-color: #dddddd;
 // button UI (white-on-green in light skin)
 $accent-fg-color: #ffffff;
 $accent-color: #76CFA6;
+$accent-color-50pct: #76CFA67F;
 
 $selection-fg-color: $primary-bg-color;
 

--- a/src/Registration.js
+++ b/src/Registration.js
@@ -45,7 +45,7 @@ export async function startAnyRegistrationFlow(options) {
     // caution though.
     const hasIlagFlow = flows.some((flow) => {
         return flow.stages.every((stage) => {
-            return ['m.login.dummy', 'm.login.recaptcha'].includes(stage);
+            return ['m.login.dummy', 'm.login.recaptcha', 'm.login.terms'].includes(stage);
         });
     });
 

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -203,7 +203,7 @@ export default React.createClass({
                 fail={this._onAuthStageFailed}
                 setEmailSid={this._setEmailSid}
                 makeRegistrationUrl={this.props.makeRegistrationUrl}
-                hideContinue={this.props.continueIsManaged}
+                showContinue={!this.props.continueIsManaged}
             />
         );
     },

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -68,6 +68,11 @@ export default React.createClass({
         // If true, poll to see if the auth flow has been completed
         // out-of-band
         poll: PropTypes.bool,
+
+        // If true, components will be told that the 'Continue' button
+        // is managed by some other party and should not be managed by
+        // the component itself.
+        continueIsManaged: PropTypes.bool,
     },
 
     getInitialState: function() {
@@ -125,6 +130,12 @@ export default React.createClass({
 
         if (this._intervalId !== null) {
             clearInterval(this._intervalId);
+        }
+    },
+
+    tryContinue: function() {
+        if (this.refs.stageComponent && this.refs.stageComponent.tryContinue) {
+            this.refs.stageComponent.tryContinue();
         }
     },
 
@@ -192,6 +203,7 @@ export default React.createClass({
                 fail={this._onAuthStageFailed}
                 setEmailSid={this._setEmailSid}
                 makeRegistrationUrl={this.props.makeRegistrationUrl}
+                hideContinue={this.props.continueIsManaged}
             />
         );
     },

--- a/src/components/views/dialogs/SetMxIdDialog.js
+++ b/src/components/views/dialogs/SetMxIdDialog.js
@@ -101,6 +101,9 @@ export default React.createClass({
     },
 
     onSubmit: function(ev) {
+        if (this.refs.uiAuth) {
+            this.refs.uiAuth.tryContinue();
+        }
         this.setState({
             doingUIAuth: true,
         });
@@ -217,6 +220,8 @@ export default React.createClass({
                 onAuthFinished={this._onUIAuthFinished}
                 inputs={{}}
                 poll={true}
+                ref="uiAuth"
+                continueIsManaged={true}
             />;
         }
         const inputClasses = classnames({

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -335,7 +335,7 @@ export const TermsAuthEntry = React.createClass({
         if (!this.props.hideContinue) {
             // XXX: button classes
             submitButton = <button className="mx_InteractiveAuthEntryComponents_termsSubmit mx_UserSettings_button"
-                                   onClick={this._trySubmit}>{_t("Continue")}</button>;
+                                   onClick={this._trySubmit} disabled={!allChecked}>{_t("Accept")}</button>;
         }
 
         return (

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -222,6 +222,7 @@ export const TermsAuthEntry = React.createClass({
         stageParams: PropTypes.object.isRequired,
         errorText: PropTypes.string,
         busy: PropTypes.bool,
+        hideContinue: PropTypes.bool,
     },
 
     componentWillMount: function() {
@@ -275,19 +276,30 @@ export const TermsAuthEntry = React.createClass({
         });
     },
 
-    _trySubmit: function(policyId) {
+    tryContinue: function() {
+        this._trySubmit();
+    },
+
+    _togglePolicy: function(policyId) {
         const newToggles = {};
-        let allChecked = true;
         for (const policy of this.state.policies) {
             let checked = this.state.toggledPolicies[policy.id];
             if (policy.id === policyId) checked = !checked;
 
             newToggles[policy.id] = checked;
+        }
+        this.setState({"toggledPolicies": newToggles});
+    },
+
+    _trySubmit: function() {
+        let allChecked = true;
+        for (const policy of this.state.policies) {
+            let checked = this.state.toggledPolicies[policy.id];
             allChecked = allChecked && checked;
         }
 
-        this.setState({"toggledPolicies": newToggles});
         if (allChecked) this.props.submitAuthDict({type: TermsAuthEntry.LOGIN_TYPE});
+        else this.setState({errorText: _t("Please review and accept all of the homeserver's policies")});
     },
 
     render: function() {
@@ -303,20 +315,25 @@ export const TermsAuthEntry = React.createClass({
             allChecked = allChecked && checked;
 
             checkboxes.push(
-                <label key={"policy_checkbox_" + policy.id}>
-                    <input type="checkbox" onClick={() => this._trySubmit(policy.id)} checked={checked} />
+                <label key={"policy_checkbox_" + policy.id} className="mx_InteractiveAuthEntryComponents_termsPolicy">
+                    <input type="checkbox" onClick={() => this._togglePolicy(policy.id)} checked={checked} />
                     <a href={policy.url} target="_blank" rel="noopener">{ policy.name }</a>
                 </label>,
             );
         }
 
         let errorSection;
-        if (this.props.errorText) {
+        if (this.props.errorText || this.state.errorText) {
             errorSection = (
                 <div className="error" role="alert">
-                    { this.props.errorText }
+                    { this.props.errorText || this.state.errorText }
                 </div>
             );
+        }
+
+        let submitButton;
+        if (!this.props.hideContinue) {
+            submitButton = <button className="mx_textButton" onClick={this._trySubmit}>{_t("Continue")}</button>;
         }
 
         return (
@@ -324,6 +341,7 @@ export const TermsAuthEntry = React.createClass({
                 <p>{_t("Please review and accept the policies of this homeserver:")}</p>
                 { checkboxes }
                 { errorSection }
+                { submitButton }
             </div>
         );
     },

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -333,7 +333,9 @@ export const TermsAuthEntry = React.createClass({
 
         let submitButton;
         if (!this.props.hideContinue) {
-            submitButton = <button className="mx_textButton" onClick={this._trySubmit}>{_t("Continue")}</button>;
+            // XXX: button classes
+            submitButton = <button className="mx_InteractiveAuthEntryComponents_termsSubmit mx_UserSettings_button"
+                                   onClick={this._trySubmit}>{_t("Continue")}</button>;
         }
 
         return (

--- a/src/components/views/login/InteractiveAuthEntryComponents.js
+++ b/src/components/views/login/InteractiveAuthEntryComponents.js
@@ -222,7 +222,7 @@ export const TermsAuthEntry = React.createClass({
         stageParams: PropTypes.object.isRequired,
         errorText: PropTypes.string,
         busy: PropTypes.bool,
-        hideContinue: PropTypes.bool,
+        showContinue: PropTypes.bool,
     },
 
     componentWillMount: function() {
@@ -332,7 +332,7 @@ export const TermsAuthEntry = React.createClass({
         }
 
         let submitButton;
-        if (!this.props.hideContinue) {
+        if (this.props.showContinue !== false) {
             // XXX: button classes
             submitButton = <button className="mx_InteractiveAuthEntryComponents_termsSubmit mx_UserSettings_button"
                                    onClick={this._trySubmit} disabled={!allChecked}>{_t("Accept")}</button>;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -646,6 +646,7 @@
     "Dismiss": "Dismiss",
     "To continue, please enter your password.": "To continue, please enter your password.",
     "Password:": "Password:",
+    "Please review and accept all of the homeserver's policies": "Please review and accept all of the homeserver's policies",
     "Please review and accept the policies of this homeserver:": "Please review and accept the policies of this homeserver:",
     "An email has been sent to %(emailAddress)s": "An email has been sent to %(emailAddress)s",
     "Please check your email to continue registration.": "Please check your email to continue registration.",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7700
**Requires https://github.com/vector-im/riot-web/pull/7710**
**Requires https://github.com/matrix-org/matrix-react-end-to-end-tests/pull/42**


* [x] Add m.login.terms to the ILAG-compatible flows
* [x] Add a dedicated "Continue" button to the terms auth stage. This button is conditionally enabled because the ILAG dialog has its own "Continue" button. In order to reduce user confusion about which button to press, we pass down clicks on the ILAG dialog's button to the stage component. The register page doesn't have its own button, however.
* [x] Fix/update the wording around the checkboxes
* [x] Fix CSS for the 'Continue' button
* [x] Fix the end to end tests
