### PR TITLE
actually clear bit 63 instead of bit 55

### DIFF
--- a/src/utils/MegolmExportEncryption.js
+++ b/src/utils/MegolmExportEncryption.js
@@ -147,7 +147,7 @@ export async function encryptMegolmKeyFile(data, password, options) {
     // clear bit 63 of the IV to stop us hitting the 64-bit counter boundary
     // (which would mean we wouldn't be able to decrypt on Android). The loss
     // of a single bit of iv is a price we have to pay.
-    iv[9] &= 0x7f;
+    iv[8] &= 0x7f;
 
     const [aesKey, hmacKey] = await deriveKeys(salt, kdfRounds, password);
     const encodedData = new TextEncoder().encode(data);


### PR DESCRIPTION
bit 63 lives in the 9th byte, which is at array index 8 rather than index 9 (Clearing bit 55 still works, because that allows for a file size of more than 18 petabytes, but the code should do what it says it's doing. ;) )

Thanks to Levans for pointing this out at https://matrix.to/#/!boLskYiwabbCQNNhlK:sw1v.org/$1556098717538ycACQ:safaradeg.net?via=matrix.org&via=kde.org&via=utwente.io