### PR TITLE
Listen for removed relations

### DIFF
--- a/src/components/views/messages/ReactionDimension.js
+++ b/src/components/views/messages/ReactionDimension.js
@@ -107,7 +107,7 @@ export default class ReactionDimension extends React.PureComponent {
             return null;
         }
         const userId = MatrixClientPeg.get().getUserId();
-        return reactions.getAnnotationsBySender()[userId];
+        return [...reactions.getAnnotationsBySender()[userId].values()];
     }
 
     onOptionClick = (ev) => {

--- a/src/components/views/messages/ReactionDimension.js
+++ b/src/components/views/messages/ReactionDimension.js
@@ -37,6 +37,7 @@ export default class ReactionDimension extends React.PureComponent {
 
         if (props.reactions) {
             props.reactions.on("Relations.add", this.onReactionsChange);
+            props.reactions.on("Relations.remove", this.onReactionsChange);
             props.reactions.on("Relations.redaction", this.onReactionsChange);
         }
     }
@@ -44,6 +45,7 @@ export default class ReactionDimension extends React.PureComponent {
     componentDidUpdate(prevProps) {
         if (prevProps.reactions !== this.props.reactions) {
             this.props.reactions.on("Relations.add", this.onReactionsChange);
+            this.props.reactions.on("Relations.remove", this.onReactionsChange);
             this.props.reactions.on("Relations.redaction", this.onReactionsChange);
             this.onReactionsChange();
         }
@@ -53,6 +55,10 @@ export default class ReactionDimension extends React.PureComponent {
         if (this.props.reactions) {
             this.props.reactions.removeListener(
                 "Relations.add",
+                this.onReactionsChange,
+            );
+            this.props.reactions.removeListener(
+                "Relations.remove",
                 this.onReactionsChange,
             );
             this.props.reactions.removeListener(

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -80,7 +80,7 @@ export default class ReactionsRow extends React.PureComponent {
             return null;
         }
         const userId = MatrixClientPeg.get().getUserId();
-        return reactions.getAnnotationsBySender()[userId];
+        return [...reactions.getAnnotationsBySender()[userId].values()];
     }
 
     render() {

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -34,6 +34,7 @@ export default class ReactionsRow extends React.PureComponent {
 
         if (props.reactions) {
             props.reactions.on("Relations.add", this.onReactionsChange);
+            props.reactions.on("Relations.remove", this.onReactionsChange);
             props.reactions.on("Relations.redaction", this.onReactionsChange);
         }
 
@@ -45,6 +46,7 @@ export default class ReactionsRow extends React.PureComponent {
     componentDidUpdate(prevProps) {
         if (prevProps.reactions !== this.props.reactions) {
             this.props.reactions.on("Relations.add", this.onReactionsChange);
+            this.props.reactions.on("Relations.remove", this.onReactionsChange);
             this.props.reactions.on("Relations.redaction", this.onReactionsChange);
             this.onReactionsChange();
         }
@@ -54,6 +56,10 @@ export default class ReactionsRow extends React.PureComponent {
         if (this.props.reactions) {
             this.props.reactions.removeListener(
                 "Relations.add",
+                this.onReactionsChange,
+            );
+            this.props.reactions.removeListener(
+                "Relations.remove",
                 this.onReactionsChange,
             );
             this.props.reactions.removeListener(


### PR DESCRIPTION
The JS SDK adds support for removing relations that were cancelled in https://github.com/matrix-org/matrix-js-sdk/pull/919, so this adjusts the React layer to listen for that. In addition, annotations by sender are now in a Set.

With this plus the JS SDK changes, we have effectively fixed https://github.com/vector-im/riot-web/issues/9731 since relations will trigger the message status bar on error.

Fixes https://github.com/vector-im/riot-web/issues/9731
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/919