### PR TITLE
Push-to-Talk Support for Jitsi

### DIFF
--- a/src/PushToTalk.js
+++ b/src/PushToTalk.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 Andrew Morgan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import PlatformPeg from './PlatformPeg';
+import ActiveWidgetStore from './stores/ActiveWidgetStore';
+import SettingsStore from './settings/SettingsStore';
+
+export function enable(keybinding) {
+    const id = 'pushToTalk';
+    PlatformPeg.get().addGlobalKeybinding(id, keybinding, () => {
+        const widgetId = ActiveWidgetStore.getPersistentWidgetId();
+
+        // Only try to un/mute if jitsi is onscreen
+        if (widgetId === null || widgetId === undefined) {
+            return;
+        }
+
+        const widgetMessaging = ActiveWidgetStore.getWidgetMessaging(widgetId);
+        widgetMessaging.unmuteJitsiAudio();
+    }, () => {
+        const widgetId = ActiveWidgetStore.getPersistentWidgetId();
+
+        // Only try to un/mute if jitsi is onscreen
+        if (widgetId === null || widgetId === undefined) {
+            return;
+        }
+
+        const widgetMessaging = ActiveWidgetStore.getWidgetMessaging(widgetId);
+        widgetMessaging.muteJitsiAudio();
+    });
+}
+
+export function disable() {
+    const id = 'pushToTalk';
+    const keybinding = SettingsStore.getValue(id).keybinding;
+    PlatformPeg.get().removeGlobalKeybinding(id, keybinding);
+}

