### PR TITLE
Fix key backup status when missing device

### DIFF
--- a/src/components/views/settings/KeyBackupPanel.js
+++ b/src/components/views/settings/KeyBackupPanel.js
@@ -221,7 +221,10 @@ export default class KeyBackupPanel extends React.PureComponent {
                         {sub}
                     </span>;
                 const device = sub => <span className="mx_KeyBackupPanel_deviceName">{deviceName}</span>;
-                const fromThisDevice = sig.device.getFingerprint() === MatrixClientPeg.get().getDeviceEd25519Key();
+                const fromThisDevice = (
+                    sig.device &&
+                    sig.device.getFingerprint() === MatrixClientPeg.get().getDeviceEd25519Key()
+                );
                 let sigStatus;
                 if (!sig.device) {
                     sigStatus = _t(


### PR DESCRIPTION
We might not have the device in `sig.device`, so we have to check for it's
existence first. This fixes the "Unable to load key backup status" message that
is incorrectly triggering.

Fixes https://github.com/vector-im/riot-web/issues/9442