### PR TITLE
Autohide the scrollbar on breadcrumbs

### DIFF
--- a/res/css/views/rooms/_RoomBreadcrumbs.scss
+++ b/res/css/views/rooms/_RoomBreadcrumbs.scss
@@ -19,9 +19,14 @@ limitations under the License.
     height: 42px;
     padding: 8px;
     padding-bottom: 0;
-    overflow-x: visible;
     display: flex;
     flex-direction: row;
+
+    // Autohide the scrollbar
+    overflow-x: hidden;
+    &:hover {
+        overflow-x: visible;
+    }
 
     .mx_AutoHideScrollbar_offset {
         display: flex;

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
 import React from "react";
 import dis from "../../../dispatcher";
 import MatrixClientPeg from "../../../MatrixClientPeg";


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9349

![image](https://user-images.githubusercontent.com/1190097/55592727-a3b4f600-56f6-11e9-9efd-bedd7f417f63.png)
![image](https://user-images.githubusercontent.com/1190097/55592728-a57eb980-56f6-11e9-8ac8-b942c69d7f9b.png)
