### PR TITLE
Re-enable E2E tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
       - "apt-get update"
-      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid"
+      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev util-linux"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,18 +10,15 @@ steps:
   - label: ":chains: End-to-End Tests"
     command:
       # TODO: Remove hacky chmod for BuildKite
-      - "echo \"--- Installing packages, & setup\""
+      - "echo '--- Setup'"
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
-      - "apt-get update"
-      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid-runtime"
-      # dependencies for chrome (installed by puppeteer)
-      - "apt-get -y install gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget"
+      - "echo '--- Install js-sdk'"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:
       - docker#v3.0.1:
-          image: "node:10"
+          image: "matrixdotorg/riotweb-ci-e2etests-env:latest"
 
   - label: ":karma: Tests"
     agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,7 @@ steps:
       # TODO: Remove hacky chmod for BuildKite
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
-      - "sudo apt-get install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
+      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,6 +12,8 @@ steps:
       # TODO: Remove hacky chmod for BuildKite
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
+      - "apt-get update"
+      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,17 +7,17 @@ steps:
       - docker#v3.0.1:
           image: "node:10"
 
- - label: ":chains: End-to-End Tests"
-   command:
-     # TODO: Remove hacky chmod for BuildKite
-     - "chmod +x ./scripts/ci/*.sh"
-     - "chmod +x ./scripts/*"
-     - "sudo apt-get install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
-     - "./scripts/ci/install-deps.sh"
-     - "./scripts/ci/end-to-end-tests.sh"
-   plugins:
-     - docker#v3.0.1:
-         image: "node:10"
+  - label: ":chains: End-to-End Tests"
+    command:
+      # TODO: Remove hacky chmod for BuildKite
+      - "chmod +x ./scripts/ci/*.sh"
+      - "chmod +x ./scripts/*"
+      - "sudo apt-get install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
+      - "./scripts/ci/install-deps.sh"
+      - "./scripts/ci/end-to-end-tests.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:10"
 
   - label: ":karma: Tests"
     agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -14,6 +14,8 @@ steps:
       - "chmod +x ./scripts/*"
       - "apt-get update"
       - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid-runtime"
+      # dependencies for chrome (installed by puppeteer)
+      - "apt-get -y install gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
       - "apt-get update"
-      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
+      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,6 +10,7 @@ steps:
   - label: ":chains: End-to-End Tests"
     command:
       # TODO: Remove hacky chmod for BuildKite
+      - "echo \"--- Installing packages, & setup\""
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
       - "apt-get update"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,7 +13,7 @@ steps:
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
       - "apt-get update"
-      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev util-linux"
+      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid-runtime"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,17 +7,17 @@ steps:
       - docker#v3.0.1:
           image: "node:10"
 
-#  - label: ":chains: End-to-End Tests"
-#    command:
-#      # TODO: Remove hacky chmod for BuildKite
-#      - "chmod +x ./scripts/ci/*.sh"
-#      - "chmod +x ./scripts/*"
-#      - "sudo apt-get install build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
-#      - "./scripts/ci/install-deps.sh"
-#      - "./scripts/ci/end-to-end-tests.sh"
-#    plugins:
-#      - docker#v3.0.1:
-#          image: "node:10"
+ - label: ":chains: End-to-End Tests"
+   command:
+     # TODO: Remove hacky chmod for BuildKite
+     - "chmod +x ./scripts/ci/*.sh"
+     - "chmod +x ./scripts/*"
+     - "sudo apt-get install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
+     - "./scripts/ci/install-deps.sh"
+     - "./scripts/ci/end-to-end-tests.sh"
+   plugins:
+     - docker#v3.0.1:
+         image: "node:10"
 
   - label: ":karma: Tests"
     agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,6 @@ steps:
       # TODO: Remove hacky chmod for BuildKite
       - "chmod +x ./scripts/ci/*.sh"
       - "chmod +x ./scripts/*"
-      - "apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev"
       - "./scripts/ci/install-deps.sh"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -1,0 +1,9 @@
