### PR TITLE
Minimize stickerpicker when the title is clicked

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -447,10 +447,14 @@ export default class AppTile extends React.Component {
         }
 
         // Toggle the view state of the apps drawer
-        dis.dispatch({
-            action: 'appsDrawer',
-            show: !this.props.show,
-        });
+        if (this.props.userWidget) {
+            this._onMinimiseClick();
+        } else {
+            dis.dispatch({
+                action: 'appsDrawer',
+                show: !this.props.show,
+            });
+        }
     }
 
     _getSafeUrl() {
@@ -626,7 +630,7 @@ export default class AppTile extends React.Component {
                         { /* Maximise widget */ }
                         { showMaximiseButton && <AccessibleButton
                             className="mx_AppTileMenuBar_iconButton mx_AppTileMenuBar_iconButton_maximise"
-                            title={_t('Minimize apps')}
+                            title={_t('Maximize apps')}
                             onClick={this._onMinimiseClick}
                         /> }
                         { /* Title */ }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -935,6 +935,7 @@
     "Failed to remove widget": "Failed to remove widget",
     "An error ocurred whilst trying to remove the widget from the room": "An error ocurred whilst trying to remove the widget from the room",
     "Minimize apps": "Minimize apps",
+    "Maximize apps": "Maximize apps",
     "Reload widget": "Reload widget",
     "Popout widget": "Popout widget",
     "Picture": "Picture",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/6437

This also fixes a bug where if the room had apps open and you clicked the sticker picker's title, you'd end up closing the apps and not the picker.

----

This is being PR'd as a community member:
```
Signed-off-by: Travis Ralston <travis@t2bot.io>
```