### PR TITLE
Hide autocomplete on Enter key press instead of sending message

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1046,6 +1046,12 @@ export default class MessageComposerInput extends React.Component {
             return change.insertText('\n');
         }
 
+        if (this.autocomplete.countCompletions() > 0) {
+            this.autocomplete.hide();
+            ev.preventDefault();
+            return true;
+        }
+
         const editorState = this.state.editorState;
 
         const lastBlock = editorState.blocks.last();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/4721

In `handleReturn`, if autocomplete is open (`countCompletions > 0`), then `hide()` it and swallow the event.

Because the autocomplete continuously edits the composer's content to match the token under selection, by simply hiding it we're left with whatever token was last selected, which is the behaviour one expects for confirmation through Enter.

Contrast this with `onEscape` which first resets the selection to 0 so that it goes back to the initial bare text regardless of what you had selected at the time, or with `onCompletionClicked` which first forces the selection of the clicked item's index, then hides (unnecessary in this case because the confirmed item is already selected).

`Signed-off-by: Pierre Boyer <pierre.s.boyer@gmail.com>`