### PR TITLE
Only show reactions in main message timeline

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -96,6 +96,9 @@ module.exports = React.createClass({
 
         // helper function to access relations for an event
         getRelationsForEvent: PropTypes.func,
+
+        // whether to show reactions for an event
+        showReactions: PropTypes.bool,
     },
 
     componentWillMount: function() {
@@ -541,6 +544,7 @@ module.exports = React.createClass({
                     last={last}
                     isSelectedEvent={highlight}
                     getRelationsForEvent={this.props.getRelationsForEvent}
+                    showReactions={this.props.showReactions}
                 />
             </li>,
         );

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1832,6 +1832,7 @@ module.exports = React.createClass({
                 membersLoaded={this.state.membersLoaded}
                 permalinkCreator={this._getPermalinkCreatorForRoom(this.state.room)}
                 resizeNotifier={this.props.resizeNotifier}
+                showReactions={true}
             />);
 
         let topUnreadMessagesBar = null;

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -106,6 +106,9 @@ const TimelinePanel = React.createClass({
 
         // placeholder text to use if the timeline is empty
         empty: PropTypes.string,
+
+        // whether to show reactions for an event
+        showReactions: PropTypes.bool,
     },
 
     statics: {
@@ -1261,6 +1264,7 @@ const TimelinePanel = React.createClass({
                 resizeNotifier={this.props.resizeNotifier}
                 getRelationsForEvent={this.getRelationsForEvent}
                 editEvent={this.state.editEvent}
+                showReactions={this.props.showReactions}
             />
         );
     },

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -160,8 +160,11 @@ module.exports = withMatrixClient(React.createClass({
         // show twelve hour timestamps
         isTwelveHour: PropTypes.bool,
 
-        // helper function to access relations for an event
+        // helper function to access relations for this event
         getRelationsForEvent: PropTypes.func,
+
+        // whether to show reactions for this event
+        showReactions: PropTypes.bool,
     },
 
     getDefaultProps: function() {
@@ -198,7 +201,7 @@ module.exports = withMatrixClient(React.createClass({
         const client = this.props.matrixClient;
         client.on("deviceVerificationChanged", this.onDeviceVerificationChanged);
         this.props.mxEvent.on("Event.decrypted", this._onDecrypted);
-        if (SettingsStore.isFeatureEnabled("feature_reactions")) {
+        if (this.props.showReactions && SettingsStore.isFeatureEnabled("feature_reactions")) {
             this.props.mxEvent.on("Event.relationsCreated", this._onReactionsCreated);
         }
     },
@@ -223,7 +226,7 @@ module.exports = withMatrixClient(React.createClass({
         const client = this.props.matrixClient;
         client.removeListener("deviceVerificationChanged", this.onDeviceVerificationChanged);
         this.props.mxEvent.removeListener("Event.decrypted", this._onDecrypted);
-        if (SettingsStore.isFeatureEnabled("feature_reactions")) {
+        if (this.props.showReactions && SettingsStore.isFeatureEnabled("feature_reactions")) {
             this.props.mxEvent.removeListener("Event.relationsCreated", this._onReactionsCreated);
         }
     },
@@ -485,6 +488,7 @@ module.exports = withMatrixClient(React.createClass({
 
     getReactions() {
         if (
+            !this.props.showReactions ||
             !this.props.getRelationsForEvent ||
             !SettingsStore.isFeatureEnabled("feature_reactions")
         ) {


### PR DESCRIPTION
This fixes an error that crashed that notifications panel because it was trying
to read reactions, even though we currently don't aggregate them there. This
change is more explicit about exactly which views should try to show reactions.

Fixes https://github.com/vector-im/riot-web/issues/9713