### PR TITLE
Fix Single Sign-on

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -369,7 +369,7 @@ async function _doSetLoggedIn(credentials, clearStorage) {
     // If there's an inconsistency between account data in local storage and the
     // crypto store, we'll be generally confused when handling encrypted data.
     // Show a modal recommending a full reset of storage.
-    if (results.dataInLocalStorage && !results.dataInCryptoStore) {
+    if (results.dataInLocalStorage && results.cryptoInited && !results.dataInCryptoStore) {
         const signOut = await _showStorageEvictedDialog();
         if (signOut) {
             await _clearStorage();

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -121,6 +121,7 @@ class MatrixClientPeg {
             // check that we have a version of the js-sdk which includes initCrypto
             if (this.matrixClient.initCrypto) {
                 await this.matrixClient.initCrypto();
+                StorageManager.setCryptoInitialised(true);
             }
         } catch (e) {
             if (e && e.name === 'InvalidCryptoStoreError') {

--- a/src/utils/StorageManager.js
+++ b/src/utils/StorageManager.js
@@ -50,11 +50,15 @@ export async function checkConsistency() {
 
     let dataInLocalStorage = false;
     let dataInCryptoStore = false;
+    let cryptoInited = false;
     let healthy = true;
 
     if (localStorage) {
         dataInLocalStorage = localStorage.length > 0;
         log(`Local storage contains data? ${dataInLocalStorage}`);
+
+        cryptoInited = localStorage.getItem("mx_crypto_initialised");
+        log(`Crypto initialised? ${cryptoInited}`);
     } else {
         healthy = false;
         error("Local storage cannot be used on this browser");
@@ -84,10 +88,11 @@ export async function checkConsistency() {
         track("Crypto store disabled");
     }
 
-    if (dataInLocalStorage && !dataInCryptoStore) {
+    if (dataInLocalStorage && cryptoInited && !dataInCryptoStore) {
         healthy = false;
         error(
-            "Data exists in local storage but not in crypto store. " +
+            "Data exists in local storage and crypto is marked as initialised " +
+            " but no data found in crypto store. " +
             "IndexedDB storage has likely been evicted by the browser!",
         );
         track("Crypto store evicted");
@@ -104,6 +109,7 @@ export async function checkConsistency() {
     return {
         dataInLocalStorage,
         dataInCryptoStore,
+        cryptoInited,
         healthy,
     };
 }
@@ -154,4 +160,16 @@ export function trackStores(client) {
             track("Sync store using IndexedDB degraded to memory");
         });
     }
+}
+
+/**
+ * Sets whether crypto has ever been successfully
+ * initialised on this client.
+ * StorageManager uses this to determine whether indexeddb
+ * has been wiped by the browser: this flag is saved to localStorage
+ * and if it is true and not crypto data is found, an error is
+ * presented to the user.
+ */
+export function setCryptoInitialised(cryptoInited) {
+    localStorage.setItem("mx_crypto_initialised", cryptoInited);
 }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/2826 checked
that we had data in the crypto store if the had credentials in
localStorage. However, SSO stores creds in localStorage and then
redirects the browser to remove the loginToken parameter from the
URL without starting crypto, so after the redirect, we see creds
in localStorage but no crypto data, and error.

Fix by marking when we've successfully initialised crypto and only
erroring if that flag is set.

As @jryans points out, we really need a thorough set of tests for registration. I have a mock CAS server I've been using to dev against that may be useful for this.

Fixes https://github.com/vector-im/riot-web/issues/9695