### PR TITLE
Use a distinct color for selected autocomplete items

### DIFF
--- a/res/css/views/rooms/_Autocomplete.scss
+++ b/res/css/views/rooms/_Autocomplete.scss
@@ -71,7 +71,7 @@
 
 .mx_Autocomplete_Completion.selected,
 .mx_Autocomplete_Completion:hover {
-    background: $menu-bg-color;
+    background: $selected-color;
     outline: none;
 }
 


### PR DESCRIPTION
This restores the ability to see which autocomplete item is selected (which
seems to have gotten lost during redesign).

<img width="246" alt="selected-light" src="https://user-images.githubusercontent.com/279572/54210015-a5fca980-44d6-11e9-8900-685cb5531436.png">
<img width="204" alt="selected-dark" src="https://user-images.githubusercontent.com/279572/54210014-a5fca980-44d6-11e9-9705-33c006d78208.png">

Fixes https://github.com/vector-im/riot-web/issues/9134