### PR TITLE
Prevent the permalink creator from causing cascading failure

### DIFF
--- a/src/matrix-to.js
+++ b/src/matrix-to.js
@@ -83,6 +83,14 @@ export class RoomPermalinkCreator {
     }
 
     load() {
+        if (!this._room || !this._room.currentState) {
+            // Under rare and unknown circumstances it is possible to have a room with no
+            // currentState, at least potentially at the early stages of joining a room.
+            // To avoid breaking everything, we'll just warn rather than throw as well as
+            // not bother updating the various aspects of the share link.
+            console.warn("Tried to load a permalink creator with no room state");
+            return;
+        }
         this._updateAllowedServers();
         this._updateHighestPlUser();
         this._updatePopulationMap();


### PR DESCRIPTION
Fixes https://github.com/matrix-org/riot-web-rageshakes/issues/1391

In that rageshake, it appears that my attempt to join a room was faster than the js-sdk could build `currentState` (somehow), which caused the permalink creator to crash the whole application. Instead of crashing in this way, the permalink creator should gracefully fall back.