### PR TITLE
Send breadcrumb updates only when they change

### DIFF
--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -242,6 +242,9 @@ export default class RoomBreadcrumbs extends React.Component {
             this.refs.scroller.moveToOrigin();
         }
 
+        // We don't track room aesthetics (badges, membership, etc) over the wire so we
+        // don't need to do this elsewhere in the file. Just where we alter the room IDs
+        // and their order.
         const roomIds = rooms.map((r) => r.room.roomId);
         if (roomIds.length > 0) {
             SettingsStore.setValue("breadcrumb_rooms", null, SettingLevel.ACCOUNT, roomIds);

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -88,11 +88,6 @@ export default class RoomBreadcrumbs extends React.Component {
                 setTimeout(() => this.setState({rooms}), 0);
             }
         }
-
-        const roomIds = rooms.map((r) => r.room.roomId);
-        if (roomIds.length > 0) {
-            SettingsStore.setValue("breadcrumb_rooms", null, SettingLevel.ACCOUNT, roomIds);
-        }
     }
 
     onAction(payload) {
@@ -245,6 +240,11 @@ export default class RoomBreadcrumbs extends React.Component {
 
         if (this.refs.scroller) {
             this.refs.scroller.moveToOrigin();
+        }
+
+        const roomIds = rooms.map((r) => r.room.roomId);
+        if (roomIds.length > 0) {
+            SettingsStore.setValue("breadcrumb_rooms", null, SettingLevel.ACCOUNT, roomIds);
         }
     }
 


### PR DESCRIPTION
Fixes an issue where hovering over the breadcrumbs could cause hundreds of web requests due to updates. This also fixes https://github.com/vector-im/riot-web/issues/9390 as the update is more reliable.