### PR TITLE
Native emoji require extra line-height

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -121,7 +121,7 @@ limitations under the License.
 /* HACK to override line-height which is already marked important elsewhere */
 .mx_EventTile_bigEmoji.mx_EventTile_bigEmoji {
     font-size: 48px ! important;
-    line-height: 52px ! important;
+    line-height: 57px ! important;
 }
 
 /* this is used for the tile for the event which is selected via the URL.


### PR DESCRIPTION
Increase line-height so that native emoji aren't cut off when we fall back to
them.

<img width="82" alt="2019-05-30 at 10 30" src="https://user-images.githubusercontent.com/279572/58623491-03c6b380-82c6-11e9-944a-8d361a76b4f7.png">

Fixes https://github.com/vector-im/riot-web/issues/9898