### PR TITLE
Initial validation logic for registration fields

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -100,6 +100,7 @@
 @import "./views/elements/_ToggleSwitch.scss";
 @import "./views/elements/_ToolTipButton.scss";
 @import "./views/elements/_Tooltip.scss";
+@import "./views/elements/_Validation.scss";
 @import "./views/globals/_MatrixToolbar.scss";
 @import "./views/groups/_GroupPublicityToggle.scss";
 @import "./views/groups/_GroupRoomList.scss";

--- a/res/css/views/elements/_Validation.scss
+++ b/res/css/views/elements/_Validation.scss
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_Validation_details {
+    padding-left: 15px;
+}
+
+.mx_Validation_detail {
+    font-weight: normal;
+
+    // TODO: Check / cross images
+    &.mx_Validation_valid {
+        color: $input-valid-border-color;
+    }
+
+    &.mx_Validation_invalid {
+        color: $input-invalid-border-color;
+    }
+}

--- a/res/css/views/elements/_Validation.scss
+++ b/res/css/views/elements/_Validation.scss
@@ -14,19 +14,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_Validation_description {
+    margin-bottom: 1em;
+}
+
 .mx_Validation_details {
-    padding-left: 15px;
+    padding-left: 20px;
+    margin: 0;
 }
 
 .mx_Validation_detail {
+    position: relative;
     font-weight: normal;
+    list-style: none;
+    margin-bottom: 0.5em;
 
-    // TODO: Check / cross images
+    &::before {
+        content: "";
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        top: 0;
+        left: -18px;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        mask-size: contain;
+    }
+
     &.mx_Validation_valid {
         color: $input-valid-border-color;
+
+        &::before {
+            mask-image: url('$(res)/img/feather-customised/check.svg');
+            background-color: $input-valid-border-color;
+        }
     }
 
     &.mx_Validation_invalid {
         color: $input-invalid-border-color;
+
+        &::before {
+            mask-image: url('$(res)/img/feather-customised/x.svg');
+            background-color: $input-invalid-border-color;
+        }
     }
 }

--- a/res/img/feather-customised/check.svg
+++ b/res/img/feather-customised/check.svg
@@ -1,0 +1,3 @@
+<svg fill="none" height="24" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="m20 6-11 11-5-5"/>
+</svg>

--- a/res/img/feather-customised/x.svg
+++ b/res/img/feather-customised/x.svg
@@ -1,0 +1,4 @@
+<svg fill="none" height="24" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="m18 6-12 12"/>
+    <path d="m6 6 12 12"/>
+</svg>

--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -86,6 +86,10 @@ export default class Field extends React.PureComponent {
         }
     };
 
