### PR TITLE
Fix typo "Scisors" -> "Scissors"

### DIFF
--- a/src/components/views/verification/VerificationShowSas.js
+++ b/src/components/views/verification/VerificationShowSas.js
@@ -140,7 +140,7 @@ _td("Light bulb");
 _td("Book");
 _td("Pencil");
 _td("Paperclip");
-_td("Scisors");
+_td("Scissors");
 _td("Padlock");
 _td("Key");
 _td("Hammer");

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -382,7 +382,7 @@
     "Book": "Book",
     "Pencil": "Pencil",
     "Paperclip": "Paperclip",
-    "Scisors": "Scisors",
+    "Scissors": "Scissors",
     "Padlock": "Padlock",
     "Key": "Key",
     "Hammer": "Hammer",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8703