### PR TITLE
Fix erroneously sending RRs, pt1.

### DIFF
--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -33,7 +33,7 @@ class UserActivity {
         this._attachedTimers = [];
         this._activityTimeout = new Timer(CURRENTLY_ACTIVE_THRESHOLD_MS);
         this._onUserActivity = this._onUserActivity.bind(this);
-        this._onDocumentBlurred = this._onDocumentBlurred.bind(this);
+        this._onWindowBlurred = this._onWindowBlurred.bind(this);
         this._onPageVisibilityChanged = this._onPageVisibilityChanged.bind(this);
         this.lastScreenX = 0;
         this.lastScreenY = 0;
@@ -74,8 +74,8 @@ class UserActivity {
         document.onmousemove = this._onUserActivity;
         document.onkeydown = this._onUserActivity;
         document.addEventListener("visibilitychange", this._onPageVisibilityChanged);
-        document.addEventListener("blur", this._onDocumentBlurred);
-        document.addEventListener("focus", this._onUserActivity);
+        window.addEventListener("blur", this._onWindowBlurred);
+        window.addEventListener("focus", this._onUserActivity);
         // can't use document.scroll here because that's only the document
         // itself being scrolled. Need to use addEventListener's useCapture.
         // also this needs to be the wheel event, not scroll, as scroll is
@@ -110,13 +110,14 @@ class UserActivity {
 
     _onPageVisibilityChanged(e) {
         if (document.visibilityState === "hidden") {
+            console.log("page hidden");
             this._activityTimeout.abort();
         } else {
             this._onUserActivity(e);
         }
     }
 
-    _onDocumentBlurred() {
+    _onWindowBlurred() {
         this._activityTimeout.abort();
     }
 

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/UserActivity.js
+++ b/src/UserActivity.js
@@ -111,7 +111,6 @@ class UserActivity {
 
     _onPageVisibilityChanged(e) {
         if (document.visibilityState === "hidden") {
-            console.log("page hidden");
             this._activityTimeout.abort();
         } else {
             this._onUserActivity(e);


### PR DESCRIPTION
Firefox fires the blur event on both document and window. Chrome
only fires it on window, so on chrome we were not seeing the window
being un-focused. window seems to be the standard so just use that.

This isn't the end of the story though since wer can get mousemove
events without the window ever having gained focus, in which case
we'll continue to think the user is active for another 2 mins when
in fact all they did was pass their cursor over the window.

https://github.com/vector-im/riot-web/issues/9023