### PR TITLE
Use webpack alias to resolve the languages file

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -23,5 +23,5 @@ ln -s "$REACT_SDK_DIR/node_modules/matrix-js-sdk" node_modules/matrix-js-sdk
 rm -r node_modules/matrix-react-sdk
 ln -s "$REACT_SDK_DIR" node_modules/matrix-react-sdk
 
-RIOT_LANGUAGES_FILE="../riot-web/webapp/i18n/languages.json" npm run build
+npm run build
 popd

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -340,8 +340,8 @@ function getLangsJson() {
     return new Promise((resolve, reject) => {
         let url;
         try {
-            // Webapp is a webpack resolve alias pointing to the output directory, see webpack config
-            url = require('Webapp/i18n/languages.json');
+            // $webapp is a webpack resolve alias pointing to the output directory, see webpack config
+            url = require('$webapp/i18n/languages.json');
         } catch (e) {
             url = i18nFolder + 'languages.json';
         }

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -338,8 +338,13 @@ export function getCurrentLanguage() {
 
 function getLangsJson() {
     return new Promise((resolve, reject) => {
-        // Webapp is a webpack resolve alias pointing to the output directory, see webpack config
-        const url = require('Webapp/i18n/languages.json');
+        let url;
+        try {
+            // Webapp is a webpack resolve alias pointing to the output directory, see webpack config
+            url; = require('Webapp/i18n/languages.json');
+        } catch (e) {
+            url = i18nFolder + 'languages.json';
+        }
         request(
             { method: "GET", url },
             (err, response, body) => {

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -341,7 +341,7 @@ function getLangsJson() {
         let url;
         try {
             // Webapp is a webpack resolve alias pointing to the output directory, see webpack config
-            url; = require('Webapp/i18n/languages.json');
+            url = require('Webapp/i18n/languages.json');
         } catch (e) {
             url = i18nFolder + 'languages.json';
         }

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -338,8 +338,8 @@ export function getCurrentLanguage() {
 
 function getLangsJson() {
     return new Promise((resolve, reject) => {
-        // LANGUAGES_FILE is a webpack compile-time define, see webpack config
-        const url = (typeof LANGUAGES_FILE === "string") ? require(LANGUAGES_FILE) : (i18nFolder + 'languages.json');
+        // Webapp is a webpack resolve alias pointing to the output directory, see webpack config
+        const url = require('Webapp/i18n/languages.json');
         request(
             { method: "GET", url },
             (err, response, body) => {


### PR DESCRIPTION
Hopefully this will end up simpler than having to figure out in riot-web what the relative path is from react-sdk's src/languageHandler.js to riot-web's webapp directory.

Requires https://github.com/vector-im/riot-web/pull/9014