### PR TITLE
Default a Field's placeholder to the label

### DIFF
--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -25,7 +25,7 @@ export default class Field extends React.PureComponent {
         type: PropTypes.string,
         // The field's label string.
         label: PropTypes.string,
-        // The field's placeholder string.
+        // The field's placeholder string. Defaults to the label.
         placeholder: PropTypes.string,
         // The type of field to create. Defaults to "input". Should be "input" or "select".
         // To define options for a select, use <Field><option ... /></Field>
@@ -55,6 +55,7 @@ export default class Field extends React.PureComponent {
         // Set some defaults for the element
         extraProps.type = extraProps.type || "text";
         extraProps.ref = "fieldInput";
+        extraProps.placeholder = extraProps.placeholder || extraProps.label;
 
         const element = this.props.element || "input";
         const fieldInput = React.createElement(element, extraProps, this.props.children);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8250

This keeps all fields in line with the design without them having to defining it twice. The option is kept in the first place as some fields might want to override the placeholder to be longer than the label or something.

![image](https://user-images.githubusercontent.com/1190097/51721507-63a70800-200f-11e9-9d17-16530a3e0dd1.png)
