### PR TITLE
Fix initial letter avatar vertical offset in Firefox

### DIFF
--- a/res/css/views/avatars/_BaseAvatar.scss
+++ b/res/css/views/avatars/_BaseAvatar.scss
@@ -16,6 +16,16 @@ limitations under the License.
 
 .mx_BaseAvatar {
     position: relative;
+    // In at least Firefox, the case of relative positioned inline elements
+    // (such as mx_BaseAvatar) with absolute positioned children (such as
+    // mx_BaseAvatar_initial) is a dark corner full of spider webs. It will give
+    // different results during full reflow of the page vs. incremental reflow
+    // of small portions. While that's surely a browser bug, we can avoid it by
+    // using `inline-block` instead of the default `inline`.
+    // https://github.com/vector-im/riot-web/issues/5594
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1535053
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=255139
+    display: inline-block;
 }
 
 .mx_BaseAvatar_initial {


### PR DESCRIPTION
In at least Firefox, the case of relative positioned inline elements (such as
mx_BaseAvatar) with absolute positioned children (such as mx_BaseAvatar_initial)
is a dark corner full of spider webs. It will give different results during full
reflow of the page vs. incremental reflow of small portions. While that's surely
a browser bug, we can avoid it by using `inline-block` instead of the default
`inline`.

Fixes https://github.com/vector-im/riot-web/issues/5594
Might help with https://github.com/vector-im/riot-web/issues/9088

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1535053 and
https://bugzilla.mozilla.org/show_bug.cgi?id=255139 for more details on browser
behavior in this case.

I used https://avatars-styling.glitch.me/ as a reduced test case for this bug.

Before:

![2019-03-14 at 18 27](https://user-images.githubusercontent.com/279572/54381969-ec910600-4686-11e9-8143-3e9ff8b5a027.png)

After:

![2019-03-14 at 18 28](https://user-images.githubusercontent.com/279572/54382012-003c6c80-4687-11e9-84aa-a9ddf2fe697d.png)