### PR TITLE
Remove username on HS input label

### DIFF
--- a/src/components/views/auth/PasswordLogin.js
+++ b/src/components/views/auth/PasswordLogin.js
@@ -211,10 +211,7 @@ export default class PasswordLogin extends React.Component {
                     name="username" // make it a little easier for browser's remember-password
                     key="username_input"
                     type="text"
-                    label={SdkConfig.get().disable_custom_urls ?
-                        _t("Username on %(hs)s", {
-                            hs: this.props.serverConfig.hsName,
-                        }) : _t("Username")}
+                    label={_t("Username")}
                     value={this.state.username}
                     onChange={this.onUsernameChanged}
                     onBlur={this.onUsernameBlur}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1329,7 +1329,6 @@
     "The phone number field must not be blank.": "The phone number field must not be blank.",
     "The password field must not be blank.": "The password field must not be blank.",
     "Email": "Email",
-    "Username on %(hs)s": "Username on %(hs)s",
     "Username": "Username",
     "Phone": "Phone",
     "Not sure of your password? <a>Set a new one</a>": "Not sure of your password? <a>Set a new one</a>",


### PR DESCRIPTION
Removes redundant HS name on the username input that duplicates the header above
it.

<img width="418" alt="2019-05-29 at 17 50" src="https://user-images.githubusercontent.com/279572/58575610-535f9d80-823a-11e9-9385-adc4f366b131.png">

Fixes https://github.com/vector-im/riot-web/issues/9884