### PR TITLE
Fix exception while saving room settings

### DIFF
--- a/src/components/views/rooms/RoomSettings.js
+++ b/src/components/views/rooms/RoomSettings.js
@@ -310,12 +310,6 @@ module.exports = React.createClass({
             promises.push(p);
         }
 
-        // url preview settings
-        const ps = this.saveUrlPreviewSettings();
-        if (ps.length > 0) {
-            ps.map((p) => promises.push(p));
-        }
-
         // related groups
         promises.push(this.saveRelatedGroups());
 
@@ -344,11 +338,6 @@ module.exports = React.createClass({
     saveColor: function() {
         if (!this.refs.color_settings) { return Promise.resolve(); }
         return this.refs.color_settings.saveSettings();
-    },
-
-    saveUrlPreviewSettings: function() {
-        if (!this.refs.url_preview_settings) { return Promise.resolve(); }
-        return this.refs.url_preview_settings.saveSettings();
     },
 
     saveEnableEncryption: function() {


### PR DESCRIPTION
I got the following exception while trying to save the room settings:
```
Uncaught TypeError: this.refs.url_preview_settings.saveSettings is not a function
    at Object.saveUrlPreviewSettings (http://localhost:8080/bundles/_dev_/bundle.js:129413:47)
    at Object._calcSavePromises (http://localhost:8080/bundles/_dev_/bundle.js:129366:23)
    at http://localhost:8080/bundles/_dev_/bundle.js:129296:50
From previous event:
    at Object.save (http://localhost:8080/bundles/_dev_/bundle.js:129295:41)
    at Object.onSettingsSaveClick (http://localhost:8080/bundles/_dev_/bundle.js:79028:33)
    at
```
`saveSettings` was indeed [removed](https://github.com/matrix-org/matrix-react-sdk/commit/db3466658397290125fe708f1228b9caa1be5913#diff-2a28b50786053aae798f4b4ccc8036f2L38), which I guess is intentional as SettingsFlag seems to save itself by default on change? Not sure though, @turt2live ?