### PR TITLE
Show the IncomingCallBox if the call is for the RoomSubList

### DIFF
--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -327,17 +327,10 @@ const RoomSubList = React.createClass({
 
         let incomingCall;
         if (this.props.incomingCall) {
-            const self = this;
-            // Check if the incoming call is for this section
-            const incomingCallRoom = this.props.list.filter(function(room) {
-                return self.props.incomingCall.roomId === room.roomId;
-            });
-
-            if (incomingCallRoom.length === 1) {
-                const IncomingCallBox = sdk.getComponent("voip.IncomingCallBox");
-                incomingCall =
-                    <IncomingCallBox className="mx_RoomSubList_incomingCall" incomingCall={this.props.incomingCall} />;
-            }
+            // We can assume that if we have an incoming call then it is for this list
+            const IncomingCallBox = sdk.getComponent("voip.IncomingCallBox");
+            incomingCall =
+                <IncomingCallBox className="mx_RoomSubList_incomingCall" incomingCall={this.props.incomingCall} />;
         }
 
         const tabindex = this.props.searchFilter === "" ? "0" : "-1";


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4369

Previously the RoomSubList would filter its list of rooms to verify that the incoming call belongs to it. This causes problems when the sub list is being told some rooms don't exist (ie: the list is filtered). It is trivial for the RoomList to instead track which RoomSubList (tag) it should be handing the call off to so we do that instead now. The RoomSubList trusts that the caller has already filtered it and will render the IncomingCallBox if it has an incoming call.