### PR TITLE
Remove duplicated conversion from `enableRichText`

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -686,17 +686,14 @@ export default class MessageComposerInput extends React.Component {
     enableRichtext(enabled: boolean) {
         if (enabled === this.state.isRichTextEnabled) return;
 
-        let editorState = null;
-        if (enabled) {
-            editorState = this.mdToRichEditorState(this.state.editorState);
-        } else {
-            editorState = this.richToMdEditorState(this.state.editorState);
-        }
-
         Analytics.setRichtextMode(enabled);
 
         this.setState({
-            editorState: this.createEditorState(enabled, editorState),
+            editorState: this.createEditorState(
+                enabled,
+                this.state.editorState,
+                this.state.isRichTextEnabled,
+            ),
             isRichTextEnabled: enabled,
         }, ()=>{
             this._editor.focus();


### PR DESCRIPTION
`enableRichText` would convert the editor state between rich and md versions
explicitly, but then it would also call `createEditorState`, which can do the
same thing.

This removes the duplication, and also supplies the right arguments to
`createEditorState` so it can do its work correctly.