### PR TITLE
Fix categorization of favourites and new rooms

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -287,7 +287,11 @@ class RoomListStore extends Store {
             // Speed optimization: Skip the loop below if we're not going to do anything productive
             if (!hasRoom || LIST_ORDERS[key] !== 'recent') {
                 listsClone[key] = this._state.lists[key];
-                inserted = true; // Ensure that we don't try and sort the room into the tag
+                if (LIST_ORDERS[key] !== 'recent' && (hasRoom || targetTags.includes(key))) {
+                    // Ensure that we don't try and sort the room into the tag
+                    inserted = true;
+                    doInsert = false;
+                }
                 continue;
             } else {
                 listsClone[key] = [];


### PR DESCRIPTION
New rooms (joined, invited, created, etc) were being ignored because they matched the check as soon as the iterator hit a non-recents section. This fixes the check to ensure there's a positive ID on the room being in the tag (or not, in the case of new rooms) before lying to the rest of the function.

Additionally, a fix for favourites has been included to stop the list expanding to fill the void - turns out it was inserting the room twice into the list, and this was breaking the tile rendering. The room sublist would allocate space for the tile, but React would prevent the tile from showing up because of duplicate keys.

Fixes https://github.com/vector-im/riot-web/issues/8868
Fixes https://github.com/vector-im/riot-web/issues/8857 correctly