### PR TITLE
Support changing options for .m.rule.tombstone push rule

### DIFF
--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -507,6 +507,7 @@ module.exports = React.createClass({
                 //'.m.rule.member_event': 'vector',
                 '.m.rule.call': 'vector',
                 '.m.rule.suppress_notices': 'vector',
+                '.m.rule.tombstone': 'vector',
 
                 // Others go to others
             };
@@ -562,6 +563,7 @@ module.exports = React.createClass({
                 //'im.vector.rule.member_event',
                 '.m.rule.call',
                 '.m.rule.suppress_notices',
+                '.m.rule.tombstone',
             ];
             for (const i in vectorRuleIds) {
                 const vectorRuleId = vectorRuleIds[i];

--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -704,6 +704,10 @@ module.exports = React.createClass({
         const rows = [];
         for (const i in this.state.vectorPushRules) {
             const rule = this.state.vectorPushRules[i];
+            if (rule.rule === undefined && rule.vectorRuleId.startsWith(".m.")) {
+                console.warn(`Skipping render of rule ${rule.vectorRuleId} due to no underlying rule`);
+                continue;
+            }
             //console.log("rendering: " + rule.description + ", " + rule.vectorRuleId + ", " + rule.vectorState);
             rows.push(this.renderNotifRulesTableRow(rule.description, rule.vectorRuleId, rule.vectorState));
         }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -325,6 +325,7 @@
     "When I'm invited to a room": "When I'm invited to a room",
     "Call invitation": "Call invitation",
     "Messages sent by bot": "Messages sent by bot",
+    "When rooms are upgraded": "When rooms are upgraded",
     "Active call (%(roomName)s)": "Active call (%(roomName)s)",
     "unknown caller": "unknown caller",
     "Incoming voice call from %(name)s": "Incoming voice call from %(name)s",

--- a/src/notifications/VectorPushRulesDefinitions.js
+++ b/src/notifications/VectorPushRulesDefinitions.js
@@ -183,4 +183,15 @@ module.exports = {
             off: StandardActions.ACTION_DONT_NOTIFY,
         },
     }),
+
+    // Room upgrades (tombstones)
+    ".m.rule.tombstone": new VectorPushRuleDefinition({
+        kind: "override",
+        description: _td("When rooms are upgraded"), // passed through _t() translation in src/components/views/settings/Notifications.js
+        vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
+            on: StandardActions.ACTION_NOTIFY,
+            loud: StandardActions.ACTION_HIGHLIGHT,
+            off: StandardActions.ACTION_DISABLED,
+        },
+    }),
 };


### PR DESCRIPTION
Part of vector-im/riot-web#8447
See also matrix-org/matrix-doc#1930

**Intended to be reviewed with https://github.com/matrix-org/matrix-js-sdk/pull/860**

Ends up doing this to the event:
![image](https://user-images.githubusercontent.com/1190097/54459770-4d731980-472d-11e9-96bb-1620b70240c8.png)

When the server doesn't support the push rule (missing https://github.com/matrix-org/synapse/pull/4867), the option is not shown. However, the option is always shown when the server supports it:
![image](https://user-images.githubusercontent.com/1190097/54459755-46e4a200-472d-11e9-9bbb-50dc7f67b76e.png)
