### PR TITLE
Fix bug with NetworkList dropdown

### DIFF
--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -131,10 +131,11 @@ export default class NetworkDropdown extends React.Component {
 
     _getMenuOptions() {
         const options = [];
+        const roomDirectory = this.props.config.roomDirectory || {};
 
         let servers = [];
-        if (this.props.config.roomDirectory.servers) {
-            servers = servers.concat(this.props.config.roomDirectory.servers);
+        if (roomDirectory.servers) {
+            servers = servers.concat(roomDirectory.servers);
         }
 
         if (!servers.includes(MatrixClientPeg.getHomeServerName())) {


### PR DESCRIPTION
The NetworkDropdown component was incorrectly guarding against a null
check when retrieving the list of networks

Signed-off-by: YaoiFangirl420 <48789208+YaoiFangirl420@users.noreply.github.com>