### PR TITLE
Message editing: adjust to js-sdk changes of marking original event as replaced

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -526,6 +526,7 @@ module.exports = React.createClass({
                 <EventTile mxEvent={mxEv}
                     continuation={continuation}
                     isRedacted={mxEv.isRedacted()}
+                    replacingEventId={mxEv.replacingEventId()}
                     onHeightChanged={this._onHeightChanged}
                     readReceipts={readReceipts}
                     readReceiptMap={this._readReceiptMap}

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -507,7 +507,7 @@ const TimelinePanel = React.createClass({
         this.forceUpdate();
     },
 
-    onRoomReplaceEvent: function(replacedEvent, newEvent, room) {
+    onRoomReplaceEvent: function(replacedEvent, room) {
         if (this.unmounted) return;
 
         // ignore events for other rooms
@@ -515,7 +515,7 @@ const TimelinePanel = React.createClass({
 
         // we could skip an update if the event isn't in our timeline,
         // but that's probably an early optimisation.
-        this._reloadEvents();
+        this.forceUpdate();
     },
 
     onRoomReceipt: function(ev, room) {

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -118,7 +118,7 @@ export default class MessageEditor extends React.Component {
             "m.new_content": newContent,
             "m.relates_to": {
                 "rel_type": "m.replace",
-                "event_id": this.props.event.getOriginalId(),
+                "event_id": this.props.event.getId(),
             },
         }, newContent);
 

--- a/src/components/views/messages/MessageEvent.js
+++ b/src/components/views/messages/MessageEvent.js
@@ -89,6 +89,7 @@ module.exports = React.createClass({
             showUrlPreview={this.props.showUrlPreview}
             tileShape={this.props.tileShape}
             maxImageHeight={this.props.maxImageHeight}
+            replacingEventId={this.props.replacingEventId}
             onHeightChanged={this.props.onHeightChanged} />;
     },
 });

--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -137,6 +137,7 @@ module.exports = React.createClass({
         // exploit that events are immutable :)
         return (nextProps.mxEvent.getId() !== this.props.mxEvent.getId() ||
                 nextProps.highlights !== this.props.highlights ||
+                nextProps.replacingEventId !== this.props.replacingEventId ||
                 nextProps.highlightLink !== this.props.highlightLink ||
                 nextProps.showUrlPreview !== this.props.showUrlPreview ||
                 nextState.links !== this.state.links ||

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -779,6 +779,7 @@ module.exports = withMatrixClient(React.createClass({
                             { thread }
                             <EventTileType ref="tile"
                                            mxEvent={this.props.mxEvent}
+                                           replacingEventId={this.props.replacingEventId}
                                            highlights={this.props.highlights}
                                            highlightLink={this.props.highlightLink}
                                            showUrlPreview={this.props.showUrlPreview}

--- a/src/editor/deserialize.js
+++ b/src/editor/deserialize.js
@@ -57,9 +57,10 @@ function parseHtmlMessage(html) {
 export function parseEvent(event) {
     const content = event.getContent();
     if (content.format === "org.matrix.custom.html") {
-        return parseHtmlMessage(content.formatted_body);
+        return parseHtmlMessage(content.formatted_body || "");
     } else {
-        const lines = content.body.split("\n");
+        const body = content.body || "";
+        const lines = body.split("\n");
         const parts = lines.reduce((parts, line, i) => {
             const isLast = i === lines.length - 1;
             const text = new PlainPart(line);

--- a/src/shouldHideEvent.js
+++ b/src/shouldHideEvent.js
@@ -45,6 +45,7 @@ export default function shouldHideEvent(ev) {
 
     // Hide redacted events
     if (ev.isRedacted() && !isEnabled('showRedactions')) return true;
+    if (ev.isRelation("m.replace")) return true;
 
     const eventDiff = memberEventDiff(ev);
 


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/914

Happy to receive suggestions on how to avoid passing `replacingEventId` all the way down to `TextualBody` to convince it to re-render. It's the best thing I could come up with, and somewhat similar to how we do it for redactions.