### PR TITLE
Show link to login even during UI auth

### DIFF
--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -505,14 +505,9 @@ module.exports = React.createClass({
             errorText = <div className="mx_Login_error">{ err }</div>;
         }
 
-        let signIn;
-        if (!this.state.doingUIAuth) {
-            signIn = (
-                <a className="mx_AuthBody_changeFlow" onClick={this.onLoginClick} href="#">
-                    { _t('Sign in instead') }
-                </a>
-            );
-        }
+        const signIn = <a className="mx_AuthBody_changeFlow" onClick={this.onLoginClick} href="#">
+            { _t('Sign in instead') }
+        </a>;
 
         return (
             <AuthPage>


### PR DESCRIPTION
This gives users an escape hatch in case something goes wrong with the UI auth
step, and they'd like to go somewhere else in the auth process.

Fixes https://github.com/vector-im/riot-web/issues/7617

![2019-02-19 at 13 20](https://user-images.githubusercontent.com/279572/53017992-2b95b800-3449-11e9-8909-196194808ade.png)