### PR TITLE
Remove padlock click handler to show unknown devices

### DIFF
--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -32,7 +32,6 @@ import {CancelButton} from './SimpleRoomHeader';
 import SettingsStore from "../../../settings/SettingsStore";
 import RoomHeaderButtons from '../right_panel/RoomHeaderButtons';
 import E2EIcon from './E2EIcon';
-import * as cryptodevices from '../../../cryptodevices';
 
 module.exports = React.createClass({
     displayName: 'RoomHeader',
@@ -146,12 +145,6 @@ module.exports = React.createClass({
         return !(currentPinEvent.getContent().pinned && currentPinEvent.getContent().pinned.length <= 0);
     },
 
-    _onShowDevicesClick: function() {
-        if (this.props.e2eStatus === "warning") {
-            cryptodevices.showUnknownDeviceDialogForMessages(MatrixClientPeg.get(), this.props.room);
-        }
-    },
-
     render: function() {
         const RoomAvatar = sdk.getComponent("avatars.RoomAvatar");
         const EmojiText = sdk.getComponent('elements.EmojiText');
@@ -162,7 +155,7 @@ module.exports = React.createClass({
         let pinnedEventsButton = null;
 
         const e2eIcon = this.props.e2eStatus ?
-            <E2EIcon status={this.props.e2eStatus} onClick={this._onShowDevicesClick} /> :
+            <E2EIcon status={this.props.e2eStatus} /> :
             undefined;
 
         if (this.props.onCancelClick) {


### PR DESCRIPTION
The unknown devices dialog is confusing at the moment due to the complex trust
model in Riot involving various possible device states.

The room header padlock allows you to access this dialog even if there are no
unknown devices, which leads users to be unsure what they can believe and
reduces confidence in Riot. For now, we'll remove the room header click handler
that shows this dialog.

Fixes https://github.com/vector-im/riot-web/issues/8815