### PR TITLE
Treat SettingsDialog as variable width

### DIFF
--- a/res/css/views/dialogs/_SettingsDialog.scss
+++ b/res/css/views/dialogs/_SettingsDialog.scss
@@ -43,8 +43,5 @@ limitations under the License.
             margin-top: 16px;
             margin-bottom: 24px;
         }
-        .mx_Dialog_fixedWidth {
-            width: 100%;
-        }
     }
 }

--- a/src/components/views/dialogs/RoomSettingsDialog.js
+++ b/src/components/views/dialogs/RoomSettingsDialog.js
@@ -64,7 +64,10 @@ export default class RoomSettingsDialog extends React.Component {
         const roomName = MatrixClientPeg.get().getRoom(this.props.roomId).name;
         return (
             <BaseDialog className='mx_RoomSettingsDialog' hasCancel={true}
-                        onFinished={this.props.onFinished} title={_t("Room Settings - %(roomName)s", {roomName})}>
+                        onFinished={this.props.onFinished}
+                        title={_t("Room Settings - %(roomName)s", {roomName})}
+                        fixedWidth={false}
+            >
                 <div className='ms_SettingsDialog_content'>
                     <TabbedView tabs={this._getTabs()} />
                 </div>

--- a/src/components/views/dialogs/UserSettingsDialog.js
+++ b/src/components/views/dialogs/UserSettingsDialog.js
@@ -88,7 +88,9 @@ export default class UserSettingsDialog extends React.Component {
 
         return (
             <BaseDialog className='mx_UserSettingsDialog' hasCancel={true}
-                        onFinished={this.props.onFinished} title={_t("Settings")}>
+                        onFinished={this.props.onFinished} title={_t("Settings")}
+                        fixedWidth={false}
+            >
                 <div className='ms_SettingsDialog_content'>
                     <TabbedView tabs={this._getTabs()} />
                 </div>


### PR DESCRIPTION
In reality it sets its own width as 90% or 1000px.

Another thing we could do here is change the fixedWidth prop to
BaseDialog to be a number which it would set the width to, then
we could remove the CSS overrides for SettingsDialog. Would
essentially be putting more style into the JS though.