### PR TITLE
Track store failures after startup

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -95,8 +95,6 @@ class MatrixClientPeg {
     }
 
     async start() {
-        StorageManager.trackStores(this.matrixClient);
-
         for (const dbType of ['indexeddb', 'memory']) {
             try {
                 const promise = this.matrixClient.store.startup();
@@ -115,6 +113,8 @@ class MatrixClientPeg {
                 }
             }
         }
+
+        StorageManager.trackStores(this.matrixClient);
 
         // try to initialise e2e on the new client
         try {

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -31,6 +31,7 @@ import {phasedRollOutExpiredForUser} from "./PhasedRollOut";
 import Modal from './Modal';
 import {verificationMethods} from 'matrix-js-sdk/lib/crypto';
 import MatrixClientBackedSettingsHandler from "./settings/handlers/MatrixClientBackedSettingsHandler";
+import * as StorageManager from './utils/StorageManager';
 
 interface MatrixClientCreds {
     homeserverUrl: string,
@@ -94,6 +95,8 @@ class MatrixClientPeg {
     }
 
     async start() {
+        StorageManager.trackStores(this.matrixClient);
+
         for (const dbType of ['indexeddb', 'memory']) {
             try {
                 const promise = this.matrixClient.store.startup();

--- a/src/utils/StorageManager.js
+++ b/src/utils/StorageManager.js
@@ -147,3 +147,11 @@ async function checkCryptoStore() {
     log("Crypto store using memory only");
     return { exists, healthy: false };
 }
+
+export function trackStores(client) {
+    if (client.store && client.store.on) {
+        client.store.on("degraded", () => {
+            track("Sync store using IndexedDB degraded to memory");
+        });
+    }
+}


### PR DESCRIPTION
This watches the `IndexedDBStore` in case it degrades. If it does, we track this
in analytics so we can observe how often it happens in the field.

Should help track errors like https://github.com/vector-im/riot-web/issues/7769

Uses event added by https://github.com/matrix-org/matrix-js-sdk/pull/884 (but can merge separately)