### PR TITLE
Tiny fixes for custom status messages on experimental

### DIFF
--- a/res/css/views/avatars/_MemberStatusMessageAvatar.scss
+++ b/res/css/views/avatars/_MemberStatusMessageAvatar.scss
@@ -17,4 +17,5 @@ limitations under the License.
 .mx_MemberStatusMessageAvatar_hasStatus {
     border: 2px solid $accent-color;
     border-radius: 40px;
+    padding-right: 0 !important; /* Override AccessibleButton styling */
 }

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -52,7 +52,7 @@ limitations under the License.
 .mx_RoomTile_nameContainer {
     display: flex;
     align-items: center;
-    width: 180px;
+    flex: 1;
     vertical-align: middle;
 }
 

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -62,11 +62,6 @@ limitations under the License.
     flex: 1;
 }
 
-.mx_RoomTile_avatar {
-    flex: 0;
-    padding: 4px;
-}
-
 .mx_RoomTile_subtext {
     display: inline-block;
     font-size: 11px;
@@ -84,11 +79,8 @@ limitations under the License.
 }
 
 .mx_RoomTile_avatar {
-    display: inline-block;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 16px;
-    padding-right: 6px;
+    flex: 0;
+    padding: 4px;
     width: 24px;
     vertical-align: middle;
 }


### PR DESCRIPTION
* Fix badges on room tiles not being right aligned - Thanks to Ryan for fixing this!
  Problem: https://t2l.io/_matrix/media/v1/download/t2l.io/da6fccb60969da1c455630faae990881
* Fix composer avatar being an oval when a custom status is set 
   Fixes this: https://t2l.io/_matrix/media/v1/download/t2l.io/0d5c7fa9a4b5bf226a020def8480a887
* Condense .mx_RoomTile_avatar properties 
   Looks like the develop->experimental merge duplicated the definition. We'll take the best of both and make it work.