### PR TITLE
Disable big emoji for m.emote messages as it looks weird

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -431,7 +431,7 @@ module.exports = React.createClass({
 
         const stripReply = ReplyThread.getParentEventId(mxEvent);
         let body = HtmlUtils.bodyToHtml(content, this.props.highlights, {
-            disableBigEmoji: !SettingsStore.getValue('TextualBody.enableBigEmoji'),
+            disableBigEmoji: content.msgtype === "m.emote" || !SettingsStore.getValue('TextualBody.enableBigEmoji'),
             // Part of Replies fallback support
             stripReplyFallback: stripReply,
         });


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9079

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

![image](https://user-images.githubusercontent.com/2403652/54570085-22125800-49d5-11e9-9624-061dfdc2afc3.png)
