### PR TITLE
Check if the message panel is at the end of the timeline on init

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -144,6 +144,7 @@ module.exports = React.createClass({
             // the end of the live timeline. It has the effect of hiding the
             // 'scroll to bottom' knob, among a couple of other things.
             atEndOfLiveTimeline: true,
+            atEndOfLiveTimelineInit: false, // used by componentDidUpdate to avoid unnecessary checks
 
             showTopUnreadMessagesBar: false,
 
@@ -427,6 +428,12 @@ module.exports = React.createClass({
                 roomView.addEventListener('dragleave', this.onDragLeaveOrEnd);
                 roomView.addEventListener('dragend', this.onDragLeaveOrEnd);
             }
+        }
+        if (this.refs.messagePanel && !this.state.atEndOfLiveTimelineInit) {
+            this.setState({
+                atEndOfLiveTimelineInit: true,
+                atEndOfLiveTimeline: this.refs.messagePanel.isAtEndOfLiveTimeline(),
+            });
         }
     },
 

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -429,6 +429,12 @@ module.exports = React.createClass({
                 roomView.addEventListener('dragend', this.onDragLeaveOrEnd);
             }
         }
+
+        // Note: We check the ref here with a flag because componentDidMount, despite
+        // documentation, does not define our messagePanel ref. It looks like our spinner
+        // in render() prevents the ref from being set on first mount, so we try and
+        // catch the messagePanel when it does mount. Because we only want the ref once,
+        // we use a boolean flag to avoid duplicate work.
         if (this.refs.messagePanel && !this.state.atEndOfLiveTimelineInit) {
             this.setState({
                 atEndOfLiveTimelineInit: true,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8503

componentDidUpdate is called a lot, and we don't really want to keep checking the messagePanel, so this introduces a new flag to check if the init is even needed.