### PR TITLE
Send Field label pointer events to input

### DIFF
--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -88,6 +88,7 @@ limitations under the License.
     top: 0px;
     margin: 7px 8px;
     padding: 2px;
+    pointer-events: none; // Allow clicks to fall through to the input
 }
 
 .mx_Field input:focus + label,
@@ -104,6 +105,7 @@ limitations under the License.
     top: -13px;
     padding: 0 2px;
     background-color: $field-focused-label-bg-color;
+    pointer-events: initial;
 }
 
 .mx_Field input:focus + label,


### PR DESCRIPTION
When the `label` element is displayed on top of the input (`label` is set and
there is no `placeholder`), it would block clicks from reaching the input. This
allows them to get through, but then also restores `label`'s events once it
moves out of the way.

Fixes https://github.com/vector-im/riot-web/issues/8469

![label-click](https://user-images.githubusercontent.com/279572/53493524-6b851c80-3a93-11e9-90c3-5df35de5bde1.gif)