### PR TITLE
Keep registration spinner inside the auth modal

### DIFF
--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -103,3 +103,7 @@ limitations under the License.
     text-align: center;
     width: 100%;
 }
+
+.mx_AuthBody_spinner {
+    margin: 1em 0;
+}

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -495,7 +495,9 @@ module.exports = React.createClass({
                 poll={true}
             />;
         } else if (this.state.busy || !this.state.flows) {
-            return <Spinner />;
+            return <div className="mx_AuthBody_spinner">
+                <Spinner />
+            </div>;
         } else {
             let onEditServerDetailsClick = null;
             // If custom URLs are allowed and we haven't selected the Free server type, wire


### PR DESCRIPTION
The spinner was taking on the full height of the modal and escaping off the
page. This keeps it contained inside the modal.

Fixes https://github.com/vector-im/riot-web/issues/8661

![image](https://user-images.githubusercontent.com/279572/53486937-07a62800-3a82-11e9-93c0-a2417a972628.png)