### PR TITLE
Set event-sending-color in dark theme

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -113,6 +113,9 @@ $panel-divider-color: $header-panel-border-color;
 
 $widget-menu-bar-bg-color: $header-panel-bg-color;
 
+// event tile lifecycle
+$event-sending-color: $text-secondary-color;
+
 // event redaction
 $event-redacted-fg-color: #606060;
 $event-redacted-border-color: #000000;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8586

![screen shot 2019-02-19 at 7 59 31 pm](https://user-images.githubusercontent.com/5855073/53060674-eee5b300-3480-11e9-9073-6156c255eee0.png)
