### PR TITLE
Avoid 'transparent black' gradients in left panel

### DIFF
--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -170,12 +170,12 @@ limitations under the License.
 
     &.mx_IndicatorScrollbar_topOverflow::before {
         top: 0;
-        background: linear-gradient($secondary-accent-color, transparent);
+        background: linear-gradient(to top, rgba(242,245,248,0), rgba(242,245,248,1));
     }
 
     &.mx_IndicatorScrollbar_bottomOverflow::after {
         bottom: 0;
-        background: linear-gradient(transparent, $secondary-accent-color);
+        background: linear-gradient(to bottom, rgba(242,245,248,0), rgba(242,245,248,1));
     }
 }
 


### PR DESCRIPTION
Fixes the 'transparent black' gradients in the left panel in some browsers. This quick fix hard codes RGBa values, but we can avoid this when we upgrade Sass in future and instead use $transparentize.

Related reading: https://css-tricks.com/thing-know-gradients-transparent-black/

Before:
<img width="1552" alt="screenshot 2018-12-18 at 17 55 23" src="https://user-images.githubusercontent.com/4626865/50173278-d9bc9e80-02ee-11e9-8e61-0ca319bb5e7f.png">

After:
<img width="1552" alt="screenshot 2018-12-18 at 17 58 35" src="https://user-images.githubusercontent.com/4626865/50173318-f527a980-02ee-11e9-90be-0857c07ed41c.png">