### PR TITLE
Use same link style in HTML messages

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -446,6 +446,7 @@ limitations under the License.
 
 .mx_EventTile_content .markdown-body a {
     color: $accent-color-alt;
+    text-decoration: underline;
 }
 
 .mx_EventTile_content .markdown-body .hljs {


### PR DESCRIPTION
Links in HTML messages were missing the usual underline style, making them
look different from links in text messages (which already do this).

Fixes vector-im/riot-web#4655.