### PR TITLE
Ensure `<b>` tags appear bold for all browsers

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -36,6 +36,12 @@ body {
     color: $warning-color;
 }
 
+b {
+    // On Firefox, the default weight for `<b>` is `bolder` which results in no bold
+    // effect since we only have specific weights of our fonts available.
+    font-weight: bold;
+}
+
 h2 {
     color: $primary-fg-color;
     font-weight: 400;


### PR DESCRIPTION
In Firefox, the default `<b>` style is such that it doesn't appear bold with our
current selection of specific font weights. This specifically sets a working
font weight.

<img width="521" alt="2019-04-12 at 15 08" src="https://user-images.githubusercontent.com/279572/56043306-e7ca7b00-5d34-11e9-85cf-aa4f5a38637d.png">