+# Update on docker hub with the following commands in the directory of this file:
+# docker build -t matrixdotorg/riotweb-ci-e2etests-env:latest .
+# docker log
+# docker push matrixdotorg/riotweb-ci-e2etests-env:latest
+FROM node:10
+RUN apt-get update
+RUN apt-get -y install build-essential python3-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libjpeg-dev libxslt1-dev uuid-runtime
+# dependencies for chrome (installed by puppeteer)
+RUN apt-get -y install gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -17,5 +17,5 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
-./run.sh
+./run.sh --no-sandbox
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -17,5 +17,5 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
-./run.sh --travis
+./run.sh
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -17,5 +17,5 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
-./run.sh --no-sandbox
+./run.sh
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -7,8 +7,7 @@
 set -ev
 
 upload_logs() {
-    buildkite-agent artifact upload synapse/installations/consent/homeserver.log
-    buildkite-agent artifact upload logs/**/*
+    buildkite-agent artifact upload "logs/**/*;synapse/installations/consent/homeserver.log"
 }
 
 handle_error() {

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -25,7 +25,7 @@ RIOT_WEB_DIR=riot-web
 REACT_SDK_DIR=`pwd`
 
 
-echo "--- Building copy of Riot"
+echo "--- Building Riot"
 scripts/ci/build.sh
 # run end to end tests
 echo "--- Fetching end-to-end tests from master"

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -7,6 +7,7 @@
 set -ev
 
 upload_logs() {
+    echo "--- Uploading logs"
     buildkite-agent artifact upload "logs/**/*;synapse/installations/consent/homeserver.log"
 }
 
@@ -23,15 +24,20 @@ trap 'handle_error' ERR
 RIOT_WEB_DIR=riot-web
 REACT_SDK_DIR=`pwd`
 
+
+echo "--- Building copy of Riot"
 scripts/ci/build.sh
 # run end to end tests
+echo "--- Fetching end-to-end tests from master"
 scripts/fetchdep.sh matrix-org matrix-react-end-to-end-tests master
 pushd matrix-react-end-to-end-tests
 ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
+echo "--- Install synapse & other dependencies"
 ./install.sh
 mkdir logs
+echo "+++ Running end-to-end tests"
 TESTS_STARTED=1
 ./run.sh --no-sandbox --log-directory logs/
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -17,6 +17,7 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
-./run.sh --no-sandbox
+./run.sh --no-sandbox --error-log e2etests.log
 cat synapse/installations/consent/homeserver.log
+cat e2etests.log
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -8,7 +8,7 @@ set -ev
 
 upload_logs() {
     buildkite-agent artifact upload synapse/installations/consent/homeserver.log
-    buildkite-agent artifact upload e2etests.log
+    buildkite-agent artifact upload logs/**/*
 }
 
 handle_error() {
@@ -32,6 +32,7 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
+mkdir logs
 TESTS_STARTED=1
-./run.sh --no-sandbox --error-log e2etests.log
+./run.sh --no-sandbox --log-directory logs/
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -4,7 +4,7 @@
 #
 # clones riot-web develop and runs the tests against our version of react-sdk.
 
-set -ev
+# set -ev
 
 RIOT_WEB_DIR=riot-web
 REACT_SDK_DIR=`pwd`
@@ -18,4 +18,5 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
 ./run.sh --no-sandbox
+cat synapse/installations/consent/homeserver.log
 popd

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -4,7 +4,22 @@
 #
 # clones riot-web develop and runs the tests against our version of react-sdk.
 
-# set -ev
+set -ev
+
+upload_logs() {
+    buildkite-agent artifact upload synapse/installations/consent/homeserver.log
+    buildkite-agent artifact upload e2etests.log
+}
+
+handle_error() {
+    EXIT_CODE=$?
+    if [ $TESTS_STARTED -eq 1 ]; then
+        upload_logs
+    fi
+    exit $EXIT_CODE
+}
+
+trap 'handle_error' ERR
 
 RIOT_WEB_DIR=riot-web
 REACT_SDK_DIR=`pwd`
@@ -17,7 +32,6 @@ ln -s $REACT_SDK_DIR/$RIOT_WEB_DIR riot/riot-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 ./install.sh
+TESTS_STARTED=1
 ./run.sh --no-sandbox --error-log e2etests.log
-cat synapse/installations/consent/homeserver.log
-cat e2etests.log
 popd


### PR DESCRIPTION
Now that the E2E tests are working for the redesigned app (https://github.com/vector-im/riot-web/issues/9371) make them run on CI again.

This also uploads the logs as artifacts instead of poluting the output with then, and also uses a custom docker image with all needed packages preinstalled to (hopefully) speed up the tests a bit, as they take a bit longer than before now (8-9 min or so)...