### PR TITLE
Add `onClick` to Markdown buttons

### DIFF
--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -257,6 +257,8 @@ export default class MessageComposer extends React.Component {
     }
 
     onInputStateChanged(inputState) {
+        // Merge the new input state with old to support partial updates
+        inputState = Object.assign({}, this.state.inputState, inputState);
         this.setState({inputState});
     }
 

--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -501,7 +501,7 @@ export default class MessageComposer extends React.Component {
                         { formatButtons }
                         <div style={{ flex: 1 }}></div>
                         <AccessibleButton className="mx_MessageComposer_formatbar_markdown mx_MessageComposer_markdownDisabled"
-                            onMouseDown={this.onToggleMarkdownClicked}
+                            onClick={this.onToggleMarkdownClicked}
                             title={_t("Markdown is disabled")}
                         />
                         <AccessibleButton element="img" title={_t("Hide Text Formatting Toolbar")}

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -628,7 +628,6 @@ export default class MessageComposerInput extends React.Component {
             }
             const inputState = {
                 marks: editorState.activeMarks,
-                isRichTextEnabled: this.state.isRichTextEnabled,
                 blockType,
             };
             this.props.onInputStateChanged(inputState);
@@ -698,8 +697,13 @@ export default class MessageComposerInput extends React.Component {
         this.setState({
             editorState: this.createEditorState(enabled, editorState),
             isRichTextEnabled: enabled,
-        }, ()=>{
+        }, () => {
             this._editor.focus();
+            if (this.props.onInputStateChanged) {
+                this.props.onInputStateChanged({
+                    isRichTextEnabled: enabled,
+                });
+            }
         });
 
         SettingsStore.setValue("MessageComposerInput.isRichTextEnabled", null, SettingLevel.ACCOUNT, enabled);

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1603,7 +1603,7 @@ export default class MessageComposerInput extends React.Component {
                 </div>
                 <div className={className}>
                     <AccessibleButton className={markdownClasses}
-                        onMouseDown={this.onMarkdownToggleClicked}
+                        onClick={this.onMarkdownToggleClicked}
                         title={this.state.isRichTextEnabled ? _t("Markdown is disabled") : _t("Markdown is enabled")}
                     />
                     <Editor ref={this._collectEditor}


### PR DESCRIPTION
The Markdown toggles need to watch `mousedown` to properly update state, so
let's drop back down to regular `div`s.

This also fixes https://github.com/vector-im/riot-web/issues/8866.