### PR TITLE
Filter out upgraded rooms from autocomplete results

### DIFF
--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -56,7 +56,7 @@ export default class RoomProvider extends AutocompleteProvider {
         const {command, range} = this.getCurrentCommand(query, selection, force);
         if (command) {
             // the only reason we need to do this is because Fuse only matches on properties
-            this.matcher.setObjects(client.getRooms().filter(
+            let matcherObjects = client.getRooms().filter(
                 (room) => !!room && !!getDisplayAliasForRoom(room),
             ).map((room) => {
                 return {
@@ -64,7 +64,23 @@ export default class RoomProvider extends AutocompleteProvider {
                     name: room.name,
                     displayedAlias: getDisplayAliasForRoom(room),
                 };
-            }));
+            });
+
+            // Filter out any matches where the user will have also autocompleted new rooms
+            matcherObjects = matcherObjects.filter((r) => {
+                const tombstone = r.room.currentState.getStateEvents("m.room.tombstone", "");
+                if (tombstone && tombstone.getContent() && tombstone.getContent()['replacement_room']) {
+                    console.log(r.displayedAlias);
+                    const hasReplacementRoom = matcherObjects.some(
+                        (r2) => r2.room.roomId === tombstone.getContent()['replacement_room'],
+                    );
+                    console.log(hasReplacementRoom);
+                    return !hasReplacementRoom;
+                }
+                return true;
+            });
+
+            this.matcher.setObjects(matcherObjects);
             const matchedString = command[0];
             completions = this.matcher.match(matchedString);
             completions = _sortBy(completions, [

--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -70,11 +70,9 @@ export default class RoomProvider extends AutocompleteProvider {
             matcherObjects = matcherObjects.filter((r) => {
                 const tombstone = r.room.currentState.getStateEvents("m.room.tombstone", "");
                 if (tombstone && tombstone.getContent() && tombstone.getContent()['replacement_room']) {
-                    console.log(r.displayedAlias);
                     const hasReplacementRoom = matcherObjects.some(
                         (r2) => r2.room.roomId === tombstone.getContent()['replacement_room'],
                     );
-                    console.log(hasReplacementRoom);
                     return !hasReplacementRoom;
                 }
                 return true;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9289

Theory is that this shouldn't happen in the first place (aliases should be transferred), but there's evidently some cases where this doesn't work, or gets state reset.