### PR TITLE
Fix NPE relating to toggling notifications

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -537,12 +537,12 @@ module.exports = React.createClass({
             case 'picture_snapshot':
                 this.uploadFile(payload.file);
                 break;
-            case 'notifier_enabled':
             case 'upload_failed':
                 // 413: File was too big or upset the server in some way.
-                if(payload.error.http_status === 413) {
+                if (payload.error && payload.error.http_status === 413) {
                     this._fetchMediaConfig(true);
                 }
+            case 'notifier_enabled':
             case 'upload_started':
             case 'upload_finished':
                 this.forceUpdate();


### PR DESCRIPTION
The fallthrough for `notifier_enabled` caused a NPE on `payload.error`, so this moves the fallthrough to where it is intended and sanity checks `payload.error` for next time.