### PR TITLE
Make pre use the same text color as code

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -412,6 +412,7 @@ limitations under the License.
 
 .mx_EventTile_content .markdown-body {
     pre, code {
+        // deliberate constants as we're behind an invert filter
         color: #333;
     }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -408,7 +408,12 @@ limitations under the License.
 .mx_EventTile_content .markdown-body code {
     // deliberate constants as we're behind an invert filter
     background-color: #f8f8f8;
-    color: #333;
+}
+
+.mx_EventTile_content .markdown-body {
+    pre, code {
+        color: #333;
+    }
 }
 
 .mx_EventTile_pre_container {


### PR DESCRIPTION
Fixes 
https://github.com/vector-im/riot-web/issues/8554#issuecomment-463222141

cc @Half-Shot 

![screen shot 2019-02-15 at 9 39 47 pm](https://user-images.githubusercontent.com/5855073/52894119-4545af80-316a-11e9-8808-8e5b2bb181cf.png)
Which one is pre and which one is code? :)