### PR TITLE
Restore `Field` value getter for `RegistrationForm`

### DIFF
--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -53,6 +53,12 @@ export default class Field extends React.PureComponent {
         };
     }
 
+    /* TODO: Remove this once `RegistrationForm` no longer uses refs */
+    get value() {
+        if (!this.refs.fieldInput) return null;
+        return this.refs.fieldInput.value;
+    }
+
     onChange = (ev) => {
         if (this.props.onValidate) {
             const result = this.props.onValidate(ev.target.value);


### PR DESCRIPTION
When working on the `Field` validation support, I thought `RegistrationForm`'s
refs would be okay to leave as is, but I missed that they also depended on the
value getter.

For the moment, it's quicker to temporarily revive the value getter to get
registration working. A better fix will happen over in https://github.com/vector-im/riot-web/issues/9172.

Fixes https://github.com/vector-im/riot-web/issues/9171