### PR TITLE
Fix: being able to size sections in leftpanel larger than their content while filtering

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -183,7 +183,7 @@ module.exports = React.createClass({
     componentDidMount: function() {
         this.dispatcherRef = dis.register(this.onAction);
         const cfg = {
-            layout: () => this._layout,
+            getLayout: () => this._layout,
         };
         this.resizer = new Resizer(this.resizeContainer, Distributor, cfg);
         this.resizer.setClassNames({

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -183,7 +183,7 @@ module.exports = React.createClass({
     componentDidMount: function() {
         this.dispatcherRef = dis.register(this.onAction);
         const cfg = {
-            layout: this._layout,
+            layout: () => this._layout,
         };
         this.resizer = new Resizer(this.resizeContainer, Distributor, cfg);
         this.resizer.setClassNames({

--- a/src/resizer/distributors/roomsublist2.js
+++ b/src/resizer/distributors/roomsublist2.js
@@ -319,8 +319,7 @@ class Handle {
 export class Distributor extends FixedDistributor {
     constructor(item, cfg) {
         super(item);
-        const layout = cfg.layout;
-        this._handle = layout().openHandle(item.id);
+        this._handle = cfg.getLayout().openHandle(item.id);
     }
 
     finish() {

--- a/src/resizer/distributors/roomsublist2.js
+++ b/src/resizer/distributors/roomsublist2.js
@@ -320,7 +320,7 @@ export class Distributor extends FixedDistributor {
     constructor(item, cfg) {
         super(item);
         const layout = cfg.layout;
-        this._handle = layout.openHandle(item.id);
+        this._handle = layout().openHandle(item.id);
     }
 
     finish() {


### PR DESCRIPTION
The layout was passed into the resizer at mount time, and then never updated. When starting to filter, we use a different layout object, and would update the sections with the new counts there, which would determine the new max size for all sections and so they would shrink.

When resizing in filtered mode, the resizer would now start modifying the layout used when not filtering, which would still have the old counts and apply the max sizes when not filtered, so you could size the sections to their unfiltered content size, while being filtered.

This PR fixes that by passing in the layout in the resizer as a lamba, so it asks for the layout object when needed.