### PR TITLE
Add target="_blank" to links that don't have it

### DIFF
--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -605,7 +605,7 @@ module.exports = React.createClass({
             <div>
                 <h3>Referral</h3>
                 <div className="mx_UserSettings_section">
-                    { _t("Refer a friend to Riot:") } <a href={href}>{ href }</a>
+                    { _t("Refer a friend to Riot:") } <a href={href} target="_blank" rel="noopener">{ href }</a>
                 </div>
             </div>
         );

--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -446,7 +446,7 @@ module.exports = React.createClass({
                         "Either use HTTPS or <a>enable unsafe scripts</a>.", {},
                         {
                             'a': (sub) => {
-                                return <a href="https://www.google.com/search?&q=enable%20unsafe%20scripts">
+                                return <a target="_blank" rel="noopener" href="https://www.google.com/search?&q=enable%20unsafe%20scripts">
                                     { sub }
                                 </a>;
                             },
@@ -460,7 +460,7 @@ module.exports = React.createClass({
                         "is not blocking requests.", {},
                         {
                             'a': (sub) => {
-                                return <a href={this.state.enteredHomeserverUrl}>{ sub }</a>;
+                                return <a target="_blank" rel="noopener" href={this.state.enteredHomeserverUrl}>{ sub }</a>;
                             },
                         },
                     ) }
@@ -508,6 +508,14 @@ module.exports = React.createClass({
     },
 
     _renderSsoStep: function(url) {
+        // XXX: This link does *not* have a target="_blank" because single sign-on relies on
+        // redirecting the user back to a URI once they're logged in. On the web, this means
+        // we use the same window and redirect back to riot. On electron, this actually
+        // opens the SSO page in the electron app itself due to
+        // https://github.com/electron/electron/issues/8841 and so happens to work.
+        // If this bug gets fixed, it will break SSO since it will open the SSO page in the
+        // user's browser, let them log into their SSO provider, then redirect their browser
+        // to vector://vector which, of course, will not work.
         return (
             <a href={url} className="mx_Login_sso_link">{ _t('Sign in with single sign-on') }</a>
         );

--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -446,7 +446,9 @@ module.exports = React.createClass({
                         "Either use HTTPS or <a>enable unsafe scripts</a>.", {},
                         {
                             'a': (sub) => {
-                                return <a target="_blank" rel="noopener" href="https://www.google.com/search?&q=enable%20unsafe%20scripts">
+                                return <a target="_blank" rel="noopener"
+                                    href="https://www.google.com/search?&q=enable%20unsafe%20scripts"
+                                >
                                     { sub }
                                 </a>;
                             },
@@ -460,7 +462,9 @@ module.exports = React.createClass({
                         "is not blocking requests.", {},
                         {
                             'a': (sub) => {
-                                return <a target="_blank" rel="noopener" href={this.state.enteredHomeserverUrl}>{ sub }</a>;
+                                return <a target="_blank" rel="noopener"
+                                    href={this.state.enteredHomeserverUrl}
+                                >{ sub }</a>;
                             },
                         },
                     ) }

--- a/src/components/views/auth/AuthFooter.js
+++ b/src/components/views/auth/AuthFooter.js
@@ -26,7 +26,7 @@ module.exports = React.createClass({
     render: function() {
         return (
             <div className="mx_AuthFooter">
-                <a href="https://matrix.org">{ _t("powered by Matrix") }</a>
+                <a href="https://matrix.org" target="_blank" rel="noopener">{ _t("powered by Matrix") }</a>
             </div>
         );
     },

--- a/src/components/views/auth/CaptchaForm.js
+++ b/src/components/views/auth/CaptchaForm.js
@@ -71,7 +71,11 @@ module.exports = React.createClass({
                 ReactDOM.render(_t(
                     "Robot check is currently unavailable on desktop - please use a <a>web browser</a>",
                     {},
-                    { 'a': (sub) => { return <a href='https://riot.im/app'>{ sub }</a>; }}), warning);
+                    {
+                        'a': (sub) => {
+                            return <a target="_blank" rel="noopener" href='https://riot.im/app'>{ sub }</a>;
+                        },
+                    }), warning);
                 this.refs.recaptchaContainer.appendChild(warning);
             } else {
                 const scriptTag = document.createElement('script');

--- a/src/components/views/settings/ChangePassword.js
+++ b/src/components/views/settings/ChangePassword.js
@@ -114,7 +114,11 @@ module.exports = React.createClass({
                         'making encrypted chat history unreadable, unless you first export your room keys ' +
                         'and re-import them afterwards. ' +
                         'In future this will be improved.',
-                    ) } (<a href="https://github.com/vector-im/riot-web/issues/2671">https://github.com/vector-im/riot-web/issues/2671</a>)
+                    ) }
+                    {' '}
+                    <a href="https://github.com/vector-im/riot-web/issues/2671" target="_blank" rel="noopener">
+                        https://github.com/vector-im/riot-web/issues/2671
+                    </a>
                 </div>,
             button: _t("Continue"),
             extraButtons: [


### PR DESCRIPTION
This is now more of a problem in the Electron app because of
https://github.com/electron/electron/issues/8841 but is still
annoying in the webapp if you're taken away from your chat client.

Exception is the SSO link, as commented (issue filed at
https://github.com/vector-im/riot-web/issues/8247).

Fixes https://github.com/vector-im/riot-web/issues/8226