### PR TITLE
Recalculate encrypted push notifications for highlights

### DIFF
--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -261,6 +261,15 @@ const Notifier = {
         if (ev.isDecryptionFailure()) return;
 
         const idx = this.pendingEncryptedEventIds.indexOf(ev.getId());
+        if (idx === -1 && ev.isEncrypted()) {
+            // Just recalculate the push actions on the event so that when the user
+            // refreshes, the message turns red for mentions. We should not be sending
+            // off popups or audio cues though.
+            //
+            // This ultimately sets new push actions, and we don't care about the returned
+            // value.
+            MatrixClientPeg.get().getPushActionsForEvent(ev, true);
+        }
         if (idx === -1) return;
 
         this.pendingEncryptedEventIds.splice(idx, 1);

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -261,15 +261,6 @@ const Notifier = {
         if (ev.isDecryptionFailure()) return;
 
         const idx = this.pendingEncryptedEventIds.indexOf(ev.getId());
-        if (idx === -1 && ev.isEncrypted()) {
-            // Just recalculate the push actions on the event so that when the user
-            // refreshes, the message turns red for mentions. We should not be sending
-            // off popups or audio cues though.
-            //
-            // This ultimately sets new push actions, and we don't care about the returned
-            // value.
-            MatrixClientPeg.get().getPushActionsForEvent(ev, true);
-        }
         if (idx === -1) return;
 
         this.pendingEncryptedEventIds.splice(idx, 1);

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -287,7 +287,7 @@ const Notifier = {
 
     _evaluateEvent: function(ev) {
         const room = MatrixClientPeg.get().getRoom(ev.getRoomId());
-        const actions = MatrixClientPeg.get().getPushActionsForEvent(ev);
+        const actions = MatrixClientPeg.get().getPushActionsForEvent(ev, ev.isEncrypted());
         if (actions && actions.notify) {
             if (this.isEnabled()) {
                 this._displayPopupNotification(ev, room);


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/7489
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/851**

~~Like with the js-sdk, I'm not entirely convinced that this is the right place to be doing any of this.~~ I've since shuffled things around.

My GIF recorder is broken, so here's a deconstructed 2 frame GIF:
![image](https://user-images.githubusercontent.com/1190097/53838440-55bf9d80-3f52-11e9-9857-cde03d931370.png)
![image](https://user-images.githubusercontent.com/1190097/53838447-5821f780-3f52-11e9-9789-486da3b1ccfa.png)