--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -35,7 +35,6 @@ const OUTBOUND_API_NAME = 'toWidget';
 
 export default class WidgetMessaging {
     constructor(widgetId, widgetUrl, target) {
-        console.log("I'm alive! My URL is:", widgetUrl)
         this.widgetId = widgetId;
         this.widgetUrl = widgetUrl;
         this.target = target;

--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -35,6 +35,7 @@ const OUTBOUND_API_NAME = 'toWidget';
 
 export default class WidgetMessaging {
     constructor(widgetId, widgetUrl, target) {
+        console.log("I'm alive! My URL is:", widgetUrl)
         this.widgetId = widgetId;
         this.widgetUrl = widgetUrl;
         this.target = target;
@@ -94,6 +95,45 @@ export default class WidgetMessaging {
                 console.warn('Got capabilities for', this.widgetId, response.capabilities);
                 return response.capabilities;
             });
+    }
+
+    /**
+     * Toggle Jitsi Audio Mute
+     * @return {Promise} To be resolved when action completed
+     */
+    toggleJitsiAudio() {
+        return this.messageToWidget({
+            api: OUTBOUND_API_NAME,
+            action: "audioMuteToggle",
+        }).then((response) => {
+            return response.success;
+        });
+    }
+
+    /**
+     * Jitsi Audio Mute
+     * @return {Promise} To be resolved when action completed
+     */
+    muteJitsiAudio() {
+        return this.messageToWidget({
+            api: OUTBOUND_API_NAME,
+            action: "audioMute",
+        }).then((response) => {
+            return response.success;
+        });
+    }
+
+    /**
+     * Jitsi Audio Unmute
+     * @return {Promise} To be resolved when action completed
+     */
+    unmuteJitsiAudio() {
+        return this.messageToWidget({
+            api: OUTBOUND_API_NAME,
+            action: "audioUnmute",
+        }).then((response) => {
+            return response.success;
+        });
     }
 
     sendVisibility(visible) {

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -685,7 +685,6 @@ module.exports = React.createClass({
         // Used for displaying ascii-representation of current keys
         // in the UI
         listenKeydown = function(event) {
-            // TODO: Show RightShift and things
             const key = self._translateKeybinding(event.code);
             const index = keyAscii.indexOf(key);
             if (index === -1) {
@@ -804,7 +803,6 @@ module.exports = React.createClass({
             PushToTalk.enable(currentPTTState.keybinding);
         } else {
             // Disable push to talk
-            console.log("Disabling push to talk...")
 
             this.setState({pushToTalkEnabled: false});
             currentPTTState.enabled = false;

--- a/src/components/views/elements/PersistedElement.js
+++ b/src/components/views/elements/PersistedElement.js
@@ -182,5 +182,4 @@ export default class PersistedElement extends React.Component {
 
         return <div ref={this.collectChildContainer}></div>;
     }
-
 }

--- a/src/components/views/elements/PersistedElement.js
+++ b/src/components/views/elements/PersistedElement.js
@@ -17,8 +17,10 @@ limitations under the License.
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-
 import ResizeObserver from 'resize-observer-polyfill';
+import SettingsStore from '../../../settings/SettingsStore';
+
+import * as PushToTalk from '../../../PushToTalk';
 
 import dis from '../../../dispatcher';
 
@@ -112,6 +114,13 @@ export default class PersistedElement extends React.Component {
     }
 
     componentDidMount() {
+        // Start Push-To-Talk service when Jitsi widget is mounted
+        // TODO: This seems quite hacky - is there a better way to
+        // check if this is a Jitsi vs. StickerPicker widget?
+        if (this.props.persistKey.includes('jitsi') && SettingsStore.getValue('pushToTalk').enabled) {
+            PushToTalk.enable(SettingsStore.getValue('pushToTalk').keybinding);
+        }
+
         this.updateChild();
     }
 
@@ -124,6 +133,11 @@ export default class PersistedElement extends React.Component {
         this.resizeObserver.disconnect();
         window.removeEventListener('resize', this._repositionChild);
         dis.unregister(this._dispatcherRef);
+
+        // Stop Push-To-Talk service when Jitsi widget is unmounted
+        if (this.props.persistKey.includes('jitsi') && SettingsStore.getValue('pushToTalk').enabled) {
+            PushToTalk.disable();
+        }
     }
 
     _onAction(payload) {
@@ -168,4 +182,5 @@ export default class PersistedElement extends React.Component {
 
         return <div ref={this.collectChildContainer}></div>;
     }
+
 }

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -79,16 +79,25 @@ export const SETTINGS = {
     // },
     "feature_pinning": {
         isFeature: true,
-        displayName: _td("Message Pinning"),
+        displayName: _td('Message Pinning'),
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
     "feature_lazyloading": {
         isFeature: true,
-        displayName: _td("Increase performance by only loading room members on first view"),
+        displayName: _td('Increase performance by only loading room members on first view'),
         supportedLevels: LEVELS_FEATURE,
         controller: new LazyLoadingController(),
         default: true,
+    },
+    "pushToTalk": {
+        displayName: _td('Push-to-Talk'),
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
+        default: {
+            enabled: false,
+            keybinding: [],
+            ascii: 'Not set',
+        },
     },
     "MessageComposerInput.dontSuggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
@@ -241,21 +250,21 @@ export const SETTINGS = {
         supportedLevels: LEVELS_ROOM_SETTINGS_WITH_ROOM,
         displayName: {
             "default": _td('Enable inline URL previews by default'),
-            "room-account": _td("Enable URL previews for this room (only affects you)"),
-            "room": _td("Enable URL previews by default for participants in this room"),
+            "room-account": _td('Enable URL previews for this room (only affects you)'),
+            "room": _td('Enable URL previews by default for participants in this room'),
         },
         default: true,
     },
     "urlPreviewsEnabled_e2ee": {
         supportedLevels: ['room-device', 'room-account'],
         displayName: {
-            "room-account": _td("Enable URL previews for this room (only affects you)"),
+            "room-account": _td('Enable URL previews for this room (only affects you)'),
         },
         default: false,
     },
     "roomColor": {
         supportedLevels: LEVELS_ROOM_SETTINGS_WITH_ROOM,
-        displayName: _td("Room Colour"),
+        displayName: _td('Room Colour'),
         default: {
             primary_color: null, // Hex string, eg: #000000
             secondary_color: null, // Hex string, eg: #000000


### PR DESCRIPTION
Implements the matrix-react-sdk portion of Push-to-Talk support for Jitsi voice and video calls. The riot-web portion is https://github.com/vector-im/riot-web/pull/7709.

Push-to-Talk allows someone to temporarily unmute their microphone during a Jitsi call with just the push of a button. Releasing the button causes their microphone to become muted again. This is exceptionally useful during calls with 3+ people.

The pipeline involved to make this work stretches quite far, from a new native node module in Riot's `electron_app`, called `iohook`, that can handle listening for whitelisted shortcuts even when Riot is minimized, to Scalar/Dimension that is hosting the Jitsi session within its own iframe.

Currently any combination of keyboard keys can be used for a shortcut. Here is the current layout:

![image](https://user-images.githubusercontent.com/1342360/48580014-48888f80-e91e-11e8-9575-b28148ff14a4.png)

The functionality of the setting is currently complete, however I may need some help aligning the different elements, and styling the Set button. Otherwise if someone has an idea for a much better-looking UI, I'm open to it (though I may opt to move it to a separate PR).

**Note:** This has currently only been tested on Linux. Testing on Mac/Windows/Other would be highly appreciated!

Future TODOs that may or may not be out of scope for this PR:

- [ ] Audio cue for when mic is un/muted, so people know their shortcut is working and their mic is active.
- [ ] Mute Jitsi by default on load if Push-to-Talk enabled

TODOs that are definitely out of scope for this PR, but that I would like to see if the future:

- [ ] Mouse keybinding support for Push-To-Talk (those many buttons on gaming mice)