### PR TITLE
Fix: make sure custom tag scroller doesn't overflow parent

### DIFF
--- a/res/css/structures/_CustomRoomTagPanel.scss
+++ b/res/css/structures/_CustomRoomTagPanel.scss
@@ -21,7 +21,11 @@ limitations under the License.
 
 .mx_CustomRoomTagPanel {
     background-color: $tagpanel-bg-color;
-    max-height: 40%;
+    max-height: 40vh;
+}
+
+.mx_CustomRoomTagPanel_scroller {
+    max-height: inherit;
 }
 
 .mx_CustomRoomTagPanel .mx_AccessibleButton {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/274386/52429157-661f5c80-2afb-11e9-8d79-67cf34d21a5f.png)
