### PR TITLE
Revert "Add some logging for riot-web#7838"

### DIFF
--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -362,34 +362,6 @@ export default class MessageComposer extends React.Component {
         const canSendMessages = !this.state.tombstone &&
             this.props.room.maySendMessage();
 
-        // TODO: Remove temporary logging for riot-web#7838
-        // Note: we rip apart the power level event ourselves because we don't want to
-        // log too much data about it - just the bits we care about. Many of the variables
-        // logged here are to help figure out where in the stack the 'cannot post in room'
-        // warning is coming from. This means logging various numbers from the PL event to
-        // verify RoomState._maySendEventOfType is doing the right thing.
-        const room = this.props.room;
-        const plEvent = room.currentState.getStateEvents('m.room.power_levels', '');
-        let plEventString = "<no power level event>";
-        if (plEvent) {
-            const content = plEvent.getContent();
-            if (!content) {
-                plEventString = "<no event content>";
-            } else {
-                const stringifyFalsey = (v) => v === null ? '<null>' : (v === undefined ? '<undefined>' : v);
-                const actualUserPl = stringifyFalsey(content.users ? content.users[room.myUserId] : "<no users in content>");
-                const usersPl = stringifyFalsey(content.users_default);
-                const actualEventPl = stringifyFalsey(content.events ? content.events['m.room.message'] : "<no events in content>");
-                const eventPl = stringifyFalsey(content.events_default);
-                plEventString = `actualUserPl=${actualUserPl} defaultUserPl=${usersPl} actualEventPl=${actualEventPl} defaultEventPl=${eventPl}`;
-            }
-        }
-        console.log(
-            `[riot-web#7838] renderComposer() hasTombstone=${!!this.state.tombstone} maySendMessage=${room.maySendMessage()}` +
-            ` myMembership=${room.getMyMembership()} maySendEvent=${room.currentState.maySendEvent('m.room.message', room.myUserId)}` +
-            ` myUserId=${room.myUserId} roomId=${room.roomId} hasPlEvent=${!!plEvent} powerLevels='${plEventString}'`
-        );
-
         if (canSendMessages) {
             // This also currently includes the call buttons. Really we should
             // check separately for whether we can call, but this is slightly
@@ -469,8 +441,6 @@ export default class MessageComposer extends React.Component {
                 </div>
             </div>);
         } else {
-            // TODO: Remove temporary logging for riot-web#7838
-            console.log("[riot-web#7838] Falling back to showing cannot post in room error");
             controls.push(
                 <div key="controls_error" className="mx_MessageComposer_noperm_error">
                     { _t('You do not have permission to post to this room') }


### PR DESCRIPTION
This reverts commit f5ff580e3506286be0887baa4cb84f4962355fa9.

The last report of https://github.com/vector-im/riot-web/issues/7838 appearing was well over a month and a half ago, and the issue has been dormant ever since. I think we can remove this logging and close the issue as we're not seeing reports of it anymore.

The logging didn't end up discovering a problem from the limited cases that did have it either.