### PR TITLE
Restore dropdown chevron to right

### DIFF
--- a/res/css/views/auth/_AuthHeader.scss
+++ b/res/css/views/auth/_AuthHeader.scss
@@ -18,6 +18,6 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     width: 206px;
-    padding: 25px 50px;
+    padding: 25px 40px;
     box-sizing: border-box;
 }

--- a/res/css/views/auth/_AuthHeaderLogo.scss
+++ b/res/css/views/auth/_AuthHeaderLogo.scss
@@ -17,6 +17,7 @@ limitations under the License.
 .mx_AuthHeaderLogo {
     margin-top: 15px;
     flex: 1;
+    padding: 0 10px;
 }
 
 .mx_AuthHeaderLogo img {

--- a/res/css/views/elements/_Dropdown.scss
+++ b/res/css/views/elements/_Dropdown.scss
@@ -44,7 +44,7 @@ limitations under the License.
 .mx_Dropdown_arrow {
     width: 10px;
     height: 6px;
-    padding-right: 8px;
+    padding-right: 9px;
     mask: url('$(res)/img/feather-icons/dropdown-arrow.svg');
     mask-repeat: no-repeat;
     background: $primary-fg-color;
@@ -54,6 +54,7 @@ limitations under the License.
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1;
 }
 
 .mx_Dropdown_option {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8339.

Here you can see both `Field` and `Dropdown` components with chevrons at the same position:

<img width="411" alt="2019-02-01 at 16 17" src="https://user-images.githubusercontent.com/279572/52152678-d847fb00-263c-11e9-8ee1-3d5747cf193f.png">

In addition, this gives the auth language dropdown a bit more space, so it doesn't feel like the chevron there is left aligned and languages fit in the space available:

<img width="311" alt="2019-02-01 at 16 19" src="https://user-images.githubusercontent.com/279572/52152764-34128400-263d-11e9-9114-9933849e2706.png">
