### PR TITLE
Pass correct args when creating event permalink in context menu

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -307,10 +307,7 @@ module.exports = React.createClass({
 
         let permalink;
         if (this.props.permalinkCreator) {
-            permalink = this.props.permalinkCreator.forEvent(
-                this.props.mxEvent.getRoomId(),
-                this.props.mxEvent.getId(),
-            );
+            permalink = this.props.permalinkCreator.forEvent(this.props.mxEvent.getId());
         }
         // XXX: if we use room ID, we should also include a server where the event can be found (other than in the domain of the event ID)
         const permalinkButton = (


### PR DESCRIPTION
After the permalink API was changed in
https://github.com/matrix-org/matrix-react-sdk/pull/2671, it seems we forgot to
update this call site, so it was creating `<room>/<room>` links, instead of
`<room>/<event>`.

Fixes https://github.com/vector-im/riot-web/issues/9110