### PR TITLE
Remove Edge from browser support statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Developer Guide
 
 Platform Targets:
  * Chrome, Firefox and Safari.
- * Edge should also work, but we're not testing it proactively.
  * WebRTC features (VoIP and Video calling) are only available in Chrome & Firefox.
  * Mobile Web is not currently a target platform - instead please use the native
    iOS (https://github.com/matrix-org/matrix-ios-kit) and Android


### PR DESCRIPTION
At the current time, we do not intend to do additional work specifically to
support Edge.  If it works for most use cases, that's great, but we do not
intend to fix issues that affect only Edge.

Fixes https://github.com/vector-im/riot-web/issues/9201