### PR TITLE
Message editing: dont jump to next part when inserting at *start* of uneditable part

### DIFF
--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -232,8 +232,9 @@ export default class EditorModel {
                     index += 1;
                     this._insertPart(index, splitPart);
                 }
-            } else {
-                // not-editable, insert str after this part
+            } else if (offset !== 0) {
+                // not-editable part, caret is not at start,
+                // so insert str after this part
                 addLen += part.text.length - offset;
                 index += 1;
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9768

![editatstart](https://user-images.githubusercontent.com/274386/58236598-bf21a200-7d32-11e9-9aba-5616131c677d.gif)
