### PR TITLE
Allow source tile handler for replacements

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -520,13 +520,20 @@ module.exports = withMatrixClient(React.createClass({
         const eventType = this.props.mxEvent.getType();
 
         // Info messages are basically information about commands processed on a room
-        const isInfoMessage = (
+        let isInfoMessage = (
             eventType !== 'm.room.message' && eventType !== 'm.sticker' && eventType != 'm.room.create'
         );
 
         let tileHandler = getHandlerTile(this.props.mxEvent);
-        if (!tileHandler && SettingsStore.getValue("showHiddenEventsInTimeline")) {
+        // If we're showing hidden events in the timeline, we should use the
+        // source tile when there's no regular tile for an event and also for
+        // replace relations (which otherwise would display as a confusing
+        // duplicate of the thing they are replacing).
+        const useSource = !tileHandler || this.props.mxEvent.isRelation("m.replace");
+        if (useSource && SettingsStore.getValue("showHiddenEventsInTimeline")) {
             tileHandler = "messages.ViewSourceEvent";
+            // Reuse info message avatar and sender profile styling
+            isInfoMessage = true;
         }
         // This shouldn't happen: the caller should check we support this type
         // before trying to instantiate us


### PR DESCRIPTION
If the debugging mode of showing hidden events in the timeline is enabled, we
should also show replacements using the same view source tile as we do for
reactions. This allows easy debugging of replacement event data and also makes
the edit event look visually distinct from regular messages.

![2019-06-03 at 16 26](https://user-images.githubusercontent.com/279572/58814098-0ce4b700-861d-11e9-8d7e-a3afb813c069.png)

Fixes https://github.com/vector-im/riot-web/issues/9937