### PR TITLE
Reload widget messaging when widgets reload

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -336,9 +336,14 @@ export default class AppTile extends React.Component {
      * Called when widget iframe has finished loading
      */
     _onLoaded() {
-        if (!ActiveWidgetStore.getWidgetMessaging(this.props.id)) {
-            this._setupWidgetMessaging();
+        // Destroy the old widget messaging before starting it back up again. Some widgets
+        // have startup routines that run when they are loaded, so we just need to reinitialize
+        // the messaging for them.
+        if (ActiveWidgetStore.getWidgetMessaging(this.props.id)) {
+            ActiveWidgetStore.delWidgetMessaging(this.props.id);
         }
+        this._setupWidgetMessaging();
+
         ActiveWidgetStore.setRoomId(this.props.id, this.props.room.roomId);
         this.setState({loading: false});
     }


### PR DESCRIPTION
Fixes a bug for some widgets where they cannot do their startup routine (capabilities negotiation, etc) when someone maximizes the widget. By reloading the widget messaging, we ensure the widget is kept in the loop.

----

This is being PR'd as a community member:
```
Signed-off-by: Travis Ralston <travis@t2bot.io>
```