### PR TITLE
Remove duplicate space in credits

### DIFF
--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
@@ -136,7 +136,7 @@ export default class HelpUserSettingsTab extends React.Component {
                     <li>
                         The <a href="themes/riot/img/backgrounds/valley.jpg" rel="noopener" target="_blank">
                         default cover photo</a> is (C)&nbsp;
-                        <a href="https://www.flickr.com/golan" rel="noopener" target="_blank">Jesús Roncero</a>&nbsp;
+                        <a href="https://www.flickr.com/golan" rel="noopener" target="_blank">Jesús Roncero</a>{' '}
                         used under the terms of&nbsp;
                         <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="noopener" target="_blank">
                         CC-BY-SA 4.0</a>. No warranties are given.


### PR DESCRIPTION
The previous code generated two spaces after the author name. Now there is only one.

This is very important.