### PR TITLE
Fix having to click the member list button twice to show it after having changed room.

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -565,20 +565,6 @@ export default React.createClass({
                     },
                 });
                 break;
-            case 'view_user':
-                // FIXME: ugly hack to expand the RightPanel and then re-dispatch.
-                if (this.state.collapsedRhs) {
-                    setTimeout(()=>{
-                        dis.dispatch({
-                            action: 'show_right_panel',
-                        });
-                        dis.dispatch({
-                            action: 'view_user',
-                            member: payload.member,
-                        });
-                    }, 0);
-                }
-                break;
             case 'view_room':
                 // Takes either a room ID or room alias: if switching to a room the client is already
                 // known to be in (eg. user clicks on a room in the recents panel), supply the ID

--- a/src/components/views/right_panel/GroupHeaderButtons.js
+++ b/src/components/views/right_panel/GroupHeaderButtons.js
@@ -23,6 +23,15 @@ import HeaderButton from './HeaderButton';
 import HeaderButtons from './HeaderButtons';
 import RightPanel from '../../structures/RightPanel';
 
+const GROUP_PHASES = [
+    RightPanel.Phase.GroupMemberInfo,
+    RightPanel.Phase.GroupMemberList,
+];
+const ROOM_PHASES = [
+    RightPanel.Phase.GroupRoomList,
+    RightPanel.Phase.GroupRoomInfo,
+];
+
 export default class GroupHeaderButtons extends HeaderButtons {
     constructor(props) {
         super(props, RightPanel.Phase.GroupMemberList);
@@ -53,33 +62,24 @@ export default class GroupHeaderButtons extends HeaderButtons {
     }
 
     _onMembersClicked() {
-        this.togglePhase(RightPanel.Phase.GroupMemberList);
+        this.togglePhase(RightPanel.Phase.GroupMemberList, GROUP_PHASES);
     }
 
     _onRoomsClicked() {
-        this.togglePhase(RightPanel.Phase.GroupRoomList);
+        this.togglePhase(RightPanel.Phase.GroupRoomList, ROOM_PHASES);
     }
 
     renderButtons() {
-        const groupPhases = [
-            RightPanel.Phase.GroupMemberInfo,
-            RightPanel.Phase.GroupMemberList,
-        ];
-        const roomPhases = [
-            RightPanel.Phase.GroupRoomList,
-            RightPanel.Phase.GroupRoomInfo,
-        ];
-
         return [
             <HeaderButton key="groupMembersButton" name="groupMembersButton"
                 title={_t('Members')}
-                isHighlighted={this.isPhase(groupPhases)}
+                isHighlighted={this.isPhase(GROUP_PHASES)}
                 onClick={this._onMembersClicked}
                 analytics={['Right Panel', 'Group Member List Button', 'click']}
             />,
             <HeaderButton key="roomsButton" name="roomsButton"
                 title={_t('Rooms')}
-                isHighlighted={this.isPhase(roomPhases)}
+                isHighlighted={this.isPhase(ROOM_PHASES)}
                 onClick={this._onRoomsClicked}
                 analytics={['Right Panel', 'Group Room List Button', 'click']}
             />,

--- a/src/components/views/right_panel/GroupHeaderButtons.js
+++ b/src/components/views/right_panel/GroupHeaderButtons.js
@@ -68,13 +68,13 @@ export default class GroupHeaderButtons extends HeaderButtons {
             <HeaderButton key="groupMembersButton" name="groupMembersButton"
                 title={_t('Members')}
                 isHighlighted={this.isPhase(groupPhases)}
-                clickPhase={RightPanel.Phase.GroupMemberList}
+                onClick={() => this.togglePhase(RightPanel.Phase.GroupMemberList)}
                 analytics={['Right Panel', 'Group Member List Button', 'click']}
             />,
             <HeaderButton key="roomsButton" name="roomsButton"
                 title={_t('Rooms')}
                 isHighlighted={this.isPhase(roomPhases)}
-                clickPhase={RightPanel.Phase.GroupRoomList}
+                onClick={() => this.togglePhase(RightPanel.Phase.GroupRoomList)}
                 analytics={['Right Panel', 'Group Room List Button', 'click']}
             />,
         ];

--- a/src/components/views/right_panel/GroupHeaderButtons.js
+++ b/src/components/views/right_panel/GroupHeaderButtons.js
@@ -26,6 +26,8 @@ import RightPanel from '../../structures/RightPanel';
 export default class GroupHeaderButtons extends HeaderButtons {
     constructor(props) {
         super(props, RightPanel.Phase.GroupMemberList);
+        this._onMembersClicked = this._onMembersClicked.bind(this);
+        this._onRoomsClicked = this._onRoomsClicked.bind(this);
     }
 
     onAction(payload) {
@@ -50,6 +52,14 @@ export default class GroupHeaderButtons extends HeaderButtons {
         }
     }
 
+    _onMembersClicked() {
+        this.togglePhase(RightPanel.Phase.GroupMemberList);
+    }
+
+    _onRoomsClicked() {
+        this.togglePhase(RightPanel.Phase.GroupRoomList);
+    }
+
     renderButtons() {
         const groupPhases = [
             RightPanel.Phase.GroupMemberInfo,
@@ -64,13 +74,13 @@ export default class GroupHeaderButtons extends HeaderButtons {
             <HeaderButton key="groupMembersButton" name="groupMembersButton"
                 title={_t('Members')}
                 isHighlighted={this.isPhase(groupPhases)}
-                onClick={() => this.togglePhase(RightPanel.Phase.GroupMemberList)}
+                onClick={this._onMembersClicked}
                 analytics={['Right Panel', 'Group Member List Button', 'click']}
             />,
             <HeaderButton key="roomsButton" name="roomsButton"
                 title={_t('Rooms')}
                 isHighlighted={this.isPhase(roomPhases)}
-                onClick={() => this.togglePhase(RightPanel.Phase.GroupRoomList)}
+                onClick={this._onRoomsClicked}
                 analytics={['Right Panel', 'Group Room List Button', 'click']}
             />,
         ];

--- a/src/components/views/right_panel/GroupHeaderButtons.js
+++ b/src/components/views/right_panel/GroupHeaderButtons.js
@@ -19,7 +19,6 @@ limitations under the License.
 
 import React from 'react';
 import { _t } from '../../../languageHandler';
-import dis from '../../../dispatcher';
 import HeaderButton from './HeaderButton';
 import HeaderButtons from './HeaderButtons';
 import RightPanel from '../../structures/RightPanel';

--- a/src/components/views/right_panel/GroupHeaderButtons.js
+++ b/src/components/views/right_panel/GroupHeaderButtons.js
@@ -33,9 +33,6 @@ export default class GroupHeaderButtons extends HeaderButtons {
         super.onAction(payload);
 
         if (payload.action === "view_user") {
-            dis.dispatch({
-                action: 'show_right_panel',
-            });
             if (payload.member) {
                 this.setPhase(RightPanel.Phase.RoomMemberInfo, {member: payload.member});
             } else {

--- a/src/components/views/right_panel/HeaderButton.js
+++ b/src/components/views/right_panel/HeaderButton.js
@@ -20,7 +20,6 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import dis from '../../../dispatcher';
 import Analytics from '../../../Analytics';
 import AccessibleButton from '../elements/AccessibleButton';
 

--- a/src/components/views/right_panel/HeaderButton.js
+++ b/src/components/views/right_panel/HeaderButton.js
@@ -32,11 +32,7 @@ export default class HeaderButton extends React.Component {
 
     onClick(ev) {
         Analytics.trackEvent(...this.props.analytics);
-        dis.dispatch({
-            action: 'view_right_panel_phase',
-            phase: this.props.clickPhase,
-            fromHeader: true,
-        });
+        this.props.onClick();
     }
 
     render() {

--- a/src/components/views/right_panel/HeaderButtons.js
+++ b/src/components/views/right_panel/HeaderButtons.js
@@ -40,12 +40,34 @@ export default class HeaderButtons extends React.Component {
         dis.unregister(this.dispatcherRef);
     }
 
+    componentDidUpdate(prevProps) {
+        if (!prevProps.collapsedRhs && this.props.collapsedRhs) {
+            this.setState({
+                phase: null,
+            });
+        }
+    }
+
     setPhase(phase, extras) {
-        // TODO: delay?
+        if (this.props.collapsedRhs) {
+            dis.dispatch({
+                action: 'show_right_panel',
+            });
+        }
         dis.dispatch(Object.assign({
             action: 'view_right_panel_phase',
             phase: phase,
         }, extras));
+    }
+
+    togglePhase(phase) {
+        if (this.state.phase === phase) {
+            dis.dispatch({
+                action: 'hide_right_panel',
+            });
+        } else {
+            this.setPhase(phase);
+        }
     }
 
     isPhase(phases) {
@@ -61,28 +83,9 @@ export default class HeaderButtons extends React.Component {
 
     onAction(payload) {
         if (payload.action === "view_right_panel_phase") {
-            // only actions coming from header buttons should collapse the right panel
-            if (this.state.phase === payload.phase && payload.fromHeader) {
-                dis.dispatch({
-                    action: 'hide_right_panel',
-                });
-                this.setState({
-                    phase: null,
-                });
-            } else {
-                if (this.props.collapsedRhs && payload.fromHeader) {
-                    dis.dispatch({
-                        action: 'show_right_panel',
-                    });
-                    // emit payload again as the RightPanel didn't exist up
-                    // till show_right_panel, just without the fromHeader flag
-                    // as that would hide the right panel again
-                    dis.dispatch(Object.assign({}, payload, {fromHeader: false}));
-                }
-                this.setState({
-                    phase: payload.phase,
-                });
-            }
+            this.setState({
+                phase: payload.phase,
+            });
         }
     }
 

--- a/src/components/views/right_panel/HeaderButtons.js
+++ b/src/components/views/right_panel/HeaderButtons.js
@@ -60,8 +60,8 @@ export default class HeaderButtons extends React.Component {
         }, extras));
     }
 
-    togglePhase(phase) {
-        if (this.state.phase === phase) {
+    togglePhase(phase, validPhases = [phase]) {
+        if (validPhases.includes(this.state.phase)) {
             dis.dispatch({
                 action: 'hide_right_panel',
             });

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -26,6 +26,9 @@ import RightPanel from '../../structures/RightPanel';
 export default class RoomHeaderButtons extends HeaderButtons {
     constructor(props) {
         super(props, RightPanel.Phase.RoomMemberList);
+        this._onMembersClicked = this._onMembersClicked.bind(this);
+        this._onFilesClicked = this._onFilesClicked.bind(this);
+        this._onNotificationsClicked = this._onNotificationsClicked.bind(this);
     }
 
     onAction(payload) {
@@ -47,6 +50,18 @@ export default class RoomHeaderButtons extends HeaderButtons {
         }
     }
 
+    _onMembersClicked() {
+        this.togglePhase(RightPanel.Phase.RoomMemberList);
+    }
+
+    _onFilesClicked() {
+        this.togglePhase(RightPanel.Phase.FilePanel);
+    }
+
+    _onNotificationsClicked() {
+        this.togglePhase(RightPanel.Phase.NotificationPanel);
+    }
+
     renderButtons() {
         const membersPhases = [
             RightPanel.Phase.RoomMemberList,
@@ -58,19 +73,19 @@ export default class RoomHeaderButtons extends HeaderButtons {
             <HeaderButton key="membersButton" name="membersButton"
                 title={_t('Members')}
                 isHighlighted={this.isPhase(membersPhases)}
-                onClick={() => this.togglePhase(RightPanel.Phase.RoomMemberList)}
+                onClick={this._onMembersClicked}
                 analytics={['Right Panel', 'Member List Button', 'click']}
             />,
             <HeaderButton key="filesButton" name="filesButton"
                 title={_t('Files')}
                 isHighlighted={this.isPhase(RightPanel.Phase.FilePanel)}
-                onClick={() => this.togglePhase(RightPanel.Phase.FilePanel)}
+                onClick={this._onFilesClicked}
                 analytics={['Right Panel', 'File List Button', 'click']}
             />,
             <HeaderButton key="notifsButton" name="notifsButton"
                 title={_t('Notifications')}
                 isHighlighted={this.isPhase(RightPanel.Phase.NotificationPanel)}
-                onClick={() => this.togglePhase(RightPanel.Phase.NotificationPanel)}
+                onClick={this._onNotificationsClicked}
                 analytics={['Right Panel', 'Notification List Button', 'click']}
             />,
         ];

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -32,9 +32,6 @@ export default class RoomHeaderButtons extends HeaderButtons {
     onAction(payload) {
         super.onAction(payload);
         if (payload.action === "view_user") {
-            dis.dispatch({
-                action: 'show_right_panel',
-            });
             if (payload.member) {
                 this.setPhase(RightPanel.Phase.RoomMemberInfo, {member: payload.member});
             } else {

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -23,6 +23,12 @@ import HeaderButton from './HeaderButton';
 import HeaderButtons from './HeaderButtons';
 import RightPanel from '../../structures/RightPanel';
 
+const MEMBER_PHASES = [
+    RightPanel.Phase.RoomMemberList,
+    RightPanel.Phase.RoomMemberInfo,
+    RightPanel.Phase.Room3pidMemberInfo,
+];
+
 export default class RoomHeaderButtons extends HeaderButtons {
     constructor(props) {
         super(props, RightPanel.Phase.RoomMemberList);
@@ -51,7 +57,7 @@ export default class RoomHeaderButtons extends HeaderButtons {
     }
 
     _onMembersClicked() {
-        this.togglePhase(RightPanel.Phase.RoomMemberList);
+        this.togglePhase(RightPanel.Phase.RoomMemberList, MEMBER_PHASES);
     }
 
     _onFilesClicked() {
@@ -63,16 +69,10 @@ export default class RoomHeaderButtons extends HeaderButtons {
     }
 
     renderButtons() {
-        const membersPhases = [
-            RightPanel.Phase.RoomMemberList,
-            RightPanel.Phase.RoomMemberInfo,
-            RightPanel.Phase.Room3pidMemberInfo,
-        ];
-
         return [
             <HeaderButton key="membersButton" name="membersButton"
                 title={_t('Members')}
-                isHighlighted={this.isPhase(membersPhases)}
+                isHighlighted={this.isPhase(MEMBER_PHASES)}
                 onClick={this._onMembersClicked}
                 analytics={['Right Panel', 'Member List Button', 'click']}
             />,

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -40,7 +40,7 @@ export default class RoomHeaderButtons extends HeaderButtons {
             } else {
                 this.setPhase(RightPanel.Phase.RoomMemberList);
             }
-        } else if (payload.action === "view_room") {
+        } else if (payload.action === "view_room" && !this.props.collapsedRhs) {
             this.setPhase(RightPanel.Phase.RoomMemberList);
         } else if (payload.action === "view_3pid_invite") {
             if (payload.event) {

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -19,7 +19,6 @@ limitations under the License.
 
 import React from 'react';
 import { _t } from '../../../languageHandler';
-import dis from '../../../dispatcher';
 import HeaderButton from './HeaderButton';
 import HeaderButtons from './HeaderButtons';
 import RightPanel from '../../structures/RightPanel';

--- a/src/components/views/right_panel/RoomHeaderButtons.js
+++ b/src/components/views/right_panel/RoomHeaderButtons.js
@@ -62,19 +62,19 @@ export default class RoomHeaderButtons extends HeaderButtons {
             <HeaderButton key="membersButton" name="membersButton"
                 title={_t('Members')}
                 isHighlighted={this.isPhase(membersPhases)}
-                clickPhase={RightPanel.Phase.RoomMemberList}
+                onClick={() => this.togglePhase(RightPanel.Phase.RoomMemberList)}
                 analytics={['Right Panel', 'Member List Button', 'click']}
             />,
             <HeaderButton key="filesButton" name="filesButton"
                 title={_t('Files')}
                 isHighlighted={this.isPhase(RightPanel.Phase.FilePanel)}
-                clickPhase={RightPanel.Phase.FilePanel}
+                onClick={() => this.togglePhase(RightPanel.Phase.FilePanel)}
                 analytics={['Right Panel', 'File List Button', 'click']}
             />,
             <HeaderButton key="notifsButton" name="notifsButton"
                 title={_t('Notifications')}
                 isHighlighted={this.isPhase(RightPanel.Phase.NotificationPanel)}
-                clickPhase={RightPanel.Phase.NotificationPanel}
+                onClick={() => this.togglePhase(RightPanel.Phase.NotificationPanel)}
                 analytics={['Right Panel', 'Notification List Button', 'click']}
             />,
         ];


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8128

Probably easiest to review commit by commit.

This centralizes emitting `show_right_panel` in HeaderButtons::setPhase, and removes different places where we had a special case for first showing the panel before changing the phase.

The idea is that anywhere outside of the header buttons where we need to show the right panel in a given phase would use a dedicated action (like `view_user`, ... see onAction method in GroupHeaderButtons and RoomHeaderButtons), which end up calling setPhase and emit (if needed) `show_right_panel` and `view_right_panel_phase` to which the RightPanel (which now exists) responds.

`GroupMemberList` also emits `view_right_panel_phase` but then it's fair to assume the right panel already exists.