### PR TITLE
Fix firefox scrolling settings tabs differently

### DIFF
--- a/res/css/structures/_TabbedView.scss
+++ b/res/css/structures/_TabbedView.scss
@@ -85,6 +85,7 @@ limitations under the License.
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    min-height: 0; // firefox
 }
 
 .mx_TabbedView_tabPanelContent {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8408

Might also fix Safari. Source: https://moduscreate.com/blog/how-to-fix-overflow-issues-in-css-flex-layouts/

The other `min-height` is also required as far as I can tell. Changing it on the fly makes no difference, however refreshing causes problems.