### PR TITLE
Always return a client from onRegistered

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1772,7 +1772,7 @@ export default React.createClass({
                     hasCancelButton: false,
                 });
 
-                return;
+                return MatrixClientPeg.get();
             }
         }
         return Lifecycle.setLoggedIn(credentials);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9406

The return value of onRegistered eventually ends up in the pusher setup, which means we were passing undefined through the stack.