### PR TITLE
Scale up settings UI to be easier to read

### DIFF
--- a/res/css/structures/_TabbedView.scss
+++ b/res/css/structures/_TabbedView.scss
@@ -28,8 +28,8 @@ limitations under the License.
 }
 
 .mx_TabbedView_tabLabels {
-    width: 150px;
-    max-width: 150px;
+    width: 170px;
+    max-width: 170px;
     color: $tab-label-fg-color;
     position: fixed;
 }
@@ -39,9 +39,8 @@ limitations under the License.
     cursor: pointer;
     display: block;
     border-radius: 3px;
-    font-size: 12px;
-    font-weight: 600;
-    min-height: 20px; // use min-height instead of height to allow the label to overflow a bit
+    font-size: 14px;
+    min-height: 24px; // use min-height instead of height to allow the label to overflow a bit
     margin-bottom: 6px;
     position: relative;
 }
@@ -55,8 +54,8 @@ limitations under the License.
     margin-left: 6px;
     margin-right: 9px;
     margin-top: 1px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     display: inline-block;
 }
 
@@ -64,9 +63,9 @@ limitations under the License.
     display: inline-block;
     background-color: $tab-label-icon-bg-color;
     mask-repeat: no-repeat;
-    mask-size: 14px;
+    mask-size: 16px;
     width: 14px;
-    height: 18px;
+    height: 22px;
     mask-position: center;
     content: '';
     vertical-align: middle;
@@ -81,7 +80,7 @@ limitations under the License.
 }
 
 .mx_TabbedView_tabPanel {
-    margin-left: 220px; // 150px sidebar + 70px padding
+    margin-left: 240px; // 170px sidebar + 70px padding
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/res/css/views/dialogs/_SettingsDialog.scss
+++ b/res/css/views/dialogs/_SettingsDialog.scss
@@ -16,8 +16,8 @@ limitations under the License.
 
 .mx_SettingsDialog {
     .mx_Dialog {
-        max-width: 900px;
-        width: 80%;
+        max-width: 1000px;
+        width: 90%;
         height: 80%;
         border-radius: 4px;
         padding-top: 0;
@@ -30,7 +30,7 @@ limitations under the License.
 
         .mx_TabbedView .mx_SettingsTab {
             box-sizing: border-box;
-            min-width: 550px;
+            min-width: 580px;
             padding-right: 130px;
 
             // Put some padding on the bottom to avoid the settings tab from

--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -21,7 +21,7 @@ limitations under the License.
 }
 
 .mx_SettingsTab_subheading {
-    font-size: 14px;
+    font-size: 16px;
     display: block;
     font-family: $font-family;
     font-weight: 600;
@@ -32,7 +32,7 @@ limitations under the License.
 
 .mx_SettingsTab_subsectionText {
     color: $settings-subsection-fg-color;
-    font-size: 12px;
+    font-size: 14px;
     padding-bottom: 12px;
     display: block;
     margin: 0 100px 0 0; // Align with the rest of the view
@@ -45,9 +45,9 @@ limitations under the License.
 }
 
 .mx_SettingsTab_section .mx_SettingsFlag .mx_SettingsFlag_label {
-    vertical-align: bottom;
+    vertical-align: middle;
     display: inline-block;
-    font-size: 12px;
+    font-size: 14px;
     color: $primary-fg-color;
     max-width: calc(100% - 48px); // Force word wrap instead of colliding with the switch
 }


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/8207

The thumbnails of the screenshots don't really do it justice, but it feels more legible with these changes. Clicking on the images should be more obvious, although might still require landing this to see how it feels.

## Before

![image](https://user-images.githubusercontent.com/1190097/52509474-890e4700-2bb5-11e9-94e9-f21d5e0dc340.png)
![image](https://user-images.githubusercontent.com/1190097/52509476-8b70a100-2bb5-11e9-9fe8-5a1fdfda37df.png)

## After

![image](https://user-images.githubusercontent.com/1190097/52509569-e99d8400-2bb5-11e9-954e-97c8ab2ce393.png)
![image](https://user-images.githubusercontent.com/1190097/52509573-ebffde00-2bb5-11e9-9c22-e9015f4b68f7.png)

