### PR TITLE
Use the correct line-height for bold emoji

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -469,7 +469,7 @@ export function bodyToHtml(content, highlights, opts={}) {
     const className = classNames({
         'mx_EventTile_body': true,
         'mx_EventTile_bigEmoji': emojiBody,
-        'markdown-body': isHtmlMessage,
+        'markdown-body': isHtmlMessage && !emojiBody,
     });
 
     return isDisplayedWithHtml ?


### PR DESCRIPTION
This avoids marking messages detected as big emoji with `markdown-body` so that
they get the correct line-height.

Fixes https://github.com/vector-im/riot-web/issues/9808