### PR TITLE
Fix: show rooms and people section when empty while filtering

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -593,7 +593,7 @@ module.exports = React.createClass({
 
         subListsProps = subListsProps.filter((props => {
             const len = props.list.length + (props.extraTiles ? props.extraTiles.length : 0);
-            return len !== 0 || (props.onAddRoom && !this.props.searchFilter);
+            return len !== 0 || props.onAddRoom;
         }));
 
         return subListsProps.reduce((components, props, i) => {


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7958

![image](https://user-images.githubusercontent.com/274386/51551484-75997700-1e66-11e9-8a3f-7d4cd9923453.png)
