### PR TITLE
Switch to `git` protocol for CI dependencies

### DIFF
--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -17,7 +17,7 @@ clone() {
     if [ -n "$branch" ]
     then
         echo "Trying to use $org/$repo#$branch"
-        git clone https://github.com/$org/$repo.git $repo --branch "$branch" && exit 0
+        git clone git://github.com/$org/$repo.git $repo --branch "$branch" && exit 0
     fi
 }
 


### PR DESCRIPTION
If you try to clone a repo that doesn't exist via `https`, `git` will prompt for
auth credentials and hang forever. Using `git` avoids this and fails immediately
instead, which is what we want for a missing repo.

Part of https://github.com/vector-im/riot-web/issues/9221