### PR TITLE
Support CI for matching branches on forks

### DIFF
--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -1,28 +1,40 @@
-#!/bin/sh
+#!/bin/bash
 
-org="$1"
-repo="$2"
+set -x
+
+deforg="$1"
+defrepo="$2"
 defbranch="$3"
 
 [ -z "$defbranch" ] && defbranch="develop"
 
-rm -r "$repo" || true
+rm -r "$defrepo" || true
 
 clone() {
-    branch=$1
+    org=$1
+    repo=$2
+    branch=$3
     if [ -n "$branch" ]
     then
-        echo "Trying to use the branch $branch"
+        echo "Trying to use $org/$repo#$branch"
         git clone https://github.com/$org/$repo.git $repo --branch "$branch" && exit 0
     fi
 }
 
-
 # Try the PR author's branch in case it exists on the deps as well.
-clone $BUILDKITE_BRANCH
+# If BUILDKITE_BRANCH is set, it will contain either:
+#   * "branch" when the author's branch and target branch are in the same repo
+#   * "author:branch" when the author's branch is in their fork
+# We can split on `:` into an array to check.
+BUILDKITE_BRANCH_ARRAY=(${BUILDKITE_BRANCH//:/ })
+if [[ "${#BUILDKITE_BRANCH_ARRAY[@]}" == "1" ]]; then
+    clone $deforg $defrepo $BUILDKITE_BRANCH
+elif [[ "${#BUILDKITE_BRANCH_ARRAY[@]}" == "2" ]]; then
+    clone ${BUILDKITE_BRANCH_ARRAY[0]} $defrepo ${BUILDKITE_BRANCH_ARRAY[1]}
+fi
 # Try the target branch of the push or PR.
-clone $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+clone $deforg $defrepo $BUILDKITE_PULL_REQUEST_BASE_BRANCH
 # Try the current branch from Jenkins.
-clone `"echo $GIT_BRANCH" | sed -e 's/^origin\///'`
+clone $deforg $defrepo `"echo $GIT_BRANCH" | sed -e 's/^origin\///'`
 # Use the default branch as the last resort.
-clone $defbranch
+clone $deforg $defrepo $defbranch


### PR DESCRIPTION
Currently, people with push access to the main Riot repos can push matching
branch names to Riot and the SDKs, and CI will test all the branches together.
This change allows contributors to access the same ability when submitting
several matching PRs from their fork of each repo.

Part of https://github.com/vector-im/riot-web/issues/9041
See also `riot-web` PR https://github.com/vector-im/riot-web/pull/9212