### PR TITLE
Ship the babelrc file to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "files": [
+    ".babelrc",
     ".eslintrc.js",
     "CHANGELOG.md",
     "CONTRIBUTING.rst",


### PR DESCRIPTION
We ship the source files, so it probably makes sense to ship the
babelrc that tells you how to compile them.