### PR TITLE
Check for `room` in all `Room.timeline*` handlers

### DIFF
--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -117,6 +117,7 @@ export default class RoomBreadcrumbs extends React.Component {
     };
 
     onRoomTimeline = (event, room) => {
+        if (!room) return; // Can be null for the notification timeline, etc.
         if (this.state.rooms.map(r => r.room.roomId).includes(room.roomId)) {
             this._calculateRoomBadges(room);
         }


### PR DESCRIPTION
All `Room.timeline*` handlers must currently test for `room` first if they
expect it to exist. It is emitted not only for rooms, but also for timeline sets
without rooms, such as for notifications.

Almost all such handlers were correctly testing as needed, but it was missing
from `RoomBreadcrumbs`.

While that's quite confusing, we can start by testing for `room` when we expect
to have one.

Fixes https://github.com/vector-im/riot-web/issues/9630