### PR TITLE
Prevent flair pushing timeline downwards

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -58,12 +58,16 @@ limitations under the License.
 .mx_EventTile .mx_SenderProfile .mx_Flair {
     opacity: 0.7;
     margin-left: 5px;
-}
+    display: inline-block;
+    vertical-align: top;
+    height: 16px;
+    overflow: hidden;
 
-.mx_EventTile .mx_SenderProfile .mx_Flair img {
-    vertical-align: -2px;
-    margin-right: 2px;
-    border-radius: 8px;
+    img {
+        vertical-align: -2px;
+        margin-right: 2px;
+        border-radius: 8px;
+    }
 }
 
 .mx_EventTile .mx_MessageTimestamp {

--- a/src/components/views/elements/Flair.js
+++ b/src/components/views/elements/Flair.js
@@ -117,7 +117,7 @@ export default class Flair extends React.Component {
 
     render() {
         if (this.state.profiles.length === 0) {
-            return <div />;
+            return <span className="mx_Flair" />;
         }
         const avatars = this.state.profiles.map((profile, index) => {
             return <FlairAvatar key={index} groupProfile={profile} />;


### PR DESCRIPTION
The flair badges in the timeline make the sender part of an event tile taller, which AFAIK doesn't serve an aesthetical purpose, and makes it harder to keep the scroll position bottom aligned.

In case something regresses with the styling, we still set .mx_Flair on the container even though there are not profiles to render so the size can't change.

Here's toggling `display: none` on the `.mx_Flair`:
![flair](https://user-images.githubusercontent.com/274386/53811342-15abeb00-3f51-11e9-8d38-9e36a25b68c8.gif)

It looks like this fixes https://github.com/vector-im/riot-web/issues/9018 & https://github.com/vector-im/riot-web/issues/8792