### PR TITLE
Disable old settings, making tabbed settings the default

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -572,7 +572,7 @@ export default React.createClass({
                 this._viewIndexedRoom(payload.roomIndex);
                 break;
             case 'view_user_settings': {
-                if (SettingsStore.isFeatureEnabled("feature_tabbed_settings")) {
+                if (true || SettingsStore.isFeatureEnabled("feature_tabbed_settings")) {
                     const UserSettingsDialog = sdk.getComponent("dialogs.UserSettingsDialog");
                     Modal.createTrackedDialog('User settings', '', UserSettingsDialog, {}, 'mx_SettingsDialog');
                 } else {

--- a/src/components/views/dialogs/RoomSettingsDialog.js
+++ b/src/components/views/dialogs/RoomSettingsDialog.js
@@ -81,7 +81,7 @@ export default class RoomSettingsDialog extends React.Component {
         tabs.push(new Tab(
             _td("Advanced"),
             "mx_RoomSettingsDialog_warningIcon",
-            <AdvancedRoomSettingsTab roomId={thisfea.props.roomId} />,
+            <AdvancedRoomSettingsTab roomId={this.props.roomId} />,
         ));
         // tabs.push(new Tab(
         //     _td("Visit old settings"),

--- a/src/components/views/dialogs/RoomSettingsDialog.js
+++ b/src/components/views/dialogs/RoomSettingsDialog.js
@@ -81,13 +81,13 @@ export default class RoomSettingsDialog extends React.Component {
         tabs.push(new Tab(
             _td("Advanced"),
             "mx_RoomSettingsDialog_warningIcon",
-            <AdvancedRoomSettingsTab roomId={this.props.roomId} />,
+            <AdvancedRoomSettingsTab roomId={thisfea.props.roomId} />,
         ));
-        tabs.push(new Tab(
-            _td("Visit old settings"),
-            "mx_RoomSettingsDialog_warningIcon",
-            <TempTab onClose={this.props.onFinished} />,
-        ));
+        // tabs.push(new Tab(
+        //     _td("Visit old settings"),
+        //     "mx_RoomSettingsDialog_warningIcon",
+        //     <TempTab onClose={this.props.onFinished} />,
+        // ));
 
         return tabs;
     }

--- a/src/components/views/dialogs/UserSettingsDialog.js
+++ b/src/components/views/dialogs/UserSettingsDialog.js
@@ -96,11 +96,11 @@ export default class UserSettingsDialog extends React.Component {
             "mx_UserSettingsDialog_helpIcon",
             <HelpSettingsTab closeSettingsFn={this.props.onFinished} />,
         ));
-        tabs.push(new Tab(
-            _td("Visit old settings"),
-            "mx_UserSettingsDialog_helpIcon",
-            <TempTab onClose={this.props.onFinished} />,
-        ));
+        // tabs.push(new Tab(
+        //     _td("Visit old settings"),
+        //     "mx_UserSettingsDialog_helpIcon",
+        //     <TempTab onClose={this.props.onFinished} />,
+        // ));
 
         return tabs;
     }

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -120,7 +120,7 @@ class RoomViewStore extends Store {
                 });
                 break;
             case 'open_room_settings':
-                if (SettingsStore.isFeatureEnabled("feature_tabbed_settings")) {
+                if (true || SettingsStore.isFeatureEnabled("feature_tabbed_settings")) {
                     const RoomSettingsDialog = sdk.getComponent("dialogs.RoomSettingsDialog");
                     Modal.createTrackedDialog('Room settings', '', RoomSettingsDialog, {
                         roomId: this._state.roomId,


### PR DESCRIPTION
This is intentionally not removing the labs flag or other supporting structures of the old settings to make a revert as easy as possible in the event that needs to happen. All of the cruft left behind (TempTab, temp styles, labs flag, old components, etc) will be removed in the very near future.