### PR TITLE
Remove refs from `RegistrationForm`

### DIFF
--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -53,12 +53,6 @@ export default class Field extends React.PureComponent {
         };
     }
 
-    /* TODO: Remove this once `RegistrationForm` no longer uses refs */
-    get value() {
-        if (!this.refs.fieldInput) return null;
-        return this.refs.fieldInput.value;
-    }
-
     onChange = (ev) => {
         if (this.props.onValidate) {
             const result = this.props.onValidate(ev.target.value);


### PR DESCRIPTION
This aligns the code in `RegistrationForm` with other users of the `Field`
component. (In https://github.com/matrix-org/matrix-react-sdk/pull/2780, I had
thought that this code would be okay to leave alone, but I had missed the usage
of the `Field` value getter.)

Fixes https://github.com/vector-im/riot-web/issues/9172