### PR TITLE
Fix: search term disappears when collapsing and expanding left panel

### DIFF
--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -199,9 +199,10 @@ const LeftPanel = React.createClass({
             },
         );
 
-        const searchBox = !this.props.collapsed ?
-            <SearchBox onSearch={ this.onSearch } onCleared={ this.onSearchCleared } /> :
-            undefined;
+        const searchBox = (<SearchBox
+            onSearch={ this.onSearch }
+            onCleared={ this.onSearchCleared }
+            collapsed={this.props.collapsed} />);
 
         return (
             <div className={containerClasses}>

--- a/src/components/structures/SearchBox.js
+++ b/src/components/structures/SearchBox.js
@@ -95,8 +95,6 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        const TintableSvg = sdk.getComponent('elements.TintableSvg');
-
         // check for collapsed here and
         // not at parent so we keep
         // searchTerm in our state

--- a/src/components/structures/SearchBox.js
+++ b/src/components/structures/SearchBox.js
@@ -97,6 +97,13 @@ module.exports = React.createClass({
     render: function() {
         const TintableSvg = sdk.getComponent('elements.TintableSvg');
 
+        // check for collapsed here and
+        // not at parent so we keep
+        // searchTerm in our state
+        // when collapsing and expanding
+        if (this.props.collapsed) {
+            return null;
+        }
         const clearButton = this.state.searchTerm.length > 0 ?
             (<AccessibleButton key="button"
                     className="mx_SearchBox_closeButton"


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/7716
![searchtermcollapse](https://user-images.githubusercontent.com/274386/52230036-4b0bdd00-28ae-11e9-8b91-a01e4d648616.gif)
