### PR TITLE
Do not try to request thumbnails with non-integer widths

### DIFF
--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -172,8 +172,8 @@ export default class MImageBody extends React.Component {
         // thumbnail resolution will be unnecessarily reduced.
         // custom timeline widths seems preferable.
         const pixelRatio = window.devicePixelRatio;
-        const thumbWidth = 800 * pixelRatio;
-        const thumbHeight = 600 * pixelRatio;
+        const thumbWidth = Math.round(800 * pixelRatio);
+        const thumbHeight = Math.round(600 * pixelRatio);
 
         const content = this.props.mxEvent.getContent();
         if (content.file !== undefined) {


### PR DESCRIPTION
Issue described in https://github.com/vector-im/riot-web/issues/9690.

With certain `window.devicePixelRatio` values
(e.g.  `1.5789473684210527`), the calculated thumb width/height
would be a non-integer value.

Passing such values to `client.mxcUrlToHttp()` causes it to
generate URLs to the thumbnail API with non-integer values.
As per the spec, non-integer values are forbidden for that API and a
400 HTTP response is returned (`Query parameter b'width' must be an
integer`).

Fixing matrix-js-sdk's `mxcUrlToHttp()` to sanitize such values
would also be a good idea and likely fix more than just matrix-react-sdk
and riot-web. Still, it feels like matrix-react-sdk should play nice
as well, and not request thumbnails for weird widths/heights.

Signed-off-by: Slavi Pantaleev <slavi@devture.com>