### PR TITLE
Add modal look to authentication flows

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -23,6 +23,7 @@
 @import "./structures/_UserSettings.scss";
 @import "./structures/_ViewSource.scss";
 @import "./structures/auth/_Login.scss";
+@import "./views/auth/_AuthBody.scss";
 @import "./views/auth/_AuthButtons.scss";
 @import "./views/auth/_AuthFooter.scss";
 @import "./views/auth/_AuthHeader.scss";

--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -14,15 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AuthFooter {
-    text-align: center;
-    width: 100%;
-    font-size: 14px;
-    opacity: 0.72;
-    margin: 20px 0;
-}
-
-.mx_AuthFooter a:link, a:hover, a:visited {
-    color: $accent-fg-color;
-    margin: 0 22px;
+.mx_AuthBody {
+    width: 500px;
+    background-color: $authpage-body-bg-color;
+    border-radius: 0 4px 4px 0;
+    padding: 25px 60px;
+    box-sizing: border-box;
 }

--- a/res/css/views/auth/_AuthFooter.scss
+++ b/res/css/views/auth/_AuthFooter.scss
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 .mx_AuthFooter {
-  display: block;
-  text-align: center;
-  margin-top: 15px;
-  width: 100%;
-  font-size: 13px;
-  opacity: 0.8;
+    display: block;
+    text-align: center;
+    margin-top: 15px;
+    width: 100%;
+    font-size: 13px;
+    opacity: 0.8;
 }
 
 .mx_AuthFooter a:link {
- color: $primary-fg-color;
+    color: $primary-fg-color;
 }

--- a/res/css/views/auth/_AuthHeader.scss
+++ b/res/css/views/auth/_AuthHeader.scss
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 .mx_AuthHeader_logo {
-  text-align: center;
-  height: 150px;
-  margin-bottom: 45px;
+    text-align: center;
+    height: 150px;
+    margin-bottom: 45px;
 }
 
 .mx_AuthHeader_logo img {
-  max-height: 100%
+    max-height: 100%
 }

--- a/res/css/views/auth/_AuthHeader.scss
+++ b/res/css/views/auth/_AuthHeader.scss
@@ -14,12 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_AuthHeader {
+    width: 206px;
+    padding: 25px 50px;
+    box-sizing: border-box;
+}
+
 .mx_AuthHeader_logo {
-    text-align: center;
-    height: 150px;
-    margin-bottom: 45px;
+    margin-top: 15px;
 }
 
 .mx_AuthHeader_logo img {
-    max-height: 100%
+    width: 100%;
 }

--- a/res/css/views/auth/_AuthPage.scss
+++ b/res/css/views/auth/_AuthPage.scss
@@ -17,12 +17,10 @@ limitations under the License.
 .mx_AuthPage {
     width: 100%;
     height: 100%;
-
     display: flex;
-    align-items: center;
-    justify-content: center;
-
+    flex-direction: column;
     overflow: auto;
+    background-color: $authpage-bg-color;
 }
 
 .mx_AuthPage h2 {
@@ -32,9 +30,11 @@ limitations under the License.
 }
 
 .mx_AuthPage_modal {
-    width: 300px;
-    min-height: 450px;
-    padding-top: 50px;
-    padding-bottom: 50px;
-    margin: auto;
+    display: flex;
+    margin: 100px auto auto;
+    border-radius: 4px;
+    // Not currently supported in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1178765
+    backdrop-filter: blur(10px);
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.33);
+    background-color: $authpage-modal-bg-color;
 }

--- a/res/css/views/auth/_AuthPage.scss
+++ b/res/css/views/auth/_AuthPage.scss
@@ -15,26 +15,26 @@ limitations under the License.
 */
 
 .mx_AuthPage {
-  width: 100%;
-  height: 100%;
+    width: 100%;
+    height: 100%;
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-  overflow: auto;
+    overflow: auto;
 }
 
 .mx_AuthPage h2 {
-  font-weight: 300;
-  margin-top: 32px;
-  margin-bottom: 20px;
+    font-weight: 300;
+    margin-top: 32px;
+    margin-bottom: 20px;
 }
 
 .mx_AuthPage_modal {
-  width: 300px;
-  min-height: 450px;
-  padding-top: 50px;
-  padding-bottom: 50px;
-  margin: auto;
+    width: 300px;
+    min-height: 450px;
+    padding-top: 50px;
+    padding-bottom: 50px;
+    margin: auto;
 }

