### PR TITLE
Change to new consistent name for `MemoryStore`

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -103,7 +103,7 @@ class MatrixClientPeg {
             } catch (err) {
                 if (dbType === 'indexeddb') {
                     console.error('Error starting matrixclient store - falling back to memory store', err);
-                    this.matrixClient.store = new Matrix.MatrixInMemoryStore({
+                    this.matrixClient.store = new Matrix.MemoryStore({
                       localStorage: global.localStorage,
                     });
                 } else {


### PR DESCRIPTION
Following the name change in https://github.com/matrix-org/matrix-js-sdk/pull/861, this updates React SDK to use the newer, more consistent name.