### PR TITLE
Go back to using mainine velocity

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "slate-react": "^0.18.10",
     "text-encoding-utf-8": "^1.0.1",
     "url": "^0.11.0",
-    "velocity-vector": "github:vector-im/velocity#059e3b2",
+    "velocity-animate": "^1.5.2",
     "whatwg-fetch": "^1.1.1",
     "zxcvbn": "^4.4.2"
   },

--- a/src/Velociraptor.js
+++ b/src/Velociraptor.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const ReactDom = require('react-dom');
 import PropTypes from 'prop-types';
-const Velocity = require('velocity-vector');
+const Velocity = require('velocity-animate');
 
 /**
  * The Velociraptor contains components and animates transitions with velocity.

--- a/src/VelocityBounce.js
+++ b/src/VelocityBounce.js
@@ -1,4 +1,4 @@
-const Velocity = require('velocity-vector');
+const Velocity = require('velocity-animate');
 
 // courtesy of https://github.com/julianshapiro/velocity/issues/283
 // We only use easeOutBounce (easeInBounce is just sort of nonsensical)

--- a/src/components/structures/BottomLeftMenu.js
+++ b/src/components/structures/BottomLeftMenu.js
@@ -19,8 +19,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import sdk from '../../index';
 import dis from '../../dispatcher';
-import Velocity from 'velocity-vector';
-import 'velocity-vector/velocity.ui';
+import Velocity from 'velocity-animate';
+import 'velocity-animate/velocity.ui';
 import SettingsStore from '../../settings/SettingsStore';
 
 const CALLOUT_ANIM_DURATION = 1000;

--- a/src/components/views/dialogs/DeactivateAccountDialog.js
+++ b/src/components/views/dialogs/DeactivateAccountDialog.js
@@ -21,7 +21,7 @@ import sdk from '../../../index';
 import Analytics from '../../../Analytics';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 import * as Lifecycle from '../../../Lifecycle';
-import Velocity from 'velocity-vector';
+import Velocity from 'velocity-animate';
 import { _t } from '../../../languageHandler';
 
 export default class DeactivateAccountDialog extends React.Component {

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -68,7 +68,7 @@ describe('MessagePanel', function() {
         // HACK: We assume all settings want to be disabled
         SettingsStore.getValue = sinon.stub().returns(false);
 
-        // This option clobbers the duratrion of all animations to be 1ms
+        // This option clobbers the duration of all animations to be 1ms
         // which makes unit testing a lot simpler (the animation doesn't
         // complete without this even if we mock the clock and tick it
         // what should be the correct amount of time).

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -31,6 +31,8 @@ import Matrix from 'matrix-js-sdk';
 const test_utils = require('test-utils');
 const mockclock = require('mock-clock');
 
+import Velocity from 'velocity-animate';
+
 let client;
 const room = new Matrix.Room();
 
@@ -65,9 +67,17 @@ describe('MessagePanel', function() {
 
         // HACK: We assume all settings want to be disabled
         SettingsStore.getValue = sinon.stub().returns(false);
+
+        // This option clobbers the duratrion of all animations to be 1ms
+        // which makes unit testing a lot simpler (the animation doesn't
+        // complete without this even if we mock the clock and tick it
+        // what should be the correct amount of time).
+        Velocity.mock = true;
     });
 
     afterEach(function() {
+        delete Velocity.mock;
+
         clock.uninstall();
         sandbox.restore();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,7 +3956,7 @@ jest-regex-util@^24.3.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.3.0.tgz#d5a65f60be1ae3e310d5214a0307581995227b36"
   integrity sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==
 
-"jquery@>= 1.4.3", jquery@^3.3.1:
+jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
   integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
@@ -6851,11 +6851,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-"velocity-vector@github:vector-im/velocity#059e3b2":
-  version "1.2.3"
-  resolved "https://codeload.github.com/vector-im/velocity/tar.gz/059e3b2348f1110888d033974d3109fd5a3af00f"
-  dependencies:
-    jquery ">= 1.4.3"
+velocity-animate@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.2.tgz#5a351d75fca2a92756f5c3867548b873f6c32105"
+  integrity sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
We moved off to our own fork of velocity many moons ago to fix
a memory leak bug when velocity was being barely maintained. They
have now merged the bugfix, so go back to mainline.