--- a/res/themes/dharma/css/_dharma.scss
+++ b/res/themes/dharma/css/_dharma.scss
@@ -193,6 +193,10 @@ $room-warning-bg-color: #fff8e3;
 
 $memberstatus-placeholder-color: $roomtile-name-color;
 
+$authpage-bg-color: #2e3649;
+$authpage-modal-bg-color: rgba(255, 255, 255, 0.59);
+$authpage-body-bg-color: #ffffff;
+
 /*** form elements ***/
 
 // .mx_textinput is a container for a text input

--- a/res/themes/light/css/_base.scss
+++ b/res/themes/light/css/_base.scss
@@ -188,6 +188,10 @@ $room-warning-bg-color: #fff8e3;
 
 $memberstatus-placeholder-color: $roomtile-name-color;
 
+$authpage-bg-color: #2e3649;
+$authpage-modal-bg-color: rgba(255, 255, 255, 0.59);
+$authpage-body-bg-color: #ffffff;
+
 // ***** Mixins! *****
 
 @define-mixin mx_DialogButton {

--- a/src/components/structures/auth/ForgotPassword.js
+++ b/src/components/structures/auth/ForgotPassword.js
@@ -185,7 +185,7 @@ module.exports = React.createClass({
     render: function() {
         const AuthPage = sdk.getComponent("auth.AuthPage");
         const AuthHeader = sdk.getComponent("auth.AuthHeader");
-        const AuthFooter = sdk.getComponent("auth.AuthFooter");
+        const AuthBody = sdk.getComponent("auth.AuthBody");
         const ServerConfig = sdk.getComponent("auth.ServerConfig");
         const Spinner = sdk.getComponent("elements.Spinner");
 
@@ -272,7 +272,6 @@ module.exports = React.createClass({
                         { _t('Create an account') }
                     </a>
                     <LanguageSelector />
-                    <AuthFooter />
                 </div>
             </div>
             );
@@ -282,7 +281,9 @@ module.exports = React.createClass({
         return (
             <AuthPage>
                 <AuthHeader />
-                { resetPasswordJsx }
+                <AuthBody>
+                    {resetPasswordJsx}
+                </AuthBody>
             </AuthPage>
         );
     },

--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -517,7 +517,7 @@ module.exports = React.createClass({
         const Loader = sdk.getComponent("elements.Spinner");
         const AuthPage = sdk.getComponent("auth.AuthPage");
         const AuthHeader = sdk.getComponent("auth.AuthHeader");
-        const AuthFooter = sdk.getComponent("auth.AuthFooter");
+        const AuthBody = sdk.getComponent("auth.AuthBody");
         const ServerConfig = sdk.getComponent("auth.ServerConfig");
         const loader = this.state.busy ? <div className="mx_Login_loader"><Loader /></div> : null;
 
@@ -560,7 +560,7 @@ module.exports = React.createClass({
         return (
             <AuthPage>
                 <AuthHeader />
-                <div>
+                <AuthBody>
                     { header }
                     { errorTextSection }
                     { this.componentForStep(this.state.currentFlow) }
@@ -570,8 +570,7 @@ module.exports = React.createClass({
                     </a>
                     { loginAsGuestJsx }
                     <LanguageSelector />
-                    <AuthFooter />
-                </div>
+                </AuthBody>
             </AuthPage>
         );
     },

--- a/src/components/structures/auth/PostRegistration.js
+++ b/src/components/structures/auth/PostRegistration.js
@@ -62,18 +62,21 @@ module.exports = React.createClass({
         const ChangeAvatar = sdk.getComponent('settings.ChangeAvatar');
         const AuthPage = sdk.getComponent('auth.AuthPage');
         const AuthHeader = sdk.getComponent('auth.AuthHeader');
+        const AuthBody = sdk.getComponent("auth.AuthBody");
         return (
             <AuthPage>
                 <AuthHeader />
-                <div className="mx_Login_profile">
-                    { _t('Set a display name:') }
-                    <ChangeDisplayName />
-                    { _t('Upload an avatar:') }
-                    <ChangeAvatar
-                        initialAvatarUrl={this.state.avatarUrl} />
-                    <button onClick={this.props.onComplete}>{ _t('Continue') }</button>
-                    { this.state.errorString }
-                </div>
+                <AuthBody>
+                    <div className="mx_Login_profile">
+                        { _t('Set a display name:') }
+                        <ChangeDisplayName />
+                        { _t('Upload an avatar:') }
+                        <ChangeAvatar
+                            initialAvatarUrl={this.state.avatarUrl} />
+                        <button onClick={this.props.onComplete}>{ _t('Continue') }</button>
+                        { this.state.errorString }
+                    </div>
+                </AuthBody>
             </AuthPage>
         );
     },

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -397,7 +397,7 @@ module.exports = React.createClass({
 
     render: function() {
         const AuthHeader = sdk.getComponent('auth.AuthHeader');
-        const AuthFooter = sdk.getComponent('auth.AuthFooter');
+        const AuthBody = sdk.getComponent("auth.AuthBody");
         const AuthPage = sdk.getComponent('auth.AuthPage');
         const InteractiveAuth = sdk.getComponent('structures.InteractiveAuth');
         const Spinner = sdk.getComponent("elements.Spinner");
@@ -481,12 +481,13 @@ module.exports = React.createClass({
                         this.state.teamSelected.domain + "/icon.png" :
                         null}
                 />
-                { header }
-                { registerBody }
-                { signIn }
-                { errorText }
-                <LanguageSelector />
-                <AuthFooter />
+                <AuthBody>
+                    { header }
+                    { registerBody }
+                    { signIn }
+                    { errorText }
+                    <LanguageSelector />
+                </AuthBody>
             </AuthPage>
         );
     },

--- a/src/components/views/auth/AuthBody.js
+++ b/src/components/views/auth/AuthBody.js
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AuthFooter {
-    text-align: center;
-    width: 100%;
-    font-size: 14px;
-    opacity: 0.72;
-    margin: 20px 0;
-}
+'use strict';
 
-.mx_AuthFooter a:link, a:hover, a:visited {
-    color: $accent-fg-color;
-    margin: 0 22px;
+import React from 'react';
+
+export default class AuthBody extends React.PureComponent {
+    render() {
+        return <div className="mx_AuthBody">
+            { this.props.children }
+        </div>;
+    }
 }

--- a/src/components/views/auth/AuthPage.js
+++ b/src/components/views/auth/AuthPage.js
@@ -18,16 +18,20 @@ limitations under the License.
 'use strict';
 
 const React = require('react');
+import sdk from '../../../index';
 
 module.exports = React.createClass({
     displayName: 'AuthPage',
 
     render: function() {
+        const AuthFooter = sdk.getComponent('auth.AuthFooter');
+
         return (
             <div className="mx_AuthPage">
                 <div className="mx_AuthPage_modal">
                     { this.props.children }
                 </div>
+                <AuthFooter />
             </div>
         );
     },


### PR DESCRIPTION
This changes the auth screens to use the modal-like style of the redesign.

This does not attempt to style the actual body content of each screen.  Instead,
it covers the header area with logo, footer links, and overall modal container
only.

![image](https://user-images.githubusercontent.com/279572/51576724-ff543f00-1e7c-11e9-86c9-86885e6bb0da.png)

![image](https://user-images.githubusercontent.com/279572/51576739-0713e380-1e7d-11e9-9b62-4a6bce71b440.png)

![image](https://user-images.githubusercontent.com/279572/51576742-0bd89780-1e7d-11e9-9fef-910a7f36cb0a.png)

Fixes https://github.com/vector-im/riot-web/issues/8223