### PR TITLE
Fix not being able to edit already edited messages

### DIFF
--- a/src/utils/EventUtils.js
+++ b/src/utils/EventUtils.js
@@ -47,6 +47,6 @@ export function isContentActionable(mxEvent) {
 
 export function canEditContent(mxEvent) {
     return isContentActionable(mxEvent) &&
-        mxEvent.getContent().msgtype === "m.text" &&
+        mxEvent.getOriginalContent().msgtype === "m.text" &&
         mxEvent.getSender() === MatrixClientPeg.get().getUserId();
 }


### PR DESCRIPTION
check msgtype of original event for now, as m.new_content doesn't have a msgtype and not sure what the correct solution is.

Requires: https://github.com/matrix-org/matrix-js-sdk/pull/923