### PR TITLE
Explicitly create `cryptoStore` in React SDK

### DIFF
--- a/src/utils/createMatrixClient.js
+++ b/src/utils/createMatrixClient.js
@@ -48,10 +48,6 @@ export default function createMatrixClient(opts, useIndexedDb) {
         useAuthorizationHeader: true,
     };
 
-    if (localStorage) {
-        storeOpts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
-    }
-
     if (indexedDB && localStorage && useIndexedDb) {
         storeOpts.store = new Matrix.IndexedDBStore({
             indexedDB: indexedDB,
@@ -59,6 +55,16 @@ export default function createMatrixClient(opts, useIndexedDb) {
             localStorage: localStorage,
             workerScript: createMatrixClient.indexedDbWorkerScript,
         });
+    }
+
+    if (localStorage) {
+        storeOpts.sessionStore = new Matrix.WebStorageSessionStore(localStorage);
+    }
+
+    if (indexedDB && useIndexedDb) {
+        storeOpts.cryptoStore = new Matrix.IndexedDBCryptoStore(
+            indexedDB, "matrix-js-sdk:crypto",
+        );
     }
 
     opts = Object.assign(storeOpts, opts);


### PR DESCRIPTION
The React SDK has a client creation path that starts 2 out of 3 stores, but then
leaves the other one for the JS SDK's default value handling.

We'll soon be adding additional code to check the health of stores, so it would
be simpler to follow and think about if we create them all in one place.