### PR TITLE
Message editing: render avatars for pills in the editor

### DIFF
--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -20,7 +20,8 @@ limitations under the License.
     // this is to try not make the text move but still have some
     // padding around and in the editor.
     // Actual values from fiddling around in inspector
-    margin: -7px 24px -5px -10px;   // right margin: -10px + 34px
+    margin: -7px -10px -5px -10px;
+    overflow: visible !important;   // override mx_EventTile_content
 
     .mx_MessageEditor_editor {
         border-radius: 4px;
@@ -90,7 +91,7 @@ limitations under the License.
         z-index: 100;
         right: 0;
         margin: 0 -110px 0 0;
-        padding-right: 138px;
+        padding-right: 147px;
 
         .mx_AccessibleButton {
             margin-left: 5px;

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -59,10 +59,14 @@ limitations under the License.
                 width: 16px;
                 height: 16px;
                 background: var(--avatar-background);    //set on parent by JS
-                color: var(--avatar-color);
+                color: $avatar-initial-color;
                 background-repeat: no-repeat;
                 background-size: 16px;
                 border-radius: 8px;
+                text-align: center;
+                font-weight: normal;
+                line-height: 16px;
+                font-size: 10.4px;
             }
         }
     }

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -40,13 +40,21 @@ limitations under the License.
             color: white;
         }
 
+        span.room-pill {
+            color: $accent-fg-color;
+            background-color: $rte-room-pill-color;
+        }
+
+        span.user-pill {
+            color: $primary-fg-color;
+            background-color: $other-user-pill-bg-color;
+        }
+
         span.user-pill, span.room-pill {
             height: 20px;
             line-height: 20px;
             border-radius: 16px;
             display: inline-block;
-            color: $primary-fg-color;
-            background-color: $other-user-pill-bg-color;
             padding-left: 21px;
             padding-right: 5px;
             position: relative;

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -45,8 +45,23 @@ limitations under the License.
             display: inline-block;
             color: $primary-fg-color;
             background-color: $other-user-pill-bg-color;
-            padding-left: 5px;
+            padding-left: 21px;
             padding-right: 5px;
+            position: relative;
+
+            &::before {
+                position: absolute;
+                left: 2px;
+                top: 2px;
+                content: var(--avatar-letter);
+                width: 16px;
+                height: 16px;
+                background: var(--avatar-background);    //set on parent by JS
+                color: var(--avatar-color);
+                background-repeat: no-repeat;
+                background-size: 16px;
+                border-radius: 8px;
+            }
         }
     }
 

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -34,32 +34,11 @@ limitations under the License.
         max-height: 200px;
         overflow-x: auto;
 
