### PR TITLE
clear min-height for typing notifs when the timeline viewport changes size

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -254,6 +254,7 @@ module.exports = React.createClass({
     },
 
     onResize: function() {
+        this.clearBlockShrinking();
         this.props.onResize();
         this.checkScroll();
         if (this._gemScroll) this._gemScroll.forceUpdate();


### PR DESCRIPTION
as the min-height will be too tall for a wider viewport, creating a white wall of doom at the bottom.