### PR TITLE
Ensure correct server URLs with .well-known and server type

### DIFF
--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -263,6 +263,11 @@ module.exports = React.createClass({
             username: username,
             discoveryError: null,
         });
+        // If the free server type is selected, we don't show server details at all,
+        // so it doesn't make sense to try .well-known discovery.
+        if (this.state.serverType === ServerType.FREE) {
+            return;
+        }
         if (username[0] === "@") {
             const serverName = username.split(':').slice(1).join(':');
             try {
@@ -385,6 +390,15 @@ module.exports = React.createClass({
         this.setState({findingHomeserver: true});
         try {
             const discovery = await AutoDiscovery.findClientConfig(serverName);
+
+            // The server type may have changed while discovery began in the background.
+            // If it has become the free server type which doesn't show server details,
+            // ignore discovery results.
+            if (this.state.serverType === ServerType.FREE) {
+                this.setState({findingHomeserver: false});
+                return;
+            }
+
             const state = discovery["m.homeserver"].state;
             if (state !== AutoDiscovery.SUCCESS && state !== AutoDiscovery.PROMPT) {
                 this.setState({


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8346 where the combo of .well-known discovery and switching server types led to a split brain situation where the UI mentioned two different HSes, so you didn't know for sure where you'd actually sign in.

This also flattens the server URLs in the login flow so we don't store so many different kinds (entered vs. discovered). Instead, there's a single place the URLs always flow towards as they change, which should be less confusing.