### PR TITLE
Make the timeline less noisy for screen readers (mk II)

### DIFF
--- a/src/components/views/elements/AccessibleButton.js
+++ b/src/components/views/elements/AccessibleButton.js
@@ -67,8 +67,8 @@ export default function AccessibleButton(props) {
     restProps.ref = restProps.inputRef;
     delete restProps.inputRef;
 
-    restProps.tabIndex = restProps.tabIndex || "0";
-    restProps.role = "button";
+    restProps.tabIndex = restProps.tabIndex === undefined ? "0" : restProps.tabIndex;
+    restProps.role = restProps.role === undefined ? "button" : restProps.role;
     restProps.className = (restProps.className ? restProps.className + " " : "") +
                           "mx_AccessibleButton";
 

--- a/src/components/views/elements/Flair.js
+++ b/src/components/views/elements/Flair.js
@@ -45,12 +45,18 @@ class FlairAvatar extends React.Component {
         const tooltip = this.props.groupProfile.name ?
             `${this.props.groupProfile.name} (${this.props.groupProfile.groupId})`:
             this.props.groupProfile.groupId;
+
+        // Note: we hide flair from screen readers but ideally we'd support
+        // reading something out on hover. There's no easy way to do this though,
+        // so instead we just hide it completely.
         return <img
             src={httpUrl}
             width="16"
             height="16"
             onClick={this.onClick}
-            title={tooltip} />;
+            title={tooltip}
+            aria-hidden={true}
+        />;
     }
 }
 

