### PR TITLE
Fix excessive timeline whitespace

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -215,7 +215,9 @@ module.exports = React.createClass({
             // this might cause the scrollbar to resize in case the max-height was not correct
             // but that's better than ending up with a lot of whitespace at the bottom of the timeline.
             // we need to above check because when showing the typing notifs, an onScroll event is also triggered
-            this.clearBlockShrinking();
+            if (!this.isAtBottom()) {
+                this.clearBlockShrinking();
+            }
 
             this._saveScrollState();
         } else {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -211,6 +211,12 @@ module.exports = React.createClass({
         // forget what we wanted, so don't overwrite the saved state unless
         // this appears to be a user-initiated scroll.
         if (sn.scrollTop != this._lastSetScroll) {
+            // when scrolling, we don't care about disappearing typing notifs shrinking the timeline
+            // this might cause the scrollbar to resize in case the max-height was not correct
+            // but that's better than ending up with a lot of whitespace at the bottom of the timeline.
+            // we need to above check because when showing the typing notifs, an onScroll event is also triggered
+            this.clearBlockShrinking();
+
             this._saveScrollState();
         } else {
             debuglog("Ignoring scroll echo");


### PR DESCRIPTION
before I added a call to `clearBlockShrinking` in `componentDidUpdate`, but the ScrollPanel doens't update when scrolling. I suspect something like this happened:

- at the bottom of the timeline
- somebody started typing, notif shown  & min-height set
- scrolled up the timeline
- timeline shrunk somehow (even though we do call clearBlockShrinking from unpagination)
- scrolled back down again
- min-height was forcing a lot of whitespace

If we're not at the bottom, we don't care about disappearing typing notifs shrinking the timeline, so clear the min-height in the onscroll handler. 