### PR TITLE
Mark a few CSS classes as not selectable

### DIFF
--- a/res/css/views/avatars/_BaseAvatar.scss
+++ b/res/css/views/avatars/_BaseAvatar.scss
@@ -26,6 +26,7 @@ limitations under the License.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1535053
     // https://bugzilla.mozilla.org/show_bug.cgi?id=255139
     display: inline-block;
+    user-select: none;
 }
 
 .mx_BaseAvatar_initial {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -31,6 +31,7 @@ limitations under the License.
     top: 14px;
     left: 8px;
     cursor: pointer;
+    user-select: none;
 }
 
 .mx_EventTile.mx_EventTile_info .mx_EventTile_avatar {
@@ -62,6 +63,7 @@ limitations under the License.
     vertical-align: top;
     height: 16px;
     overflow: hidden;
+    user-select: none;
 
     img {
         vertical-align: -2px;
@@ -80,6 +82,7 @@ limitations under the License.
     width: 46px; /* 8 + 30 (avatar) + 8 */
     text-align: center;
     position: absolute;
+    user-select: none;
 }
 
 .mx_EventTile_line, .mx_EventTile_reply {
@@ -226,9 +229,6 @@ limitations under the License.
     width: 19px;
     height: 19px;
     background-image: url($edit-button-url);
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 
@@ -243,6 +243,7 @@ limitations under the License.
     width: 14px;
     height: 14px;
     top: 29px;
+    user-select: none;
 }
 
 .mx_EventTile_continuation .mx_EventTile_readAvatars,


### PR DESCRIPTION
Should be enough to make copy-pasting not a nightmare.

For vector-im/riot-web#7460

~~The different prefixed versions of user-select are missing which I'll add if the PR is wanted :)~~ Done