### PR TITLE
Don't duplicate direct chats from other tags

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -319,7 +319,9 @@ class RoomListStore extends Store {
             const dmRoomMap = DMRoomMap.shared();
             if (myMembership === 'invite') {
                 tags.push("im.vector.fake.invite");
-            } else if (dmRoomMap.getUserIdForRoomId(room.roomId)) {
+            } else if (dmRoomMap.getUserIdForRoomId(room.roomId) && tags.length === 0) {
+                // We intentionally don't duplicate rooms in other tags into the people list
+                // as a feature.
                 tags.push("im.vector.fake.direct");
             } else if (tags.length === 0) {
                 tags.push("im.vector.fake.recent");


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8971

![image](https://user-images.githubusercontent.com/1190097/53670157-dcb10500-3c36-11e9-8aa8-3c5e07e17193.png)

(ignore the part where the rooms are obviously broken and not showing avatars/names of these people - the homeserver this was tested on is a dumpster fire at the moment)