### PR TITLE
Allow arrow keys navigation in autocomplete list

### DIFF
--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -116,6 +116,10 @@ export default class MessageEditor extends React.Component {
                     autoComplete.onUpArrow(event); break;
                 case "ArrowDown":
                     autoComplete.onDownArrow(event); break;
+                case "ArrowLeft":
+                    autoComplete.onLeftArrow(event); break;
+                case "ArrowRight":
+                    autoComplete.onRightArrow(event); break;
                 case "Tab":
                     autoComplete.onTab(event); break;
                 case "Escape":

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -116,10 +116,6 @@ export default class MessageEditor extends React.Component {
                     autoComplete.onUpArrow(event); break;
                 case "ArrowDown":
                     autoComplete.onDownArrow(event); break;
-                case "ArrowLeft":
-                    autoComplete.onLeftArrow(event); break;
-                case "ArrowRight":
-                    autoComplete.onRightArrow(event); break;
                 case "Tab":
                     autoComplete.onTab(event); break;
                 case "Escape":

--- a/src/components/views/rooms/Autocomplete.js
+++ b/src/components/views/rooms/Autocomplete.js
@@ -171,26 +171,13 @@ export default class Autocomplete extends React.Component {
     }
 
     // called from MessageComposerInput
-    onUpArrow(): ?Completion {
+    moveSelection(delta): ?Completion {
         const completionCount = this.countCompletions();
-        // completionCount + 1, since 0 means composer is selected
-        const selectionOffset = (completionCount + 1 + this.state.selectionOffset - 1)
-            % (completionCount + 1);
-        if (!completionCount) {
-            return null;
-        }
-        this.setSelection(selectionOffset);
-    }
+        if (completionCount === 0) return; // there are no items to move the selection through
 
-    // called from MessageComposerInput
-    onDownArrow(): ?Completion {
-        const completionCount = this.countCompletions();
-        // completionCount + 1, since 0 means composer is selected
-        const selectionOffset = (this.state.selectionOffset + 1) % (completionCount + 1);
-        if (!completionCount) {
-            return null;
-        }
-        this.setSelection(selectionOffset);
+        // Note: selectionOffset 0 represents the unsubstituted text, while 1 means first pill selected
+        const index = (this.state.selectionOffset + delta + completionCount + 1) % (completionCount + 1);
+        this.setSelection(index);
     }
 
     onEscape(e): boolean {

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -670,6 +670,31 @@ export default class MessageComposerInput extends React.Component {
 
     onKeyDown = (ev: KeyboardEvent, change: Change, editor: Editor) => {
         this.suppressAutoComplete = false;
+        this.direction = '';
+
+        // Navigate autocomplete list with arrow keys
+        if (this.autocomplete.state.completionList.length > 0) {
+            if (!(ev.ctrlKey || ev.shiftKey || ev.altKey || ev.metaKey)) {
+                switch (ev.keyCode) {
+                    case KeyCode.LEFT:
+                        this.moveAutocompleteSelection(true);
+                        ev.preventDefault();
+                        return true;
+                    case KeyCode.RIGHT:
+                        this.moveAutocompleteSelection(false);
+                        ev.preventDefault();
+                        return true;
+                    case KeyCode.UP:
+                        this.moveAutocompleteSelection(true);
+                        ev.preventDefault();
+                        return true;
+                    case KeyCode.DOWN:
+                        this.moveAutocompleteSelection(false);
+                        ev.preventDefault();
+                        return true;
+                }
+            }
+        }
 
         // skip void nodes - see
         // https://github.com/ianstormtaylor/slate/issues/762#issuecomment-304855095

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -702,8 +702,6 @@ export default class MessageComposerInput extends React.Component {
             this.direction = 'Previous';
         } else if (ev.keyCode === KeyCode.RIGHT) {
             this.direction = 'Next';
-        } else {
-            this.direction = '';
         }
 
         switch (ev.keyCode) {
@@ -1197,35 +1195,28 @@ export default class MessageComposerInput extends React.Component {
     };
 
     onVerticalArrow = (e, up) => {
-        if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) {
-            return;
-        }
+        if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;
 
-        // Select history only if we are not currently auto-completing
-        if (this.autocomplete.state.completionList.length === 0) {
-            const selection = this.state.editorState.selection;
+        // Select history
+        const selection = this.state.editorState.selection;
 
-            // selection must be collapsed
-            if (!selection.isCollapsed) return;
-            const document = this.state.editorState.document;
+        // selection must be collapsed
+        if (!selection.isCollapsed) return;
+        const document = this.state.editorState.document;
 
-            // and we must be at the edge of the document (up=start, down=end)
-            if (up) {
-                if (!selection.anchor.isAtStartOfNode(document)) return;
+        // and we must be at the edge of the document (up=start, down=end)
+        if (up) {
+            if (!selection.anchor.isAtStartOfNode(document)) return;
 
-                const editEvent = findEditableEvent(this.props.room, false);
-                if (editEvent) {
-                    // We're selecting history, so prevent the key event from doing anything else
-                    e.preventDefault();
-                    dis.dispatch({
-                        action: 'edit_event',
-                        event: editEvent,
-                    });
-                }
+            const editEvent = findEditableEvent(this.props.room, false);
+            if (editEvent) {
+                // We're selecting history, so prevent the key event from doing anything else
+                e.preventDefault();
+                dis.dispatch({
+                    action: 'edit_event',
+                    event: editEvent,
+                });
             }
-        } else {
-            this.moveAutocompleteSelection(up);
-            e.preventDefault();
         }
     };
 

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -673,23 +673,23 @@ export default class MessageComposerInput extends React.Component {
         this.direction = '';
 
         // Navigate autocomplete list with arrow keys
-        if (this.autocomplete.state.completionList.length > 0) {
+        if (this.autocomplete.countCompletions() > 0) {
             if (!(ev.ctrlKey || ev.shiftKey || ev.altKey || ev.metaKey)) {
                 switch (ev.keyCode) {
                     case KeyCode.LEFT:
-                        this.moveAutocompleteSelection(true);
+                        this.autocomplete.moveSelection(-1);
                         ev.preventDefault();
                         return true;
                     case KeyCode.RIGHT:
-                        this.moveAutocompleteSelection(false);
+                        this.autocomplete.moveSelection(+1);
                         ev.preventDefault();
                         return true;
                     case KeyCode.UP:
-                        this.moveAutocompleteSelection(true);
+                        this.autocomplete.moveSelection(-1);
                         ev.preventDefault();
                         return true;
                     case KeyCode.DOWN:
-                        this.moveAutocompleteSelection(false);
+                        this.autocomplete.moveSelection(+1);
                         ev.preventDefault();
                         return true;
                 }
@@ -1225,21 +1225,17 @@ export default class MessageComposerInput extends React.Component {
             someCompletions: null,
         });
         e.preventDefault();
-        if (this.autocomplete.state.completionList.length === 0) {
+        if (this.autocomplete.countCompletions() === 0) {
             // Force completions to show for the text currently entered
             const completionCount = await this.autocomplete.forceComplete();
             this.setState({
                 someCompletions: completionCount > 0,
             });
             // Select the first item by moving "down"
-            await this.moveAutocompleteSelection(false);
+            await this.autocomplete.moveSelection(+1);
         } else {
-            await this.moveAutocompleteSelection(e.shiftKey);
+            await this.autocomplete.moveSelection(e.shiftKey ? -1 : +1);
         }
-    };
-
-    moveAutocompleteSelection = (up) => {
-        up ? this.autocomplete.onUpArrow() : this.autocomplete.onDownArrow();
     };
 
     onEscape = async (e) => {

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -63,14 +63,6 @@ export default class AutocompleteWrapperModel {
         this._getAutocompleterComponent().moveSelection(+1);
     }
 
-    onLeftArrow() {
-        this._getAutocompleterComponent().moveSelection(-1);
-    }
-
-    onRightArrow() {
-        this._getAutocompleterComponent().moveSelection(+1);
-    }
-
     onPartUpdate(part, offset) {
         // cache the typed value and caret here
         // so we can restore it in onComponentSelectionChange when the value is undefined (meaning it should be the typed text)

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -55,6 +55,22 @@ export default class AutocompleteWrapperModel {
         });
     }
 
+    onUpArrow() {
+        this._getAutocompleterComponent().moveSelection(-1);
+    }
+
+    onDownArrow() {
+        this._getAutocompleterComponent().moveSelection(+1);
+    }
+
+    onLeftArrow() {
+        this._getAutocompleterComponent().moveSelection(-1);
+    }
+
+    onRightArrow() {
+        this._getAutocompleterComponent().moveSelection(+1);
+    }
+
     onPartUpdate(part, offset) {
         // cache the typed value and caret here
         // so we can restore it in onComponentSelectionChange when the value is undefined (meaning it should be the typed text)

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -42,29 +42,17 @@ export default class AutocompleteWrapperModel {
     async onTab(e) {
         const acComponent = this._getAutocompleterComponent();
 
-        if (acComponent.state.completionList.length === 0) {
+        if (acComponent.countCompletions() === 0) {
             // Force completions to show for the text currently entered
             await acComponent.forceComplete();
             // Select the first item by moving "down"
-            await acComponent.onDownArrow();
+            await acComponent.moveSelection(+1);
         } else {
-            if (e.shiftKey) {
-                await acComponent.onUpArrow();
-            } else {
-                await acComponent.onDownArrow();
-            }
+            await acComponent.moveSelection(e.shiftKey ? -1 : +1);
         }
         this._updateCallback({
             close: true,
         });
-    }
-
-    onUpArrow() {
-        this._getAutocompleterComponent().onUpArrow();
-    }
-
-    onDownArrow() {
-        this._getAutocompleterComponent().onDownArrow();
     }
 
     onPartUpdate(part, offset) {


### PR DESCRIPTION
(Referencing https://github.com/vector-im/riot-web/issues/4737)

This allows left/right arrow keys to navigate backwards/forwards in the autocomplete list (on top of the up/down arrow keys which already did that).

The first commit is the minimal code change for that, while the rest are follow-up cleanup/refactor (now that names like `onVerticalArrow`, `onUpArrow` and `onDownArrow` make less sense).

<details>
<summary>Misc notes</summary>

- `this.direction = ''` needs to be at the top *before* the bunch of `autocomplete.moveSelection`, as the latter calls `setState`, which triggers `onChange`, which looks at `this.direction`, somewhere in the middle. It would be at the last `keyDown` event's value if it wasn't reset here first, which is incorrect.
- It arguably also should not be set by the current `keyDown` event, as this isn't supposed to be textual navigation, but instead is supposed to be "swallowed up" by the autocomplete list. This is why the rest of the `// skip void nodes` block is *after* the `autocomplete.moveSelection`s, so that it only happens if the latter didn't match and didn't `return true` first.
- The switch condition can be collapsed further (see below), by relying on fall-through behaviour, but that was deemed unnecessarily confusing for future readers so I kept it as is.
```
switch (ev.keyCode) {
    case KeyCode.LEFT:
        this.autocomplete.moveSelection(-1);
    case KeyCode.RIGHT:
        this.autocomplete.moveSelection(+1);
    case KeyCode.UP:
        this.autocomplete.moveSelection(-1);
    case KeyCode.DOWN:
        this.autocomplete.moveSelection(+1);
        
    ev.preventDefault();
    return true;
}
```
- I took the liberty of removing the `this.moveAutocompleteSelection -> this.autocomplete.onUpArrow` indirection step as it didn't really add anything.
</details>

`Signed-off-by: Pierre Boyer <pierre.s.boyer@gmail.com>`