### PR TITLE
Prevent user pills containing only emoji from embiggening

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -516,7 +516,10 @@ export function bodyToHtml(content, highlights, opts={}) {
         contentBodyTrimmed = contentBodyTrimmed.replace(ZWJ_REGEX, '');
 
         const match = EMOJI_REGEX.exec(contentBodyTrimmed);
-        emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length;
+        emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length
+                    // Prevent user pills expanding for users with only emoji in
+                    // their username
+                    && content.formatted_body == undefined;
     }
 
     const className = classNames({

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -519,7 +519,7 @@ export function bodyToHtml(content, highlights, opts={}) {
         emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length
                     // Prevent user pills expanding for users with only emoji in
                     // their username
-                    && content.formatted_body == undefined;
+                    && !content.formatted_body.includes("https://matrix.to/");
     }
 
     const className = classNames({

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -519,7 +519,8 @@ export function bodyToHtml(content, highlights, opts={}) {
         emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length
                     // Prevent user pills expanding for users with only emoji in
                     // their username
-                    && (!content.formatted_body || !content.formatted_body.includes("https://matrix.to/"));
+                    && (content.formatted_body == undefined
+		        || !content.formatted_body.includes("https://matrix.to/"));
     }
 
     const className = classNames({

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -519,7 +519,7 @@ export function bodyToHtml(content, highlights, opts={}) {
         emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length
                     // Prevent user pills expanding for users with only emoji in
                     // their username
-                    && (content.formatted_body && !content.formatted_body.includes("https://matrix.to/"));
+                    && (!content.formatted_body || !content.formatted_body.includes("https://matrix.to/"));
     }
 
     const className = classNames({

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -519,7 +519,7 @@ export function bodyToHtml(content, highlights, opts={}) {
         emojiBody = match && match[0] && match[0].length === contentBodyTrimmed.length
                     // Prevent user pills expanding for users with only emoji in
                     // their username
-                    && !content.formatted_body.includes("https://matrix.to/");
+                    && (content.formatted_body && !content.formatted_body.includes("https://matrix.to/"));
     }
 
     const className = classNames({


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8035

Emoji-only messages shouldn't have a formatted body. User pill messages do. We can exploit this to prevent user-pill username messages from being blown up.

![image](https://user-images.githubusercontent.com/1342360/55898559-c2b1fd00-5bba-11e9-9784-33d1118bcf45.png)
