### PR TITLE
Fix settings dialog layout

### DIFF
--- a/res/css/views/dialogs/_SettingsDialog.scss
+++ b/res/css/views/dialogs/_SettingsDialog.scss
@@ -44,7 +44,7 @@ limitations under the License.
             margin-bottom: 24px;
         }
         .mx_Dialog_fixedWidth {
-            width: 90vw;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
The close 'x' was ending up off the right hand side which made
everything else overlap with the left panel, depending on how wide
your window was.

This isn't the end of the dialog problems but it will at least stop
settings from being mangled on develop.