### PR TITLE
Ability to bulk accept all invites (and fix rejecting all invites)

### DIFF
--- a/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
@@ -40,6 +40,10 @@ limitations under the License.
     margin-right: 10px;
 }
 
+.mx_SecurityUserSettingsTab_bulkOptions .mx_AccessibleButton {
+    margin-right: 10px;
+}
+
 .mx_SecurityUserSettingsTab_importExportButtons {
     margin-bottom: 15px;
 }

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -129,7 +129,7 @@ export default class SecurityUserSettingsTab extends React.Component {
                 if (e.errcode === "M_LIMIT_EXCEEDED") {
                     // Add a delay between each invite change in order to avoid rate
                     // limiting by the server.
-                    await Promise.delay(e.retry_after_ms);
+                    await Promise.delay(e.retry_after_ms || 2500);
 
                     // Redo last action
                     i--;

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -26,9 +26,6 @@ import Promise from "bluebird";
 import Modal from "../../../../../Modal";
 import sdk from "../../../../..";
 
-// Delay between failing invite acceptance/rejections to avoid rate-limiting
-const INVITE_MANAGEMENT_DELAY = 10000;
-
 export class IgnoredUser extends React.Component {
     static propTypes = {
         userId: PropTypes.string.isRequired,
@@ -132,7 +129,7 @@ export default class SecurityUserSettingsTab extends React.Component {
                 if (e.errcode === "M_LIMIT_EXCEEDED") {
                     // Add a delay between each invite change in order to avoid rate
                     // limiting by the server.
-                    await Promise.delay(INVITE_MANAGEMENT_DELAY);
+                    await Promise.delay(e.retry_after_ms);
 
                     // Redo last action
                     i--;

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -26,6 +26,9 @@ import Promise from "bluebird";
 import Modal from "../../../../../Modal";
 import sdk from "../../../../..";
 
+// Delay between failing invite acceptance/rejections to avoid rate-limiting
+const INVITE_MANAGEMENT_DELAY = 10000;
+
 export class IgnoredUser extends React.Component {
     static propTypes = {
         userId: PropTypes.string.isRequired,
@@ -52,9 +55,13 @@ export default class SecurityUserSettingsTab extends React.Component {
     constructor() {
         super();
 
+        // Get number of rooms we're invited to
+        const invitedRooms = this._getInvitedRooms();
+
         this.state = {
             ignoredUserIds: MatrixClientPeg.get().getIgnoredUsers(),
-            rejectingInvites: false,
+            managingInvites: false,
+            invitedRoomAmt: invitedRooms.length,
         };
     }
 
@@ -93,22 +100,60 @@ export default class SecurityUserSettingsTab extends React.Component {
         this.setState({ignoredUsers});
     };
 
-    _onRejectAllInvitesClicked = (rooms, ev) => {
+    _getInvitedRooms = () => {
+        return MatrixClientPeg.get().getRooms().filter((r) => {
+            return r.hasMembershipState(MatrixClientPeg.get().getUserId(), "invite");
+        });
+    };
+
+    _manageInvites = async (accept) => {
         this.setState({
-            rejectingInvites: true,
+            managingInvites: true,
         });
-        // reject the invites
-        const promises = rooms.map((room) => {
-            return MatrixClientPeg.get().leave(room.roomId).catch((e) => {
-                // purposefully drop errors to the floor: we'll just have a non-zero number on the UI
-                // after trying to reject all the invites.
+
+        // Compile array of invitation room ids
+        const invitedRoomIds = this._getInvitedRooms().map((room) => {
+            return room.roomId;
+        });
+
+        // Execute all acceptances/rejections sequentially
+        const self = this;
+        const cli = MatrixClientPeg.get();
+        const action = accept ? cli.joinRoom.bind(cli) : cli.leave.bind(cli);
+        for (let i = 0; i < invitedRoomIds.length; i++) {
+            const roomId = invitedRoomIds[i];
+
+            // Accept/reject invite
+            await action(roomId).then(() => {
+                // No error, update invited rooms button
+                this.setState({invitedRoomAmt: self.state.invitedRoomAmt - 1});
+            }, async (e) => {
+                // Action failure
+                if (e.errcode === "M_LIMIT_EXCEEDED") {
+                    // Add a delay between each invite change in order to avoid rate
+                    // limiting by the server.
+                    await Promise.delay(INVITE_MANAGEMENT_DELAY);
+
+                    // Redo last action
+                    i--;
+                } else {
+                    // Print out error with joining/leaving room
+                    console.warn(e);
+                }
             });
+        }
+
+        this.setState({
+            managingInvites: false,
         });
-        Promise.all(promises).then(() => {
-            this.setState({
-                rejectingInvites: false,
-            });
-        });
+    };
+
+    _onAcceptAllInvitesClicked = (ev) => {
+        this._manageInvites(true);
+    };
+
+    _onRejectAllInvitesClicked = (ev) => {
+        this._manageInvites(false);
     };
 
     _renderCurrentDeviceInfo() {
@@ -173,21 +218,25 @@ export default class SecurityUserSettingsTab extends React.Component {
         );
     }
 
-    _renderRejectInvites() {
-        const invitedRooms = MatrixClientPeg.get().getRooms().filter((r) => {
-            return r.hasMembershipState(MatrixClientPeg.get().getUserId(), "invite");
-        });
-        if (invitedRooms.length === 0) {
+    _renderManageInvites() {
+        if (this.state.invitedRoomAmt === 0) {
             return null;
         }
 
-        const onClick = this._onRejectAllInvitesClicked.bind(this, invitedRooms);
+        const invitedRooms = this._getInvitedRooms();
+        const InlineSpinner = sdk.getComponent('elements.InlineSpinner');
+        const onClickAccept = this._onAcceptAllInvitesClicked.bind(this, invitedRooms);
+        const onClickReject = this._onRejectAllInvitesClicked.bind(this, invitedRooms);
         return (
-            <div className='mx_SettingsTab_section'>
+            <div className='mx_SettingsTab_section mx_SecurityUserSettingsTab_bulkOptions'>
                 <span className='mx_SettingsTab_subheading'>{_t('Bulk options')}</span>
-                <AccessibleButton onClick={onClick} kind='danger' disabled={this.state.rejectingInvites}>
-                    {_t("Reject all %(invitedRooms)s invites", {invitedRooms: invitedRooms.length})}
+                <AccessibleButton onClick={onClickAccept} kind='primary' disabled={this.state.managingInvites}>
+                    {_t("Accept all %(invitedRooms)s invites", {invitedRooms: this.state.invitedRoomAmt})}
                 </AccessibleButton>
+                <AccessibleButton onClick={onClickReject} kind='danger' disabled={this.state.managingInvites}>
+                    {_t("Reject all %(invitedRooms)s invites", {invitedRooms: this.state.invitedRoomAmt})}
+                </AccessibleButton>
+                {this.state.managingInvites ? <InlineSpinner /> : <div />}
             </div>
         );
     }
@@ -232,7 +281,7 @@ export default class SecurityUserSettingsTab extends React.Component {
                                   onChange={this._updateAnalytics} />
                 </div>
                 {this._renderIgnoredUsers()}
-                {this._renderRejectInvites()}
+                {this._renderManageInvites()}
             </div>
         );
     }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -559,6 +559,7 @@
     "Device key:": "Device key:",
     "Ignored users": "Ignored users",
     "Bulk options": "Bulk options",
+    "Accept all %(invitedRooms)s invites": "Accept all %(invitedRooms)s invites",
     "Reject all %(invitedRooms)s invites": "Reject all %(invitedRooms)s invites",
     "Key backup": "Key backup",
     "Security & Privacy": "Security & Privacy",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1342360/53886705-823ded00-4018-11e9-86c5-ae0d98cb3262.png)

![image](https://user-images.githubusercontent.com/1342360/53886735-94b82680-4018-11e9-8df3-b824bd5fc435.png)



This adds a new button into Settings->Security & Privacy which allows you to accept all of your current invites.

This also fixes the current state of the "Reject all invites" button which is currently broken if you try to accept more than ~8 invites at once due to server ratelimiting.

We now check to see if we receive a `M_LIMIT_EXCEEDED` and if so wait 10s before trying to join the same room again. If there's another error, we log it to the console and continue onto the next room.