### PR TITLE
Ignore failing group users response

### DIFF
--- a/src/stores/GroupStore.js
+++ b/src/stores/GroupStore.js
@@ -147,6 +147,15 @@ class GroupStore extends EventEmitter {
                 return;
             }
 
+            // Requests to Synapse for group members may fail with an internal
+            // error in the presence of duplicate invites.
+            // https://github.com/matrix-org/synapse/issues/2633
+            if (stateKey === this.STATE_KEY.GroupMembers &&
+                err.httpStatus === 500 && err.message === "More than one row matched") {
+                console.error(`Ignoring known failure to get resource ${stateKey} for ${groupId}`, err);
+                return;
+            }
+
             console.error(`Failed to get resource ${stateKey} for ${groupId}`, err);
             this.emit('error', err, groupId);
         }).finally(() => {


### PR DESCRIPTION
Synapse is currently known (matrix-org/synapse#2633) to return 500 errors for
requests to `/groups/$groupId/users` when a user has multiple invites to the
group.

If you are affected by this issue, Riot will display a community invite when you
select it for a few seconds until it receives this 500 error, but then it will
replace the invite view with a "Failed to load <group>" message.

By ignoring this error response in Riot for now, it is possible to view and
accept the invite.

Fixes vector-im/riot-web#7727.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>