### PR TITLE
Set a minimum width on the settings tab content

### DIFF
--- a/res/css/views/dialogs/_SettingsDialog.scss
+++ b/res/css/views/dialogs/_SettingsDialog.scss
@@ -30,6 +30,7 @@ limitations under the License.
 
         .mx_TabbedView .mx_SettingsTab {
             box-sizing: border-box;
+            min-width: 550px;
             padding-right: 130px;
 
             // Put some padding on the bottom to avoid the settings tab from


### PR DESCRIPTION
This prevents random controls from squishing themselves, at sacrifice of scrollbars and not-responsiveness.

At 600px:
![image](https://user-images.githubusercontent.com/1190097/52142772-da975e80-2616-11e9-82f8-37c2bfcedbe2.png)
