### PR TITLE
Include the current power level in the selector

### DIFF
--- a/src/components/views/elements/PowerSelector.js
+++ b/src/components/views/elements/PowerSelector.js
@@ -73,8 +73,12 @@ module.exports = React.createClass({
     _initStateFromProps: function(newProps) {
         // This needs to be done now because levelRoleMap has translated strings
         const levelRoleMap = Roles.levelRoleMap(newProps.usersDefault);
-        const options = Object.keys(levelRoleMap).filter((l) => {
-            return l === undefined || l <= newProps.maxValue || l == newProps.value;
+        const options = Object.keys(levelRoleMap).filter(level => {
+            return (
+                level === undefined ||
+                level <= newProps.maxValue ||
+                level == newProps.value
+            );
         });
 
         const isCustom = levelRoleMap[newProps.value] === undefined;

--- a/src/components/views/elements/PowerSelector.js
+++ b/src/components/views/elements/PowerSelector.js
@@ -74,7 +74,7 @@ module.exports = React.createClass({
         // This needs to be done now because levelRoleMap has translated strings
         const levelRoleMap = Roles.levelRoleMap(newProps.usersDefault);
         const options = Object.keys(levelRoleMap).filter((l) => {
-            return l === undefined || l <= newProps.maxValue;
+            return l === undefined || l <= newProps.maxValue || l == newProps.value;
         });
 
         const isCustom = levelRoleMap[newProps.value] === undefined;
@@ -130,7 +130,7 @@ module.exports = React.createClass({
                 <Field id={`powerSelector_custom_${this.props.powerLevelKey}`} type="number"
                        label={this.props.label || _t("Power level")} max={this.props.maxValue}
                        onBlur={this.onCustomBlur} onKeyPress={this.onCustomKeyPress} onChange={this.onCustomChange}
-                       value={this.state.customValue} disabled={this.props.disabled} />
+                       value={String(this.state.customValue)} disabled={this.props.disabled} />
             );
         } else {
             // Each level must have a definition in this.state.levelRoleMap
@@ -148,7 +148,7 @@ module.exports = React.createClass({
             picker = (
                 <Field id={`powerSelector_notCustom_${this.props.powerLevelKey}`} element="select"
                        label={this.props.label || _t("Power level")} onChange={this.onSelectChange}
-                       value={this.state.selectValue} disabled={this.props.disabled}>
+                       value={String(this.state.selectValue)} disabled={this.props.disabled}>
                     {options}
                 </Field>
             );


### PR DESCRIPTION
This ensures we always include the current power level in the power selector,
even if it's greater than the level you're allowed to set yourself. This ensures
the selector can display the current value correctly when disabled.

Fixes https://github.com/vector-im/riot-web/issues/9340