### PR TITLE
Update change power level event to use MXID instead of display name

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -336,7 +336,7 @@ function textForEncryptionEvent(event) {
 
 // Currently will only display a change if a user's power level is changed
 function textForPowerEvent(event) {
-    const senderName = event.sender ? event.sender.name : event.getSender();
+    const senderName = event.sender ? event.sender.userId : event.getSender();
     if (!event.getPrevContent() || !event.getPrevContent().users) {
         return '';
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7751

I'm happy to update it to display `Display Name (mxid)` but that makes the lines really long. I also would have updated the `senderName` variable to be `senderId` but wouldn't that just put more work on the translators for no reason?