### PR TITLE
Apply 50% opacity to left breadcrumbs

### DIFF
--- a/res/css/views/rooms/_RoomBreadcrumbs.scss
+++ b/res/css/views/rooms/_RoomBreadcrumbs.scss
@@ -47,6 +47,9 @@ limitations under the License.
         transform: scale(0);
     }
 
+    .mx_RoomBreadcrumbs_left {
+        opacity: 0.5;
+    }
 
     // Note: we have to manually control the gradient and stuff, but the IndicatorScrollbar
     // will deal with left/right positioning for us. Normally we'd use position:sticky on

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -88,8 +88,12 @@ export default class RoomBreadcrumbs extends React.Component {
 
     onMyMembership = (room, membership) => {
         if (membership === "leave" || membership === "ban") {
-            // Force left rooms to render appropriately
-            this.forceUpdate();
+            const rooms = this.state.rooms.slice();
+            const roomState = rooms.find((r) => r.room.roomId === room.roomId);
+            if (roomState) {
+                roomState.left = true;
+                this.setState({rooms});
+            }
         }
     };
 
@@ -142,24 +146,24 @@ export default class RoomBreadcrumbs extends React.Component {
             return null;
         }
         const rooms = this.state.rooms;
-        const avatars = rooms.map(({room, animated, hover}, i) => {
+        const avatars = rooms.map((r, i) => {
             const isFirst = i === 0;
             const classes = classNames({
                 "mx_RoomBreadcrumbs_crumb": true,
-                "mx_RoomBreadcrumbs_preAnimate": isFirst && !animated,
+                "mx_RoomBreadcrumbs_preAnimate": isFirst && !r.animated,
                 "mx_RoomBreadcrumbs_animate": isFirst,
-                "mx_RoomBreadcrumbs_left": !['invite', 'join'].includes(room.getMyMembership()),
+                "mx_RoomBreadcrumbs_left": r.left,
             });
 
             let tooltip = null;
-            if (hover) {
-                tooltip = <Tooltip label={room.name} />;
+            if (r.hover) {
+                tooltip = <Tooltip label={r.room.name} />;
             }
 
             return (
-                <AccessibleButton className={classes} key={room.roomId} onClick={() => this._viewRoom(room)}
-                    onMouseEnter={() => this._onMouseEnter(room)} onMouseLeave={() => this._onMouseLeave(room)}>
-                    <RoomAvatar room={room} width={32} height={32} />
+                <AccessibleButton className={classes} key={r.room.roomId} onClick={() => this._viewRoom(r.room)}
+                    onMouseEnter={() => this._onMouseEnter(r.room)} onMouseLeave={() => this._onMouseLeave(r.room)}>
+                    <RoomAvatar room={r.room} width={32} height={32} />
                     {tooltip}
                 </AccessibleButton>
             );

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -52,10 +52,15 @@ export default class RoomBreadcrumbs extends React.Component {
                 console.error("Failed to parse breadcrumbs:", e);
             }
         }
+
+        MatrixClientPeg.get().on("Room.myMembership", this.onMyMembership);
     }
 
     componentWillUnmount() {
         dis.unregister(this._dispatcherRef);
+
+        const client = MatrixClientPeg.get();
+        if (client) client.removeListener("Room.myMembership", this.onMyMembership);
     }
 
     componentDidUpdate() {
@@ -80,6 +85,13 @@ export default class RoomBreadcrumbs extends React.Component {
                 break;
         }
     }
+
+    onMyMembership = (room, membership) => {
+        if (membership === "leave" || membership === "ban") {
+            // Force left rooms to render appropriately
+            this.forceUpdate();
+        }
+    };
 
     _appendRoomId(roomId) {
         const room = MatrixClientPeg.get().getRoom(roomId);
@@ -136,6 +148,7 @@ export default class RoomBreadcrumbs extends React.Component {
                 "mx_RoomBreadcrumbs_crumb": true,
                 "mx_RoomBreadcrumbs_preAnimate": isFirst && !animated,
                 "mx_RoomBreadcrumbs_animate": isFirst,
+                "mx_RoomBreadcrumbs_left": !['invite', 'join'].includes(room.getMyMembership()),
             });
 
             let tooltip = null;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8564

We listen for membership changes to make sure the state is kept up to date.

![image](https://user-images.githubusercontent.com/1190097/55348971-b240aa80-5475-11e9-8919-36c75fca6761.png)

TTS are left, KLJ are joined.