### PR TITLE
Change room recovery reminder button style

### DIFF
--- a/res/css/views/rooms/_RoomRecoveryReminder.scss
+++ b/res/css/views/rooms/_RoomRecoveryReminder.scss
@@ -40,4 +40,5 @@ limitations under the License.
 
 .mx_RoomRecoveryReminder_button.mx_RoomRecoveryReminder_secondary {
     @mixin mx_DialogButton_secondary;
+    background-color: transparent;
 }


### PR DESCRIPTION
Change the button to a transparent background so that it's less prominent and
you focus on the primary button instead.

Fixes https://github.com/vector-im/riot-web/issues/7856.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>