### PR TITLE
Remove unbalanced padding in create key backup dialog

### DIFF
--- a/res/css/views/dialogs/keybackup/_CreateKeyBackupDialog.scss
+++ b/res/css/views/dialogs/keybackup/_CreateKeyBackupDialog.scss
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_CreateKeyBackupDialog {
-    padding-right: 40px;
-}
-
 .mx_CreateKeyBackupDialog .mx_Dialog_title {
     /* TODO: Consider setting this for all dialog titles. */
     margin-bottom: 1em;


### PR DESCRIPTION
This padding only one side made it impossible to center things in the dialog.
Since the dialog also has nice spacing without the padding, this change removes
it.

Fixes https://github.com/vector-im/riot-web/issues/7862.