### PR TITLE
Add a basic tooltip showing who reacted

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -557,4 +557,3 @@ textarea {
 .mx_Username_color8 {
     color: $username-variant8-color;
 }
-

--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -119,6 +119,7 @@
 @import "./views/messages/_ReactionDimension.scss";
 @import "./views/messages/_ReactionsRow.scss";
 @import "./views/messages/_ReactionsRowButton.scss";
+@import "./views/messages/_ReactionsRowButtonTooltip.scss";
 @import "./views/messages/_RoomAvatarEvent.scss";
 @import "./views/messages/_SenderProfile.scss";
 @import "./views/messages/_TextualEvent.scss";

--- a/res/css/views/elements/_Tooltip.scss
+++ b/res/css/views/elements/_Tooltip.scss
@@ -74,3 +74,16 @@ limitations under the License.
         animation: mx_fadeout 0.1s forwards;
     }
 }
+
+.mx_Tooltip_timeline {
+    box-shadow: none;
+    background-color: $tooltip-timeline-bg-color;
+    color: $tooltip-timeline-fg-color;
+    text-align: center;
+    border: none;
+    border-radius: 3px;
+
+    .mx_Tooltip_chevron::after {
+        border-right-color: $tooltip-timeline-bg-color;
+    }
+}

--- a/res/css/views/messages/_ReactionsRowButtonTooltip.scss
+++ b/res/css/views/messages/_ReactionsRowButtonTooltip.scss
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_ReactionsRowButtonTooltip {
+    box-shadow: none;
+    background-color: $reaction-row-button-tooltip-bg-color;
+    color: $reaction-row-button-tooltip-fg-color;
+    text-align: center;
+    font-size: 8px;
+    padding: 6px;
+    border: none;
+    border-radius: 3px;
+
+    .mx_Tooltip_chevron::after {
+        border-right-color: $reaction-row-button-tooltip-bg-color;
+    }
+
+    .mx_ReactionsRowButtonTooltip_reactedWith {
+        opacity: 0.7;
+    }
+}

