### PR TITLE
Only show the first line of each commit in changelog dialog

### DIFF
--- a/src/components/views/dialogs/ChangelogDialog.js
+++ b/src/components/views/dialogs/ChangelogDialog.js
@@ -51,7 +51,7 @@ export default class ChangelogDialog extends React.Component {
         return (
             <li key={commit.sha} className="mx_ChangelogDialog_li">
                 <a href={commit.html_url} target="_blank" rel="noopener">
-                    {commit.commit.message}
+                    {commit.commit.message.split('\n')[0]}
                 </a>
             </li>
         );


### PR DESCRIPTION
Multi-line commits aren't actually formatted correctly, and most likely the
first line is enough of a summary anyway, so this change trims to the first
line. The commits are linked, so you can click through if you want more detail.

Fixes https://github.com/vector-im/riot-web/issues/8285