### PR TITLE
Make alt-enter insert new line on macOS

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1041,7 +1041,8 @@ export default class MessageComposerInput extends React.Component {
     };
 
     handleReturn = (ev, change) => {
-        if (ev.shiftKey) {
+        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        if (ev.shiftKey || (isMac && ev.altKey)) {
             return change.insertText('\n');
         }
 


### PR DESCRIPTION
Alt-enter is a common macOS shortcut for inserting a new line in an input that has a separate action tied to the enter key. For example, it inserts a new line in Messages.app, Slack, Facebook Messenger, and Skype.

I apologize for the lack of tests here, but I didn't see a good place to add them since MessageComposerInput-test.js is skipped in its entirety. I'd love to add a test if anyone has a suggestion for how to do so.

The test for whether we're on macOS was stolen from Keyboard.js: https://github.com/matrix-org/matrix-react-sdk/blob/21de0235b046c6ac8d64cd4a2206e61eeec35417/src/Keyboard.js#L64

If there's a preferred way to check platform, I'm happy to change this.