### PR TITLE
Only expose the fallback_hs_url if the homeserver is the default homeserver

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -203,9 +203,12 @@ export default React.createClass({
         };
     },
 
-    // TODO: TravisR - Remove this or put it somewhere else
     getFallbackHsUrl: function() {
-        return this.props.config.fallback_hs_url;
+        if (this.props.serverConfig.isDefault) {
+            return this.props.config.fallback_hs_url;
+        } else {
+            return null;
+        }
     },
 
     getServerProperties() {

--- a/src/utils/AutoDiscoveryUtils.js
+++ b/src/utils/AutoDiscoveryUtils.js
@@ -26,6 +26,8 @@ export class ValidatedServerConfig {
 
     isUrl: string;
     identityEnabled: boolean;
+
+    isDefault: boolean;
 }
 
 export default class AutoDiscoveryUtils {
@@ -99,6 +101,7 @@ export default class AutoDiscoveryUtils {
             hsNameIsDifferent: url.hostname !== preferredHomeserverName,
             isUrl: preferredIdentityUrl,
             identityEnabled: !SdkConfig.get()['disable_identity_server'],
+            isDefault: false,
         });
     }
 }


### PR DESCRIPTION
**Reviewer**: Note that this is pointed at the .well-known feature branch, not develop. This is intentional as the feature branch is still unsafe to merge to develop.

See https://github.com/vector-im/riot-web/issues/9290
Paired with https://github.com/vector-im/riot-web/pull/9721