### PR TITLE
Remove the arrow-paren lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,7 +97,6 @@ module.exports = {
         "new-cap": ["warn"],
         "key-spacing": ["warn"],
         "prefer-const": ["warn"],
-        "arrow-parens": "off",
 
         // crashes currently: https://github.com/eslint/eslint/issues/6274
         "generator-star-spacing": "off",


### PR DESCRIPTION
It's now in the base lint rules file: https://github.com/matrix-org/matrix-js-sdk/pull/834