### PR TITLE
Fix simple header counters to correctly handle zero, take two

### DIFF
--- a/src/components/views/rooms/AuxPanel.js
+++ b/src/components/views/rooms/AuxPanel.js
@@ -213,35 +213,33 @@ module.exports = React.createClass({
                 const severity = counter.severity;
                 const stateKey = counter.stateKey;
 
-                if (title && value && severity) {
-                    let span = <span>{ title }: { value }</span>
+                let span = <span>{ title }: { value }</span>
 
-                    if (link) {
-                        span = (
-                            <a href={link} target="_blank" rel="noopener">
-                                { span }
-                            </a>
-                        );
-                    }
-
+                if (link) {
                     span = (
-                        <span
-                            className="m_RoomView_auxPanel_stateViews_span"
-                            data-severity={severity}
-                            key={ "x-" + stateKey }
-                        >
-                            {span}
-                        </span>
-                    );
-
-                    counters.push(span);
-                    counters.push(
-                        <span
-                            className="m_RoomView_auxPanel_stateViews_delim"
-                            key={"delim" + idx}
-                        > ─ </span>
+                        <a href={link} target="_blank" rel="noopener">
+                            { span }
+                        </a>
                     );
                 }
+
+                span = (
+                    <span
+                        className="m_RoomView_auxPanel_stateViews_span"
+                        data-severity={severity}
+                        key={ "x-" + stateKey }
+                    >
+                        {span}
+                    </span>
+                );
+
+                counters.push(span);
+                counters.push(
+                    <span
+                        className="m_RoomView_auxPanel_stateViews_delim"
+                        key={"delim" + idx}
+                    > ─ </span>
+                );
             });
 
             if (counters.length > 0) {


### PR DESCRIPTION
I missed a bit form #2772 :(

This PR just removes the `if (title && value && severity)` guard, since we've already filtered out bad values before putting them in the `counters` list