+    focus() {
+        this.input.focus();
+    }
+
     validate({ value, focused }) {
         if (!this.props.onValidate) {
             return;
@@ -107,6 +111,7 @@ export default class Field extends React.PureComponent {
 
         // Set some defaults for the <input> element
         inputProps.type = inputProps.type || "text";
+        inputProps.ref = input => this.input = input;
         inputProps.placeholder = inputProps.placeholder || inputProps.label;
 
         inputProps.onFocus = this.onFocus;

--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -94,11 +94,11 @@ export default class Field extends React.PureComponent {
             mx_Field_invalid: onValidate && this.state.valid === false,
         });
 
-        // handle displaying feedback on validity
+        // Handle displaying feedback on validity
         const Tooltip = sdk.getComponent("elements.Tooltip");
-        let feedback;
+        let tooltip;
         if (this.state.feedback) {
-            feedback = <Tooltip
+            tooltip = <Tooltip
                 tooltipClassName="mx_Field_tooltip"
                 label={this.state.feedback}
             />;
@@ -108,7 +108,7 @@ export default class Field extends React.PureComponent {
             {prefixContainer}
             {fieldInput}
             <label htmlFor={this.props.id}>{this.props.label}</label>
-            {feedback}
+            {tooltip}
         </div>;
     }
 }

--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -74,7 +74,6 @@ export default class Field extends React.PureComponent {
 
         // Set some defaults for the <input> element
         inputProps.type = inputProps.type || "text";
-        inputProps.ref = "fieldInput";
         inputProps.placeholder = inputProps.placeholder || inputProps.label;
 
         inputProps.onChange = this.onChange;

--- a/src/components/views/elements/Field.js
+++ b/src/components/views/elements/Field.js
@@ -53,19 +53,52 @@ export default class Field extends React.PureComponent {
         };
     }
 
-    onChange = (ev) => {
-        if (this.props.onValidate) {
-            const result = this.props.onValidate(ev.target.value);
-            this.setState({
-                valid: result.valid,
-                feedback: result.feedback,
-            });
+    onFocus = (ev) => {
+        this.validate({
+            value: ev.target.value,
+            focused: true,
+        });
+        // Parent component may have supplied its own `onFocus` as well
+        if (this.props.onFocus) {
+            this.props.onFocus(ev);
         }
+    };
+
+    onChange = (ev) => {
+        this.validate({
+            value: ev.target.value,
+            focused: true,
+        });
         // Parent component may have supplied its own `onChange` as well
         if (this.props.onChange) {
             this.props.onChange(ev);
         }
     };
+
+    onBlur = (ev) => {
+        this.validate({
+            value: ev.target.value,
+            focused: false,
+        });
+        // Parent component may have supplied its own `onBlur` as well
+        if (this.props.onBlur) {
+            this.props.onBlur(ev);
+        }
+    };
+
+    validate({ value, focused }) {
+        if (!this.props.onValidate) {
+            return;
+        }
+        const { valid, feedback } = this.props.onValidate({
+            value,
+            focused,
+        });
+        this.setState({
+            valid,
+            feedback,
+        });
+    }
 
     render() {
         const { element, prefix, onValidate, children, ...inputProps } = this.props;
@@ -76,7 +109,9 @@ export default class Field extends React.PureComponent {
         inputProps.type = inputProps.type || "text";
         inputProps.placeholder = inputProps.placeholder || inputProps.label;
 
+        inputProps.onFocus = this.onFocus;
         inputProps.onChange = this.onChange;
+        inputProps.onBlur = this.onBlur;
 
         const fieldInput = React.createElement(inputElement, inputProps, children);
 

--- a/src/components/views/elements/Validation.js
+++ b/src/components/views/elements/Validation.js
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import classNames from 'classnames';
+
+/**
+ * Creates a validation function from a set of rules describing what to validate.
+ *
+ * @param {String} description
+ *     Summary of the kind of value that will meet the validation rules. Shown at
+ *     the top of the validation feedback.
+ * @param {Object} rules
+ *     An array of rules describing how to check to input value. Each rule in an object
+ *     and may have the following properties:
+ *     - `key`: A unique ID for the rule. Required.
+ *     - `regex`: A regex used to determine the rule's current validity. Required.
+ *     - `valid`: Text to show when the rule is valid. Only shown if set.
+ *     - `invalid`: Text to show when the rule is invalid. Only shown if set.
+ * @returns {Function}
+ *     A validation function that takes in the current input value and returns
+ *     the overall validity and a feedback UI that can be rendered for more detail.
+ */
+export default function withValidation({ description, rules }) {
+    return function onValidate(value) {
+        // TODO: Hide on blur
+        // TODO: Re-run only after ~200ms of inactivity
+        if (!value) {
+            return {
+                valid: null,
+                feedback: null,
+            };
+        }
+
+        const results = [];
+        let valid = true;
+        if (rules && rules.length) {
+            for (const rule of rules) {
+                if (!rule.key || !rule.regex) {
+                    continue;
+                }
+                const ruleValid = rule.regex.test(value);
+                valid = valid && ruleValid;
+                if (ruleValid && rule.valid) {
+                    // If the rule's result is valid and has text to show for
+                    // the valid state, show it.
+                    results.push({
+                        key: rule.key,
+                        valid: true,
+                        text: rule.valid,
+                    });
+                } else if (!ruleValid && rule.invalid) {
+                    // If the rule's result is invalid and has text to show for
+                    // the invalid state, show it.
+                    results.push({
+                        key: rule.key,
+                        valid: false,
+                        text: rule.invalid,
+                    });
+                }
+            }
+        }
+
+        let details;
+        if (results && results.length) {
+            details = <ul className="mx_Validation_details">
+                {results.map(result => {
+                    const classes = classNames({
+                        "mx_Validation_detail": true,
+                        "mx_Validation_valid": result.valid,
+                        "mx_Validation_invalid": !result.valid,
+                    });
+                    return <li key={result.key} className={classes}>
+                        {result.text}
+                    </li>;
+                })}
+            </ul>;
+        }
+
+        const feedback = <div className="mx_Validation">
+            <div>{description}</div>
+            {details}
+        </div>;
+
+        return {
+            valid,
+            feedback,
+        };
+    };
+}

--- a/src/components/views/elements/Validation.js
+++ b/src/components/views/elements/Validation.js
@@ -97,7 +97,7 @@ export default function withValidation({ description, rules }) {
         }
 
         const feedback = <div className="mx_Validation">
-            <div>{description}</div>
+            <div className="mx_Validation_description">{description}</div>
             {details}
         </div>;
 

--- a/src/components/views/elements/Validation.js
+++ b/src/components/views/elements/Validation.js
@@ -34,8 +34,7 @@ import classNames from 'classnames';
  *     the overall validity and a feedback UI that can be rendered for more detail.
  */
 export default function withValidation({ description, rules }) {
-    return function onValidate(value) {
-        // TODO: Hide on blur
+    return function onValidate({ value, focused }) {
         // TODO: Re-run only after ~200ms of inactivity
         if (!value) {
             return {
@@ -71,6 +70,14 @@ export default function withValidation({ description, rules }) {
                     });
                 }
             }
+        }
+
+        // Hide feedback when not focused
+        if (!focused) {
+            return {
+                valid,
+                feedback: null,
+            };
         }
 
         let details;

--- a/src/components/views/elements/Validation.js
+++ b/src/components/views/elements/Validation.js
@@ -19,16 +19,16 @@ import classNames from 'classnames';
 /**
  * Creates a validation function from a set of rules describing what to validate.
  *
- * @param {String} description
- *     Summary of the kind of value that will meet the validation rules. Shown at
- *     the top of the validation feedback.
+ * @param {Function} description
+ *     Function that returns a string summary of the kind of value that will
+ *     meet the validation rules. Shown at the top of the validation feedback.
  * @param {Object} rules
  *     An array of rules describing how to check to input value. Each rule in an object
  *     and may have the following properties:
  *     - `key`: A unique ID for the rule. Required.
  *     - `regex`: A regex used to determine the rule's current validity. Required.
- *     - `valid`: Text to show when the rule is valid. Only shown if set.
- *     - `invalid`: Text to show when the rule is invalid. Only shown if set.
+ *     - `valid`: Function returning text to show when the rule is valid. Only shown if set.
+ *     - `invalid`: Function returning text to show when the rule is invalid. Only shown if set.
  * @returns {Function}
  *     A validation function that takes in the current input value and returns
  *     the overall validity and a feedback UI that can be rendered for more detail.
@@ -58,7 +58,7 @@ export default function withValidation({ description, rules }) {
                     results.push({
                         key: rule.key,
                         valid: true,
-                        text: rule.valid,
+                        text: rule.valid(),
                     });
                 } else if (!ruleValid && rule.invalid) {
                     // If the rule's result is invalid and has text to show for
@@ -66,7 +66,7 @@ export default function withValidation({ description, rules }) {
                     results.push({
                         key: rule.key,
                         valid: false,
-                        text: rule.invalid,
+                        text: rule.invalid(),
                     });
                 }
             }
@@ -96,8 +96,13 @@ export default function withValidation({ description, rules }) {
             </ul>;
         }
 
+        let summary;
+        if (description) {
+            summary = <div className="mx_Validation_description">{description()}</div>;
+        }
+
         const feedback = <div className="mx_Validation">
-            <div className="mx_Validation_description">{description}</div>
+            {summary}
             {details}
         </div>;
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1314,6 +1314,8 @@
     "Change": "Change",
     "Sign in with": "Sign in with",
     "If you don't specify an email address, you won't be able to reset your password. Are you sure?": "If you don't specify an email address, you won't be able to reset your password. Are you sure?",
+    "Use letters, numbers, dashes and underscores only": "Use letters, numbers, dashes and underscores only",
+    "Some characters not allowed": "Some characters not allowed",
     "Create your Matrix account": "Create your Matrix account",
     "Create your Matrix account on %(serverName)s": "Create your Matrix account on %(serverName)s",
     "Email (optional)": "Email (optional)",


### PR DESCRIPTION
**Reviewer:** Each commit in this PR is self-contained and has some additional context in the commit message, so you may want to review commit by commit. This PR currently leaves the registration form in a half-converted state with two validation systems. If the code generally looks good, but you'd prefer that we only merge the fully converted version, we can do that instead. Mainly, I want to make sure this approach seems broadly reasonable.

This adds a general validation helper and wires it up to the username field on registration as an example. Validation is handled by describing a rule to check and text to show for each state, which is then shown in a tooltip.

Various TODOs are sprinkled in to mark bits of the previous validation that can be removed after the next phase of converting the other validation checks.

![auth-validation-first-cut](https://user-images.githubusercontent.com/279572/56292736-9bf64800-611f-11e9-8658-35d857ae07a9.gif)

Part of the work for https://github.com/vector-im/riot-web/issues/8170