### PR TITLE
Move checkmark to the front of key backup message

### DIFF
--- a/src/components/views/settings/KeyBackupPanel.js
+++ b/src/components/views/settings/KeyBackupPanel.js
@@ -180,7 +180,7 @@ export default class KeyBackupPanel extends React.PureComponent {
             if (MatrixClientPeg.get().getKeyBackupEnabled()) {
                 clientBackupStatus = <div>
                     <p>{encryptedMessageAreEncrypted}</p>
-                    <p>{_t("This device is backing up your keys. ")}✅</p>
+                    <p>✅ {_t("This device is backing up your keys. ")}</p>
                 </div>;
             } else {
                 clientBackupStatus = <div>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1342360/58181336-85ee2100-7ca3-11e9-933a-ea98ec9245ca.png)

After:

![image](https://user-images.githubusercontent.com/1342360/58181367-969e9700-7ca3-11e9-9bff-72bd69be934f.png)

Looks nicer imo.