### PR TITLE
Key Backup: Don't fail if no keys

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1120,6 +1120,7 @@
     "No backup found!": "No backup found!",
     "Error Restoring Backup": "Error Restoring Backup",
     "Backup could not be decrypted with this key: please verify that you entered the correct recovery key.": "Backup could not be decrypted with this key: please verify that you entered the correct recovery key.",
+    "Backup could not be decrypted with this passphrase: please verify that you entered the correct recovery passphrase.": "Backup could not be decrypted with this passphrase: please verify that you entered the correct recovery passphrase.",
     "Backup Restored": "Backup Restored",
     "Failed to decrypt %(failedCount)s sessions!": "Failed to decrypt %(failedCount)s sessions!",
     "Restored %(sessionCount)s session keys": "Restored %(sessionCount)s session keys",


### PR DESCRIPTION
Only fail if there were any keys in the backup (which does mean
that the backup will always succeed if there aren't any keys which
could also be misleading, but is probably not as bad and can probably
be fixed with Trust on Decrypt).

Also cheekily fix the error message so it talks about passphrases
if you used a passphrase and recovery keys if you used a recovery key.