--- a/res/css/views/messages/_ReactionsRowButtonTooltip.scss
+++ b/res/css/views/messages/_ReactionsRowButtonTooltip.scss
@@ -15,18 +15,8 @@ limitations under the License.
 */
 
 .mx_ReactionsRowButtonTooltip {
-    box-shadow: none;
-    background-color: $reaction-row-button-tooltip-bg-color;
-    color: $reaction-row-button-tooltip-fg-color;
-    text-align: center;
     font-size: 8px;
     padding: 6px;
-    border: none;
-    border-radius: 3px;
-
-    .mx_Tooltip_chevron::after {
-        border-right-color: $reaction-row-button-tooltip-bg-color;
-    }
 
     .mx_ReactionsRowButtonTooltip_reactedWith {
         opacity: 0.7;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -490,6 +490,11 @@ limitations under the License.
 }
 */
 
+.mx_EventTile_editedTooltip {
+    font-size: 10px;
+    padding: 5px 6px;
+}
+
 /* end of overrides */
 
 .mx_MatrixChat_useCompactLayout {

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -156,8 +156,9 @@ $reaction-row-button-border-color: #616b7f;
 $reaction-row-button-hover-border-color: $header-panel-text-primary-color;
 $reaction-row-button-selected-bg-color: #1f6954;
 $reaction-row-button-selected-border-color: $accent-color;
-$reaction-row-button-tooltip-bg-color: $tagpanel-bg-color;
-$reaction-row-button-tooltip-fg-color: #ffffff;
+
+$tooltip-timeline-bg-color: $tagpanel-bg-color;
+$tooltip-timeline-fg-color: #ffffff;
 
 // ***** Mixins! *****
 

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -156,6 +156,8 @@ $reaction-row-button-border-color: #616b7f;
 $reaction-row-button-hover-border-color: $header-panel-text-primary-color;
 $reaction-row-button-selected-bg-color: #1f6954;
 $reaction-row-button-selected-border-color: $accent-color;
+$reaction-row-button-tooltip-bg-color: $tagpanel-bg-color;
+$reaction-row-button-tooltip-fg-color: #ffffff;
 
 // ***** Mixins! *****
 

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -264,8 +264,9 @@ $reaction-row-button-border-color: #e9edf1;
 $reaction-row-button-hover-border-color: $focus-bg-color;
 $reaction-row-button-selected-bg-color: #e9fff9;
 $reaction-row-button-selected-border-color: $accent-color;
-$reaction-row-button-tooltip-bg-color: $tagpanel-bg-color;
-$reaction-row-button-tooltip-fg-color: #ffffff;
+
+$tooltip-timeline-bg-color: $tagpanel-bg-color;
+$tooltip-timeline-fg-color: #ffffff;
 
 // ***** Mixins! *****
 

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -264,6 +264,8 @@ $reaction-row-button-border-color: #e9edf1;
 $reaction-row-button-hover-border-color: $focus-bg-color;
 $reaction-row-button-selected-bg-color: #e9fff9;
 $reaction-row-button-selected-border-color: $accent-color;
+$reaction-row-button-tooltip-bg-color: $tagpanel-bg-color;
+$reaction-row-button-tooltip-fg-color: #ffffff;
 
 // ***** Mixins! *****
 

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -108,6 +108,17 @@ function unicodeToImage(str, addAlt) {
 }
 
 /**
+ * Returns the shortcode for an emoji character.
+ *
+ * @param {String} char The emoji character
+ * @return {String} The shortcode (such as :thumbup:)
+ */
+export function unicodeToShort(char) {
+    const unicode = emojione.jsEscapeMap[char];
+    return emojione.mapUnicodeToShort()[unicode];
+}
+
+/**
  * Given one or more unicode characters (represented by unicode
  * character number), return an image node with the corresponding
  * emoji.

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -116,8 +116,8 @@ export default class ReactionsRow extends React.PureComponent {
             return <ReactionsRowButton
                 key={content}
                 content={content}
-                count={count}
                 mxEvent={mxEvent}
+                reactionEvents={events}
                 myReactionEvent={myReactionEvent}
             />;
         });

--- a/src/components/views/messages/ReactionsRowButtonTooltip.js
+++ b/src/components/views/messages/ReactionsRowButtonTooltip.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MatrixClientPeg from '../../../MatrixClientPeg';
+import sdk from '../../../index';
+import { unicodeToShort } from '../../../HtmlUtils';
+import { _t } from '../../../languageHandler';
+
+export default class ReactionsRowButtonTooltip extends React.PureComponent {
+    static propTypes = {
+        // The event we're displaying reactions for
+        mxEvent: PropTypes.object.isRequired,
+        // The reaction content / key / emoji
+        content: PropTypes.string.isRequired,
+        // A Set of Martix reaction events for this key
+        reactionEvents: PropTypes.object.isRequired,
+        visible: PropTypes.bool.isRequired,
+    }
+
+    render() {
+        const Tooltip = sdk.getComponent('elements.Tooltip');
+        const { content, reactionEvents, mxEvent, visible } = this.props;
+
+        const room = MatrixClientPeg.get().getRoom(mxEvent.getRoomId());
+        let tooltipLabel;
+        if (room) {
+            const senders = [];
+            for (const reactionEvent of reactionEvents) {
+                const { name } = room.getMember(reactionEvent.getSender());
+                senders.push(name);
+            }
+            const shortName = unicodeToShort(content) || content;
+            tooltipLabel = <div>{_t(
+                "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>",
+                {
+                    shortName,
+                },
+                {
+                    reactors: () => {
+                        return <div className="mx_ReactionsRowButtonTooltip_senders">
+                            {senders.join(", ")}
+                        </div>;
+                    },
+                    reactedWith: (sub) => {
+                        return <div className="mx_ReactionsRowButtonTooltip_reactedWith">
+                            {sub}
+                        </div>;
+                    },
+                },
+            )}</div>;
+        }
+
+        let tooltip;
+        if (tooltipLabel) {
+            tooltip = <Tooltip
+                tooltipClassName="mx_ReactionsRowButtonTooltip"
+                visible={visible}
+                label={tooltipLabel}
+            />;
+        }
+
+        return tooltip;
+    }
+}

--- a/src/components/views/messages/ReactionsRowButtonTooltip.js
+++ b/src/components/views/messages/ReactionsRowButtonTooltip.js
@@ -69,7 +69,7 @@ export default class ReactionsRowButtonTooltip extends React.PureComponent {
         let tooltip;
         if (tooltipLabel) {
             tooltip = <Tooltip
-                tooltipClassName="mx_ReactionsRowButtonTooltip"
+                tooltipClassName="mx_ReactionsRowButtonTooltip mx_Tooltip_timeline"
                 visible={visible}
                 label={tooltipLabel}
             />;

--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -448,14 +448,17 @@ module.exports = React.createClass({
             const Tooltip = sdk.getComponent('elements.Tooltip');
             const editEvent = this.props.mxEvent.replacingEvent();
             const date = editEvent && formatDate(editEvent.getDate());
-            editedTooltip = <Tooltip label={_t("Edited at %(date)s.", {date})} />;
+            editedTooltip = <Tooltip
+                tooltipClassName="mx_EventTile_editedTooltip mx_Tooltip_timeline"
+                label={_t("Edited at %(date)s.", {date})}
+            />;
         }
         return (
             <div
                 key="editedMarker" className="mx_EventTile_edited"
                 onMouseEnter={this._onMouseEnterEditedMarker}
                 onMouseLeave={this._onMouseLeaveEditedMarker}
-            >{editedTooltip}<span>{`(${_t("Edited")})`}</span></div>
+            >{editedTooltip}<span>{`(${_t("edited")})`}</span></div>
         );
     },
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -907,6 +907,7 @@
     "Invalid file%(extra)s": "Invalid file%(extra)s",
     "Error decrypting image": "Error decrypting image",
     "Error decrypting video": "Error decrypting video",
+    "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>": "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>",
     "%(senderDisplayName)s changed the avatar for %(roomName)s": "%(senderDisplayName)s changed the avatar for %(roomName)s",
     "%(senderDisplayName)s removed the room avatar.": "%(senderDisplayName)s removed the room avatar.",
     "%(senderDisplayName)s changed the room avatar to <img/>": "%(senderDisplayName)s changed the room avatar to <img/>",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -918,7 +918,7 @@
     "Add an Integration": "Add an Integration",
     "You are about to be taken to a third-party site so you can authenticate your account for use with %(integrationsUrl)s. Do you wish to continue?": "You are about to be taken to a third-party site so you can authenticate your account for use with %(integrationsUrl)s. Do you wish to continue?",
     "Edited at %(date)s.": "Edited at %(date)s.",
-    "Edited": "Edited",
+    "edited": "edited",
     "Removed or unknown message type": "Removed or unknown message type",
     "Message removed by %(userId)s": "Message removed by %(userId)s",
     "Message removed": "Message removed",

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -125,20 +125,25 @@ export function _t(text, variables, tags) {
  * @return a React <span> component if any non-strings were used in substitutions, otherwise a string
  */
 export function substitute(text, variables, tags) {
-    const regexpMapping = {};
+    let result = text;
 
     if (variables !== undefined) {
+        const regexpMapping = {};
         for (const variable in variables) {
             regexpMapping[`%\\(${variable}\\)s`] = variables[variable];
         }
+        result = replaceByRegexes(result, regexpMapping);
     }
 
     if (tags !== undefined) {
+        const regexpMapping = {};
         for (const tag in tags) {
             regexpMapping[`(<${tag}>(.*?)<\\/${tag}>|<${tag}>|<${tag}\\s*\\/>)`] = tags[tag];
         }
+        result = replaceByRegexes(result, regexpMapping);
     }
-    return replaceByRegexes(text, regexpMapping);
+
+    return result;
 }
 
 /*


### PR DESCRIPTION
<img width="186" alt="2019-05-17 at 12 22" src="https://user-images.githubusercontent.com/279572/57924933-71261d80-789e-11e9-9ccb-bba60a447fac.png">

Also tweaks the edited tooltip to match:

<img width="252" alt="2019-05-17 at 12 22" src="https://user-images.githubusercontent.com/279572/57924955-7e430c80-789e-11e9-9da9-2fdb8ba63be9.png">

This does not match the designed tooltip, but it's a step along the way.

Part of https://github.com/vector-im/riot-web/issues/9722