### PR TITLE
Fix: dont assume settings label only has one line

### DIFF
--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -40,7 +40,6 @@ limitations under the License.
 
 .mx_SettingsTab_section .mx_SettingsFlag {
     margin-right: 100px;
-    height: 25px;
     margin-bottom: 10px;
 }
 
@@ -50,6 +49,8 @@ limitations under the License.
     font-size: 14px;
     color: $primary-fg-color;
     max-width: calc(100% - 48px); // Force word wrap instead of colliding with the switch
+    box-sizing: border-box;
+    padding-right: 10px;
 }
 
 .mx_SettingsTab_section .mx_SettingsFlag .mx_ToggleSwitch {


### PR DESCRIPTION
Before:
![labs1](https://user-images.githubusercontent.com/274386/52633495-e6134100-2ec4-11e9-9567-2c5c0e7bd523.png)
After:
![labs2](https://user-images.githubusercontent.com/274386/52633498-e7dd0480-2ec4-11e9-96db-d1d3efca3b23.png)
