### PR TITLE
Handle errors when fetching commits for changelog

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -887,6 +887,7 @@
     "What GitHub issue are these logs for?": "What GitHub issue are these logs for?",
     "Notes:": "Notes:",
     "Send logs": "Send logs",
+    "Unable to load commit detail: %(msg)s": "Unable to load commit detail: %(msg)s",
     "Unavailable": "Unavailable",
     "Changelog": "Changelog",
     "Create a new chat or reuse an existing one": "Create a new chat or reuse an existing one",


### PR DESCRIPTION
It's possible to get errors when fetching commits (for example, if the rate
limit is exceeded), so this will handle the error case and display it instead of
an infinite spinner.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>