### PR TITLE
Restore access to message quote option on first click

### DIFF
--- a/src/components/views/messages/MessageActionBar.js
+++ b/src/components/views/messages/MessageActionBar.js
@@ -28,8 +28,8 @@ export default class MessageActionBar extends React.PureComponent {
     static propTypes = {
         mxEvent: PropTypes.object.isRequired,
         permalinkCreator: PropTypes.object,
-        tile: PropTypes.element,
-        replyThread: PropTypes.element,
+        getTile: PropTypes.func,
+        getReplyThread: PropTypes.func,
         onFocusChange: PropTypes.func,
     };
 
@@ -63,7 +63,9 @@ export default class MessageActionBar extends React.PureComponent {
         const x = buttonRect.right + window.pageXOffset;
         const y = (buttonRect.top + (buttonRect.height / 2) + window.pageYOffset) - 19;
 
-        const {tile, replyThread} = this.props;
+        const { getTile, getReplyThread } = this.props;
+        const tile = getTile && getTile();
+        const replyThread = getReplyThread && getReplyThread();
 
         let e2eInfoCallback = null;
         if (this.props.mxEvent.isEncrypted()) {

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -464,6 +464,14 @@ module.exports = withMatrixClient(React.createClass({
         });
     },
 
+    getTile() {
+        return this.refs.tile;
+    },
+
+    getReplyThread() {
+        return this.refs.replyThread;
+    },
+
     render: function() {
         const MessageTimestamp = sdk.getComponent('messages.MessageTimestamp');
         const SenderProfile = sdk.getComponent('messages.SenderProfile');
@@ -580,8 +588,8 @@ module.exports = withMatrixClient(React.createClass({
         const actionBar = <MessageActionBar
             mxEvent={this.props.mxEvent}
             permalinkCreator={this.props.permalinkCreator}
-            tile={this.refs.tile}
-            replyThread={this.refs.replyThread}
+            getTile={this.getTile}
+            getReplyThread={this.getReplyThread}
             onFocusChange={this.onActionBarFocusChange}
         />;
 


### PR DESCRIPTION
**Reviewer:** This targets the release branch.

This repairs access to the "Quote" option of the message context menu by passing
down a getter so that we always access the most recent tile and reply thread
instances. This ensures the context menu uses the newest information about the
current event when determining menu options to show.

Fixes https://github.com/vector-im/riot-web/issues/9639