### PR TITLE
always rerender room tiles

### DIFF
--- a/src/components/views/elements/LazyRenderList.js
+++ b/src/components/views/elements/LazyRenderList.js
@@ -73,12 +73,6 @@ export default class LazyRenderList extends React.Component {
         }
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        const itemsChanged = nextProps.items !== this.props.items;
-        const rangeChanged = nextState.renderRange !== this.state.renderRange;
-        return itemsChanged || rangeChanged;
-    }
-
     render() {
         const {itemHeight, items, renderItem} = this.props;
 


### PR DESCRIPTION
as not all state that goes into rendering comes from state or props,
we shouldn't be blocking rendering at all

This might rerender a few times more, but it shouldn't be worse
than what was there before the redesigned roomlist.