### PR TITLE
Attach an onChange listener to the room's blacklist devices option

### DIFF
--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.js
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.js
@@ -197,6 +197,10 @@ export default class SecurityRoomSettingsTab extends React.Component {
         });
     };
 
+    _updateBlacklistDevicesFlag = (checked) => {
+        MatrixClientPeg.get().getRoom(this.props.roomId).setBlacklistUnverifiedDevices(checked);
+    };
+
     _renderRoomAccess() {
         const client = MatrixClientPeg.get();
         const room = client.getRoom(this.props.roomId);
@@ -318,6 +322,7 @@ export default class SecurityRoomSettingsTab extends React.Component {
         let encryptionSettings = null;
         if (isEncrypted) {
             encryptionSettings = <SettingsFlag name="blacklistUnverifiedDevices" level={SettingLevel.ROOM_DEVICE}
+                                               onChange={this._updateBlacklistDevicesFlag}
                                                roomId={this.props.roomId} />;
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9235

The global option in user settings is unaffected by this bug. Users who have previously set the per-room flag without success can simply refresh the page and the change will be picked up. The bug here is that the current session would not update accordingly, however.

Introduced in https://github.com/matrix-org/matrix-react-sdk/pull/2523