### PR TITLE
Set h3-color in dark theme

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -67,6 +67,8 @@ $menu-selected-color: $room-highlight-color;
 $avatar-initial-color: #ffffff;
 $avatar-bg-color: $bg-color;
 
+$h3-color: $primary-fg-color;
+
 $dialog-background-bg-color: $header-panel-bg-color;
 $lightbox-background-bg-color: #000;
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8679

This is what it was set to in the old dark theme https://github.com/matrix-org/matrix-react-sdk/blob/v0.14.8/res/themes/dark/css/_dark.scss#L80

![screen shot 2019-02-15 at 9 58 44 pm](https://user-images.githubusercontent.com/5855073/52894303-eafa1e00-316c-11e9-82af-fc2a9f613084.png)
