### PR TITLE
Guard against null rooms in `onEventDecrypted`

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -556,6 +556,9 @@ const TimelinePanel = React.createClass({
     },
 
     onEventDecrypted: function(ev) {
+        // Can be null for the notification timeline, etc.
+        if (!this.props.timelineSet.room) return;
+
         // Need to update as we don't display event tiles for events that
         // haven't yet been decrypted. The event will have just been updated
         // in place so we just need to re-render.


### PR DESCRIPTION
Timeline sets may have a null room, such as with the notification timeline set.
Here we check that case when events are decrypted to avoid throw an error.

Fixes https://github.com/vector-im/riot-web/issues/9798