### PR TITLE
Merge users faster

### DIFF
--- a/src/MergedUsers.js
+++ b/src/MergedUsers.js
@@ -79,7 +79,12 @@ class MergedUsers {
 
         // Don't bother looking up profiles for people who aren't going to be merged
         const domain = userId.split(":").slice(1).join(":"); // extract everything after the first colon
-        if (!this._mergableHosts.includes(domain)) return Promise.resolve();
+        const isMergableHost = this._mergableHosts.some(h => {
+            if (h.endsWith("*")) {
+                return domain.toLowerCase().startsWith(h.toLowerCase().substring(0, h.length - 1));
+            } else return domain.toLowerCase() === h.toLowerCase();
+        });
+        if (!isMergableHost) return Promise.resolve();
 
         const localpart = this._getLocalpart(userId);
         if (!localpart) return Promise.resolve();

--- a/src/MergedUsers.js
+++ b/src/MergedUsers.js
@@ -55,7 +55,7 @@ class MergedUsers {
                 if (container.localparts) this._localpartCache = container.localparts;
                 if (container.profiles) this._profileCache = container.profiles;
             }
-        }catch (e) {
+        } catch (e) {
             console.error("Error loading MergedUsers caches");
             console.error(e);
         }
@@ -187,7 +187,8 @@ class MergedUsers {
      * parentIds, false otherwise.
      */
     isChildOf(userId, parentIds) {
-        return parentIds.map(i => this._getLocalpart(i)).includes(this._getLocalpart(userId));
+        const localpart = this._getLocalpart(userId);
+        return parentIds.some(i => this._getLocalpart(i) === localpart);
     }
 
     /**
@@ -288,8 +289,10 @@ class MergedUsers {
         if (fastProfile && (fastProfile.displayname || fastProfile.avatar_url)) return fastProfile;
 
         const room = MatrixClientPeg.get().getRoom(roomMember.roomId);
-        const parentMember = room.currentState.members[userId];
-        if (parentMember) roomMember = parentMember;
+        if (room) {
+            const parentMember = room.currentState.members[userId];
+            if (parentMember) roomMember = parentMember;
+        }
 
         return {
             displayname: roomMember.name,
@@ -437,7 +440,7 @@ class MergedUsers {
 
         // if I have created a room and invited people through
         // 3rd party invites
-        if (myMembership == 'join') {
+        if (myMembership === 'join') {
             const thirdPartyInvites =
                 room.currentState.getStateEvents("m.room.third_party_invite");
 


### PR DESCRIPTION
**This is for demonstration purposes only and is not intended for real usage.**

This PR does 3 things:
* Deduplicates requests made to `trackUser()`, avoiding scenarios where a few hundred/thousand excess alias lookups are done
* Adds a new `mergable_hosts` array to the config.json which lists off the domains to consider as "mergable". If a domain is not in this list, `MergedUsers` short circuits in places to skip tracking the user or going down slower routes.
* Fixes misc bugs like lack of null checks in some areas

