### PR TITLE
Fix favourites losing rooms and sorting weirdly

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -287,6 +287,7 @@ class RoomListStore extends Store {
             // Speed optimization: Skip the loop below if we're not going to do anything productive
             if (!hasRoom || LIST_ORDERS[key] !== 'recent') {
                 listsClone[key] = this._state.lists[key];
+                inserted = true; // Ensure that we don't try and sort the room into the tag
                 continue;
             } else {
                 listsClone[key] = [];


### PR DESCRIPTION
By not flagging the room as inserted, we end up sorting it.

Fixes https://github.com/vector-im/riot-web/issues/8857