### PR TITLE
Hide WhoIsTyping component if the MessagePanel is shaped e.g file grid

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -716,7 +716,7 @@ module.exports = React.createClass({
         );
 
         let whoIsTyping;
-        if (this.props.room) {
+        if (this.props.room && !this.props.tileShape) {
             whoIsTyping = (<WhoIsTypingTile
                 room={this.props.room}
                 onShown={this._onTypingShown}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8626

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

![8626](https://user-images.githubusercontent.com/2403652/58051361-db161f80-7b49-11e9-8755-8f0704013b1f.gif)
