### PR TITLE
Normalise room list font weight, bold unreads

### DIFF
--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -102,7 +102,6 @@ limitations under the License.
 
 .mx_RoomTile_name {
     font-size: 14px;
-    font-weight: 600;
     padding: 0 6px;
     color: $roomtile-name-color;
     white-space: nowrap;
@@ -155,7 +154,7 @@ limitations under the License.
 
 .mx_RoomTile_unread, .mx_RoomTile_highlight {
     .mx_RoomTile_name {
-        // font-weight: 700; // bold is too loud in the end
+        font-weight: 600;
         color: $roomtile-selected-color;
     }
 }


### PR DESCRIPTION
Closes [#8935](https://github.com/vector-im/riot-web/issues/8935).

Before:
<img width="1386" alt="screenshot 2019-02-25 at 17 58 33" src="https://user-images.githubusercontent.com/4626865/53355801-2691a680-392a-11e9-806b-d1d5df421d58.png">


After:
<img width="1386" alt="screenshot 2019-02-25 at 17 56 58" src="https://user-images.githubusercontent.com/4626865/53355808-2a252d80-392a-11e9-9c9b-aa75e6b26a13.png">
