### PR TITLE
Login page customizations

### DIFF
--- a/src/components/views/auth/PasswordLogin.js
+++ b/src/components/views/auth/PasswordLogin.js
@@ -245,9 +245,9 @@ class PasswordLogin extends React.Component {
     render() {
         const Field = sdk.getComponent('elements.Field');
 
-        let forgotPasswordJsx;
+        let forgotPasswordJsx = null;
 
-        if (this.props.onForgotPasswordClick) {
+        if (!SdkConfig.get().disable_password_change && this.props.onForgotPasswordClick) {
             forgotPasswordJsx = <span>
                 {_t('Not sure of your password? <a>Set a new one</a>', {}, {
                     a: sub => <a className="mx_Login_forgot"

--- a/src/components/views/auth/PasswordLogin.js
+++ b/src/components/views/auth/PasswordLogin.js
@@ -193,7 +193,9 @@ class PasswordLogin extends React.Component {
                     name="username" // make it a little easier for browser's remember-password
                     key="username_input"
                     type="text"
-                    label={SdkConfig.get().disable_custom_urls ?
+                    label={SdkConfig.get().username_description ?
+                        SdkConfig.get().username_description :
+                        SdkConfig.get().disable_custom_urls ?
                         _t("Username on %(hs)s", {
                             hs: this.props.hsUrl.replace(/^https?:\/\//, ''),
                         }) : _t("Username")}


### PR DESCRIPTION
Our homeservers support LDAP login only, and no password changes.
Because the organization has not just one user account, we need a description of which one to use.

Add two more configuration options to `config.json`:
* Customization of the username login field (e.g. "Informatics department account"): `username_description`
* Disabling the link for performing password resets: `disable_password_change`