### PR TITLE
Show spinner while waiting on status message to commit

### DIFF
--- a/res/css/views/context_menus/_StatusMessageContextMenu.scss
+++ b/res/css/views/context_menus/_StatusMessageContextMenu.scss
@@ -36,6 +36,10 @@ input.mx_StatusMessageContextMenu_message {
     color: $memberstatus-placeholder-color;
 }
 
+.mx_StatusMessageContextMenu_actionContainer {
+    display: flex;
+}
+
 .mx_StatusMessageContextMenu_submit,
 .mx_StatusMessageContextMenu_clear {
     @mixin mx_DialogButton;
@@ -43,6 +47,7 @@ input.mx_StatusMessageContextMenu_message {
     font-size: 12px;
     padding: 6px 1em;
     border: 1px solid transparent;
+    margin-right: 10px;
 }
 
 .mx_StatusMessageContextMenu_submit[disabled] {
@@ -53,4 +58,8 @@ input.mx_StatusMessageContextMenu_message {
     color: $warning-color;
     background-color: transparent;
     border: 1px solid $warning-color;
+}
+
+.mx_StatusMessageContextMenu_actionContainer .mx_Spinner {
+    justify-content: start;
 }


### PR DESCRIPTION
It can take some time to actually set the status message and see it play back as
a committed event.  This adds a spinner for immediate feedback so it's clear
that something is happening.

Fixes https://github.com/vector-im/riot-web/issues/8135.