### PR TITLE
Fix: 'jump to bottom' creates big amounts of whitespace at the bottom

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -642,14 +642,13 @@ module.exports = React.createClass({
 
     updateTimelineMinHeight: function() {
         const scrollPanel = this.refs.scrollPanel;
-        const whoIsTyping = this.refs.whoIsTyping;
-        const isTypingVisible = whoIsTyping && whoIsTyping.isVisible();
 
         if (scrollPanel) {
-            if (isTypingVisible) {
+            const isAtBottom = scrollPanel.isAtBottom();
+            const whoIsTyping = this.refs.whoIsTyping;
+            const isTypingVisible = whoIsTyping && whoIsTyping.isVisible();
+            if (isAtBottom && isTypingVisible) {
                 scrollPanel.blockShrinking();
-            } else {
-                scrollPanel.clearBlockShrinking();
             }
         }
     },

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -169,6 +169,10 @@ module.exports = React.createClass({
         //
         // This will also re-check the fill state, in case the paginate was inadequate
         this.checkScroll();
+
+        if (!this.isAtBottom()) {
+            this.clearBlockShrinking();
+        }
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/8392

To make sure the `min-height` on the timeline gets cleared when needed, do it on `ScrollPanel::componentDidUpdate` if not at the bottom (we only care about a min-height (to avoid jumping when typing notifs disappear) when at the bottom). This *should* catch all cases when the timeline can shrink.

Also don't clear the `min-height` on a new message when typing is not visible because this will still cause the timeline to shrink and jump up when a message comes in after the typing has disappeared.