### PR TITLE
Tweak field padding to avoid overlapping with selected text

### DIFF
--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -100,7 +100,8 @@ limitations under the License.
         top 0.25s ease-out 0s,
         background-color 0.25s ease-out 0s;
     font-size: 10px;
-    top: -14px;
+    top: -13px;
+    padding: 0 2px;
     background-color: $field-focused-label-bg-color;
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8209

<img width="196" alt="2019-02-05 at 15 48" src="https://user-images.githubusercontent.com/279572/52285245-9fa16d80-292b-11e9-91d8-9c8e560ccc4f.png">
