### PR TITLE
Tweak auth components when dark theme is default

### DIFF
--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -22,37 +22,42 @@ limitations under the License.
     box-sizing: border-box;
     font-size: 12px;
     color: $authpage-secondary-color;
-}
 
-.mx_AuthBody h2 {
-    font-size: 24px;
-    font-weight: 600;
-    margin-top: 8px;
-    color: $authpage-primary-color;
-}
+    h2 {
+        font-size: 24px;
+        font-weight: 600;
+        margin-top: 8px;
+        color: $authpage-primary-color;
+    }
 
-.mx_AuthBody h3 {
-    font-size: 14px;
-    font-weight: 600;
-    color: $authpage-primary-color;
-}
+    h3 {
+        font-size: 14px;
+        font-weight: 600;
+        color: $authpage-primary-color;
+    }
 
-.mx_AuthBody input[type=text],
-.mx_AuthBody input[type=password] {
-    color: $authpage-primary-color;
-}
+    a:link,
+    a:hover,
+    a:visited {
+        color: $accent-color;
+        text-decoration: none;
+    }
 
-.mx_AuthBody .mx_Field input,
-.mx_AuthBody .mx_Field select {
-    color: $authpage-primary-color;
-    background-color: $authpage-body-bg-color;
-}
+    input[type=text],
+    input[type=password] {
+        color: $authpage-primary-color;
+    }
 
-.mx_AuthBody .mx_Field label {
-    color: $authpage-primary-color;
-}
+    .mx_Field input,
+    .mx_Field select {
+        color: $authpage-primary-color;
+        background-color: $authpage-body-bg-color;
+    }
 
-.mx_AuthBody {
+    .mx_Field label {
+        color: $authpage-primary-color;
+    }
+
     .mx_Field input:focus + label,
     .mx_Field input:not(:placeholder-shown) + label,
     .mx_Field textarea:focus + label,
@@ -61,21 +66,21 @@ limitations under the License.
     .mx_Field_labelAlwaysTopLeft label {
         background-color: $authpage-body-bg-color;
     }
-}
 
-.mx_AuthBody input.error {
-    color: $warning-color;
+    input.error {
+        color: $warning-color;
+    }
+
+    .mx_Field input {
+        width: 100%;
+        box-sizing: border-box;
+    }
 }
 
 .mx_AuthBody_editServerDetails {
     padding-left: 1em;
     font-size: 12px;
     font-weight: normal;
-}
-
-.mx_AuthBody .mx_Field input {
-    width: 100%;
-    box-sizing: border-box;
 }
 
 .mx_AuthBody_fieldRow {
@@ -94,13 +99,6 @@ limitations under the License.
 
 .mx_AuthBody_fieldRow > .mx_Field:last-child {
     margin-right: 0;
-}
-
-.mx_AuthBody a:link,
-.mx_AuthBody a:hover,
-.mx_AuthBody a:visited {
-    color: $accent-color;
-    text-decoration: none;
 }
 
 .mx_AuthBody_changeFlow {

--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -75,6 +75,18 @@ limitations under the License.
         width: 100%;
         box-sizing: border-box;
     }
+
+    .mx_Dropdown_arrow {
+        background: $authpage-primary-color;
+    }
+
+    .mx_Dropdown_menu {
+        background-color: $authpage-body-bg-color;
+
+        .mx_Dropdown_option_highlight {
+            background-color: $authpage-focus-bg-color;
+        }
+    }
 }
 
 .mx_AuthBody_editServerDetails {

--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -52,10 +52,15 @@ limitations under the License.
     color: $authpage-primary-color;
 }
 
-.mx_AuthBody .mx_Field input:focus + label,
-.mx_AuthBody .mx_Field input:not(:placeholder-shown) + label,
-.mx_AuthBody .mx_Field select + label /* Always show a select's label on top to not collide with the value */ {
-    background-color: $authpage-body-bg-color;
+.mx_AuthBody {
+    .mx_Field input:focus + label,
+    .mx_Field input:not(:placeholder-shown) + label,
+    .mx_Field textarea:focus + label,
+    .mx_Field textarea:not(:placeholder-shown) + label,
+    .mx_Field select + label /* Always show a select's label on top to not collide with the value */,
+    .mx_Field_labelAlwaysTopLeft label {
+        background-color: $authpage-body-bg-color;
+    }
 }
 
 .mx_AuthBody input.error {

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -246,6 +246,7 @@ $memberstatus-placeholder-color: $roomtile-name-color;
 $authpage-bg-color: #2e3649;
 $authpage-modal-bg-color: rgba(255, 255, 255, 0.59);
 $authpage-body-bg-color: #ffffff;
+$authpage-focus-bg-color: #dddddd;
 $authpage-lang-color: #4e5054;
 $authpage-primary-color: #232f32;
 $authpage-secondary-color: #61708b;


### PR DESCRIPTION
This fixes several styling issues with the auth phone input when dark theme is enabled.

**Reviewer:** Each commit in this PR is self-contained and has some additional context in the commit message, so you may want to review commit by commit.

<img width="312" alt="2019-03-06 at 16 45" src="https://user-images.githubusercontent.com/279572/53898153-6f82e280-402f-11e9-9b63-53ae3d29ea67.png">

Fixes https://github.com/vector-im/riot-web/issues/8990