### PR TITLE
 upgrade expect from 1.16.0 to 23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "estree-walker": "^0.5.0",
     "expect": "^23.6.0",
     "flow-parser": "^0.57.3",
+    "jest-mock": "^23.2.0",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^0.2.3",
     "karma-cli": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-react": "^7.7.0",
     "estree-walker": "^0.5.0",
-    "expect": "^1.16.0",
+    "expect": "^23.6.0",
     "flow-parser": "^0.57.3",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^0.2.3",

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -54,7 +54,7 @@ describe('DecryptionFailureTracker', function() {
         // Immediately track the newest failures
         tracker.trackFailures();
 
-        expect(count).toNotBe(0, 'should track a failure for an event that failed decryption');
+        expect(count).not.toBe(0, 'should track a failure for an event that failed decryption');
 
         done();
     });

--- a/test/components/structures/GroupView-test.js
+++ b/test/components/structures/GroupView-test.js
@@ -185,21 +185,21 @@ describe('GroupView', function() {
             const avatar = ReactTestUtils.findRenderedComponentWithType(root, sdk.getComponent('avatars.GroupAvatar'));
             const img = ReactTestUtils.findRenderedDOMComponentWithTag(avatar, 'img');
             const avatarImgElement = ReactDOM.findDOMNode(img);
-            expect(avatarImgElement).toExist();
-            expect(avatarImgElement.src).toInclude(
+            expect(avatarImgElement).toBeTruthy();
+            expect(avatarImgElement.src).toContain(
                 'https://my.home.server/_matrix/media/v1/thumbnail/' +
                 'someavatarurl?width=48&height=48&method=crop',
             );
 
             const name = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_header_name');
             const nameElement = ReactDOM.findDOMNode(name);
-            expect(nameElement).toExist();
-            expect(nameElement.innerText).toInclude('The name of a community');
-            expect(nameElement.innerText).toInclude(groupId);
+            expect(nameElement).toBeTruthy();
+            expect(nameElement.innerText).toContain('The name of a community');
+            expect(nameElement.innerText).toContain(groupId);
 
             const shortDesc = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_header_shortDesc');
             const shortDescElement = ReactDOM.findDOMNode(shortDesc);
-            expect(shortDescElement).toExist();
+            expect(shortDescElement).toBeTruthy();
             expect(shortDescElement.innerText).toBe('This is a community');
         });
 
@@ -219,7 +219,7 @@ describe('GroupView', function() {
 
             const longDesc = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_groupDesc');
             const longDescElement = ReactDOM.findDOMNode(longDesc);
-            expect(longDescElement).toExist();
+            expect(longDescElement).toBeTruthy();
             expect(longDescElement.innerText).toBe('This is a LONG description.');
             expect(longDescElement.innerHTML).toBe('<div dir="auto">This is a <b>LONG</b> description.</div>');
         });
@@ -239,7 +239,7 @@ describe('GroupView', function() {
             const placeholder = ReactTestUtils
                 .findRenderedDOMComponentWithClass(root, 'mx_GroupView_groupDesc_placeholder');
             const placeholderElement = ReactDOM.findDOMNode(placeholder);
-            expect(placeholderElement).toExist();
+            expect(placeholderElement).toBeTruthy();
         });
 
         httpBackend
@@ -258,15 +258,15 @@ describe('GroupView', function() {
         const prom = waitForUpdate(groupView, 4).then(() => {
             const longDesc = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_groupDesc');
             const longDescElement = ReactDOM.findDOMNode(longDesc);
-            expect(longDescElement).toExist();
+            expect(longDescElement).toBeTruthy();
 
-            expect(longDescElement.innerHTML).toInclude('<h1>This is a more complicated group page</h1>');
-            expect(longDescElement.innerHTML).toInclude('<p>With paragraphs</p>');
-            expect(longDescElement.innerHTML).toInclude('<ul>');
-            expect(longDescElement.innerHTML).toInclude('<li>And lists!</li>');
+            expect(longDescElement.innerHTML).toContain('<h1>This is a more complicated group page</h1>');
+            expect(longDescElement.innerHTML).toContain('<p>With paragraphs</p>');
+            expect(longDescElement.innerHTML).toContain('<ul>');
+            expect(longDescElement.innerHTML).toContain('<li>And lists!</li>');
 
             const imgSrc = "https://my.home.server/_matrix/media/v1/thumbnail/someimageurl?width=800&amp;height=600";
-            expect(longDescElement.innerHTML).toInclude('<img src="' + imgSrc + '">');
+            expect(longDescElement.innerHTML).toContain('<img src="' + imgSrc + '">');
         });
 
         httpBackend
@@ -285,11 +285,11 @@ describe('GroupView', function() {
         const prom = waitForUpdate(groupView, 4).then(() => {
             const longDesc = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_groupDesc');
             const longDescElement = ReactDOM.findDOMNode(longDesc);
-            expect(longDescElement).toExist();
+            expect(longDescElement).toBeTruthy();
 
             // If this fails, the URL could be in an img `src`, which is what we care about but
             // there's no harm in keeping this simple and checking the entire HTML string.
-            expect(longDescElement.innerHTML).toExclude('evilimageurl');
+            expect(longDescElement.innerHTML).not.toContain('evilimageurl');
         });
 
         httpBackend
@@ -308,7 +308,7 @@ describe('GroupView', function() {
         const prom = waitForUpdate(groupView, 4).then(() => {
             const roomDetailList = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_RoomDetailList');
             const roomDetailListElement = ReactDOM.findDOMNode(roomDetailList);
-            expect(roomDetailListElement).toExist();
+            expect(roomDetailListElement).toBeTruthy();
         });
 
         httpBackend.when('GET', '/groups/' + groupIdEncoded + '/summary').respond(200, summaryResponse);
@@ -325,7 +325,7 @@ describe('GroupView', function() {
         const prom = waitForUpdate(groupView, 4).then(() => {
             const roomDetailList = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_RoomDetailList');
             const roomDetailListElement = ReactDOM.findDOMNode(roomDetailList);
-            expect(roomDetailListElement).toExist();
+            expect(roomDetailListElement).toBeTruthy();
 
             const roomDetailListRoomName = ReactTestUtils.findRenderedDOMComponentWithClass(
                 root,
@@ -333,7 +333,7 @@ describe('GroupView', function() {
             );
             const roomDetailListRoomNameElement = ReactDOM.findDOMNode(roomDetailListRoomName);
 
-            expect(roomDetailListRoomNameElement).toExist();
+            expect(roomDetailListRoomNameElement).toBeTruthy();
             expect(roomDetailListRoomNameElement.innerText).toEqual('Some room name');
         });
 
@@ -364,7 +364,7 @@ describe('GroupView', function() {
         const prom = waitForUpdate(groupView, 3).then(() => {
             const shortDesc = ReactTestUtils.findRenderedDOMComponentWithClass(root, 'mx_GroupView_header_shortDesc');
             const shortDescElement = ReactDOM.findDOMNode(shortDesc);
-            expect(shortDescElement).toExist();
+            expect(shortDescElement).toBeTruthy();
             expect(shortDescElement.innerText).toBe('This is a community');
         });
 

--- a/test/components/structures/login/Registration-test.js
+++ b/test/components/structures/login/Registration-test.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const jest = require('jest-mock');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-addons-test-utils');
@@ -87,8 +88,8 @@ describe('Registration', function() {
     });
 
     it('should NOT track a referral following successful registration of a non-team member', function(done) {
-        const onLoggedIn = expect.createSpy().andCall(function(creds, teamToken) {
-            expect(teamToken).toNotExist();
+        const onLoggedIn = jest.fn(function(creds, teamToken) {
+            expect(teamToken).toBeFalsy();
             done();
         });
 

--- a/test/components/views/dialogs/InteractiveAuthDialog-test.js
+++ b/test/components/views/dialogs/InteractiveAuthDialog-test.js
@@ -83,8 +83,8 @@ describe('InteractiveAuthDialog', function() {
                     submitNode = node;
                 }
             }
-            expect(passwordNode).toExist();
-            expect(submitNode).toExist();
+            expect(passwordNode).toBeTruthy();
+            expect(submitNode).toBeTruthy();
 
             // submit should be disabled
             expect(submitNode.disabled).toBe(true);

--- a/test/components/views/groups/GroupMemberList-test.js
+++ b/test/components/views/groups/GroupMemberList-test.js
@@ -114,7 +114,7 @@ describe("GroupMemberList", function() {
 
             const memberList = ReactTestUtils.findRenderedDOMComponentWithClass(root, "mx_MemberList_joined");
             const memberListElement = ReactDOM.findDOMNode(memberList);
-            expect(memberListElement).toExist();
+            expect(memberListElement).toBeTruthy();
             expect(memberListElement.innerText).toBe("Test");
         });
 
@@ -134,7 +134,7 @@ describe("GroupMemberList", function() {
 
             const memberList = ReactTestUtils.findRenderedDOMComponentWithClass(root, "mx_MemberList_joined");
             const memberListElement = ReactDOM.findDOMNode(memberList);
-            expect(memberListElement).toExist();
+            expect(memberListElement).toBeTruthy();
             expect(memberListElement.innerText).toBe("Failed to load group members");
         });
 

--- a/test/components/views/login/RegistrationForm-test.js
+++ b/test/components/views/login/RegistrationForm-test.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const jest = require('jest-mock');
 const React = require('react');
 const ReactDOM = require("react-dom");
 const ReactTestUtils = require('react-addons-test-utils');
@@ -55,14 +56,14 @@ function doInputEmail(inputEmail, onTeamSelected) {
 }
 
 function expectTeamSelectedFromEmailInput(inputEmail, expectedTeam) {
-    const onTeamSelected = expect.createSpy();
+    const onTeamSelected = jest.fn();
     doInputEmail(inputEmail, onTeamSelected);
 
     expect(onTeamSelected).toHaveBeenCalledWith(expectedTeam);
 }
 
 function expectSupportFromEmailInput(inputEmail, isSupportShown) {
-    const onTeamSelected = expect.createSpy();
+    const onTeamSelected = jest.fn();
     const res = doInputEmail(inputEmail, onTeamSelected);
 
     expect(res.state.showSupportEmail).toBe(isSupportShown);

--- a/test/components/views/rooms/MessageComposerInput-test.js
+++ b/test/components/views/rooms/MessageComposerInput-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
 import ReactDOM from 'react-dom';
-import expect, {createSpy} from 'expect';
+import expect from 'expect';
 import sinon from 'sinon';
 import Promise from 'bluebird';
 import * as testUtils from '../../../test-utils';

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -69,7 +69,7 @@ describe('RoomList', () => {
         ReactTestUtils.findRenderedComponentWithType(root, RoomList);
 
         movingRoom = createRoom({name: 'Moving room'});
-        expect(movingRoom.roomId).toNotBe(null);
+        expect(movingRoom.roomId).not.toBe(null);
 
         // Mock joined member
         myMember = new RoomMember(movingRoomId, myUserId);
@@ -139,7 +139,7 @@ describe('RoomList', () => {
             throw err;
         }
 
-        expect(expectedRoomTile).toExist();
+        expect(expectedRoomTile).toBeTruthy();
         expect(expectedRoomTile.props.room).toBe(room);
     }
 

--- a/test/components/views/rooms/RoomSettings-test.js
+++ b/test/components/views/rooms/RoomSettings-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import expect, {createSpy} from 'expect';
+import expect from 'expect';
+import jest from 'jest-mock';
 import Promise from 'bluebird';
 import * as testUtils from '../../../test-utils';
 import sdk from 'matrix-react-sdk';
@@ -18,12 +19,12 @@ describe('RoomSettings', () => {
 
     function expectSentStateEvent(roomId, eventType, expectedEventContent) {
         let found = false;
-        for (const call of client.sendStateEvent.calls) {
+        for (const call of client.sendStateEvent.mock.calls) {
             const [
                 actualRoomId,
                 actualEventType,
                 actualEventContent,
-            ] = call.arguments.slice(0, 3);
+            ] = call.slice(0, 3);
 
             if (roomId === actualRoomId && actualEventType === eventType) {
                 expect(actualEventContent).toEqual(expectedEventContent);
@@ -40,20 +41,20 @@ describe('RoomSettings', () => {
         client = MatrixClientPeg.get();
         client.credentials = {userId: '@me:domain.com'};
 
-        client.setRoomName = createSpy().andReturn(Promise.resolve());
-        client.setRoomTopic = createSpy().andReturn(Promise.resolve());
-        client.setRoomDirectoryVisibility = createSpy().andReturn(Promise.resolve());
+        client.setRoomName = jest.fn().mockReturnValue(Promise.resolve());
+        client.setRoomTopic = jest.fn().mockReturnValue(Promise.resolve());
+        client.setRoomDirectoryVisibility = jest.fn().mockReturnValue(Promise.resolve());
 
         // Covers any room state event (e.g. name, avatar, topic)
-        client.sendStateEvent = createSpy().andReturn(Promise.resolve());
+        client.sendStateEvent = jest.fn().mockReturnValue(Promise.resolve());
 
         // Covers room tagging
-        client.setRoomTag = createSpy().andReturn(Promise.resolve());
-        client.deleteRoomTag = createSpy().andReturn(Promise.resolve());
+        client.setRoomTag = jest.fn().mockReturnValue(Promise.resolve());
+        client.deleteRoomTag = jest.fn().mockReturnValue(Promise.resolve());
 
         // Covers any setting in the SettingsStore
         // (including local client settings not stored via matrix)
-        SettingsStore.setValue = createSpy().andReturn(Promise.resolve());
+        SettingsStore.setValue = jest.fn().mockReturnValue(Promise.resolve());
 
         parentDiv = document.createElement('div');
         document.body.appendChild(parentDiv);
@@ -83,9 +84,9 @@ describe('RoomSettings', () => {
 
     it('should not set when no setting is changed', (done) => {
         roomSettings.save().then(() => {
-            expect(client.sendStateEvent).toNotHaveBeenCalled();
-            expect(client.setRoomTag).toNotHaveBeenCalled();
-            expect(client.deleteRoomTag).toNotHaveBeenCalled();
+            expect(client.sendStateEvent).not.toHaveBeenCalled();
+            expect(client.setRoomTag).not.toHaveBeenCalled();
+            expect(client.deleteRoomTag).not.toHaveBeenCalled();
             done();
         });
     });
@@ -93,7 +94,7 @@ describe('RoomSettings', () => {
     // XXX: Apparently we do call SettingsStore.setValue
     xit('should not settings via the SettingsStore when no setting is changed', (done) => {
         roomSettings.save().then(() => {
-            expect(SettingsStore.setValue).toNotHaveBeenCalled();
+            expect(SettingsStore.setValue).not.toHaveBeenCalled();
             done();
         });
     });
@@ -103,7 +104,7 @@ describe('RoomSettings', () => {
         roomSettings.setName(name);
 
         roomSettings.save().then(() => {
-            expect(client.setRoomName.calls[0].arguments.slice(0, 2))
+            expect(client.setRoomName.mock.calls[0].slice(0, 2))
                 .toEqual(['!DdJkzRliezrwpNebLk:matrix.org', name]);
 
             done();
@@ -115,7 +116,7 @@ describe('RoomSettings', () => {
         roomSettings.setTopic(topic);
 
         roomSettings.save().then(() => {
-            expect(client.setRoomTopic.calls[0].arguments.slice(0, 2))
+            expect(client.setRoomTopic.mock.calls[0].slice(0, 2))
                 .toEqual(['!DdJkzRliezrwpNebLk:matrix.org', topic]);
 
             done();

--- a/test/matrix-to-test.js
+++ b/test/matrix-to-test.js
@@ -39,7 +39,7 @@ describe('matrix-to', function() {
     it('should pick no candidate servers when the room is not found', function() {
         peg.get().getRoom = () => null;
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -50,7 +50,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -74,7 +74,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(3);
         expect(pickedServers[0]).toBe("pl_95");
         // we don't check the 2nd and 3rd servers because that is done by the next test
@@ -112,7 +112,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(3);
         expect(pickedServers[0]).toBe("first");
         expect(pickedServers[1]).toBe("second");
@@ -143,7 +143,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(3);
         expect(pickedServers[0]).toBe("first");
         expect(pickedServers[1]).toBe("second");
@@ -178,7 +178,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(3);
     });
 
@@ -194,7 +194,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -210,7 +210,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -226,7 +226,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -242,7 +242,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -258,7 +258,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(1);
         expect(pickedServers[0]).toBe("example.org:8448");
     });
@@ -292,7 +292,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -325,7 +325,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(0);
     });
 
@@ -358,7 +358,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(1);
         expect(pickedServers[0]).toEqual("evilcorp.com");
     });
@@ -392,7 +392,7 @@ describe('matrix-to', function() {
             };
         };
         const pickedServers = pickServerCandidates("!somewhere:example.org");
-        expect(pickedServers).toExist();
+        expect(pickedServers).toBeTruthy();
         expect(pickedServers.length).toBe(1);
         expect(pickedServers[0]).toEqual("evilcorp.com");
     });


### PR DESCRIPTION
Change broken into three commits

1. first package json change to upgrade library
2. matcher changes required to use new version of expect
3. expect.createSpy() got replaced with jest.fn()

Fixes https://github.com/vector-im/riot-web/issues/7947
===
_Random Test Suite Feedback_
The test suite is a mix of jest spys that were coming out of expect.createSpy and sinon spy's. And you are using the jest expect lib with the karma tests. At some point I'd suggest just going all in on Jest. It would reduce the complexity of your test suite as jest provides mocking, expectations, and test running out of the box.