### PR TITLE
Add /shrug command

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -75,12 +75,12 @@ export const CommandMap = {
         args: '<message>',
         description: _td('Prepends ¯\\_(ツ)_/¯ to a plain-text message'),
         runFn: function(roomId, args) {
-            let message = '¯\\_(ツ)_/¯'
+            let message = '¯\\_(ツ)_/¯';
             if (args) {
-                message = message + ' ' + args
+                message = message + ' ' + args;
             }
             return success(MatrixClientPeg.get().sendTextMessage(roomId, message));
-        }
+        },
     }),
 
     ddg: new Command({

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -70,6 +70,19 @@ function success(promise) {
 /* eslint-disable babel/no-invalid-this */
 
 export const CommandMap = {
+    shrug: new Command({
+        name: 'shrug',
+        args: '<message>',
+        description: _td('Prepends ¯\\_(ツ)_/¯ to a plain-text message'),
+        runFn: function(roomId, args) {
+            var message = '¯\\_(ツ)_/¯'
+            if (args) {
+                message = message + ' ' + args
+            }
+            return success(MatrixClientPeg.get().sendTextMessage(roomId, message));
+        }
+    }),
+
     ddg: new Command({
         name: 'ddg',
         args: '<query>',

--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -75,7 +75,7 @@ export const CommandMap = {
         args: '<message>',
         description: _td('Prepends ¯\\_(ツ)_/¯ to a plain-text message'),
         runFn: function(roomId, args) {
-            var message = '¯\\_(ツ)_/¯'
+            let message = '¯\\_(ツ)_/¯'
             if (args) {
                 message = message + ' ' + args
             }

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -261,6 +261,7 @@
     "%(senderName)s placed a %(callType)s call.": "%(senderName)s placed a %(callType)s call.",
     "Please check your email and click on the link it contains. Once this is done, click continue.": "Please check your email and click on the link it contains. Once this is done, click continue.",
     "Power level must be positive integer.": "Power level must be positive integer.",
+    "Prepends ¯\\_(ツ)_/¯ to a plain-text message": "Prepends ¯\\_(ツ)_/¯ to a plain-text message",
     "Privacy warning": "Privacy warning",
     "Privileged Users": "Privileged Users",
     "Profile": "Profile",


### PR DESCRIPTION
Certain popular web-based chat systems support a `/shrug` command which appends the `¯\_(ツ)_/¯` text emoticon (kaomoji) to a message. I've often found myself wishing Riot had something similar, so I decided to add it myself. (If Riot ever gets a user-extensible /-command system, this will probably no longer be necessary. But since it doesn't have that, here I am). Doesn't support markdown / rich text messages because I didn't want to dig that far into Riot/the SDKs for my first PR; if someone else would like to add that, by all means.

Signed-off-by: Andrew Chronister <chr@chronal.net>