### PR TITLE
Ensure the page URL is redacted before tracking analytics events

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -201,6 +201,7 @@ class Analytics {
 
     trackEvent(category, action, name, value) {
         if (this.disabled) return;
+        this._paq.push(['setCustomUrl', getRedactedUrl()]);
         this._paq.push(['trackEvent', category, action, name, value]);
     }
 


### PR DESCRIPTION
Sometimes the page URL isn't redacted, so we manually set it to be redacted prior to tracking the event. This isn't entirely documented by piwik, but having looked at the requests leaving the browser it seems to fix the issue.