### PR TITLE
Redesign: give right panel default width

### DIFF
--- a/src/components/structures/MainSplit.js
+++ b/src/components/structures/MainSplit.js
@@ -41,10 +41,13 @@ export default class MainSplit extends React.Component {
             {onResized: this._onResized},
         );
         resizer.setClassNames(classNames);
-        const rhsSize = window.localStorage.getItem("mx_rhs_size");
+        let rhsSize = window.localStorage.getItem("mx_rhs_size");
         if (rhsSize !== null) {
-            resizer.forHandleAt(0).resize(parseInt(rhsSize, 10));
+            rhsSize = parseInt(rhsSize, 10);
+        } else {
+            rhsSize = 350;
         }
+        resizer.forHandleAt(0).resize(rhsSize);
 
         resizer.attach();
         this.resizer = resizer;


### PR DESCRIPTION
so it doesn't explode when going to member info panel with avatar with aspect ratio > 1 (I think). Confirmed to fix the issue.

https://github.com/vector-im/riot-web/issues/7884