### PR TITLE
Translate scroll movement if the deltaX is the same as the threshold

### DIFF
--- a/src/components/structures/IndicatorScrollbar.js
+++ b/src/components/structures/IndicatorScrollbar.js
@@ -129,7 +129,7 @@ export default class IndicatorScrollbar extends React.Component {
             // the harshness of the scroll behaviour. Should be a value between 0 and 1.
             const yRetention = 1.0;
 
-            if (Math.abs(e.deltaX) < xyThreshold) {
+            if (Math.abs(e.deltaX) <= xyThreshold) {
                 // noinspection JSSuspiciousNameCombination
                 this._scrollElement.scrollLeft += e.deltaY * yRetention;
             }


### PR DESCRIPTION
Because the threshold is zero and the X movement is zero, we were not translating vertical movement to horizontal scrolling. 

Fixes https://github.com/vector-im/riot-web/issues/9804