### PR TITLE
Remove cancel button from final key backup screen

### DIFF
--- a/src/async-components/views/dialogs/keybackup/CreateKeyBackupDialog.js
+++ b/src/async-components/views/dialogs/keybackup/CreateKeyBackupDialog.js
@@ -503,7 +503,7 @@ export default React.createClass({
             <BaseDialog className='mx_CreateKeyBackupDialog'
                 onFinished={this.props.onFinished}
                 title={this._titleForPhase(this.state.phase)}
-                hasCancel={[PHASE_DONE].includes(this.state.phase)}
+                hasCancel={false}
             >
             <div>
                 {content}


### PR DESCRIPTION
Canceling the dialog once the backup was created meant onFinished
was called with false which RoomView interprets as the backup not
being done.

This does mean you can't just hit esc to clear the dialog once you're
done: if we wanted this we could fix this in a better way.

https://github.com/vector-im/riot-web/issues/8066