### PR TITLE
Cache-bust languages.json with file-loader

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,9 @@ module.exports = {
       "flowtype",
       "babel"
     ],
+    globals: {
+        LANGUAGES_FILE: "readonly",
+    },
     env: {
         es6: true,
     },

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -23,5 +23,5 @@ ln -s "$REACT_SDK_DIR/node_modules/matrix-js-sdk" node_modules/matrix-js-sdk
 rm -r node_modules/matrix-react-sdk
 ln -s "$REACT_SDK_DIR" node_modules/matrix-react-sdk
 
-npm run build
+RIOT_LANGUAGES_FILE="../riot-web/webapp/i18n/languages.json" npm run build
 popd

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -338,9 +338,9 @@ export function getCurrentLanguage() {
 
 function getLangsJson() {
     return new Promise((resolve, reject) => {
-        const url = require("../../riot-web/webapp/i18n/languages.json");
+        // LANGUAGES_FILE is a webpack compile-time define, see webpack config
         request(
-            { method: "GET", url },
+            { method: "GET", url: require(LANGUAGES_FILE) },
             (err, response, body) => {
                 if (err || response.status < 200 || response.status >= 300) {
                     reject({err: err, response: response});

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -339,8 +339,9 @@ export function getCurrentLanguage() {
 function getLangsJson() {
     return new Promise((resolve, reject) => {
         // LANGUAGES_FILE is a webpack compile-time define, see webpack config
+        const url = (typeof LANGUAGES_FILE === "string") ? require(LANGUAGES_FILE) : (i18nFolder + 'languages.json');
         request(
-            { method: "GET", url: require(LANGUAGES_FILE) },
+            { method: "GET", url },
             (err, response, body) => {
                 if (err || response.status < 200 || response.status >= 300) {
                     reject({err: err, response: response});

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -338,8 +338,9 @@ export function getCurrentLanguage() {
 
 function getLangsJson() {
     return new Promise((resolve, reject) => {
+        const url = require("../../riot-web/webapp/i18n/languages.json");
         request(
-            { method: "GET", url: i18nFolder + 'languages.json' },
+            { method: "GET", url },
             (err, response, body) => {
                 if (err || response.status < 200 || response.status >= 300) {
                     reject({err: err, response: response});


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/pull/8710

To get a filename with a content hash in it, we use the file-loader plugin for webpack just like for other resources. But because the file is located in riot-web, we moved the relative path into the webpack config so react-sdk doesn't depend on riot-web directly.