### PR TITLE
layout composer independent of avatar being present

### DIFF
--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -20,6 +20,7 @@ limitations under the License.
     margin: auto;
     border-top: 1px solid $primary-hairline-color;
     position: relative;
+    padding-left: 84px;
 }
 
 .mx_MessageComposer_replaced_wrapper {
@@ -58,7 +59,8 @@ limitations under the License.
 }
 
 .mx_MessageComposer .mx_MessageComposer_avatar {
-    padding: 0 27px;
+    position: absolute;
+    left: 27px;
 }
 
 .mx_MessageComposer .mx_MessageComposer_avatar .mx_BaseAvatar {


### PR DESCRIPTION
Fix layout part of https://github.com/vector-im/riot-web/issues/8335

![image](https://user-images.githubusercontent.com/274386/52059763-921e6900-2562-11e9-8106-8da3910e9e73.png)
