### PR TITLE
Colour, contrast & legibility improvements

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -47,7 +47,7 @@ h2 {
 a:hover,
 a:link,
 a:visited {
-    color: $accent-color;
+    color: $accent-color-alt;
 }
 
 input[type=text], input[type=password], textarea {
@@ -301,7 +301,7 @@ textarea {
 }
 
 .mx_textButton {
-    @mixin mx_DialogButton_small;    
+    @mixin mx_DialogButton_small;
 }
 
 .mx_textButton:hover {

--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -114,7 +114,7 @@ limitations under the License.
 }
 
 .mx_RoomSubList_badgeHighlight {
-    background-color: $accent-color;
+    background-color: $warning-color;
 }
 
 .mx_RoomSubList_chevron {

--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -94,7 +94,7 @@ limitations under the License.
     font-weight: 600;
     font-size: 12px;
     padding: 0 5px;
-    background-color: $accent-color;
+    background-color: $roomtile-name-color;
 }
 
 .mx_RoomSubList_addRoom, .mx_RoomSubList_badge {
@@ -114,7 +114,7 @@ limitations under the License.
 }
 
 .mx_RoomSubList_badgeHighlight {
-    background-color: $warning-color;
+    background-color: $accent-color;
 }
 
 .mx_RoomSubList_chevron {

--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -131,12 +131,12 @@ limitations under the License.
 
 .mx_TagPanel_groupsButton > .mx_GroupsButton:before {
     mask: url('../../img/feather-icons/users.svg');
-    mask-position: center 10px;
+    mask-position: center 11px;
 }
 
 .mx_TagPanel_groupsButton > .mx_TagPanel_report:before {
     mask: url('../../img/feather-icons/life-buoy.svg');
-    mask-position: center 10px;
+    mask-position: center 9px;
 }
 
 .mx_TagPanel_groupsButton > .mx_AccessibleButton {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -445,7 +445,7 @@ limitations under the License.
 }
 
 .mx_EventTile_content .markdown-body a {
-    color: $accent-color;
+    color: $accent-color-alt;
 }
 
 .mx_EventTile_content .markdown-body .hljs {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -116,7 +116,7 @@ limitations under the License.
 }
 
 .mx_RoomTile_highlight .mx_RoomTile_badge {
-    background-color: $accent-color;
+    background-color: $warning-color;
 }
 
 .mx_RoomTile_unread, .mx_RoomTile_highlight {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -158,4 +158,3 @@ limitations under the License.
 .mx_RoomTile.mx_RoomTile_transparent:focus {
     background-color: $roomtile-transparent-focused-color;
 }
-

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -130,10 +130,6 @@ limitations under the License.
 .mx_RoomTile_selected {
     border-radius: 4px;
     background-color: $roomtile-selected-bg-color;
-
-    .mx_RoomTile_name {
-        color: $roomtile-selected-color;
-    }
 }
 
 .mx_DNDRoomTile {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -112,11 +112,11 @@ limitations under the License.
 }
 
 .mx_RoomTile_unreadNotify .mx_RoomTile_badge {
-    background-color: $accent-color;
+    background-color: $roomtile-name-color;
 }
 
 .mx_RoomTile_highlight .mx_RoomTile_badge {
-    background-color: $warning-color;
+    background-color: $accent-color;
 }
 
 .mx_RoomTile_unread, .mx_RoomTile_highlight {

--- a/res/img/feather-icons/life-buoy.svg
+++ b/res/img/feather-icons/life-buoy.svg
@@ -1,8 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+
 <svg width="22px" height="22px" viewBox="0 0 22 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-    <title>life-buoy</title>
-    <desc>Created with Sketch.</desc>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
         <g id="LifeBuoy" transform="translate(-77.000000, -862.000000)" stroke="#2E3648" stroke-width="1.6">
             <g id="Buoy" transform="translate(68.000000, 853.000000)">

--- a/res/img/feather-icons/search-input.svg
+++ b/res/img/feather-icons/search-input.svg
@@ -1,0 +1,11 @@
+
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="LifeBuoy" transform="translate(-1378.000000, -91.000000)" stroke="#61708b" stroke-width="1.6">
+            <g id="search-copy" transform="translate(1379.000000, 92.000000)">
+                <circle id="Oval" cx="6.22222222" cy="6.22222222" r="6.22222222"></circle>
+                <path d="M14,14 L10.6166667,10.6166667" id="Path"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/res/img/icons-close.svg
+++ b/res/img/icons-close.svg
@@ -75,18 +75,18 @@
 				<g
    id="icons_create_room"
    transform="translate(20,18)">
-					
+
 					<path
    id="Line"
    class="st1"
    d="M -2.5,28.5 4.6,21.4"
-   style="fill:none;stroke:#9fa9ba;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
+   style="fill:none;stroke:#454545;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
    inkscape:connector-curvature="0" />
 					<path
    id="Line_1_"
    class="st1"
    d="m -2.5,21.5 7.1,7.1"
-   style="fill:none;stroke:#9fa9ba;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
+   style="fill:none;stroke:#454545;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
    inkscape:connector-curvature="0" />
 				</g>
 			</g>

--- a/res/img/topleft-chevron.svg
+++ b/res/img/topleft-chevron.svg
@@ -64,7 +64,7 @@
     <g
        id="matrix-my-stuff-no-lines-message-context-menu-smaller-icons"
        transform="translate(-203,-25)"
-       style="stroke:#212121;stroke-width:1.29999995">
+       style="stroke:#61708b;stroke-width:1.6">
       <g
          id="Group-3"
          transform="translate(128,15)">

--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -121,13 +121,13 @@ $rte-group-pill-color: #aaa;
 
 $topleftmenu-color: #212121;
 $roomheader-color: #45474a;
-$roomheader-addroom-color: #929eb4;
+$roomheader-addroom-color: #91A1C0;
 $roomtopic-color: #9fa9ba;
 $eventtile-meta-color: $roomtopic-color;
 
 // ********************
 
-$roomtile-name-color: #929eb4;
+$roomtile-name-color: #61708b;
 $roomtile-selected-color: #212121;
 $roomtile-notified-color: #212121;
 $roomtile-selected-bg-color: #fff;
@@ -215,7 +215,10 @@ $progressbar-color: #000;
         > input[type=search] {
             border: none;
             flex: 1;
-            color: inherit; //from .mx_textinput
+            color: $primary-fg-color;
+        },
+        input::placeholder {
+          color: $roomsublist-label-fg-color;
         }
     }
 }

--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -20,19 +20,20 @@ $focus-bg-color: #dddddd;
 
 // button UI (white-on-green in light skin)
 $accent-fg-color: #ffffff;
-$accent-color: #f56679;
-$accent-color-50pct: #f56679;
+$accent-color: #7ac9a1;
+$accent-color-50pct: #92caad;
+$accent-color-alt: #238CF5;
 
 $selection-fg-color: $primary-bg-color;
 
-$focus-brightness: 125%;
+$focus-brightness: 105%;
 
 // red warning colour
-$warning-color: #ff0064;
+$warning-color: #f56679;
 // background colour for warnings
 $warning-bg-color: #DF2A8B;
 $info-bg-color: #2A9EDF;
-$mention-user-pill-bg-color: #ff0064;
+$mention-user-pill-bg-color: $warning-color;
 $other-user-pill-bg-color: rgba(0, 0, 0, 0.1);
 
 // pinned events indicator

--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -262,9 +262,11 @@ input[type=search].mx_textinput_icon {
     background-position: 10px center;
 }
 
+
+// FIXME THEME - Tint by CSS rather than referencing a duplicate asset
 input[type=text].mx_textinput_icon.mx_textinput_search,
 input[type=search].mx_textinput_icon.mx_textinput_search {
-    background-image: url('../../img/feather-icons/search.svg');
+    background-image: url('../../img/feather-icons/search-input.svg');
 }
 
 // dont search UI as not all browsers support it,


### PR DESCRIPTION
Improved colour, contrast and legibility of the left panel/room list and use of colour all round. More specifically, this PR actions:

https://github.com/vector-im/riot-web/issues/7892
https://github.com/vector-im/riot-web/issues/7887
https://github.com/vector-im/riot-web/issues/7881
https://github.com/vector-im/riot-web/issues/7891
https://github.com/vector-im/riot-web/issues/7885

During development, I lost confidence in [#7891](https://github.com/vector-im/riot-web/issues/7891
) making sense anymore while using the app with all these changes in chorus. I've left it in, to dogfood, and we can just revert commit [9b8f07c](https://github.com/matrix-org/matrix-react-sdk/commit/9b8f07c19f39f57986d4be71f89bd29374e9c692) if need be.

Looks like:

# Unreads
**Before:**
<img width="1552" alt="screenshot 2018-12-20 at 11 40 06" src="https://user-images.githubusercontent.com/4626865/50282905-249ff880-044c-11e9-97a0-577ee5d8c85d.png">
**After :**
<img width="1552" alt="screenshot 2018-12-20 at 11 27 46" src="https://user-images.githubusercontent.com/4626865/50282947-48633e80-044c-11e9-8d99-46c297cf4721.png">


# Unreads and Mentions
**Before:**
<img width="1552" alt="screenshot 2018-12-20 at 11 40 32" src="https://user-images.githubusercontent.com/4626865/50282910-2964ac80-044c-11e9-9e0e-61fcc13a4f98.png">
**After :**
<img width="1552" alt="screenshot 2018-12-20 at 11 28 10" src="https://user-images.githubusercontent.com/4626865/50282951-4c8f5c00-044c-11e9-9555-439ffa627043.png">

# Contextual colours
**Before:**
<img width="1552" alt="screenshot 2018-12-20 at 12 51 58" src="https://user-images.githubusercontent.com/4626865/50286054-12c35300-0456-11e9-96c0-a1f88aeac4c8.png">

**After :**
<img width="1552" alt="screenshot 2018-12-20 at 12 42 31" src="https://user-images.githubusercontent.com/4626865/50286068-1c4cbb00-0456-11e9-8143-388fdb9dcb9b.png">
