### PR TITLE
Ensure toggle switches listen to property changes

### DIFF
--- a/src/components/views/elements/ToggleSwitch.js
+++ b/src/components/views/elements/ToggleSwitch.js
@@ -38,6 +38,12 @@ export default class ToggleSwitch extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.checked !== this.state.checked) {
+            this.setState({checked: nextProps.checked});
+        }
+    }
+
     _onClick = (e) => {
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
They do local echo on changes to avoid jumping back and forth while requests are ongoing, however some areas modify the checked state after the toggle has mounted.

Fixes https://github.com/vector-im/riot-web/issues/8432