### PR TITLE
Fix z ordering of the overflow tile

### DIFF
--- a/res/css/views/rooms/_WhoIsTypingTile.scss
+++ b/res/css/views/rooms/_WhoIsTypingTile.scss
@@ -40,6 +40,7 @@ limitations under the License.
 }
 
 .mx_WhoIsTypingTile_remainingAvatarPlaceholder {
+    position: relative;
     display: inline-block;
     color: #acacac;
     background-color: #ddd;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8404

![image](https://user-images.githubusercontent.com/2403652/53294668-e83d9f80-37e2-11e9-9235-cf71e6691b5f.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>