### PR TITLE
Fix waste of space of collapsed left panel

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -24,13 +24,13 @@ limitations under the License.
 
 .mx_LeftPanel_container.collapsed {
     min-width: unset;
-    /* Collapsed LeftPanel 70px */
-    flex: 0 0 70px;
+    /* Collapsed LeftPanel 50px */
+    flex: 0 0 50px;
 }
 
 .mx_LeftPanel_container.collapsed.mx_LeftPanel_container_hasTagPanel {
-    /* TagPanel 70px + Collapsed LeftPanel 70px */
-    flex: 0 0 140px;
+    /* TagPanel 70px + Collapsed LeftPanel 50px */
+    flex: 0 0 120px;
 }
 
 .mx_LeftPanel_tagPanelContainer {

--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -143,7 +143,7 @@ limitations under the License.
     }
 
     .mx_RoomSubList_labelContainer {
-        margin-right: 14px;
+        margin-right: 8px;
         margin-left: 2px;
     }
 

--- a/res/css/structures/_TopLeftMenuButton.scss
+++ b/res/css/structures/_TopLeftMenuButton.scss
@@ -22,7 +22,7 @@ limitations under the License.
     display: flex;
     align-items: center;
     min-width: 0;
-    padding: 0 7px;
+    padding: 0 4px;
     overflow: hidden;
 }
 

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -117,7 +117,7 @@ limitations under the License.
 
 .collapsed {
     .mx_RoomTile {
-        margin: 0 2px;
+        margin: 0 6px;
         padding: 0 2px;
         position: relative;
         justify-content: center;

--- a/src/components/structures/TopLeftMenuButton.js
+++ b/src/components/structures/TopLeftMenuButton.js
@@ -98,10 +98,12 @@ export default class TopLeftMenuButton extends React.Component {
     render() {
         const name = this._getDisplayName();
         let nameElement;
+        let chevronElement;
         if (!this.props.collapsed) {
             nameElement = <div className="mx_TopLeftMenuButton_name">
                 { name }
             </div>;
+            chevronElement = <span className="mx_TopLeftMenuButton_chevron" />;
         }
 
         return (
@@ -121,7 +123,7 @@ export default class TopLeftMenuButton extends React.Component {
                     resizeMethod="crop"
                 />
                 { nameElement }
-                <span className="mx_TopLeftMenuButton_chevron" />
+                { chevronElement }
             </AccessibleButton>
         );
     }


### PR DESCRIPTION
Hello,

I've made a fix to make left panel look more pleasant in collapsed mode. I've tuned some CSS and removed chevron in collapsed mode.

### Before
<img width="100" alt="image" src="https://user-images.githubusercontent.com/7202664/53094304-1046ad80-351a-11e9-96c3-315b9f2633c6.png">

### After

<img width="82" alt="image" src="https://user-images.githubusercontent.com/7202664/53094351-2d7b7c00-351a-11e9-8289-ab0f0acdc124.png">
