### PR TITLE
Sync breadcrumb rooms through account data

### DIFF
--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -18,13 +18,13 @@ limitations under the License.
 import React from "react";
 import dis from "../../../dispatcher";
 import MatrixClientPeg from "../../../MatrixClientPeg";
+import SettingsStore, {SettingLevel} from "../../../settings/SettingsStore";
 import AccessibleButton from '../elements/AccessibleButton';
 import RoomAvatar from '../avatars/RoomAvatar';
 import classNames from 'classnames';
 import sdk from "../../../index";
 import * as RoomNotifs from '../../../RoomNotifs';
 import * as FormattingUtils from "../../../utils/FormattingUtils";
-import SettingsStore, {SettingLevel} from "../../../settings/SettingsStore";
 
 const MAX_ROOMS = 20;
 

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -88,7 +88,9 @@ export default class RoomBreadcrumbs extends React.Component {
         }
 
         const roomIds = rooms.map((r) => r.room.roomId);
-        SettingsStore.setValue("breadcrumb_rooms", null, SettingLevel.ACCOUNT, roomIds);
+        if (roomIds.length > 0) {
+            SettingsStore.setValue("breadcrumb_rooms", null, SettingLevel.ACCOUNT, roomIds);
+        }
     }
 
     onAction(payload) {
@@ -147,6 +149,8 @@ export default class RoomBreadcrumbs extends React.Component {
     };
 
     _loadRoomIds(roomIds) {
+        if (!roomIds || roomIds.length <= 0) return; // Skip updates with no rooms
+
         // If we're here, the list changed.
         const rooms = roomIds.map((r) => MatrixClientPeg.get().getRoom(r)).filter((r) => r).map((r) => {
             const badges = this._calculateBadgesForRoom(r) || {};

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -258,6 +258,10 @@ export const SETTINGS = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: "en",
     },
+    "breadcrumb_rooms": {
+        supportedLevels: ['account'],
+        default: [],
+    },
     "analyticsOptIn": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         displayName: _td('Send analytics data'),


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9315

Other clients would need to listen for and update `im.vector.riot.breadcrumb_rooms` in account data.

![breadcrumbs-synced mp4](https://user-images.githubusercontent.com/1190097/55588523-3b144c00-56eb-11e9-9ba7-fea4386438fa.gif)
