### PR TITLE
Add simple animations to toggle switches

### DIFF
--- a/res/css/views/elements/_ToggleSwitch.scss
+++ b/res/css/views/elements/_ToggleSwitch.scss
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: Fancy transitions
-
 .mx_ToggleSwitch {
+    transition: background-color 0.20s ease-out 0.1s;
     width: 48px;
     height: 24px;
     border-radius: 14px;
@@ -33,6 +32,7 @@ limitations under the License.
 }
 
 .mx_ToggleSwitch_ball {
+    transition: left 0.15s ease-out 0.1s;
     margin: 2px;
     width: 20px;
     height: 20px;
@@ -47,5 +47,5 @@ limitations under the License.
 }
 
 .mx_ToggleSwitch_on > .mx_ToggleSwitch_ball {
-    right: 2px;
+    left: 23px; // 48px switch - 20px ball - 5px padding = 23px
 }


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/8207

Before:
![before-toggles](https://user-images.githubusercontent.com/1190097/51725252-8260cb00-201e-11e9-9756-fee7dd09e832.gif)

After (where my screen recorder decided it would show clicks, sorry):
![after-toggles](https://user-images.githubusercontent.com/1190097/51725261-8b519c80-201e-11e9-9f61-6150b9f864ee.gif)
