### PR TITLE
Fix unmount TypeError in `DeviceVerifyButtons`

### DIFF
--- a/src/components/views/elements/DeviceVerifyButtons.js
+++ b/src/components/views/elements/DeviceVerifyButtons.js
@@ -42,7 +42,9 @@ export default React.createClass({
 
     componentWillUnmount: function() {
         const cli = MatrixClientPeg.get();
-        cli.removeListener("deviceVerificationChanged", this.onDeviceVerificationChanged);
+        if (cli) {
+            cli.removeListener("deviceVerificationChanged", this.onDeviceVerificationChanged);
+        }
     },
 
     onDeviceVerificationChanged: function(userId, deviceId, deviceInfo) {


### PR DESCRIPTION
I seemed to hit this while trying to sign out.