### PR TITLE
Add widget screenshots to the Labs section

### DIFF
--- a/src/components/views/settings/tabs/LabsSettingsTab.js
+++ b/src/components/views/settings/tabs/LabsSettingsTab.js
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import {_t} from "../../../../languageHandler";
 import PropTypes from "prop-types";
-import SettingsStore from "../../../../settings/SettingsStore";
+import SettingsStore, {SettingLevel} from "../../../../settings/SettingsStore";
 import MatrixClientPeg from "../../../../MatrixClientPeg";
 import LabelledToggleSwitch from "../../elements/LabelledToggleSwitch";
 const Modal = require("../../../../Modal");
@@ -77,12 +77,14 @@ export default class LabsSettingsTab extends React.Component {
     }
 
     render() {
+        const SettingsFlag = sdk.getComponent("views.elements.SettingsFlag");
         const flags = SettingsStore.getLabsFeatures().map(f => <LabsSettingToggle featureId={f} key={f} />);
         return (
             <div className="mx_SettingsTab">
                 <div className="mx_SettingsTab_heading">{_t("Labs")}</div>
                 <div className="mx_SettingsTab_section">
                     {flags}
+                    <SettingsFlag name={"enableWidgetScreenshots"} level={SettingLevel.ACCOUNT} />
                 </div>
             </div>
         );


### PR DESCRIPTION
This is a normal setting and not a real labs setting, however the design calls for it to be here.

![image](https://user-images.githubusercontent.com/1190097/51704021-2faef100-1fd5-11e9-8df6-cd7b1dbff024.png)
