### PR TITLE
Make Community Long Description Placeholder More Explanatory

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -44,7 +44,7 @@ const LONG_DESC_PLACEHOLDER = _td(
     some important <a href="foo">links</a>
 </p>
 <p>
-    You can even use 'img' tags
+    You can even add images with Matrix URLs <img src="mxc://foo/bar">
 </p>
 `);
 


### PR DESCRIPTION
"You can even use 'img' tags" implies that the tags may be used as you normally would in any HTML page, but only Matrix URLs may be used. This caveat should be expressed clearly and included in an example.

If merged this would solve https://github.com/vector-im/riot-web/issues/7100

Ideally some documentation which explains how to find and use Matrix URLs for images would be made available, so users don't need to read the comments on an old issue like I had to.

Signed-off-by: Joe Thompson joe@thisisjoes.site