### PR TITLE
RoomDirectory Dropdown should use roomDirectory.servers

### DIFF
--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -131,8 +131,8 @@ export default class NetworkDropdown extends React.Component {
         const options = [];
 
         let servers = [];
-        if (this.props.config.servers) {
-            servers = servers.concat(this.props.config.servers);
+        if (this.props.config.roomDirectory.servers) {
+            servers = servers.concat(this.props.config.roomDirectory.servers);
         }
 
         if (servers.indexOf(MatrixClientPeg.getHomeServerName()) == -1) {


### PR DESCRIPTION
The sample config.json in riot-web has "roomDirectory.servers" and not "servers".
Are other systems than riot-web use "servers" without "roomDirectory" ? Then this would break these.