### PR TITLE
Iterate upon the room upgrade warning bar

### DIFF
--- a/src/components/views/dialogs/RoomUpgradeDialog.js
+++ b/src/components/views/dialogs/RoomUpgradeDialog.js
@@ -29,13 +29,15 @@ export default React.createClass({
         onFinished: PropTypes.func.isRequired,
     },
 
-    componentWillMount: function() {
-        this._targetVersion = this.props.room.shouldUpgradeToVersion();
+    componentWillMount: async function() {
+        const recommended = await this.props.room.getRecommendedVersion();
+        this._targetVersion = recommended.version;
+        this.setState({busy: false});
     },
 
     getInitialState: function() {
         return {
-            busy: false,
+            busy: true,
         };
     },
 

--- a/src/components/views/rooms/RoomUpgradeWarningBar.js
+++ b/src/components/views/rooms/RoomUpgradeWarningBar.js
@@ -26,6 +26,7 @@ module.exports = React.createClass({
 
     propTypes: {
         room: PropTypes.object.isRequired,
+        recommendation: PropTypes.object.isRequired,
     },
 
     onUpgradeClick: function() {
@@ -35,19 +36,40 @@ module.exports = React.createClass({
 
     render: function() {
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
-        return (
-            <div className="mx_RoomUpgradeWarningBar">
-                <div className="mx_RoomUpgradeWarningBar_header">
-                    {_t("There is a known vulnerability affecting this room.")}
-                </div>
+
+        let upgradeText = (
+            <div>
                 <div className="mx_RoomUpgradeWarningBar_body">
-                    {_t("This room version is vulnerable to malicious modification of room state.")}
+                    {_t("This room is using an unstable room version. If you aren't expecting this, please upgrade the room.")}
                 </div>
                 <p className="mx_RoomUpgradeWarningBar_upgradelink">
                     <AccessibleButton onClick={this.onUpgradeClick}>
-                        {_t("Click here to upgrade to the latest room version and ensure room integrity is protected.")}
+                        {_t("Click here to upgrade to the latest room version.")}
                     </AccessibleButton>
                 </p>
+            </div>
+        );
+        if (this.props.recommendation.urgent) {
+            upgradeText = (
+                <div>
+                    <div className="mx_RoomUpgradeWarningBar_header">
+                        {_t("There is a known vulnerability affecting this room.")}
+                    </div>
+                    <div className="mx_RoomUpgradeWarningBar_body">
+                        {_t("This room version is vulnerable to malicious modification of room state.")}
+                    </div>
+                    <p className="mx_RoomUpgradeWarningBar_upgradelink">
+                        <AccessibleButton onClick={this.onUpgradeClick}>
+                            {_t("Click here to upgrade to the latest room version and ensure room integrity is protected.")}
+                        </AccessibleButton>
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className="mx_RoomUpgradeWarningBar">
+                {upgradeText}
                 <div className="mx_RoomUpgradeWarningBar_small">
                     {_t("Only room administrators will see this warning")}
                 </div>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -743,6 +743,8 @@
     "Internal room ID: ": "Internal room ID: ",
     "Room version number: ": "Room version number: ",
     "Add a topic": "Add a topic",
+    "This room is using an unstable room version. If you aren't expecting this, please upgrade the room.": "This room is using an unstable room version. If you aren't expecting this, please upgrade the room.",
+    "Click here to upgrade to the latest room version.": "Click here to upgrade to the latest room version.",
     "There is a known vulnerability affecting this room.": "There is a known vulnerability affecting this room.",
     "This room version is vulnerable to malicious modification of room state.": "This room version is vulnerable to malicious modification of room state.",
     "Click here to upgrade to the latest room version and ensure room integrity is protected.": "Click here to upgrade to the latest room version and ensure room integrity is protected.",


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/8251
Endpoint requires https://github.com/matrix-org/synapse/pull/4472
**Please review with https://github.com/matrix-org/matrix-js-sdk/pull/830**

----

This lessens the warning for unstable-but-not-official versions while still communicating that the version is unstable. In the future, we may want to make this state dismissable.