### PR TITLE
Extract auth header logo to new component

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -27,6 +27,7 @@
 @import "./views/auth/_AuthButtons.scss";
 @import "./views/auth/_AuthFooter.scss";
 @import "./views/auth/_AuthHeader.scss";
+@import "./views/auth/_AuthHeaderLogo.scss";
 @import "./views/auth/_AuthPage.scss";
 @import "./views/auth/_InteractiveAuthEntryComponents.scss";
 @import "./views/auth/_ServerConfig.scss";

--- a/res/css/views/auth/_AuthHeaderLogo.scss
+++ b/res/css/views/auth/_AuthHeaderLogo.scss
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AuthHeader {
-    width: 206px;
-    padding: 25px 50px;
-    box-sizing: border-box;
+.mx_AuthHeaderLogo {
+    margin-top: 15px;
+}
+
+.mx_AuthHeaderLogo img {
+    width: 100%;
 }

--- a/src/components/views/auth/AuthHeader.js
+++ b/src/components/views/auth/AuthHeader.js
@@ -18,16 +18,17 @@ limitations under the License.
 'use strict';
 
 const React = require('react');
+import sdk from '../../../index';
 
 module.exports = React.createClass({
     displayName: 'AuthHeader',
 
     render: function() {
+        const AuthHeaderLogo = sdk.getComponent('auth.AuthHeaderLogo');
+
         return (
             <div className="mx_AuthHeader">
-                <div className="mx_AuthHeader_logo">
-                    Matrix
-                </div>
+                <AuthHeaderLogo />
             </div>
         );
     },

--- a/src/components/views/auth/AuthHeaderLogo.js
+++ b/src/components/views/auth/AuthHeaderLogo.js
@@ -14,8 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AuthHeader {
-    width: 206px;
-    padding: 25px 50px;
-    box-sizing: border-box;
+'use strict';
+
+import React from 'react';
+
+export default class AuthHeaderLogo extends React.PureComponent {
+    render() {
+        return <div className="mx_AuthHeaderLogo">
+            Matrix
+        </div>;
+    }
 }


### PR DESCRIPTION
This will allow `riot-web` to replace only the logo, rather than the whole
header.