### PR TITLE
Fix registration after clicking email link

### DIFF
--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -67,6 +67,8 @@ module.exports = React.createClass({
         let initialPhase = PHASE_SERVER_DETAILS;
         if (
             // if we have these two, skip to the good bit
+            // (they could come in from the URL params in a
+            // registration email link)
             (this.props.clientSecret && this.props.sessionId) ||
             // or if custom URLs aren't allowed, skip them
             !customURLsAllowed

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -64,6 +64,15 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         const customURLsAllowed = !SdkConfig.get()['disable_custom_urls'];
+        let initialPhase = PHASE_SERVER_DETAILS;
+        if (
+            // if we have these two, skip to the good bit
+            (this.props.clientSecret && this.props.sessionId) ||
+            // or if custom URLs aren't allowed, skip them
+            !customURLsAllowed
+        ) {
+            initialPhase = PHASE_REGISTRATION;
+        }
 
         return {
             busy: false,
@@ -87,7 +96,7 @@ module.exports = React.createClass({
             hsUrl: this.props.customHsUrl,
             isUrl: this.props.customIsUrl,
             // Phase of the overall registration dialog.
-            phase: customURLsAllowed ? PHASE_SERVER_DETAILS : PHASE_REGISTRATION,
+            phase: initialPhase,
             flows: null,
         };
     },
@@ -111,7 +120,7 @@ module.exports = React.createClass({
         });
     },
 
-    onServerTypeChange(type) {
+    onServerTypeChange(type, initial) {
         this.setState({
             serverType: type,
         });
@@ -137,9 +146,15 @@ module.exports = React.createClass({
                     hsUrl: this.props.defaultHsUrl,
                     isUrl: this.props.defaultIsUrl,
                 });
-                this.setState({
-                    phase: PHASE_SERVER_DETAILS,
-                });
+                // if this is the initial value from the control and we're
+                // already in the registration phase, don't go back to the
+                // server details phase (but do if it's actually a change resulting
+                // from user interaction).
+                if (!initial || !this.state.phase === PHASE_REGISTRATION) {
+                    this.setState({
+                        phase: PHASE_SERVER_DETAILS,
+                    });
+                }
                 break;
         }
     },
@@ -372,9 +387,12 @@ module.exports = React.createClass({
         // If we're on a different phase, we only show the server type selector,
         // which is always shown if we allow custom URLs at all.
         if (PHASES_ENABLED && this.state.phase !== PHASE_SERVER_DETAILS) {
+            // if we've been given a custom HS URL we should actually pass that, so
+            // that the appropriate section is selected at the start to match the
+            // homeserver URL we're using
             return <div>
                 <ServerTypeSelector
-                    defaultHsUrl={this.props.defaultHsUrl}
+                    defaultHsUrl={this.props.customHsUrl || this.props.defaultHsUrl}
                     onChange={this.onServerTypeChange}
                 />
             </div>;

--- a/src/components/views/auth/ServerTypeSelector.js
+++ b/src/components/views/auth/ServerTypeSelector.js
@@ -92,7 +92,7 @@ export default class ServerTypeSelector extends React.PureComponent {
         if (onChange) {
             // FIXME: Supply a second 'initial' param here to flag that this is
             // initialising the value rather than from user interaction
-            // (which sometuimes we'll want to ignore). Must be a better way
+            // (which sometimes we'll want to ignore). Must be a better way
             // to do this.
             onChange(type, true);
         }

--- a/src/components/views/auth/ServerTypeSelector.js
+++ b/src/components/views/auth/ServerTypeSelector.js
@@ -90,7 +90,11 @@ export default class ServerTypeSelector extends React.PureComponent {
             selected: type,
         };
         if (onChange) {
-            onChange(type);
+            // FIXME: Supply a second 'initial' param here to flag that this is
+            // initialising the value rather than from user interaction
+            // (which sometuimes we'll want to ignore). Must be a better way
+            // to do this.
+            onChange(type, true);
         }
     }
 


### PR DESCRIPTION
We weren't correctly jumping into the appropriate bit of the registration
flow when coming in from an email link.

 * If we have client secret / sessionId, go straight to registration phase
 * Don't reset server URLs when the server type component tells us its
   initial value
 * Confusingly, pass the custom server URL as 'default server URL' to
   the custom server type, as this is what we want the inital section
   to be based on.

Fixes https://github.com/vector-im/riot-web/issues/8490