### PR TITLE
Redesign: fix add room button alignment when collapsed

### DIFF
--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -192,7 +192,7 @@ limitations under the License.
 
     .mx_RoomSubList_addRoom {
         margin-left: 3px;
-        margin-right: 28px;
+        margin-right: 10px;
     }
 
     .mx_RoomSubList_label > span {


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7778
Before:
![image](https://user-images.githubusercontent.com/274386/49799410-c5036800-fd3c-11e8-9aa1-e26684456a7d.png)
After:
![image](https://user-images.githubusercontent.com/274386/49799380-b61cb580-fd3c-11e8-897e-2eeb6d6bd135.png)
