### PR TITLE
Trim the logging for URL previews

### DIFF
--- a/src/components/views/rooms/LinkPreviewWidget.js
+++ b/src/components/views/rooms/LinkPreviewWidget.js
@@ -52,7 +52,7 @@ module.exports = React.createClass({
                 this.props.onHeightChanged,
             );
         }, (error)=>{
-            console.error("Failed to get preview for " + this.props.link + " " + error);
+            console.error("Failed to get URL preview: " + error);
         }).done();
     },
 


### PR DESCRIPTION
It should be sufficient to have the error stack and general log message for URL
preview failure.