### PR TITLE
Remove reacted with text when shortcode missing

### DIFF
--- a/src/components/views/messages/ReactionsRowButtonTooltip.js
+++ b/src/components/views/messages/ReactionsRowButtonTooltip.js
@@ -46,7 +46,7 @@ export default class ReactionsRowButtonTooltip extends React.PureComponent {
                 const { name } = room.getMember(reactionEvent.getSender());
                 senders.push(name);
             }
-            const shortName = unicodeToShortcode(content) || content;
+            const shortName = unicodeToShortcode(content);
             tooltipLabel = <div>{_t(
                 "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>",
                 {
@@ -59,6 +59,9 @@ export default class ReactionsRowButtonTooltip extends React.PureComponent {
                         </div>;
                     },
                     reactedWith: (sub) => {
+                        if (!shortName) {
+                            return null;
+                        }
                         return <div className="mx_ReactionsRowButtonTooltip_reactedWith">
                             {sub}
                         </div>;


### PR DESCRIPTION
If we don't have the shortcode for some emoji, don't show any "reacted with X"
text in the reaction tooltip.

Fixes https://github.com/vector-im/riot-web/issues/9786