### PR TITLE
Fixup for tab completion: take part length into account as well

### DIFF
--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -314,7 +314,7 @@ export class PillCandidatePart extends PlainPart {
     }
 
     acceptsInsertion(chr, i) {
-        if (i === 0) {
+        if ((this.text.length + i) === 0) {
             return true;
         } else {
             return super.acceptsInsertion(chr, i);


### PR DESCRIPTION
Fixup for: https://github.com/matrix-org/matrix-react-sdk/pull/3024

Realized just after I merged it :man_facepalming:, sorry.
The API isn't ideal and I want to rework it a bit at a later point.

Otherwise multiple :/#/@ could still end up in on pill-candidate part, confusing the autocomplete.