### PR TITLE
Nudge karma to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "file-loader": "^3.0.1",
     "flow-parser": "^0.57.3",
     "jest-mock": "^23.2.0",
-    "karma": "^3.0.0",
+    "karma": "^3.1.2",
     "karma-chrome-launcher": "^0.2.3",
     "karma-cli": "^1.0.1",
     "karma-junit-reporter": "^0.4.2",


### PR DESCRIPTION
This includes a fix for detecting the version of Chrome used to run tests.