### PR TITLE
Restore room name ellipsis on overflow

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -41,10 +41,6 @@ limitations under the License.
     cursor: pointer;
 }
 
-.mx_LeftPanel_callView {
-
-}
-
 .mx_LeftPanel {
     flex: 1;
     overflow-x: hidden;

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -54,12 +54,14 @@ limitations under the License.
     align-items: center;
     flex: 1;
     vertical-align: middle;
+    min-width: 0;
 }
 
 .mx_RoomTile_labelContainer {
     display: flex;
     flex-direction: column;
     flex: 1;
+    min-width: 0;
 }
 
 .mx_RoomTile_subtext {
@@ -99,7 +101,6 @@ limitations under the License.
 }
 
 .mx_RoomTile_name {
-    flex: 1 5 auto;
     font-size: 14px;
     font-weight: 600;
     padding: 0 6px;


### PR DESCRIPTION
<img width="244" alt="room-name-ellip" src="https://user-images.githubusercontent.com/279572/50790582-e9435d80-1284-11e9-86d8-986aceda14e0.png">

Fixes https://github.com/vector-im/riot-web/issues/8037.