### PR TITLE
Convert objects and such to usable strings in rageshake

### DIFF
--- a/src/rageshake/rageshake.js
+++ b/src/rageshake/rageshake.js
@@ -71,6 +71,18 @@ class ConsoleLogger {
     log(level, ...args) {
         // We don't know what locale the user may be running so use ISO strings
         const ts = new Date().toISOString();
+
+        // Convert objects and errors to helpful things
+        args = args.map((arg) => {
+            if (arg instanceof Error) {
+                return arg.message + (arg.stack ? `\n${arg.stack}` : '');
+            } else if (typeof(arg) === 'object') {
+                return JSON.stringify(arg);
+            } else {
+                return arg;
+            }
+        });
+
         // Some browsers support string formatting which we're not doing here
         // so the lines are a little more ugly but easy to implement / quick to
         // run.


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7844

Test script:
```
console.error({"hello": "world"}); 
console.error(new Error("Testing")); 
console.error("Hello world:", {test:1});
try{
    throw new Error("Thrown");
}catch(e){
    console.error(e);
} 
```

Before:

```
2019-03-01T16:57:48.440Z E [object Object]
2019-03-01T16:57:48.440Z E Error: Testing
2019-03-01T16:57:48.440Z E Hello world: [object Object]
2019-03-01T16:57:48.440Z E Error: Thrown
```

After:

```
2019-03-01T16:59:17.856Z E {"hello":"world"}
2019-03-01T16:59:17.856Z E Testing
Error: Testing
    at <anonymous>:2:15
2019-03-01T16:59:17.856Z E Hello world: {"test":1}
2019-03-01T16:59:17.856Z E Thrown
Error: Thrown
    at <anonymous>:5:11
```