### PR TITLE
fix dropdown style when input is shown

### DIFF
--- a/src/components/views/elements/Dropdown.js
+++ b/src/components/views/elements/Dropdown.js
@@ -310,7 +310,7 @@ export default class Dropdown extends React.Component {
         // Note the menu sits inside the AccessibleButton div so it's anchored
         // to the input, but overflows below it. The root contains both.
         return <div className={classnames(dropdownClasses)} ref={this._collectRoot}>
-            <AccessibleButton className="mx_Dropdown_input" onClick={this._onInputClick}>
+            <AccessibleButton className="mx_Dropdown_input mx_no_textinput" onClick={this._onInputClick}>
                 { currentValue }
                 <span className="mx_Dropdown_arrow"></span>
                 { menu }


### PR DESCRIPTION
![countrydropdown](https://user-images.githubusercontent.com/274386/51976202-ff0b0380-247b-11e9-9744-3a9771d6c8d0.png)

caused by the global text input styles not being scoped well, will clean that up post RC/launch, for now there is this workaround.