### PR TITLE
Redesign: Update room filter focus handling to avoid infinite loop

### DIFF
--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -151,7 +151,7 @@ const LeftPanel = React.createClass({
             }
         } while (element && !(
             classes.contains("mx_RoomTile") ||
-            classes.contains("mx_SearchBox_search")));
+            classes.contains("mx_textinput_search")));
 
         if (element) {
             element.focus();


### PR DESCRIPTION
The classes on the search box input were changed without updating the focusing
loop in the room filter which used one of these classes as a boundary condition.
This led to a case that could loop forever.

Regressed by #2267.
Fixes vector-im/riot-web#7926.