### PR TITLE
Ensure events forwarded by a previous dispatch are not re-dispatched

### DIFF
--- a/src/stores/OpenRoomsStore.js
+++ b/src/stores/OpenRoomsStore.js
@@ -164,7 +164,8 @@ class OpenRoomsStore extends Store {
             }
         }
         const currentRoom = this._getActiveOpenRoom();
-        if (currentRoom) {
+        if (currentRoom && payload["__forwarded_to_room_id"] !== currentRoom.roomId) {
+            payload["__forwarded_to_room_id"] = currentRoom.roomId;
             currentRoom.dispatcher.dispatch(payload, true);
         }
     }


### PR DESCRIPTION
This fixes an issue where the login page was infinitely loaded after a user logged out, preventing them from logging in until they reloaded the page. Only applied after the user viewed a room before logging out.

**This is against a demo branch, not a regular development branch.**