### PR TITLE
Set E2E room status to warning when crypto is disabled

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -730,8 +730,19 @@ module.exports = React.createClass({
         if (!MatrixClientPeg.get().isRoomEncrypted(room.roomId)) {
             return;
         }
+        if (!MatrixClientPeg.get().isCryptoEnabled()) {
+            // If crypto is not currently enabled, we aren't tracking devices at all,
+            // so we don't know what the answer is. Let's error on the safe side and show
+            // a warning for this case.
+            this.setState({
+                e2eStatus: "warning",
+            });
+            return;
+        }
         room.hasUnverifiedDevices().then((hasUnverifiedDevices) => {
-            this.setState({e2eStatus: hasUnverifiedDevices ? "warning" : "verified"});
+            this.setState({
+                e2eStatus: hasUnverifiedDevices ? "warning" : "verified",
+            });
         });
     },
 


### PR DESCRIPTION
When crypto is disabled for the current device, we can't tell whether there are
unverified devices since we aren't tracking devices at all.

Let's be safe and default to the warning state.

See also https://github.com/matrix-org/matrix-js-sdk/pull/889