### PR TITLE
Mute screen readers over reactions

### DIFF
--- a/src/components/views/messages/ReactionDimension.js
+++ b/src/components/views/messages/ReactionDimension.js
@@ -168,6 +168,7 @@ export default class ReactionDimension extends React.PureComponent {
 
         return <span className="mx_ReactionDimension"
             title={this.props.title}
+            aria-hidden={true}
         >
             {items}
         </span>;


### PR DESCRIPTION
As much fun as it is to hear "Thumbs up sign thumbs down sign smiling face slightly pensive face" for *every* message on hover.