### PR TITLE
Fix: maintain caret at current line when position is on newline part

### DIFF
--- a/src/editor/caret.js
+++ b/src/editor/caret.js
@@ -44,14 +44,11 @@ export function setCaretPosition(editor, model, caretPosition) {
     let focusNode;
     const lineNode = editor.childNodes[lineIndex];
     if (lineNode) {
-        if (lineNode.childNodes.length === 0 && offset === 0) {
+        focusNode = lineNode.childNodes[nodeIndex];
+        if (!focusNode) {
             focusNode = lineNode;
-        } else {
-            focusNode = lineNode.childNodes[nodeIndex];
-
-            if (focusNode && focusNode.nodeType === Node.ELEMENT_NODE) {
-                focusNode = focusNode.childNodes[0];
-            }
+        } else if (focusNode.nodeType === Node.ELEMENT_NODE) {
+            focusNode = focusNode.childNodes[0];
         }
     }
     // node not found, set caret at end

--- a/src/editor/caret.js
+++ b/src/editor/caret.js
@@ -20,13 +20,23 @@ export function setCaretPosition(editor, model, caretPosition) {
     sel.removeAllRanges();
     const range = document.createRange();
     const {parts} = model;
+    const {index} = caretPosition;
+    let {offset} = caretPosition;
     let lineIndex = 0;
     let nodeIndex = -1;
-    for (let i = 0; i <= caretPosition.index; ++i) {
+    for (let i = 0; i <= index; ++i) {
         const part = parts[i];
         if (part && part.type === "newline") {
-            lineIndex += 1;
-            nodeIndex = -1;
+            if (i < index) {
+                lineIndex += 1;
+                nodeIndex = -1;
+            } else {
+                // if index points at a newline part,
+                // put the caret at the end of the previous part
+                // so it stays on the same line
+                const prevPart = parts[i - 1];
+                offset = prevPart ? prevPart.text.length : 0;
+            }
         } else {
             nodeIndex += 1;
         }
@@ -34,7 +44,7 @@ export function setCaretPosition(editor, model, caretPosition) {
     let focusNode;
     const lineNode = editor.childNodes[lineIndex];
     if (lineNode) {
-        if (lineNode.childNodes.length === 0 && caretPosition.offset === 0) {
+        if (lineNode.childNodes.length === 0 && offset === 0) {
             focusNode = lineNode;
         } else {
             focusNode = lineNode.childNodes[nodeIndex];
@@ -50,7 +60,7 @@ export function setCaretPosition(editor, model, caretPosition) {
         range.collapse(false);
     } else {
         // make sure we have a text node
-        range.setStart(focusNode, caretPosition.offset);
+        range.setStart(focusNode, offset);
         range.collapse(true);
     }
     sel.addRange(range);

--- a/src/editor/render.js
+++ b/src/editor/render.js
@@ -61,12 +61,13 @@ export function renderModel(editor, model) {
             let foundBR = false;
             let partNode = lineContainer.firstChild;
             while (partNode) {
+                const nextNode = partNode.nextSibling;
                 if (!foundBR && partNode.tagName === "BR") {
                     foundBR = true;
                 } else {
                     lineContainer.removeChild(partNode);
                 }
-                partNode = partNode.nextSibling;
+                partNode = nextNode;
             }
             if (!foundBR) {
                 lineContainer.appendChild(document.createElement("br"));


### PR DESCRIPTION
Fix for https://github.com/vector-im/riot-web/issues/9803
Fixes multiple small issues:
 - put caret at end of pill on autocomplete when there is no plain part behind it on the same line
 - fix not all nodes being cleared when inserting a newline between two lines
 - fix setting caret at editor end when inserting a newline between two lines