### PR TITLE
Always append the current room to the breadcrumbs

### DIFF
--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -29,7 +29,6 @@ export default class RoomBreadcrumbs extends React.Component {
         super(props);
         this.state = {rooms: []};
         this.onAction = this.onAction.bind(this);
-        this._previousRoomId = null;
         this._dispatcherRef = null;
     }
 
@@ -55,10 +54,8 @@ export default class RoomBreadcrumbs extends React.Component {
     onAction(payload) {
         switch (payload.action) {
             case 'view_room':
-                if (this._previousRoomId) {
-                    this._appendRoomId(this._previousRoomId);
-                }
-                this._previousRoomId = payload.room_id;
+                this._appendRoomId(payload.room_id);
+                break;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8659
Fixes https://github.com/vector-im/riot-web/issues/8970

8970 is fixed because we no longer track a `_previousRoomId` which was never appended to the list.