### PR TITLE
Use integer padding / border for avatar

### DIFF
--- a/res/css/views/avatars/_MemberStatusMessageAvatar.scss
+++ b/res/css/views/avatars/_MemberStatusMessageAvatar.scss
@@ -15,13 +15,13 @@ limitations under the License.
 */
 
 .mx_MessageComposer_avatar .mx_BaseAvatar {
-    padding: 1.5px;
-    border: 1.2px solid transparent;
-    border-radius: 14px;
+    padding: 2px;
+    border: 1px solid transparent;
+    border-radius: 15px;
 }
 
 .mx_MessageComposer_avatar .mx_BaseAvatar_initial {
-    left: 1.5px;
+    left: 2px;
 }
 
 .mx_MemberStatusMessageAvatar_hasStatus .mx_BaseAvatar {


### PR DESCRIPTION
It seems fractional spacing results in different behavior across browsers,
including unbalanced spacing, making the avatar appear uncentered.

Here we avoid this by using integers that seem to closely match the comps.

Fixes https://github.com/vector-im/riot-web/issues/8134.

Design:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/279572/51212933-643cf180-18df-11e9-9236-f4eda556132a.png">

Firefox:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/279572/51213265-33a98780-18e0-11e9-8c89-a60429d40315.png">

Chrome:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/279572/51213317-5d62ae80-18e0-11e9-8a7e-42372d9abc23.png">

Safari:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/279572/51213355-74090580-18e0-11e9-80ac-2252aa8306cf.png">
