### PR TITLE
Avoid "jumpiness" with inline typing indicator

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -171,6 +171,10 @@ limitations under the License.
 .mx_RoomView_MessageList {
     list-style-type: none;
     padding: 18px;
+    margin: 0;
+    /* needed as min-height is set to clientHeight in ScrollPanel
+    to prevent shrinking when WhoIsTypingTile is hidden */
+    box-sizing: border-box;
 }
 
 .mx_RoomView_MessageList li {

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -631,9 +631,11 @@ module.exports = React.createClass({
         }
     },
 
-    _scrollDownIfAtBottom: function() {
+    _onTypingVisible: function() {
         const scrollPanel = this.refs.scrollPanel;
-        if (scrollPanel) {
+        if (scrollPanel && scrollPanel.getScrollState().stuckAtBottom) {
+            scrollPanel.blockShrinking();
+            // scroll down if at bottom
             scrollPanel.checkScroll();
         }
     },
@@ -666,7 +668,7 @@ module.exports = React.createClass({
 
         let whoIsTyping;
         if (this.props.room) {
-            whoIsTyping = (<WhoIsTypingTile room={this.props.room} onVisible={this._scrollDownIfAtBottom} />);
+            whoIsTyping = (<WhoIsTypingTile room={this.props.room} onVisible={this._onTypingVisible} />);
         }
 
         return (

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -640,6 +640,20 @@ module.exports = React.createClass({
         }
     },
 
+    updateTimelineMinHeight: function() {
+        const scrollPanel = this.refs.scrollPanel;
+        const whoIsTyping = this.refs.whoIsTyping;
+        const isTypingVisible = whoIsTyping && whoIsTyping.isVisible();
+
+        if (scrollPanel) {
+            if (isTypingVisible) {
+                scrollPanel.blockShrinking();
+            } else {
+                scrollPanel.clearBlockShrinking();
+            }
+        }
+    },
+
     onResize: function() {
         dis.dispatch({ action: 'timeline_resize' }, true);
     },
@@ -668,7 +682,7 @@ module.exports = React.createClass({
 
         let whoIsTyping;
         if (this.props.room) {
-            whoIsTyping = (<WhoIsTypingTile room={this.props.room} onVisible={this._onTypingVisible} />);
+            whoIsTyping = (<WhoIsTypingTile room={this.props.room} onVisible={this._onTypingVisible} ref="whoIsTyping" />);
         }
 
         return (

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -223,6 +223,8 @@ module.exports = React.createClass({
 
     onResize: function() {
         this.props.onResize();
+        // clear min-height as the height might have changed
+        this.clearBlockShrinking();
         this.checkScroll();
         if (this._gemScroll) this._gemScroll.forceUpdate();
     },
@@ -372,6 +374,8 @@ module.exports = React.createClass({
             }
             this._unfillDebouncer = setTimeout(() => {
                 this._unfillDebouncer = null;
+                // if timeline shrinks, min-height should be cleared
+                this.clearBlockShrinking();
                 this.props.onUnfillRequest(backwards, markerScrollToken);
             }, UNFILL_REQUEST_DEBOUNCE_MS);
         }
@@ -676,6 +680,27 @@ module.exports = React.createClass({
 
     _collectGeminiScroll: function(gemScroll) {
         this._gemScroll = gemScroll;
+    },
+    /**
+     * Set the current height as the min height for the message list
+     * so the timeline cannot shrink. This is used to avoid
+     * jumping when the typing indicator gets replaced by a smaller message.
+     */
+    blockShrinking: function() {
+        const messageList = this.refs.itemlist;
+        if (messageList) {
+            const currentHeight = messageList.clientHeight - 18;
+            messageList.style.minHeight = `${currentHeight}px`;
+        }
+    },
+    /**
+     * Clear the previously set min height
+     */
+    clearBlockShrinking: function() {
+        const messageList = this.refs.itemlist;
+        if (messageList) {
+            messageList.style.minHeight = null;
+        }
     },
 
     render: function() {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -689,7 +689,7 @@ module.exports = React.createClass({
     blockShrinking: function() {
         const messageList = this.refs.itemlist;
         if (messageList) {
-            const currentHeight = messageList.clientHeight - 18;
+            const currentHeight = messageList.clientHeight;
             messageList.style.minHeight = `${currentHeight}px`;
         }
     },

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -681,6 +681,7 @@ module.exports = React.createClass({
     _collectGeminiScroll: function(gemScroll) {
         this._gemScroll = gemScroll;
     },
+
     /**
      * Set the current height as the min height for the message list
      * so the timeline cannot shrink. This is used to avoid
@@ -693,6 +694,7 @@ module.exports = React.createClass({
             messageList.style.minHeight = `${currentHeight}px`;
         }
     },
+
     /**
      * Clear the previously set min height
      */

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -455,7 +455,7 @@ var TimelinePanel = React.createClass({
                 //
                 const myUserId = MatrixClientPeg.get().credentials.userId;
                 const sender = ev.sender ? ev.sender.userId : null;
-                var callback = null;
+                var callRMUpdated = false;
                 if (sender != myUserId && !UserActivity.userCurrentlyActive()) {
                     updatedState.readMarkerVisible = true;
                 } else if (lastEv && this.getReadMarkerPosition() === 0) {
@@ -465,11 +465,16 @@ var TimelinePanel = React.createClass({
                     this._setReadMarker(lastEv.getId(), lastEv.getTs(), true);
                     updatedState.readMarkerVisible = false;
                     updatedState.readMarkerEventId = lastEv.getId();
-                    callback = this.props.onReadMarkerUpdated;
+                    callRMUpdated = true;
                 }
             }
 
-            this.setState(updatedState, callback);
+            this.setState(updatedState, () => {
+                this.refs.messagePanel.updateTimelineMinHeight();
+                if (callRMUpdated) {
+                    this.props.onReadMarkerUpdated();
+                }
+            });
         });
     },
 

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -45,6 +45,11 @@ module.exports = React.createClass({
         return {
             usersTyping: WhoIsTyping.usersTypingApartFromMe(this.props.room),
             userTimers: {},
+            // a map with userid => Timer to delay
+            // hiding the "x is typing" message for a
+            // user so hiding it can coincide
+            // with the sent message by the other side
+            // resulting in less timeline jumpiness
         };
     },
 
@@ -78,6 +83,7 @@ module.exports = React.createClass({
             // remove user from usersTyping
             const usersTyping = this.state.usersTyping.filter((m) => m.userId !== userId);
             this.setState({usersTyping});
+            // abort timer if any
             this._abortUserTimer(userId);
         }
     },
@@ -177,6 +183,9 @@ module.exports = React.createClass({
         let usersTyping = this.state.usersTyping;
         const stoppedUsersOnTimer = Object.keys(this.state.userTimers)
             .map((userId) => this.props.room.getMember(userId));
+        // append the users that have been reported not typing anymore
+        // but have a timeout timer running so they can disappear
+        // when a message comes in
         usersTyping = usersTyping.concat(stoppedUsersOnTimer);
 
         const typingString = WhoIsTyping.whoIsTypingString(

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -110,7 +110,9 @@ module.exports = React.createClass({
         // abort all the timers for the users that started typing again
         usersThatStartedTyping.forEach((m) => {
             const timer = this.state.delayedStopTypingTimers[m.userId];
-            timer && timer.abort();
+            if (timer) {
+                timer.abort();
+            }
         });
         // prepare new delayedStopTypingTimers object to update state with
         let delayedStopTypingTimers = Object.assign({}, this.state.delayedStopTypingTimers);

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -74,12 +74,23 @@ module.exports = React.createClass({
 
     onRoomTimeline: function(event, room) {
         if (room.roomId === this.props.room.roomId) {
-            console.log(`WhoIsTypingTile: incoming timeline event for ${event.getSender()}`);
-            this._abortUserTimer(event.getSender(), "timeline event");
+            const userId = event.getSender();
+            const userWasTyping = this.state.usersTyping.some((m) => m.userId === userId);
+            if (userWasTyping) {
+                console.log(`WhoIsTypingTile: remove ${userId} from usersTyping`);
+            }
+            const usersTyping = this.state.usersTyping.filter((m) => m.userId !== userId);
+            this.setState({usersTyping});
+
+            if (this.state.userTimers[userId]) {
+                console.log(`WhoIsTypingTile: incoming timeline event for ${userId}`);
+            }
+            this._abortUserTimer(userId, "timeline event");
         }
     },
 
     onRoomMemberTyping: function(ev, member) {
+        //TODO: don't we need to check the roomId here?
         console.log(`WhoIsTypingTile: incoming typing event for`, ev.getContent().user_ids);
         const usersTyping = WhoIsTyping.usersTypingApartFromMeAndIgnored(this.props.room);
         this.setState({

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -78,7 +78,7 @@ module.exports = React.createClass({
     },
 
     isVisible: function() {
-        return this.state.usersTyping.length !== 0 || Object.keys(this.state.delayedStopTypingTimers) !== 0;
+        return this.state.usersTyping.length !== 0 || Object.keys(this.state.delayedStopTypingTimers).length !== 0;
     },
 
     onRoomTimeline: function(event, room) {

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -77,6 +77,10 @@ module.exports = React.createClass({
         Object.values(this.state.delayedStopTypingTimers).forEach((t) => t.abort());
     },
 
+    isVisible: function() {
+        return this.state.usersTyping.length !== 0 || Object.keys(this.state.delayedStopTypingTimers) !== 0;
+    },
+
     onRoomTimeline: function(event, room) {
         if (room.roomId === this.props.room.roomId) {
             const userId = event.getSender();

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -128,7 +128,7 @@ module.exports = React.createClass({
                 delayedStopTypingTimers[m.userId] = timer;
                 timer.start();
                 timer.finished().then(
-                    () => this._removeUserTimer(m.userId),  //on elapsed
+                    () => this._removeUserTimer(m.userId), // on elapsed
                     () => {/* aborted */},
                 );
             }

--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -191,6 +191,9 @@ module.exports = React.createClass({
         // but have a timeout timer running so they can disappear
         // when a message comes in
         usersTyping = usersTyping.concat(stoppedUsersOnTimer);
+        // sort them so the typing members don't change order when
+        // moved to delayedStopTypingTimers
+        usersTyping.sort((a, b) => a.name.localeCompare(b.name));
 
         const typingString = WhoIsTyping.whoIsTypingString(
             usersTyping,


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7882

First, hide typing notification until message arrives (or 5s later).
Also use min-height so the timeline can never shrink again when the typing indicator disappears.

![typingnotif](https://user-images.githubusercontent.com/274386/51490227-7f59a680-1da2-11e9-90f7-5ac07c2cb47f.gif)

