### PR TITLE
Avoid disabling the entire UI for the experimental warning dialog

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -67,12 +67,10 @@ import {sendLoginRequest} from "./Login";
  *     Resolves to `true` if we ended up starting a session, or `false` if we
  *     failed.
  */
-/* eslint-disable no-unreachable */
 export async function loadSession(opts) {
     const ExperimentalOutdatedDialog =
         sdk.getComponent("views.dialogs.ExperimentalOutdatedDialog");
-    return Modal.createDialog(ExperimentalOutdatedDialog);
-    // noinspection UnreachableCodeJS
+    Modal.createDialog(ExperimentalOutdatedDialog);
     try {
         let enableGuest = opts.enableGuest || false;
         const guestHsUrl = opts.guestHsUrl;
@@ -113,7 +111,6 @@ export async function loadSession(opts) {
         return _handleLoadSessionFailure(e);
     }
 }
-/* eslint-enable no-unreachable */
 
 /**
  * @param {Object} queryParams    string->string map of the


### PR DESCRIPTION
Fixes problems that were attempted to be worked around in https://github.com/matrix-org/matrix-react-sdk/commit/4f31c3c084786ed6d96d0457e252fc3d6645f66a and https://github.com/matrix-org/matrix-react-sdk/commit/9fc32ce2e457577c327919fcb4c07c2db6f5e38f

The riot-web tests explode if we don't load the UI, so just let it load and still hold a blocking dialog in front of the user.