### PR TITLE
Don't reset cached room list values when they are falsey

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -277,7 +277,7 @@ class RoomListStore extends Store {
         const roomCache = this._state.roomCache;
         if (!roomCache[roomId]) roomCache[roomId] = {};
 
-        if (value) roomCache[roomId][type] = value;
+        if (typeof value !== "undefined") roomCache[roomId][type] = value;
         else delete roomCache[roomId][type];
 
         this._setState({roomCache});


### PR DESCRIPTION
`unread` and `unread-muted` store booleans in the cache, and can easily be `false`. Without this patch, both of those cached types would be cleared from the object where a later call to `getRoomState` would try and re-populate them. `getRoomState` is supposed to use the cache where possible to avoid making the more expensive calls required to calculate those booleans.

On my account in a test environment, this brings the `generateRoomLists` execution time down from ~250ms to just ~30ms. 

This still does not solve the whole issue, but should solve the more common case of performance woes for people.

Should make the app more bearable (see https://github.com/vector-im/riot-web/issues/8033)