### PR TITLE
Bring back the lowered opacity for offline/unavailable avatars.

### DIFF
--- a/res/css/views/rooms/_EntityTile.scss
+++ b/res/css/views/rooms/_EntityTile.scss
@@ -81,7 +81,6 @@ limitations under the License.
     color: $primary-fg-color;
 }
 
-/*
 .mx_EntityTile_unavailable .mx_EntityTile_avatar,
 .mx_EntityTile_unavailable .mx_EntityTile_name,
 .mx_EntityTile_unavailable .mx_EntityTile_name_hover,
@@ -89,7 +88,7 @@ limitations under the License.
 .mx_EntityTile_offline_beenactive .mx_EntityTile_name,
 .mx_EntityTile_offline_beenactive .mx_EntityTile_name_hover
 {
-    opacity: 0.66;
+    opacity: 0.5;
 }
 
 .mx_EntityTile_offline_neveractive .mx_EntityTile_avatar,
@@ -105,7 +104,6 @@ limitations under the License.
 {
     opacity: 0.25;
 }
-*/
 
 .mx_EntityTile_subtext {
     font-size: 11px;


### PR DESCRIPTION
At some point during the riot redesign, the bit of css that lowered the opacity for offline/unavailable contacts
was removed. This makes it impossible to discern presence for a contact unless you hover your cursor over their avatar.

It's very handy to be able to see presence at a glance without any hovering, so this PR reintroduces the lowered opacity.
I've also slightly decreased the opacity level from 0.66 to 0.5 to make it slightly more noticable.