### PR TITLE
Redesign: restyle jump to first unread message & rework read marker logic

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -87,8 +87,12 @@ limitations under the License.
     flex: 1;
 }
 
-.mx_RoomView_body .mx_RoomView_topUnreadMessagesBar {
-    order: 1;
+.mx_RoomView_body .mx_RoomView_timeline {
+    /* offset parent for mx_RoomView_topUnreadMessagesBar  */
+    position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 .mx_RoomView_body .mx_RoomView_messagePanel {

--- a/res/css/views/rooms/_TopUnreadMessagesBar.scss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.scss
@@ -38,22 +38,6 @@ limitations under the License.
     height: 38px;
     mask: url('../../img/icon-jump-to-first-unread.svg');
     mask-repeat: no-repeat;
-    mask-position: 9px 16px;
+    mask-position: 9px 13px;
     background: $roomtile-name-color;
-}
-
-.mx_TopUnreadMessagesBar_badgeContainer {
-    position: relative;
-    top: -8px;
-    text-align: center;
-}
-
-.mx_TopUnreadMessagesBar_badge {
-    display: inline-block;
-    border-radius: 0.8em;
-    padding: 0 0.4em;
-    color: $accent-fg-color;
-    background-color: $accent-color;
-    font-weight: 600;
-    font-size: 12px;
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.scss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.scss
@@ -15,39 +15,45 @@ limitations under the License.
 */
 
 .mx_TopUnreadMessagesBar {
-    margin: auto;  /* centre horizontally */
-    max-width: 960px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid $primary-hairline-color;
+    z-index: 1000;
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    width: 38px;
 }
 
 .mx_TopUnreadMessagesBar_scrollUp {
-    display: inline;
-    cursor: pointer;
-    text-decoration: underline;
-}
-
-.mx_TopUnreadMessagesBar_scrollUp img {
-    padding-left: 10px;
-    padding-right: 31px;
-    vertical-align: middle;
-}
-
-.mx_TopUnreadMessagesBar_scrollUp span {
-    opacity: 0.5;
-}
-
-.mx_TopUnreadMessagesBar_close {
-    float: right;
-    padding-right: 14px;
-    padding-top: 3px;
+    height: 38px;
+    border-radius: 19px;
+    box-sizing: border-box;
+    background: $primary-bg-color;
+    border: 1.3px solid $roomtile-name-color;
     cursor: pointer;
 }
 
-.mx_MatrixChat_useCompactLayout {
-    .mx_TopUnreadMessagesBar {
-        padding-top: 4px;
-        padding-bottom: 4px;
-    }
+.mx_TopUnreadMessagesBar_scrollUp:before {
+    content: "";
+    position: absolute;
+    width: 38px;
+    height: 38px;
+    mask: url('../../img/icon-jump-to-first-unread.svg');
+    mask-repeat: no-repeat;
+    mask-position: 9px 16px;
+    background: $roomtile-name-color;
+}
+
+.mx_TopUnreadMessagesBar_badgeContainer {
+    position: relative;
+    top: -8px;
+    text-align: center;
+}
+
+.mx_TopUnreadMessagesBar_badge {
+    display: inline-block;
+    border-radius: 0.8em;
+    padding: 0 0.4em;
+    color: $accent-fg-color;
+    background-color: $accent-color;
+    font-weight: 600;
+    font-size: 12px;
 }

--- a/res/img/icon-jump-to-first-unread.svg
+++ b/res/img/icon-jump-to-first-unread.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="fill:none"
+   version="1.1"
+   viewBox="0 0 18.666187 8.7375818"
+   height="8.7375822"
+   width="18.666187">
+  <defs
+     id="defs8" />
+  <path
+     d="M 17.909095,7.981591 9.3330939,0.74997995 0.75709259,7.981591"
+     style="fill:none;stroke:#000000;stroke-width:1.29999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path2-8-3" />
+</svg>

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -70,7 +70,7 @@ class Presence {
     }
 
     _onAction(payload) {
-        if (payload.action === 'user_activity_start') {
+        if (payload.action === 'user_activity') {
             this.setState("online");
             this._unavailableTimer.restart();
         }

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -82,7 +82,6 @@ class Presence {
      * @param {string} newState the new presence state (see PRESENCE enum)
      */
     async setState(newState) {
-        console.log("setting Presence state!!", newState);
         if (newState === this.state) {
             return;
         }

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -17,21 +17,32 @@ limitations under the License.
 
 const MatrixClientPeg = require("./MatrixClientPeg");
 const dis = require("./dispatcher");
+import Timer from './utils/Timer';
 
  // Time in ms after that a user is considered as unavailable/away
 const UNAVAILABLE_TIME_MS = 3 * 60 * 1000; // 3 mins
 const PRESENCE_STATES = ["online", "offline", "unavailable"];
 
 class Presence {
+
+    constructor() {
+        this._activitySignal = null;
+        this._unavailableTimer = new Timer(UNAVAILABLE_TIME_MS);
+        this._onAction = this._onAction.bind(this);
+        this._dispatcherRef = null;
+    }
     /**
      * Start listening the user activity to evaluate his presence state.
      * Any state change will be sent to the Home Server.
      */
-    start() {
-        this.running = true;
-        if (undefined === this.state) {
-            this._resetTimer();
-            this.dispatcherRef = dis.register(this._onAction.bind(this));
+    async start() {
+        // the user_activity_start action starts the timer
+        this._dispatcherRef = dis.register(this._onAction);
+        while (this._unavailableTimer) {
+            try {
+                await this._unavailableTimer.promise(); // won't resolve until started
+                this.setState("unavailable");
+            } catch(e) { /* aborted, stop got called */ }
         }
     }
 
@@ -39,13 +50,12 @@ class Presence {
      * Stop tracking user activity
      */
     stop() {
-        this.running = false;
-        if (this.timer) {
-            clearInterval(this.timer);
-            this.timer = undefined;
-            dis.unregister(this.dispatcherRef);
+        if (this._dispatcherRef) {
+            dis.unregister(this._dispatcherRef);
+            this._dispatcherRef = null;
         }
-        this.state = undefined;
+        this._unavailableTimer.abort();
+        this._unavailableTimer = null;
     }
 
     /**
@@ -56,20 +66,25 @@ class Presence {
         return this.state;
     }
 
+    _onAction(payload) {
+        if (payload.action === 'user_activity_start') {
+            this.setState("online");
+            this._unavailableTimer =
+                this._unavailableTimer.cloneIfRun().restart();
+        }
+    }
+
     /**
      * Set the presence state.
      * If the state has changed, the Home Server will be notified.
      * @param {string} newState the new presence state (see PRESENCE enum)
      */
-    setState(newState) {
+    async setState(newState) {
         if (newState === this.state) {
             return;
         }
         if (PRESENCE_STATES.indexOf(newState) === -1) {
             throw new Error("Bad presence state: " + newState);
-        }
-        if (!this.running) {
-            return;
         }
         const old_state = this.state;
         this.state = newState;
@@ -78,41 +93,13 @@ class Presence {
             return; // don't try to set presence when a guest; it won't work.
         }
 
-        const self = this;
-        MatrixClientPeg.get().setPresence(this.state).done(function() {
+        try {
+            await MatrixClientPeg.get().setPresence(this.state);
             console.log("Presence: %s", newState);
-        }, function(err) {
+        } catch(err) {
             console.error("Failed to set presence: %s", err);
-            self.state = old_state;
-        });
-    }
-
-    /**
-     * Callback called when the user made no action on the page for UNAVAILABLE_TIME ms.
-     * @private
-     */
-    _onUnavailableTimerFire() {
-        this.setState("unavailable");
-    }
-
-    _onAction(payload) {
-        if (payload.action === "user_activity") {
-            this._resetTimer();
+            this.state = old_state;
         }
-    }
-
-    /**
-     * Callback called when the user made an action on the page
-     * @private
-     */
-    _resetTimer() {
-        const self = this;
-        this.setState("online");
-        // Re-arm the timer
-        clearTimeout(this.timer);
-        this.timer = setTimeout(function() {
-            self._onUnavailableTimerFire();
-        }, UNAVAILABLE_TIME_MS);
     }
 }
 

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -27,7 +27,7 @@ class Presence {
 
     constructor() {
         this._activitySignal = null;
-        this._unavailableTimer = new Timer(UNAVAILABLE_TIME_MS);
+        this._unavailableTimer = null;
         this._onAction = this._onAction.bind(this);
         this._dispatcherRef = null;
     }
@@ -36,6 +36,7 @@ class Presence {
      * Any state change will be sent to the Home Server.
      */
     async start() {
+        this._unavailableTimer = new Timer(UNAVAILABLE_TIME_MS);
         // the user_activity_start action starts the timer
         this._dispatcherRef = dis.register(this._onAction);
         while (this._unavailableTimer) {

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -40,7 +40,7 @@ class Presence {
         this._dispatcherRef = dis.register(this._onAction);
         while (this._unavailableTimer) {
             try {
-                await this._unavailableTimer.promise(); // won't resolve until started
+                await this._unavailableTimer.finished();
                 this.setState("unavailable");
             } catch(e) { /* aborted, stop got called */ }
         }
@@ -69,8 +69,7 @@ class Presence {
     _onAction(payload) {
         if (payload.action === 'user_activity_start') {
             this.setState("online");
-            this._unavailableTimer =
-                this._unavailableTimer.cloneIfRun().restart();
+            this._unavailableTimer.restart();
         }
     }
 
@@ -80,6 +79,7 @@ class Presence {
      * @param {string} newState the new presence state (see PRESENCE enum)
      */
     async setState(newState) {
+        console.log("setting Presence state!!", newState);
         if (newState === this.state) {
             return;
         }

--- a/src/Presence.js
+++ b/src/Presence.js
@@ -55,8 +55,10 @@ class Presence {
             dis.unregister(this._dispatcherRef);
             this._dispatcherRef = null;
         }
-        this._unavailableTimer.abort();
-        this._unavailableTimer = null;
+        if (this._unavailableTimer) {
+            this._unavailableTimer.abort();
+            this._unavailableTimer = null;
+        }
     }
 
     /**

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -129,6 +129,7 @@ class UserActivity {
             this.lastScreenY = event.screenY;
         }
 
+        dis.dispatch({action: 'user_activity'});
         if (!this._activityTimeout.isRunning()) {
             this._activityTimeout.start();
             dis.dispatch({action: 'user_activity_start'});

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -29,7 +29,6 @@ const CURRENTLY_ACTIVE_THRESHOLD_MS = 2 * 60 * 1000;
  * and starts/stops attached timers while the user is active.
  */
 class UserActivity {
-
     constructor() {
         this._attachedTimers = [];
         this._activityTimeout = new Timer(CURRENTLY_ACTIVE_THRESHOLD_MS);
@@ -41,12 +40,10 @@ class UserActivity {
     }
 
     /**
-     * Runs the given timer (or the returned copy if it ran already)
-     * while the user is active, aborting when the user becomes inactive.
+     * Runs the given timer while the user is active, aborting when the user becomes inactive.
      * Can be called multiple times with the same already running timer, which is a NO-OP.
-     * Can be called before the user becomes active,
-     * in which case it is only started later on when the user does become active.
-     * @return {Timer} the timer, or a clone
+     * Can be called before the user becomes active, in which case it is only started
+     * later on when the user does become active.
      */
     timeWhileActive(timer) {
         // important this happens first
@@ -59,8 +56,9 @@ class UserActivity {
                 if (index !== -1) { // should never be -1
                     this._attachedTimers.splice(index, 1);
                 }
-            }).catch((err) => {});  // as we fork the promise here,
-                                    // avoid unhandled rejection warnings
+            // as we fork the promise here,
+            // avoid unhandled rejection warnings
+            }).catch((err) => {});
         }
         if (this.userCurrentlyActive()) {
             timer.start();
@@ -137,7 +135,7 @@ class UserActivity {
             this._attachedTimers.forEach((t) => t.start());
             try {
                 await this._activityTimeout.finished();
-            } catch(_e) { /* aborted */ }
+            } catch (_e) { /* aborted */ }
             this._attachedTimers.forEach((t) => t.abort());
         } else {
             this._activityTimeout.restart();

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -134,12 +134,10 @@ class UserActivity {
         if (!this._activityTimeout.isRunning()) {
             this._activityTimeout.start();
             dis.dispatch({action: 'user_activity_start'});
-            console.log("user is active now");
             this._attachedTimers.forEach((t) => t.start());
             try {
                 await this._activityTimeout.finished();
             } catch(_e) { /* aborted */ }
-            console.log("user is inactive now");
             this._attachedTimers.forEach((t) => t.abort());
         } else {
             this._activityTimeout.restart();

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -43,12 +43,11 @@ class UserActivity {
      */
     timeWhileActive(timer) {
         // important this happens first
-        timer = timer.cloneIfRun();
         const index = this._attachedTimers.indexOf(timer);
         if (index === -1) {
             this._attachedTimers.push(timer);
             // remove when done or aborted
-            timer.promise().finally(() => {
+            timer.finished().finally(() => {
                 const index = this._attachedTimers.indexOf(timer);
                 if (index !== -1) { // should not happen
                     this._attachedTimers.splice(index, 1);
@@ -59,7 +58,6 @@ class UserActivity {
         if (this.userCurrentlyActive()) {
             timer.start();
         }
-        return timer;
     }
 
     /**
@@ -108,12 +106,11 @@ class UserActivity {
         }
 
         if (!this._activityTimeout.isRunning()) {
-            this._activityTimeout = this._activityTimeout.clone();
             this._activityTimeout.start();
             console.log("user is active now");
             dis.dispatch({action: 'user_activity_start'});
             this._attachedTimers.forEach((t) => t.start());
-            await this._activityTimeout.promise();
+            await this._activityTimeout.finished();
             this._attachedTimers.forEach((t) => t.abort());
             console.log("user is inactive now");
         } else {

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1794,14 +1794,10 @@ module.exports = React.createClass({
         let topUnreadMessagesBar = null;
         if (this.state.showTopUnreadMessagesBar) {
             const TopUnreadMessagesBar = sdk.getComponent('rooms.TopUnreadMessagesBar');
-            topUnreadMessagesBar = (
-                <div className="mx_RoomView_topUnreadMessagesBar">
-                    <TopUnreadMessagesBar
-                       onScrollUpClick={this.jumpToReadMarker}
-                       onCloseClick={this.forgetReadMarker}
-                    />
-                </div>
-            );
+            topUnreadMessagesBar = (<TopUnreadMessagesBar
+                                       onScrollUpClick={this.jumpToReadMarker}
+                                       onCloseClick={this.forgetReadMarker}
+                                    />);
         }
         const statusBarAreaClass = classNames(
             "mx_RoomView_statusArea",
@@ -1838,9 +1834,11 @@ module.exports = React.createClass({
                 <MainSplit panel={rightPanel} collapsedRhs={this.props.collapsedRhs}>
                     <div className={fadableSectionClasses}>
                         { auxPanel }
-                        { topUnreadMessagesBar }
-                        { messagePanel }
-                        { searchResultsPanel }
+                        <div className="mx_RoomView_timeline">
+                            { topUnreadMessagesBar }
+                            { messagePanel }
+                            { searchResultsPanel }
+                        </div>
                         <div className={statusBarAreaClass}>
                             <div className="mx_RoomView_statusAreaBox">
                                 <div className="mx_RoomView_statusAreaBox_line"></div>

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1795,7 +1795,6 @@ module.exports = React.createClass({
         if (this.state.showTopUnreadMessagesBar) {
             const TopUnreadMessagesBar = sdk.getComponent('rooms.TopUnreadMessagesBar');
             topUnreadMessagesBar = (<TopUnreadMessagesBar
-                                       messageCount={this.refs.messagePanel ? this.refs.messagePanel.getMessageCountToReadMarker() : undefined}
                                        onScrollUpClick={this.jumpToReadMarker}
                                        onCloseClick={this.forgetReadMarker}
                                     />);

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1795,6 +1795,7 @@ module.exports = React.createClass({
         if (this.state.showTopUnreadMessagesBar) {
             const TopUnreadMessagesBar = sdk.getComponent('rooms.TopUnreadMessagesBar');
             topUnreadMessagesBar = (<TopUnreadMessagesBar
+                                       messageCount={this.refs.messagePanel ? this.refs.messagePanel.getMessageCountToReadMarker() : undefined}
                                        onScrollUpClick={this.jumpToReadMarker}
                                        onCloseClick={this.forgetReadMarker}
                                     />);

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -971,7 +971,6 @@ var TimelinePanel = React.createClass({
                 }
 
                 this.sendReadReceipt();
-                this.updateReadMarker();
             });
         };
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -749,6 +749,16 @@ var TimelinePanel = React.createClass({
         this._loadTimeline(this.state.readMarkerEventId, 0, 1/3);
     },
 
+    getMessageCountToReadMarker: function() {
+        const events = this._timelineWindow.getEvents();
+        const markerId = this.state.readMarkerEventId;
+        const markerIndex = events.findIndex((e) => e.getId() === markerId);
+        if (markerIndex === -1) {
+            return {atLeast: events.length};
+        } else {
+            return {exact: events.length - markerIndex - 1};
+        }
+    },
 
     /* update the read-up-to marker to match the read receipt
      */

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -749,17 +749,6 @@ var TimelinePanel = React.createClass({
         this._loadTimeline(this.state.readMarkerEventId, 0, 1/3);
     },
 
-    getMessageCountToReadMarker: function() {
-        const events = this._timelineWindow.getEvents();
-        const markerId = this.state.readMarkerEventId;
-        const markerIndex = events.findIndex((e) => e.getId() === markerId);
-        if (markerIndex === -1) {
-            return {atLeast: events.length};
-        } else {
-            return {exact: events.length - markerIndex - 1};
-        }
-    },
-
     /* update the read-up-to marker to match the read receipt
      */
     forgetReadMarker: function() {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -536,11 +536,12 @@ var TimelinePanel = React.createClass({
     updateReadMarkerOnUserActivity: async function() {
         this._readMarkerActivityTimer = new Timer(10000);
         while (this._readMarkerActivityTimer) { //unset on unmount
-            this._readMarkerActivityTimer =
-                UserActivity.timeWhileActive(this._readMarkerActivityTimer);
+            console.log("updateReadMarkerOnUserActivity iteration")
+            UserActivity.timeWhileActive(this._readMarkerActivityTimer);
             try {
-                await this._readMarkerActivityTimer.promise();
+                await this._readMarkerActivityTimer.finished();
             } catch(e) { continue; /* aborted */ }
+            // outside of try/catch to not swallow errors
             this.updateReadMarker();
         }
     },
@@ -548,11 +549,12 @@ var TimelinePanel = React.createClass({
     updateReadReceiptOnUserActivity: async function() {
         this._readReceiptActivityTimer = new Timer(500);
         while (this._readReceiptActivityTimer) { //unset on unmount
-            this._readReceiptActivityTimer =
-                UserActivity.timeWhileActive(this._readReceiptActivityTimer);
+            console.log("updateReadReceiptOnUserActivity iteration")
+            UserActivity.timeWhileActive(this._readReceiptActivityTimer);
             try {
-                await this._readReceiptActivityTimer.promise();
+                await this._readReceiptActivityTimer.finished();
             } catch(e) { continue; /* aborted */ }
+            // outside of try/catch to not swallow errors
             this.sendReadReceipt();
         }
     },

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -190,10 +190,10 @@ var TimelinePanel = React.createClass({
         this.lastRMSentEventId = undefined;
 
         if (this.props.manageReadReceipts) {
-            this.updateReadReceiptOnActivity();
+            this.updateReadReceiptOnUserActivity();
         }
         if (this.props.manageReadMarkers) {
-            this.updateReadMarkerOnActivity();
+            this.updateReadMarkerOnUserActivity();
         }
 
         this.dispatcherRef = dis.register(this.onAction);
@@ -533,7 +533,7 @@ var TimelinePanel = React.createClass({
         this.setState({clientSyncState: state});
     },
 
-    updateReadMarkerOnActivity: async function() {
+    updateReadMarkerOnUserActivity: async function() {
         this._readMarkerActivityTimer = new Timer(10000);
         while (this._readMarkerActivityTimer) { //unset on unmount
             this._readMarkerActivityTimer =
@@ -545,7 +545,7 @@ var TimelinePanel = React.createClass({
         }
     },
 
-    updateReadReceiptOnActivity: async function() {
+    updateReadReceiptOnUserActivity: async function() {
         this._readReceiptActivityTimer = new Timer(500);
         while (this._readReceiptActivityTimer) { //unset on unmount
             this._readReceiptActivityTimer =

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -880,14 +880,10 @@ var TimelinePanel = React.createClass({
 
     canJumpToReadMarker: function() {
         // 1. Do not show jump bar if neither the RM nor the RR are set.
-        // 2. Only show jump bar if RR !== RM. If they are the same, there are only fully
-        // read messages and unread messages. We already have a badge count and the bottom
-        // bar to jump to "live" when we have unread messages.
         // 3. We want to show the bar if the read-marker is off the top of the screen.
         // 4. Also, if pos === null, the event might not be paginated - show the unread bar
         const pos = this.getReadMarkerPosition();
         return this.state.readMarkerEventId !== null && // 1.
-            this.state.readMarkerEventId !== this._getCurrentReadReceipt() && // 2.
             (pos < 0 || pos === null); // 3., 4.
     },
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -681,8 +681,6 @@ var TimelinePanel = React.createClass({
             // we don't want to rewind it.
             return;
         }
-
-        console.log("Updating the RM!!");
         // move the RM to *after* the message at the bottom of the screen. This
         // avoids a problem whereby we never advance the RM if there is a huge
         // message which doesn't fit on the screen.
@@ -870,7 +868,6 @@ var TimelinePanel = React.createClass({
         const pos = this.getReadMarkerPosition();
         const ret = this.state.readMarkerEventId !== null && // 1.
             (pos < 0 || pos === null); // 3., 4.
-        console.log("canJumpToReadMarker? ", ret);
         return ret;
     },
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -266,11 +266,14 @@ var TimelinePanel = React.createClass({
         //
         // (We could use isMounted, but facebook have deprecated that.)
         this.unmounted = true;
-
-        this._readReceiptActivityTimer.abort();
-        this._readReceiptActivityTimer = null;
-        this._readMarkerActivityTimer.abort();
-        this._readMarkerActivityTimer = null;
+        if (this._readReceiptActivityTimer) {
+            this._readReceiptActivityTimer.abort();
+            this._readReceiptActivityTimer = null;
+        }
+        if (this._readMarkerActivityTimer) {
+            this._readMarkerActivityTimer.abort();
+            this._readMarkerActivityTimer = null;
+        }
 
         dis.unregister(this.dispatcherRef);
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -387,12 +387,11 @@ var TimelinePanel = React.createClass({
                 this.setState({readMarkerVisible: true});
             }
 
-            // if read marker position goes between 0 and -1/1, (and user is active), switch timeout
-            if (rmPosition === 0) {
-                this._readMarkerActivityTimer.changeTimeout(READ_MARKER_INVIEW_THRESHOLD_MS);
-            } else {
-                this._readMarkerActivityTimer.changeTimeout(READ_MARKER_OUTOFVIEW_THRESHOLD_MS);
-            }
+            // if read marker position goes between 0 and -1/1,
+            // (and user is active), switch timeout
+            const timeout = this._readMarkerTimeout(rmPosition);
+            // NO-OP when timeout already has set to the given value
+            this._readMarkerActivityTimer.changeTimeout(timeout);
         }
     },
 
@@ -544,11 +543,14 @@ var TimelinePanel = React.createClass({
         this.setState({clientSyncState: state});
     },
 
-    updateReadMarkerOnUserActivity: async function() {
-        const initialTimeout = this.getReadMarkerPosition() === 0 ?
+    _readMarkerTimeout(readMarkerPosition) {
+        return readMarkerPosition === 0 ?
             READ_MARKER_INVIEW_THRESHOLD_MS :
             READ_MARKER_OUTOFVIEW_THRESHOLD_MS;
+    },
 
+    updateReadMarkerOnUserActivity: async function() {
+        const initialTimeout = this._readMarkerTimeout(this.getReadMarkerPosition());
         this._readMarkerActivityTimer = new Timer(initialTimeout);
 
         while (this._readMarkerActivityTimer) { //unset on unmount

--- a/src/components/views/rooms/TopUnreadMessagesBar.js
+++ b/src/components/views/rooms/TopUnreadMessagesBar.js
@@ -21,6 +21,8 @@ const React = require('react');
 import PropTypes from 'prop-types';
 import { _t } from '../../../languageHandler';
 import AccessibleButton from '../elements/AccessibleButton';
+import {formatCount} from '../../../utils/FormattingUtils';
+
 const sdk = require('../../../index');
 
 module.exports = React.createClass({
@@ -28,17 +30,25 @@ module.exports = React.createClass({
 
     propTypes: {
         onScrollUpClick: PropTypes.func,
-        onCloseClick: PropTypes.func,
     },
 
     render: function() {
+        let badgeLabel = "?";
+        const count = this.props.messageCount;
+        if (count) {
+            if (count.exact) {
+                badgeLabel = formatCount(this.props.messageCount.exact);
+            } else if (count.atLeast) {
+                badgeLabel = `+${formatCount(this.props.messageCount.atLeast)}`;
+            }
+        }
         return (
             <div className="mx_TopUnreadMessagesBar">
                 <AccessibleButton className="mx_TopUnreadMessagesBar_scrollUp"
                     title={_t('Jump to first unread message.')}
                     onClick={this.props.onScrollUpClick}>
                     <div className="mx_TopUnreadMessagesBar_badgeContainer">
-                        <div className="mx_TopUnreadMessagesBar_badge">x</div>
+                        <div className="mx_TopUnreadMessagesBar_badge">{badgeLabel}</div>
                     </div>
                 </AccessibleButton>
             </div>

--- a/src/components/views/rooms/TopUnreadMessagesBar.js
+++ b/src/components/views/rooms/TopUnreadMessagesBar.js
@@ -33,23 +33,11 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        let badgeLabel = "?";
-        const count = this.props.messageCount;
-        if (count) {
-            if (count.exact) {
-                badgeLabel = formatCount(this.props.messageCount.exact);
-            } else if (count.atLeast) {
-                badgeLabel = `+${formatCount(this.props.messageCount.atLeast)}`;
-            }
-        }
         return (
             <div className="mx_TopUnreadMessagesBar">
                 <AccessibleButton className="mx_TopUnreadMessagesBar_scrollUp"
                     title={_t('Jump to first unread message.')}
                     onClick={this.props.onScrollUpClick}>
-                    <div className="mx_TopUnreadMessagesBar_badgeContainer">
-                        <div className="mx_TopUnreadMessagesBar_badge">{badgeLabel}</div>
-                    </div>
                 </AccessibleButton>
             </div>
         );

--- a/src/components/views/rooms/TopUnreadMessagesBar.js
+++ b/src/components/views/rooms/TopUnreadMessagesBar.js
@@ -35,21 +35,12 @@ module.exports = React.createClass({
         return (
             <div className="mx_TopUnreadMessagesBar">
                 <AccessibleButton className="mx_TopUnreadMessagesBar_scrollUp"
-                        onClick={this.props.onScrollUpClick}>
-                    <img src="img/scrollto.svg" width="24" height="24"
-                        // No point on setting up non empty alt on this image
-                        // as it only complements the text which follows it.
-                        alt=""
-                        title={_t('Scroll to unread messages')}
-                        // In order not to use this title attribute for accessible name
-                        // calculation of the parent button set the role presentation
-                        role="presentation" />
-                    { _t("Jump to first unread message.") }
+                    title={_t('Jump to first unread message.')}
+                    onClick={this.props.onScrollUpClick}>
+                    <div className="mx_TopUnreadMessagesBar_badgeContainer">
+                        <div className="mx_TopUnreadMessagesBar_badge">x</div>
+                    </div>
                 </AccessibleButton>
-                <AccessibleButton element='img' className="mx_TopUnreadMessagesBar_close mx_filterFlipColor"
-                    src="img/cancel.svg" width="18" height="18"
-                    alt={_t("Close")} title={_t("Close")}
-                    onClick={this.props.onCloseClick} />
             </div>
         );
     },

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -604,7 +604,6 @@
     "Stickerpack": "Stickerpack",
     "Hide Stickers": "Hide Stickers",
     "Show Stickers": "Show Stickers",
-    "Scroll to unread messages": "Scroll to unread messages",
     "Jump to first unread message.": "Jump to first unread message.",
     "Invalid alias format": "Invalid alias format",
     "'%(alias)s' is not a valid format for an alias": "'%(alias)s' is not a valid format for an alias",

--- a/src/utils/Timer.js
+++ b/src/utils/Timer.js
@@ -60,7 +60,6 @@ export default class Timer {
         if (timeout === this._timeout) {
             return;
         }
-        console.log(`changing timer timeout from ${this._timeout} to ${timeout}`);
         const isSmallerTimeout = timeout < this._timeout;
         this._timeout = timeout;
         if (this.isRunning() && isSmallerTimeout) {

--- a/src/utils/Timer.js
+++ b/src/utils/Timer.js
@@ -1,0 +1,131 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+A countdown timer, exposing a promise api.
+A timer starts in a non-started state,
+and needs to be started by calling `start()`` on it first.
+
+Timers can be `abort()`-ed which makes the promise reject prematurely.
+
+Once a timer is finished or aborted, it can't be started again
+(because the promise should not be replaced). Instead, create
+a new one through `clone()` or `cloneIfRun()`.
+*/
+export default class Timer {
+
+    constructor(timeout) {
+        this._timeout = timeout;
+        this._timerHandle = null;
+        this._onTimeout = this._onTimeout.bind(this);
+        this._startTs = null;
+        this._promise = new Promise((resolve, reject) => {
+            this._resolve = resolve;
+            this._reject = reject;
+        }).finally(() => {
+            this._timerHandle = null;
+        });
+    }
+
+    _onTimeout() {
+        const now = Date.now();
+        const elapsed = now - this._startTs;
+        if (elapsed >= this._timeout) {
+            this._resolve();
+        } else {
+            const delta = this._timeout - elapsed;
+            this._timerHandle = setTimeout(this._onTimeout, delta);
+        }
+    }
+
+    /**
+     * if not started before, starts the timer.
+     */
+    start() {
+        if (!this._wasStarted() && !this.isRunning()) {
+            this._startTs = Date.now();
+            this._timerHandle = setTimeout(this._onTimeout, this._timeout);
+        }
+        return this;
+    }
+
+    /**
+     * (re)start the timer. If it's running, reset the timeout. If not, start it.
+     */
+    restart() {
+        if (this.isRunning()) {
+            // don't clearTimeout here as this method
+            // can be called in fast succession,
+            // instead just take note and compare
+            // when the already running timeout expires
+            this._startTs = Date.now();
+            return this;
+        } else {
+            return this.start();
+        }
+    }
+
+    /**
+     * if the timer is running, abort it,
+     * and reject the promise for this timer.
+     */
+    abort() {
+        if (this.isRunning()) {
+            console.log("clearTimeout in abort");
+            clearTimeout(this._timerHandle);
+            this._reject(new Error("Timer was aborted."));
+        }
+        return this;
+    }
+
+    /**
+     * creates a new timer with the same timeout
+     * @return {Timer} a new timer
+     */
+    clone() {
+        return new Timer(this._timeout);
+    }
+
+    /**
+     * Clones the timer if its promise resolved already,
+     * otherwise returns the same instance
+     * @return {Timer} a new or the same timer
+     */
+    cloneIfRun() {
+        if (this._wasStarted() && !this.isRunning()) {
+            return this.clone();
+        } else {
+            return this;
+        }
+    }
+
+    /**
+     *promise that will resolve when the timer elapses,
+     *or is rejected when abort is called
+     *@return {Promise}
+     */
+    promise() {
+        return this._promise;
+    }
+
+    isRunning() {
+        return this._timerHandle !== null;
+    }
+
+    _wasStarted() {
+        return this._startTs !== null;
+    }
+}

--- a/src/utils/Timer.js
+++ b/src/utils/Timer.js
@@ -56,6 +56,19 @@ export default class Timer {
         }
     }
 
+    changeTimeout(timeout) {
+        if (timeout === this._timeout) {
+            return;
+        }
+        console.log(`changing timer timeout from ${this._timeout} to ${timeout}`);
+        const isSmallerTimeout = timeout < this._timeout;
+        this._timeout = timeout;
+        if (this.isRunning() && isSmallerTimeout) {
+            clearTimeout(this._timerHandle);
+            this._onTimeout();
+        }
+    }
+
     /**
      * if not started before, starts the timer.
      */
@@ -89,7 +102,6 @@ export default class Timer {
      */
     abort() {
         if (this.isRunning()) {
-            console.log("clearTimeout in abort");
             clearTimeout(this._timerHandle);
             this._reject(new Error("Timer was aborted."));
             this._setNotStarted();


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7591

![image](https://user-images.githubusercontent.com/274386/49446313-cfb57e80-f7cb-11e8-852c-b05439244e45.png)

The read marker logic is also changed, as https://github.com/vector-im/riot-web/issues/4134 has been a long outstanding issue, and making the feature look different without making it work well didn't make sense.

The read marker is now also updated if it is currently above the viewport:
 - if the marker is currently above the viewport, the timeout to move it is 30s.
 - if the marker is within the viewport, the timeout to move it is 10s.
After the timeout elapses, the read marker is moved below the last event in the viewport when timeout elapses, as before.

The timeout is aborted when the user becomes inactive. The read marker is not touched, and the timer starts counting again once the user is active again. What is considered user activity changed a bit as well: the user is considered active when activating the tab/window, moving the mouse or scrollwheel, or using the keyboard. The user is considered inactive when blurring the window/tab, or 2 minutes have elapsed since the last interaction event was fired. This to prevent the read marker being updated when we know the user is not looking at the page.

Also added a Timer class using promises as the clear/setTimeout's were going to grow a bit unwieldy. Should be reusable for other timeout related usecases.

I'm not doing the badge count for now, as many rooms have gaps in their timeline so we can't give an accurate number of messages since the unread marker. Tried it and it looks confusing.

Parked the work for the badge on the `bwindels/jumptofirstunread-badgecount` branch (also on js-sdk) if we ever want to get back to it.