### PR TITLE
Fix usage of static title name

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1797,7 +1797,7 @@ export default React.createClass({
     },
 
     _setPageSubtitle: function(subtitle='') {
-        document.title = `Riot ${subtitle}`;
+        document.title = `${SdkConfig.get().brand || 'Riot'} ${subtitle}`;
     },
 
     updateStatusIndicator: function(state, prevState) {


### PR DESCRIPTION
use brand name from SdkConfig for the title bar instead of static "Riot", defaults still to "Riot"

Signed-off-by: Thomas Karner <thomas.karner@bytepoets.com>