### PR TITLE
Demo: quickfix for exception after #2300

### DIFF
--- a/src/MergedUsers.js
+++ b/src/MergedUsers.js
@@ -62,6 +62,7 @@ class MergedUsers {
     }
 
     _isMergable(userId) {
+        if (typeof userId !== "string") return false;
         const domain = userId.split(":").slice(1).join(":"); // extract everything after the first colon
         return this._mergableHosts.some(h => {
             if (h.endsWith("*")) {


### PR DESCRIPTION
Get this exception on experimental2 after #2300, doing a quickfix so I'm not blocked. @turt2live 

```
Uncaught TypeError: Cannot read property 'split' of undefined
    at MergedUsers._isMergable (http://localhost:8080/bundles/_dev_/bundle.js:53482:33)
    at MergedUsers.isChild (http://localhost:8080/bundles/_dev_/bundle.js:53656:23)
    at MergedUsers.isParent (http://localhost:8080/bundles/_dev_/bundle.js:53675:26)
    at MergedUsers.getEffectiveParents (http://localhost:8080/bundles/_dev_/bundle.js:53736:48)
    at MergedUsers.calculateRoomName (http://localhost:8080/bundles/_dev_/bundle.js:54079:35)
    at Object.getInitialState (http://localhost:8080/bundles/_dev_/bundle.js:123469:45)
    at new <anonymous> (http://localhost:8080/bundles/_dev_/bundle.js:281555:54)
    at http://localhost:8080/bundles/_dev_/bundle.js:306653:18
    at measureLifeCyclePerf (http://localhost:8080/bundles/_dev_/bundle.js:306434:12)
    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (http://localhost:8080/bundles/_dev_/bundle.js:306652:16)
    at ReactCompositeComponentWrapper._constructComponent (http://localhost:8080/bundles/_dev_/bundle.js:306643:19)
    at ReactCompositeComponentWrapper.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:306546:21)
    at Object.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:313806:35)
    at ReactDOMComponent.mountChildren (http://localhost:8080/bundles/_dev_/bundle.js:312641:44)
    at ReactDOMComponent._createInitialChildren (http://localhost:8080/bundles/_dev_/bundle.js:308089:32)
    at ReactDOMComponent.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:307908:12)
    at Object.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:313806:35)
    at ReactDOMComponent.mountChildren (http://localhost:8080/bundles/_dev_/bundle.js:312641:44)
    at ReactDOMComponent._createInitialChildren (http://localhost:8080/bundles/_dev_/bundle.js:308089:32)
    at ReactDOMComponent.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:307908:12)
    at Object.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:313806:35)
    at ReactCompositeComponentWrapper.performInitialMount (http://localhost:8080/bundles/_dev_/bundle.js:306729:34)
    at ReactCompositeComponentWrapper.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:306616:21)
    at Object.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:313806:35)
    at ReactCompositeComponentWrapper.performInitialMount (http://localhost:8080/bundles/_dev_/bundle.js:306729:34)
    at ReactCompositeComponentWrapper.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:306616:21)
    at Object.mountComponent (http://localhost:8080/bundles/_dev_/bundle.js:313806:35)
    at ReactDOMComponent.mountChildren (http://localhost:8080/bundles/_dev_/bundle.js:312641:44)
From previous event:
    at Object._viewRoom (http://localhost:8080/bundles/_dev_/bundle.js:71486:17)
    at Object.onAction (http://localhost:8080/bundles/_dev_/bundle.js:71202:22)
    at MatrixDispatcher._invokeCallback (http://localhost:8080/bundles/_dev_/bundle.js:159737:24)
    at MatrixDispatcher.dispatch (http://localhost:8080/bundles/_dev_/bundle.js:159713:14)
```