### PR TITLE
Fixed drop shadow for tooltip.

### DIFF
--- a/res/css/views/elements/_Tooltip.scss
+++ b/res/css/views/elements/_Tooltip.scss
@@ -54,7 +54,7 @@ limitations under the License.
     position: fixed;
     border: 1px solid $menu-border-color;
     border-radius: 4px;
-    box-shadow: 4px 4px 12px 0 rgba(118, 131, 156, 0.6);
+    box-shadow: 4px 4px 12px 0 $menu-box-shadow-color;
     background-color: $menu-bg-color;
     z-index: 2000;
     padding: 10px;


### PR DESCRIPTION
The box-shadow color value is from $menu-box-shadow-color. The shadow now looks consistent on light or dark theme.