### PR TITLE
fix COLR font check being racy

### DIFF
--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -23,7 +23,7 @@ limitations under the License.
 
 function safariVersionCheck(ua) {
     try {
-        const safariVersionMatch = ua.match(/Mac OS X ([\d|_]+).*Version\/([\d|\.]+) Safari/);
+        const safariVersionMatch = ua.match(/Mac OS X ([\d|_]+).*Version\/([\d|.]+).*Safari/);
         if (safariVersionMatch) {
             const macOSVersionStr = safariVersionMatch[1];
             const safariVersionStr = safariVersionMatch[2];

--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -22,18 +22,22 @@ limitations under the License.
  */
 
 function safariVersionCheck(ua) {
-    const safariVersionMatch = ua.match(/Mac OS X ([\d|_]+).*Version\/([\d|\.]+) Safari/);
-    if (safariVersionMatch) {
-        const macOSVersionStr = safariVersionMatch[1];
-        const safariVersionStr = safariVersionMatch[2];
-        const macOSVersion = macOSVersionStr.split("_").map(n => parseInt(n, 10));
-        const safariVersion = safariVersionStr.split(".").map(n => parseInt(n, 10));
-        const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
-        // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
-        console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
-            `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr},` +
-            `supported: ${colrFontSupported}`);
-        return colrFontSupported;
+    try {
+        const safariVersionMatch = ua.match(/Mac OS X ([\d|_]+).*Version\/([\d|\.]+) Safari/);
+        if (safariVersionMatch) {
+            const macOSVersionStr = safariVersionMatch[1];
+            const safariVersionStr = safariVersionMatch[2];
+            const macOSVersion = macOSVersionStr.split("_").map(n => parseInt(n, 10));
+            const safariVersion = safariVersionStr.split(".").map(n => parseInt(n, 10));
+            const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
+            // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
+            console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
+                `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr},` +
+                `supported: ${colrFontSupported}`);
+            return colrFontSupported;
+        }
+    } catch (err) {
+        console.error("Couldn't determine Safari version to check COLR font support, assuming no.", err);
     }
     return false;
 }

--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -33,7 +33,7 @@ function safariVersionCheck(ua) {
             // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
             console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
                 `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr},` +
-                `supported: ${colrFontSupported}`);
+                `COLR supported: ${colrFontSupported}`);
             return colrFontSupported;
         }
     } catch (err) {

--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -31,7 +31,7 @@ function safariVersionCheck(ua) {
             const safariVersion = safariVersionStr.split(".").map(n => parseInt(n, 10));
             const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
             // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
-            console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
+            console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12, ` +
                 `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr}, ` +
                 `COLR supported: ${colrFontSupported}`);
             return colrFontSupported;

--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -21,6 +21,23 @@ limitations under the License.
  * MIT license
  */
 
+function safariVersionCheck(ua) {
+    const safariVersionMatch = ua.match(/Mac OS X ([\d|_]+).*Version\/([\d|\.]+) Safari/);
+    if (safariVersionMatch) {
+        const macOSVersionStr = safariVersionMatch[1];
+        const safariVersionStr = safariVersionMatch[2];
+        const macOSVersion = macOSVersionStr.split("_").map(n => parseInt(n, 10));
+        const safariVersion = safariVersionStr.split(".").map(n => parseInt(n, 10));
+        const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
+        // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
+        console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
+            `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr},` +
+            `supported: ${colrFontSupported}`);
+        return colrFontSupported;
+    }
+    return false;
+}
+
 async function isColrFontSupported() {
     console.log("Checking for COLR support");
 
@@ -31,6 +48,12 @@ async function isColrFontSupported() {
     if (navigator.userAgent.includes("Firefox")) {
         console.log("Browser is Firefox - assuming COLR is supported");
         return true;
+    }
+    // Safari doesn't wait for the font to load (if it doesn't have it in cache)
+    // to emit the load event on the image, so there is no way to not make the check
+    // reliable. Instead sniff the version.
+    if (navigator.userAgent.includes("Safari")) {
+        return safariVersionCheck(navigator.userAgent);
     }
 
     try {

--- a/src/utils/FontManager.js
+++ b/src/utils/FontManager.js
@@ -32,7 +32,7 @@ function safariVersionCheck(ua) {
             const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
             // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
             console.log(`Browser is Safari - requiring macOS 10.14 and Safari 12,` +
-                `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr},` +
+                `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr}, ` +
                 `COLR supported: ${colrFontSupported}`);
             return colrFontSupported;
         }


### PR DESCRIPTION
also make sure it doesn't run more than once.
keeping the FF sniffing because missing "extract canvas data" permissions
would still break the check.