### PR TITLE
Support a backup room ID in PermalinkCreator

### DIFF
--- a/src/components/views/messages/RoomCreate.js
+++ b/src/components/views/messages/RoomCreate.js
@@ -49,7 +49,7 @@ module.exports = React.createClass({
             return <div />; // We should never have been instaniated in this case
         }
         const prevRoom = MatrixClientPeg.get().getRoom(predecessor['room_id']);
-        const permalinkCreator = new RoomPermalinkCreator(prevRoom);
+        const permalinkCreator = new RoomPermalinkCreator(prevRoom, predecessor['room_id']);
         permalinkCreator.load();
         const predecessorPermalink = permalinkCreator.forEvent(predecessor['event_id']);
         return <div className="mx_CreateEvent">

--- a/src/matrix-to.js
+++ b/src/matrix-to.js
@@ -70,14 +70,22 @@ const MAX_SERVER_CANDIDATES = 3;
 // the list and magically have the link work.
 
 export class RoomPermalinkCreator {
-    constructor(room) {
+    // We support being given a roomId as a fallback in the event the `room` object
+    // doesn't exist or is not healthy for us to rely on. For example, loading a
+    // permalink to a room which the MatrixClient doesn't know about.
+    constructor(room, roomId=null) {
         this._room = room;
+        this._roomId = room ? room.roomId : roomId;
         this._highestPlUserId = null;
         this._populationMap = null;
         this._bannedHostsRegexps = null;
         this._allowedHostsRegexps = null;
         this._serverCandidates = null;
         this._started = false;
+
+        if (!this._roomId) {
+            throw new Error("Failed to resolve a roomId for the permalink creator to use");
+        }
 
         this.onMembership = this.onMembership.bind(this);
         this.onRoomState = this.onRoomState.bind(this);
@@ -116,13 +124,13 @@ export class RoomPermalinkCreator {
     }
 
     forEvent(eventId) {
-        const roomId = this._room.roomId;
+        const roomId = this._roomId;
         const permalinkBase = `${baseUrl}/#/${roomId}/${eventId}`;
         return `${permalinkBase}${encodeServerCandidates(this._serverCandidates)}`;
     }
 
     forRoom() {
-        const roomId = this._room.roomId;
+        const roomId = this._roomId;
         const permalinkBase = `${baseUrl}/#/${roomId}`;
         return `${permalinkBase}${encodeServerCandidates(this._serverCandidates)}`;
     }
@@ -245,7 +253,6 @@ export class RoomPermalinkCreator {
         this._serverCandidates = candidates;
     }
 }
-
 
 export function makeUserPermalink(userId) {
     return `${baseUrl}/#/${userId}`;

--- a/test/matrix-to-test.js
+++ b/test/matrix-to-test.js
@@ -74,7 +74,7 @@ describe('matrix-to', function() {
     });
 
     it('should pick no candidate servers when the room has no members', function() {
-        const room = mockRoom(null, []);
+        const room = mockRoom("!fake:example.org", []);
         const creator = new RoomPermalinkCreator(room);
         creator.load();
         expect(creator._serverCandidates).toBeTruthy();
@@ -82,7 +82,7 @@ describe('matrix-to', function() {
     });
 
     it('should pick a candidate server for the highest power level user in the room', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:pl_50",
                 powerLevel: 50,
@@ -109,7 +109,7 @@ describe('matrix-to', function() {
             userId: "@alice:pl_95",
             powerLevel: 95,
         };
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:pl_50",
                 powerLevel: 50,
@@ -132,7 +132,7 @@ describe('matrix-to', function() {
     });
 
     it('should pick candidate servers based on user population', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:first",
                 powerLevel: 0,
@@ -168,7 +168,7 @@ describe('matrix-to', function() {
     });
 
     it('should pick prefer candidate servers with higher power levels', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:first",
                 powerLevel: 100,
@@ -195,7 +195,7 @@ describe('matrix-to', function() {
     });
 
     it('should pick a maximum of 3 candidate servers', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:alpha",
                 powerLevel: 100,
@@ -224,7 +224,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider IPv4 hosts', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:127.0.0.1",
                 powerLevel: 100,
@@ -237,7 +237,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider IPv6 hosts', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:[::1]",
                 powerLevel: 100,
@@ -250,7 +250,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider IPv4 hostnames with ports', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:127.0.0.1:8448",
                 powerLevel: 100,
@@ -263,7 +263,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider IPv6 hostnames with ports', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:[::1]:8448",
                 powerLevel: 100,
@@ -276,7 +276,7 @@ describe('matrix-to', function() {
     });
 
     it('should work with hostnames with ports', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:example.org:8448",
                 powerLevel: 100,
@@ -291,7 +291,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider servers explicitly denied by ACLs', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:evilcorp.com",
                 powerLevel: 100,
@@ -311,7 +311,7 @@ describe('matrix-to', function() {
     });
 
     it('should not consider servers not allowed by ACLs', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:evilcorp.com",
                 powerLevel: 100,
@@ -331,7 +331,7 @@ describe('matrix-to', function() {
     });
 
     it('should consider servers not explicitly banned by ACLs', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:evilcorp.com",
                 powerLevel: 100,
@@ -352,7 +352,7 @@ describe('matrix-to', function() {
     });
 
     it('should consider servers not disallowed by ACLs', function() {
-        const room = mockRoom(null, [
+        const room = mockRoom("!fake:example.org", [
             {
                 userId: "@alice:evilcorp.com",
                 powerLevel: 100,


### PR DESCRIPTION
In the case of room upgrades, it is possible the client is trying to render the room create event, but the user has never been in the old room. This results in an error because the PermalinkCreator cannot possibly figure out a room ID. 

Instead, we'll feed the creator an alternate room ID to try if the room object can't be provided.

Fixes https://github.com/vector-im/riot-web/issues/9636