--- a/src/components/views/messages/MessageTimestamp.js
+++ b/src/components/views/messages/MessageTimestamp.js
@@ -23,12 +23,17 @@ export default class MessageTimestamp extends React.Component {
     static propTypes = {
         ts: PropTypes.number.isRequired,
         showTwelveHour: PropTypes.bool,
+        ariaHidden: PropTypes.bool,
     };
 
     render() {
         const date = new Date(this.props.ts);
         return (
-            <span className="mx_MessageTimestamp" title={formatFullDate(date, this.props.showTwelveHour)}>
+            <span
+                className="mx_MessageTimestamp"
+                title={formatFullDate(date, this.props.showTwelveHour)}
+                aria-hidden={this.props.ariaHidden}
+            >
                 { formatTime(date, this.props.showTwelveHour) }
             </span>
         );

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -789,7 +789,7 @@ module.exports = withMatrixClient(React.createClass({
                         </div>
                         { sender }
                         <div className="mx_EventTile_line">
-                            <a href={permalink} onClick={this.onPermalinkClicked} aria-hidden={muteScreenReader}>
+                            <a href={permalink} onClick={this.onPermalinkClicked} aria-hidden={true}>
                                 { timestamp }
                             </a>
                             { this._renderE2EPadlock() }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -581,11 +581,14 @@ module.exports = withMatrixClient(React.createClass({
         // Hopefully all of that leads to us not reading out messages in duplicate or triplicate.
         const sentByMyUserId = this.props.mxEvent.getSender() === MatrixClientPeg.get().getUserId();
         const sentByThisDevice = !!this.props.mxEvent.getUnsigned()["transaction_id"];
-        const screenReaderShouldSpeak = isSending ? false : (
-            this.props.eventSendStatus
-            ? sentByMyUserId && this.props.eventSendStatus === 'sent'
-            : !sentByMyUserId || !sentByThisClient
-        );
+        let screenReaderShouldSpeak = false;
+        if (!isSending) {
+            if (this.props.eventSendStatus === 'sent') {
+                screenReaderShouldSpeak = sentByMyUserId;
+            } else if (!this.props.eventSendStatus) {
+                screenReaderShouldSpeak = !sentByMyUserId || !sentByThisDevice;
+            }
+        }
 
         const classes = classNames({
             mx_EventTile: true,

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -545,6 +545,8 @@ module.exports = withMatrixClient(React.createClass({
         const isRedacted = isMessageEvent(this.props.mxEvent) && this.props.isRedacted;
         const isEncryptionFailure = this.props.mxEvent.isDecryptionFailure();
 
+        const muteScreenReader = isSending || !this.props.eventSendStatus;
+
         const classes = classNames({
             mx_EventTile: true,
             mx_EventTile_isEditing: this.props.isEditing,
@@ -601,9 +603,13 @@ module.exports = withMatrixClient(React.createClass({
         if (this.props.mxEvent.sender && avatarSize) {
             avatar = (
                     <div className="mx_EventTile_avatar">
-                        <MemberAvatar member={this.props.mxEvent.sender}
+                        <MemberAvatar
+                            member={this.props.mxEvent.sender}
                             width={avatarSize} height={avatarSize}
                             viewUserOnClick={true}
+                            aria-hidden={true} /* silence screen readers */
+                            buttonRole={null} /* trick screen readers into thinking this is not a button */
+                            tabIndex={null} /* trick screen readers into thinking this is not a button */
                         />
                     </div>
             );
@@ -773,7 +779,7 @@ module.exports = withMatrixClient(React.createClass({
                     'replyThread',
                 );
                 return (
-                    <div className={classes}>
+                    <div className={classes} aria-hidden={muteScreenReader}>
                         <div className="mx_EventTile_msgOption">
                             { readAvatars }
                         </div>
@@ -797,7 +803,7 @@ module.exports = withMatrixClient(React.createClass({
                             { actionBar }
                         </div>
                         {
-                            // The avatar goes after the event tile as it's absolutly positioned to be over the
+                            // The avatar goes after the event tile as it's absolutely positioned to be over the
                             // event tile line, so needs to be later in the DOM so it appears on top (this avoids
                             // the need for further z-indexing chaos)
                         }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -640,8 +640,12 @@ module.exports = withMatrixClient(React.createClass({
             onFocusChange={this.onActionBarFocusChange}
         /> : undefined;
 
-        const timestamp = this.props.mxEvent.getTs() ?
-            <MessageTimestamp showTwelveHour={this.props.isTwelveHour} ts={this.props.mxEvent.getTs()} /> : null;
+        const timestamp = this.props.mxEvent.getTs()
+            ? <MessageTimestamp
+                showTwelveHour={this.props.isTwelveHour}
+                ts={this.props.mxEvent.getTs()}
+                ariaHidden={muteScreenReader}
+            /> : null;
 
         const keyRequestHelpText =
             <div className="mx_EventTile_keyRequestInfo_tooltip_contents">
@@ -785,7 +789,7 @@ module.exports = withMatrixClient(React.createClass({
                         </div>
                         { sender }
                         <div className="mx_EventTile_line">
-                            <a href={permalink} onClick={this.onPermalinkClicked}>
+                            <a href={permalink} onClick={this.onPermalinkClicked} aria-hidden={muteScreenReader}>
                                 { timestamp }
                             </a>
                             { this._renderE2EPadlock() }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -550,7 +550,7 @@ module.exports = withMatrixClient(React.createClass({
         // changes to DOM elements. As such, we hack a bunch of conditions together.
         //
         // Screen readers do not react well to aria attributes changing dynamically after
-        // parsing them. Although readers watch the DOM, the cannot react to aria-hidden
+        // parsing them. Although readers watch the DOM, they cannot react to aria-hidden
         // going from true to false. To work around that, we check to see if the eventSendStatus
         // is something worthwhile for us to read out. We specifically don't want to read
         // out pending/queued messages because they'll be read out again when they are sent.
@@ -568,7 +568,7 @@ module.exports = withMatrixClient(React.createClass({
         // which sent the event). This allows us to do a few checks on whether to speak:
         //  * If the event was sent by our user ID and the eventSendStatus is 'sent', then speak.
         //    We cannot check the transaction_id at this point because it is undefined. We can
-        //    make the assumption that 'sent' means this exact client is handling it though.
+        //    make the assumption that 'sent' means this exact device is handling it though.
         //  * If the event was sent by our user ID and the eventSendStatus is falsey (null), then
         //    only speak if the event was not sent by us (no transaction_id).
         //  * If the event was not sent by our user ID then speak.
@@ -580,7 +580,7 @@ module.exports = withMatrixClient(React.createClass({
         //
         // Hopefully all of that leads to us not reading out messages in duplicate or triplicate.
         const sentByMyUserId = this.props.mxEvent.getSender() === MatrixClientPeg.get().getUserId();
-        const sentByThisClient = !!this.props.mxEvent.getUnsigned()["transaction_id"];
+        const sentByThisDevice = !!this.props.mxEvent.getUnsigned()["transaction_id"];
         const screenReaderShouldSpeak = isSending ? false : (
             this.props.eventSendStatus
             ? sentByMyUserId && this.props.eventSendStatus === 'sent'

--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -211,11 +211,13 @@ module.exports = React.createClass({
                 <MemberAvatar
                     member={this.props.member}
                     fallbackUserId={this.props.fallbackUserId}
-                    aria-hidden="true"
                     width={14} height={14} resizeMethod="crop"
                     style={style}
                     title={title}
                     onClick={this.props.onClick}
+                    aria-hidden={true} /* silence screen readers */
+                    buttonRole={null} /* trick screen readers into thinking this is not a button */
+                    tabIndex={null} /* trick screen readers into thinking this is not a button */
                 />
             </Velociraptor>
         );


### PR DESCRIPTION
There's some room for improvement here: we could be making the reader say "You sent a message at 18:46  [body]" or "TravisR sent a message at 18:46 [body]" to make it clearer. Currently it'll read out the sender profile if it is available, and if not just the timestamp + message. This improvement is best left to a future PR though.

Fixes https://github.com/vector-im/riot-web/issues/2716
Fixes https://github.com/vector-im/riot-web/issues/5697
See https://github.com/vector-im/riot-web/issues/9747

Original PR: https://github.com/matrix-org/matrix-react-sdk/pull/3007