### PR TITLE
Limit Field label to size of input

### DIFF
--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -89,6 +89,10 @@ limitations under the License.
     margin: 7px 8px;
     padding: 2px;
     pointer-events: none; // Allow clicks to fall through to the input
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: calc(100% - 18px);
 }
 
 .mx_Field input:focus + label,

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -92,7 +92,7 @@ limitations under the License.
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    max-width: calc(100% - 18px);
+    max-width: calc(100% - 20px); // 100% of parent minus margin and padding
 }
 
 .mx_Field input:focus + label,


### PR DESCRIPTION
This avoids awkward wrapping if the label is longer than the input. This will
show an ellipsis to suggest there's more text in the label than can be shown.

<img width="203" alt="2019-03-04 at 18 04" src="https://user-images.githubusercontent.com/279572/53752965-f9a03f00-3ea7-11e9-9a07-0bc5620b337f.png">

This seems particular important for i18n where strings could be much longer than in English.