### PR TITLE
override font for usercontent download link

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -145,6 +145,7 @@ function remoteRender(event) {
     a.target = data.target;
     a.download = data.download;
     a.style = data.style;
+    a.style.fontFamily = "Arial, Helvetica, Sans-Serif";
     a.href = window.URL.createObjectURL(data.blob);
     a.appendChild(img);
     a.appendChild(document.createTextNode(data.textContent));


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9867

The download link in encrypted rooms is rendered in an iframe, with all (inherited) styles from the app applied to the inline style of the link. So font-family is copied over, including Nunito and the (native) emoji fonts. None of the webfonts are loaded though, so it will fallback to the first native font that can render a glyph, which appears to be the emoji font for numbers.

Ideally we'd render the link in Nunito, but that would be a bit more involved, so override the font-family to Arial, ... which was the font the link was rendered with in practice in the past.