### PR TITLE
Remove unnecessary ref from Stickerpicker

### DIFF
--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -349,7 +349,6 @@ export default class Stickerpicker extends React.Component {
                     key="controls_hide_stickers"
                     className="mx_MessageComposer_button mx_MessageComposer_stickers mx_Stickers_hideStickers"
                     onClick={this._onHideStickersClick}
-                    ref='target'
                     title={_t("Hide Stickers")}
                 >
                 </AccessibleButton>;


### PR DESCRIPTION
There is a ref=target in the call to render AccessibleButton for
the hide stickers button. This ref is not present in the show case.

When clicking the stickerpicker show button, React gives a warning:

> Warning: Stateless function components cannot be given refs
> (See ref "target" in AccessibleButton created by Stickerpicker).
> Attempts to access this ref will fail.

Removed the ref. Stickerpicker hide/show still works fine, no warning.

Signed-off-by: Jason Robinson <jasonr@matrix.org>