### PR TITLE
Fix styling regression in member list filter

### DIFF
--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -246,8 +246,8 @@ input[type=password] {
 }
 
 .dark-panel {
-    :not(.mx_textinput) > input[type=text],
-    :not(.mx_textinput) > input[type=search],
+    :not(.mx_textinput):not(.mx_Field) > input[type=text],
+    :not(.mx_textinput):not(.mx_Field) > input[type=search],
     .mx_textinput {
         color: $input-darker-fg-color;
         background-color: $input-darker-bg-color;
@@ -256,8 +256,8 @@ input[type=password] {
 }
 
 .light-panel {
-    :not(.mx_textinput) > input[type=text],
-    :not(.mx_textinput) > input[type=search],
+    :not(.mx_textinput):not(.mx_Field) > input[type=text],
+    :not(.mx_textinput):not(.mx_Field) > input[type=search],
     .mx_textinput {
         color: $input-lighter-fg-color;
         background-color: $input-lighter-bg-color;


### PR DESCRIPTION
<img width="257" alt="2019-01-21 at 08 57" src="https://user-images.githubusercontent.com/279572/51482013-eb182100-1d5a-11e9-904a-cf16648ce866.png">

Fixes https://github.com/vector-im/riot-web/issues/8182.