### PR TITLE
Mark tiles sent by the current user

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -538,7 +538,7 @@ module.exports = withMatrixClient(React.createClass({
             mx_EventTile_bad: isEncryptionFailure,
             mx_EventTile_emote: msgtype === 'm.emote',
             mx_EventTile_redacted: isRedacted,
-            mx_EventTile_sender: isSender
+            mx_EventTile_sender: isSender,
         });
 
         const permalink = makeEventPermalink(this.props.mxEvent.getRoomId(), this.props.mxEvent.getId());

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -518,6 +518,7 @@ module.exports = withMatrixClient(React.createClass({
         const isSending = (['sending', 'queued', 'encrypting'].indexOf(this.props.eventSendStatus) !== -1);
         const isRedacted = isMessageEvent(this.props.mxEvent) && this.props.isRedacted;
         const isEncryptionFailure = this.props.mxEvent.isDecryptionFailure();
+        const isSender = this.props.mxEvent.getSender() === this.props.matrixClient.credentials.userId;
 
         const classes = classNames({
             mx_EventTile: true,
@@ -537,6 +538,7 @@ module.exports = withMatrixClient(React.createClass({
             mx_EventTile_bad: isEncryptionFailure,
             mx_EventTile_emote: msgtype === 'm.emote',
             mx_EventTile_redacted: isRedacted,
+            mx_EventTile_sender: isSender
         });
 
         const permalink = makeEventPermalink(this.props.mxEvent.getRoomId(), this.props.mxEvent.getId());


### PR DESCRIPTION
Hello. First time contributing to the project, please tell me if I've done anything wrong.

I'd like to theme riot and add a better way to distinguish messages / events send by myself, and the ones sent by other people. Unfortunately, right now there seems to be no straightforward way to do this (in terms of theming).

I think that the best way to do this is by adding a class to mark these tiles. Really small addition, but does the job.