### PR TITLE
Override Firefox UA style for placeholders

### DIFF
--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -295,6 +295,13 @@ input[type=search]::-webkit-search-results-decoration {
 .input[type=search]::-moz-placeholder {
     color: #a5aab2;
 }
+
+// Override Firefox's UA style so we get a consistent look across browsers
+input::placeholder,
+textarea::placeholder {
+    opacity: initial;
+}
+
 // ***** Mixins! *****
 
 @define-mixin mx_DialogButton {


### PR DESCRIPTION
With this change, the placeholder now matches the icon color as it does in other browsers:

<img width="202" alt="2019-01-21 at 14 32" src="https://user-images.githubusercontent.com/279572/51497686-79a39700-1d89-11e9-9b95-e14269844fe7.png">

Fixes https://github.com/vector-im/riot-web/issues/8195