### PR TITLE
Redesign: fix room header avatar in edit mode

### DIFF
--- a/res/css/views/rooms/_RoomHeader.scss
+++ b/res/css/views/rooms/_RoomHeader.scss
@@ -179,13 +179,13 @@ limitations under the License.
 }
 
 .mx_RoomHeader_avatarPicker {
-    margin-top: 23px;
     position: relative;
 }
 
 .mx_RoomHeader_avatarPicker_edit {
-    margin-left: 16px;
-    margin-top: 4px;
+    position: absolute;
+    left: 16px;
+    top: 18px;
 }
 
 .mx_RoomHeader_avatarPicker_edit > label {


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7779

![editroomheader](https://user-images.githubusercontent.com/274386/49800362-380dde00-fd3f-11e8-9372-ab119c4b7c53.gif)
