### PR TITLE
Fix mx_RoomTile_name weighting

### DIFF
--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -154,8 +154,6 @@ limitations under the License.
 }
 
 .mx_RoomTile_unread, .mx_RoomTile_highlight {
-    font-weight: 700 !important;
-
     .mx_RoomTile_name {
         // Parent weighting won't apply to this because the above mx_RoomTile_name overrides.
         font-weight: 700;

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -153,9 +153,11 @@ limitations under the License.
     background-color: $warning-color;
 }
 
-.mx_RoomTile_unread, .mx_RoomTile_highlight .mx_RoomTile_name {
-    font-weight: 700;
-    color: $roomtile-selected-color;
+.mx_RoomTile_unread, .mx_RoomTile_highlight {
+    .mx_RoomTile_name {
+        font-weight: 700;
+        color: $roomtile-selected-color;
+    }
 }
 
 .mx_RoomTile_selected {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -153,12 +153,9 @@ limitations under the License.
     background-color: $warning-color;
 }
 
-.mx_RoomTile_unread, .mx_RoomTile_highlight {
-    .mx_RoomTile_name {
-        // Parent weighting won't apply to this because the above mx_RoomTile_name overrides.
-        font-weight: 700;
-        color: $roomtile-selected-color;
-    }
+.mx_RoomTile_unread, .mx_RoomTile_highlight .mx_RoomTile_name {
+    font-weight: 700;
+    color: $roomtile-selected-color;
 }
 
 .mx_RoomTile_selected {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -157,6 +157,8 @@ limitations under the License.
     font-weight: 700 !important;
 
     .mx_RoomTile_name {
+        // Parent weighting won't apply to this because the above mx_RoomTile_name overrides.
+        font-weight: 700;
         color: $roomtile-selected-color;
     }
 }


### PR DESCRIPTION
**EDIT**: For the record it was unclear design-wise if this was the right thing to do.

I think @ara4n came to an agreement with @nadonomy that a font-weight of `700` was okay though. Either way, bolded text is good for readability.