### PR TITLE
Test `defaultServerName` before showing it on forgot password

### DIFF
--- a/src/components/structures/auth/ForgotPassword.js
+++ b/src/components/structures/auth/ForgotPassword.js
@@ -222,7 +222,7 @@ module.exports = React.createClass({
         }
 
         let yourMatrixAccountText = _t('Your Matrix account');
-        if (this.state.enteredHsUrl === this.props.defaultHsUrl) {
+        if (this.state.enteredHsUrl === this.props.defaultHsUrl && this.props.defaultServerName) {
             yourMatrixAccountText = _t('Your Matrix account on %(serverName)s', {
                 serverName: this.props.defaultServerName,
             });


### PR DESCRIPTION
The Forgot Password screen wasn't checking the default server name for a value
before showing it, leading to a possible "Your Matrix account on <blank>"
message.

Fixes https://github.com/vector-im/riot-web/issues/9507