-        span {
-            display: inline-block;
-            padding: 0 5px;
-            border-radius: 4px;
-            color: white;
-        }
-
-        span.room-pill {
-            color: $accent-fg-color;
-            background-color: $rte-room-pill-color;
-        }
-
-        span.user-pill {
-            color: $primary-fg-color;
-            background-color: $other-user-pill-bg-color;
-        }
-
-        span.user-pill, span.room-pill {
-            height: 20px;
-            line-height: 20px;
-            border-radius: 16px;
-            display: inline-block;
+        span.mx_UserPill, span.mx_RoomPill {
             padding-left: 21px;
-            padding-right: 5px;
             position: relative;
 
+            // avatar psuedo element
             &::before {
                 position: absolute;
                 left: 2px;

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -41,6 +41,8 @@ limitations under the License.
         }
 
         span.user-pill, span.room-pill {
+            height: 20px;
+            line-height: 20px;
             border-radius: 16px;
             display: inline-block;
             color: $primary-fg-color;

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -20,7 +20,7 @@ limitations under the License.
     // this is to try not make the text move but still have some
     // padding around and in the editor.
     // Actual values from fiddling around in inspector
-    margin: -7px -10px -5px -10px;
+    margin: -7px 24px -5px -10px;   // right margin: -10px + 34px
 
     .mx_MessageEditor_editor {
         border-radius: 4px;
@@ -90,7 +90,7 @@ limitations under the License.
         z-index: 100;
         right: 0;
         margin: 0 -110px 0 0;
-        padding-right: 104px;
+        padding-right: 138px;
 
         .mx_AccessibleButton {
             margin-left: 5px;

--- a/res/css/views/elements/_MessageEditor.scss
+++ b/res/css/views/elements/_MessageEditor.scss
@@ -66,7 +66,7 @@ limitations under the License.
                 content: var(--avatar-letter);
                 width: 16px;
                 height: 16px;
-                background: var(--avatar-background);    //set on parent by JS
+                background: var(--avatar-background), $avatar-bg-color;
                 color: $avatar-initial-color;
                 background-repeat: no-repeat;
                 background-size: 16px;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -41,6 +41,11 @@ limitations under the License.
 
 .mx_EventTile_continuation {
     padding-top: 0px ! important;
+
+    &.mx_EventTile_isEditing {
+        padding-top: 5px ! important;
+        margin-top: -5px;
+    }
 }
 
 .mx_EventTile_isEditing {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -40,10 +40,10 @@ limitations under the License.
 }
 
 .mx_EventTile_continuation {
-    padding-top: 0px ! important;
+    padding-top: 0px !important;
 
     &.mx_EventTile_isEditing {
-        padding-top: 5px ! important;
+        padding-top: 5px !important;
         margin-top: -5px;
     }
 }

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -58,4 +58,36 @@ module.exports = {
         }
         return require('../res/img/' + images[total % images.length] + '.png');
     },
+
+    /**
+     * returns the first (non-sigil) character of 'name',
+     * converted to uppercase
+     */
+    getInitialLetter(name) {
+        if (name.length < 1) {
+            return undefined;
+        }
+
+        let idx = 0;
+        const initial = name[0];
+        if ((initial === '@' || initial === '#' || initial === '+') && name[1]) {
+            idx++;
+        }
+
+        // string.codePointAt(0) would do this, but that isn't supported by
+        // some browsers (notably PhantomJS).
+        let chars = 1;
+        const first = name.charCodeAt(idx);
+
+        // check if it’s the start of a surrogate pair
+        if (first >= 0xD800 && first <= 0xDBFF && name[idx+1]) {
+            const second = name.charCodeAt(idx+1);
+            if (second >= 0xDC00 && second <= 0xDFFF) {
+                chars++;
+            }
+        }
+
+        const firstChar = name.substring(idx, idx+chars);
+        return firstChar.toUpperCase();
+    },
 };

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -133,38 +133,6 @@ module.exports = React.createClass({
         }
     },
 
-    /**
-     * returns the first (non-sigil) character of 'name',
-     * converted to uppercase
-     */
-    _getInitialLetter: function(name) {
-        if (name.length < 1) {
-            return undefined;
-        }
-
-        let idx = 0;
-        const initial = name[0];
-        if ((initial === '@' || initial === '#' || initial === '+') && name[1]) {
-            idx++;
-        }
-
-        // string.codePointAt(0) would do this, but that isn't supported by
-        // some browsers (notably PhantomJS).
-        let chars = 1;
-        const first = name.charCodeAt(idx);
-
-        // check if it’s the start of a surrogate pair
-        if (first >= 0xD800 && first <= 0xDBFF && name[idx+1]) {
-            const second = name.charCodeAt(idx+1);
-            if (second >= 0xDC00 && second <= 0xDFFF) {
-                chars++;
-            }
-        }
-
-        const firstChar = name.substring(idx, idx+chars);
-        return firstChar.toUpperCase();
-    },
-
     render: function() {
         const EmojiText = sdk.getComponent('elements.EmojiText');
         const imageUrl = this.state.imageUrls[this.state.urlsIndex];

--- a/src/components/views/avatars/BaseAvatar.js
+++ b/src/components/views/avatars/BaseAvatar.js
@@ -176,7 +176,7 @@ module.exports = React.createClass({
         } = this.props;
 
         if (imageUrl === this.state.defaultImageUrl) {
-            const initialLetter = this._getInitialLetter(name);
+            const initialLetter = AvatarLogic.getInitialLetter(name);
             const textNode = (
                 <EmojiText className="mx_BaseAvatar_initial" aria-hidden="true"
                     style={{ fontSize: (width * 0.65) + "px",

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -19,7 +19,7 @@ import {ContentRepo} from "matrix-js-sdk";
 import MatrixClientPeg from "../../../MatrixClientPeg";
 import Modal from '../../../Modal';
 import sdk from "../../../index";
-import DMRoomMap from '../../../utils/DMRoomMap';
+import Avatar from '../../../Avatar';
 
 module.exports = React.createClass({
     displayName: 'RoomAvatar',
@@ -89,7 +89,6 @@ module.exports = React.createClass({
                 props.resizeMethod,
             ), // highest priority
             this.getRoomAvatarUrl(props),
-            this.getOneToOneAvatar(props), // lowest priority
         ].filter(function(url) {
             return (url != null && url != "");
         });
@@ -98,39 +97,12 @@ module.exports = React.createClass({
     getRoomAvatarUrl: function(props) {
         if (!props.room) return null;
 
-        return props.room.getAvatarUrl(
-            MatrixClientPeg.get().getHomeserverUrl(),
+        return Avatar.avatarUrlForRoom(
+            props.room,
             Math.floor(props.width * window.devicePixelRatio),
             Math.floor(props.height * window.devicePixelRatio),
             props.resizeMethod,
-            false,
         );
-    },
-
-    getOneToOneAvatar: function(props) {
-        const room = props.room;
-        if (!room) {
-            return null;
-        }
-        let otherMember = null;
-        const otherUserId = DMRoomMap.shared().getUserIdForRoomId(room.roomId);
-        if (otherUserId) {
-            otherMember = room.getMember(otherUserId);
-        } else {
-            // if the room is not marked as a 1:1, but only has max 2 members
-            // then still try to show any avatar (pref. other member)
-            otherMember = room.getAvatarFallbackMember();
-        }
-        if (otherMember) {
-            return otherMember.getAvatarUrl(
-                MatrixClientPeg.get().getHomeserverUrl(),
-                Math.floor(props.width * window.devicePixelRatio),
-                Math.floor(props.height * window.devicePixelRatio),
-                props.resizeMethod,
-                false,
-            );
-        }
-        return null;
     },
 
     onRoomAvatarClick: function() {

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -40,16 +40,17 @@ export default class MessageEditor extends React.Component {
 
     constructor(props, context) {
         super(props, context);
+        const room = this.context.matrixClient.getRoom(this.props.event.getRoomId());
         const partCreator = new PartCreator(
             () => this._autocompleteRef,
             query => this.setState({query}),
+            room,
         );
         this.model = new EditorModel(
-            parseEvent(this.props.event),
+            parseEvent(this.props.event, room),
             partCreator,
             this._updateEditorState,
         );
-        const room = this.context.matrixClient.getRoom(this.props.event.getRoomId());
         this.state = {
             autoComplete: null,
             room,

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -27,6 +27,7 @@ import Autocomplete from '../rooms/Autocomplete';
 import {PartCreator} from '../../../editor/parts';
 import {renderModel} from '../../../editor/render';
 import {MatrixEvent, MatrixClient} from 'matrix-js-sdk';
+import classNames from 'classnames';
 
 export default class MessageEditor extends React.Component {
     static propTypes = {
@@ -177,7 +178,7 @@ export default class MessageEditor extends React.Component {
             </div>;
         }
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
-        return <div className="mx_MessageEditor">
+        return <div className={classNames("mx_MessageEditor", this.props.className)}>
                 { autoComplete }
                 <div
                     className="mx_MessageEditor_editor"

--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -471,7 +471,7 @@ module.exports = React.createClass({
     render: function() {
         if (this.props.isEditing) {
             const MessageEditor = sdk.getComponent('elements.MessageEditor');
-            return <MessageEditor event={this.props.mxEvent} />;
+            return <MessageEditor event={this.props.mxEvent} className="mx_EventTile_content" />;
         }
         const EmojiText = sdk.getComponent('elements.EmojiText');
         const mxEvent = this.props.mxEvent;

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -89,7 +89,7 @@ export default class AutocompleteWrapperModel {
             }
             case "#": {
                 const displayAlias = completion.completionId;
-                return new RoomPillPart(displayAlias, this._room);
+                return new RoomPillPart(displayAlias);
             }
             // also used for emoji completion
             default:

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -17,11 +17,12 @@ limitations under the License.
 import {UserPillPart, RoomPillPart, PlainPart} from "./parts";
 
 export default class AutocompleteWrapperModel {
-    constructor(updateCallback, getAutocompleterComponent, updateQuery) {
+    constructor(updateCallback, getAutocompleterComponent, updateQuery, room) {
         this._updateCallback = updateCallback;
         this._getAutocompleterComponent = getAutocompleterComponent;
         this._updateQuery = updateQuery;
         this._query = null;
+        this._room = room;
     }
 
     onEscape(e) {
@@ -83,11 +84,12 @@ export default class AutocompleteWrapperModel {
             case "@": {
                 const displayName = completion.completion;
                 const userId = completion.completionId;
-                return new UserPillPart(userId, displayName);
+                const member = this._room.getMember(userId);
+                return new UserPillPart(userId, displayName, member);
             }
             case "#": {
                 const displayAlias = completion.completionId;
-                return new RoomPillPart(displayAlias);
+                return new RoomPillPart(displayAlias, this._room);
             }
             // also used for emoji completion
             default:

--- a/src/editor/deserialize.js
+++ b/src/editor/deserialize.js
@@ -38,7 +38,7 @@ function parseHtmlMessage(html, room) {
                         const prefix = pillMatch[2]; // The first character of prefix
                         switch (prefix) {
                             case "@": return new UserPillPart(resourceId, n.textContent, room.getMember(resourceId));
-                            case "#": return new RoomPillPart(resourceId, n.textContent, room);
+                            case "#": return new RoomPillPart(resourceId);
                             default: return new PlainPart(n.textContent);
                         }
                     }

--- a/src/editor/deserialize.js
+++ b/src/editor/deserialize.js
@@ -17,7 +17,7 @@ limitations under the License.
 import { MATRIXTO_URL_PATTERN } from '../linkify-matrix';
 import { PlainPart, UserPillPart, RoomPillPart, NewlinePart } from "./parts";
 
-function parseHtmlMessage(html) {
+function parseHtmlMessage(html, room) {
     const REGEX_MATRIXTO = new RegExp(MATRIXTO_URL_PATTERN);
     // no nodes from parsing here should be inserted in the document,
     // as scripts in event handlers, etc would be executed then.
@@ -37,8 +37,8 @@ function parseHtmlMessage(html) {
                         const resourceId = pillMatch[1]; // The room/user ID
                         const prefix = pillMatch[2]; // The first character of prefix
                         switch (prefix) {
-                            case "@": return new UserPillPart(resourceId, n.textContent);
-                            case "#": return new RoomPillPart(resourceId, n.textContent);
+                            case "@": return new UserPillPart(resourceId, n.textContent, room.getMember(resourceId));
+                            case "#": return new RoomPillPart(resourceId, n.textContent, room);
                             default: return new PlainPart(n.textContent);
                         }
                     }
@@ -54,10 +54,10 @@ function parseHtmlMessage(html) {
     return parts;
 }
 
-export function parseEvent(event) {
+export function parseEvent(event, room) {
     const content = event.getContent();
     if (content.format === "org.matrix.custom.html") {
-        return parseHtmlMessage(content.formatted_body || "");
+        return parseHtmlMessage(content.formatted_body || "", room);
     } else {
         const body = content.body || "";
         const lines = body.split("\n");

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -276,7 +276,10 @@ export class UserPillPart extends PillPart {
     setAvatar(node) {
         const name = this._member.name || this._member.userId;
         const defaultAvatarUrl = Avatar.defaultAvatarUrlForString(this._member.userId);
-        let avatarUrl = Avatar.avatarUrlForMember(this._member, 16 * window.devicePixelRatio, 16 * window.devicePixelRatio);
+        let avatarUrl = Avatar.avatarUrlForMember(
+            this._member,
+            16 * window.devicePixelRatio,
+            16 * window.devicePixelRatio);
         let initialLetter = "";
         if (avatarUrl === defaultAvatarUrl) {
             // the url from defaultAvatarUrlForString is meant to go in an img element,

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 import AutocompleteWrapperModel from "./autocomplete";
 import Avatar from "../Avatar";
+import MatrixClientPeg from "../MatrixClientPeg";
 
 const DPR = window.devicePixelRatio;
 
@@ -221,12 +222,31 @@ export class NewlinePart extends BasePart {
 }
 
 export class RoomPillPart extends PillPart {
-    constructor(displayAlias, room) {
+    constructor(displayAlias) {
         super(displayAlias, displayAlias);
-        this._room = room;
+        this._room = this._findRoomByAlias(displayAlias);
+    }
+
+    _findRoomByAlias(alias) {
+        const client = MatrixClientPeg.get();
+        if (alias[0] === '#') {
+            return client.getRooms().find((r) => {
+                return r.getAliases().includes(alias);
+            });
+        } else {
+            return client.getRoom(alias);
+        }
     }
 
     setAvatar(node) {
+        let initialLetter = "";
+        let avatarUrl = Avatar.avatarUrlForRoom(this._room, 16 * DPR, 16 * DPR);
+        if (!avatarUrl) {
+            initialLetter = Avatar.getInitialLetter(this._room.name);
+            avatarUrl = `../../${Avatar.defaultAvatarUrlForString(this._room.roomId)}`;
+        }
+        node.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
+        node.style.setProperty("--avatar-letter", `'${initialLetter}'`);
     }
 
     get type() {

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -154,7 +154,7 @@ class PillPart extends BasePart {
 
     toDOMNode() {
         const container = document.createElement("span");
-        container.className = this.type;
+        container.className = this.className;
         container.appendChild(document.createTextNode(this.text));
         this.setAvatar(container);
         return container;
@@ -163,12 +163,10 @@ class PillPart extends BasePart {
     updateDOMNode(node) {
         const textNode = node.childNodes[0];
         if (textNode.textContent !== this.text) {
-            // console.log("changing pill text from", textNode.textContent, "to", this.text);
             textNode.textContent = this.text;
         }
-        if (node.className !== this.type) {
-            // console.log("turning", node.className, "into", this.type);
-            node.className = this.type;
+        if (node.className !== this.className) {
+            node.className = this.className;
         }
         this.setAvatar(node);
     }
@@ -178,6 +176,20 @@ class PillPart extends BasePart {
                node.nodeName === "SPAN" &&
                node.childNodes.length === 1 &&
                node.childNodes[0].nodeType === Node.TEXT_NODE;
+    }
+
+    // helper method for subclasses
+    _setAvatarVars(node, avatarUrl, initialLetter) {
+        const avatarBackground = `url('${avatarUrl}')`;
+        const avatarLetter = `'${initialLetter}'`;
+        // check if the value is changing,
+        // otherwise the avatars flicker on every keystroke while updating.
+        if (node.style.getPropertyValue("--avatar-background") !== avatarBackground) {
+            node.style.setProperty("--avatar-background", avatarBackground);
+        }
+        if (node.style.getPropertyValue("--avatar-letter") !== avatarLetter) {
+            node.style.setProperty("--avatar-letter", avatarLetter);
+        }
     }
 
     get canEdit() {
@@ -245,12 +257,15 @@ export class RoomPillPart extends PillPart {
             initialLetter = Avatar.getInitialLetter(this._room.name);
             avatarUrl = `../../${Avatar.defaultAvatarUrlForString(this._room.roomId)}`;
         }
-        node.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
-        node.style.setProperty("--avatar-letter", `'${initialLetter}'`);
+        this._setAvatarVars(node, avatarUrl, initialLetter);
     }
 
     get type() {
         return "room-pill";
+    }
+
+    get className() {
+        return "mx_RoomPill mx_Pill";
     }
 }
 
@@ -273,12 +288,15 @@ export class UserPillPart extends PillPart {
             avatarUrl = `../../${avatarUrl}`;
             initialLetter = Avatar.getInitialLetter(name);
         }
-        node.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
-        node.style.setProperty("--avatar-letter", `'${initialLetter}'`);
+        this._setAvatarVars(node, avatarUrl, initialLetter);
     }
 
     get type() {
         return "user-pill";
+    }
+
+    get className() {
+        return "mx_UserPill mx_Pill";
     }
 }
 

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -216,8 +216,9 @@ export class NewlinePart extends BasePart {
 }
 
 export class RoomPillPart extends PillPart {
-    constructor(displayAlias) {
+    constructor(displayAlias, room) {
         super(displayAlias, displayAlias);
+        this._room = room;
     }
 
     get type() {
@@ -226,6 +227,11 @@ export class RoomPillPart extends PillPart {
 }
 
 export class UserPillPart extends PillPart {
+    constructor(userId, displayName, member) {
+        super(userId, displayName);
+        this._member = member;
+    }
+
     get type() {
         return "user-pill";
     }
@@ -256,9 +262,14 @@ export class PillCandidatePart extends PlainPart {
 }
 
 export class PartCreator {
-    constructor(getAutocompleterComponent, updateQuery) {
+    constructor(getAutocompleterComponent, updateQuery, room) {
         this._autoCompleteCreator = (updateCallback) => {
-            return new AutocompleteWrapperModel(updateCallback, getAutocompleterComponent, updateQuery);
+            return new AutocompleteWrapperModel(
+                updateCallback,
+                getAutocompleterComponent,
+                updateQuery,
+                room,
+            );
         };
     }
 

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import AutocompleteWrapperModel from "./autocomplete";
+import Avatar from "../Avatar";
 
 class BasePart {
     constructor(text = "") {
@@ -230,6 +231,20 @@ export class UserPillPart extends PillPart {
     constructor(userId, displayName, member) {
         super(userId, displayName);
         this._member = member;
+    }
+
+    toDOMNode() {
+        const pill = super.toDOMNode();
+        const avatarUrl = Avatar.avatarUrlForMember(this._member, 16, 16);
+        if (avatarUrl) {
+            pill.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
+            pill.style.setProperty("--avatar-letter", "''");
+        } else {
+            pill.style.setProperty("--avatar-background", `green`);
+            pill.style.setProperty("--avatar-color", `white`);
+            pill.style.setProperty("--avatar-letter", `'${this.text[0].toUpperCase()}'`);
+        }
+        return pill;
     }
 
     get type() {

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -17,6 +17,8 @@ limitations under the License.
 import AutocompleteWrapperModel from "./autocomplete";
 import Avatar from "../Avatar";
 
+const DPR = window.devicePixelRatio;
+
 class BasePart {
     constructor(text = "") {
         this._text = text;
@@ -153,6 +155,7 @@ class PillPart extends BasePart {
         const container = document.createElement("span");
         container.className = this.type;
         container.appendChild(document.createTextNode(this.text));
+        this.setAvatar(container);
         return container;
     }
 
@@ -166,6 +169,7 @@ class PillPart extends BasePart {
             // console.log("turning", node.className, "into", this.type);
             node.className = this.type;
         }
+        this.setAvatar(node);
     }
 
     canUpdateDOMNode(node) {
@@ -222,6 +226,9 @@ export class RoomPillPart extends PillPart {
         this._room = room;
     }
 
+    setAvatar(node) {
+    }
+
     get type() {
         return "room-pill";
     }
@@ -233,18 +240,21 @@ export class UserPillPart extends PillPart {
         this._member = member;
     }
 
-    toDOMNode() {
-        const pill = super.toDOMNode();
-        const avatarUrl = Avatar.avatarUrlForMember(this._member, 16, 16);
-        if (avatarUrl) {
-            pill.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
-            pill.style.setProperty("--avatar-letter", "''");
-        } else {
-            pill.style.setProperty("--avatar-background", `green`);
-            pill.style.setProperty("--avatar-color", `white`);
-            pill.style.setProperty("--avatar-letter", `'${this.text[0].toUpperCase()}'`);
+    setAvatar(node) {
+        const name = this._member.name || this._member.userId;
+        const defaultAvatarUrl = Avatar.defaultAvatarUrlForString(this._member.userId);
+        let avatarUrl = Avatar.avatarUrlForMember(this._member, 16 * DPR, 16 * DPR);
+        let initialLetter = "";
+        if (avatarUrl === defaultAvatarUrl) {
+            // the url from defaultAvatarUrlForString is meant to go in an img element,
+            // which has the base of the document. we're using it in css,
+            // which has the base of the theme css file, two levels deeper than the document,
+            // so go up to the level of the document.
+            avatarUrl = `../../${avatarUrl}`;
+            initialLetter = Avatar.getInitialLetter(name);
         }
-        return pill;
+        node.style.setProperty("--avatar-background", `url('${avatarUrl}')`);
+        node.style.setProperty("--avatar-letter", `'${initialLetter}'`);
     }
 
     get type() {

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -18,8 +18,6 @@ import AutocompleteWrapperModel from "./autocomplete";
 import Avatar from "../Avatar";
 import MatrixClientPeg from "../MatrixClientPeg";
 
-const DPR = window.devicePixelRatio;
-
 class BasePart {
     constructor(text = "") {
         this._text = text;
@@ -252,7 +250,7 @@ export class RoomPillPart extends PillPart {
 
     setAvatar(node) {
         let initialLetter = "";
-        let avatarUrl = Avatar.avatarUrlForRoom(this._room, 16 * DPR, 16 * DPR);
+        let avatarUrl = Avatar.avatarUrlForRoom(this._room, 16 * window.devicePixelRatio, 16 * window.devicePixelRatio);
         if (!avatarUrl) {
             initialLetter = Avatar.getInitialLetter(this._room.name);
             avatarUrl = `../../${Avatar.defaultAvatarUrlForString(this._room.roomId)}`;
@@ -278,7 +276,7 @@ export class UserPillPart extends PillPart {
     setAvatar(node) {
         const name = this._member.name || this._member.userId;
         const defaultAvatarUrl = Avatar.defaultAvatarUrlForString(this._member.userId);
-        let avatarUrl = Avatar.avatarUrlForMember(this._member, 16 * DPR, 16 * DPR);
+        let avatarUrl = Avatar.avatarUrlForMember(this._member, 16 * window.devicePixelRatio, 16 * window.devicePixelRatio);
         let initialLetter = "";
         if (avatarUrl === defaultAvatarUrl) {
             // the url from defaultAvatarUrlForString is meant to go in an img element,


### PR DESCRIPTION
![edit-pill-avatars](https://user-images.githubusercontent.com/274386/58026021-29ed9600-7b05-11e9-9f7e-8cdd9fded82c.gif)

Note that this doesn't use `Pill` like `MessageComposerInput` because the editor contents isn't rendered by React. It moves most of the logic to `Avatar` though, if it isn't there already, to avoid duplication to some extent.

It's implemented as a pseudo-element on the span, with css variables set in JS passing the avatar url and letter down from the span. This way, it's sure to not interfere with the caret in the editor like an `<img>` would.

Part of https://github.com/vector-im/riot-web/issues/9487