### PR TITLE
Install latest JS SDK when linting

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,7 +1,12 @@
 steps:
   - label: ":eslint: Lint"
     command:
-      - "yarn install"
+      # TODO: Remove hacky chmod for BuildKite
+      - "echo '--- Setup'"
+      - "chmod +x ./scripts/ci/*.sh"
+      - "chmod +x ./scripts/*"
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
       - "yarn lintwithexclusions"
       - "yarn stylelint"
     plugins:


### PR DESCRIPTION
Since React SDK's linting rules depend on JS SDK, we should use the latest
changes when linting as well in case there's been a recent rule change.