### PR TITLE
Use leaveRoomChain when leaving a room

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -431,7 +431,7 @@ export const CommandMap = {
 
             if (!targetRoomId) targetRoomId = roomId;
             return success(
-                cli.leave(targetRoomId).then(function() {
+                cli.leaveRoomChain(targetRoomId).then(function() {
                     dis.dispatch({action: 'view_next_room'});
                 }),
             );

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1058,34 +1058,47 @@ export default React.createClass({
             button: _t("Leave"),
             onFinished: (shouldLeave) => {
                 if (shouldLeave) {
-                    const d = MatrixClientPeg.get().leave(roomId);
+                    const d = MatrixClientPeg.get().leaveRoomChain(roomId);
 
                     // FIXME: controller shouldn't be loading a view :(
                     const Loader = sdk.getComponent("elements.Spinner");
                     const modal = Modal.createDialog(Loader, null, 'mx_Dialog_spinner');
 
-                    d.then(() => {
+                    d.then((errors) => {
                         modal.close();
+
+                        if (errors[roomId]) {
+                            // Something went wrong
+                            const err = errors[roomId];
+                            console.error("Failed to leave room " + roomId + " " + err);
+                            let title = _t("Failed to leave room");
+                            let message = _t("Server may be unavailable, overloaded, or you hit a bug.");
+                            if (err.errcode === 'M_CANNOT_LEAVE_SERVER_NOTICE_ROOM') {
+                                title = _t("Can't leave Server Notices room");
+                                message = _t(
+                                    "This room is used for important messages from the Homeserver, " +
+                                    "so you cannot leave it.",
+                                );
+                            } else if (err && err.message) {
+                                message = err.message;
+                            }
+                            Modal.createTrackedDialog('Failed to leave room', '', ErrorDialog, {
+                                title: title,
+                                description: message,
+                            });
+                            return;
+                        }
+
                         if (this.state.currentRoomId === roomId) {
                             dis.dispatch({action: 'view_next_room'});
                         }
                     }, (err) => {
+                        // This should only happen if something went seriously wrong with leaving the chain.
                         modal.close();
                         console.error("Failed to leave room " + roomId + " " + err);
-                        let title = _t("Failed to leave room");
-                        let message = _t("Server may be unavailable, overloaded, or you hit a bug.");
-                        if (err.errcode == 'M_CANNOT_LEAVE_SERVER_NOTICE_ROOM') {
-                            title = _t("Can't leave Server Notices room");
-                            message = _t(
-                                "This room is used for important messages from the Homeserver, " +
-                                "so you cannot leave it.",
-                            );
-                        } else if (err && err.message) {
-                            message = err.message;
-                        }
                         Modal.createTrackedDialog('Failed to leave room', '', ErrorDialog, {
                             title: title,
-                            description: message,
+                            description: _t("Unknown error"),
                         });
                     });
                 }

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1098,7 +1098,7 @@ export default React.createClass({
                         modal.close();
                         console.error("Failed to leave room " + roomId + " " + err);
                         Modal.createTrackedDialog('Failed to leave room', '', ErrorDialog, {
-                            title: title,
+                            title: _t("Failed to leave room"),
                             description: _t("Unknown error"),
                         });
                     });

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1067,10 +1067,11 @@ export default React.createClass({
                     d.then((errors) => {
                         modal.close();
 
-                        if (errors[roomId]) {
-                            // Something went wrong
-                            const err = errors[roomId];
-                            console.error("Failed to leave room " + roomId + " " + err);
+                        for (const leftRoomId of Object.keys(errors)) {
+                            const err = errors[leftRoomId];
+                            if (!err) continue;
+
+                            console.error("Failed to leave room " + leftRoomId + " " + err);
                             let title = _t("Failed to leave room");
                             let message = _t("Server may be unavailable, overloaded, or you hit a bug.");
                             if (err.errcode === 'M_CANNOT_LEAVE_SERVER_NOTICE_ROOM') {


### PR DESCRIPTION
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/868**
Fixes https://github.com/vector-im/riot-web/issues/8539

We don't need to use leaveRoomChain when rejecting invites because we won't have the references needed. This leaves the couple spots where we do actually leave a room, and use the new function for that.