### PR TITLE
Don't refresh custom status on logout

### DIFF
--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -91,6 +91,8 @@ module.exports = React.createClass({
     },
 
     _getStatusMessageUser() {
+        if (!MatrixClientPeg.get()) return null; // We've probably been logged out
+
         const selfId = MatrixClientPeg.get().getUserId();
         const otherMember = this.props.room.currentState.getMembersExcept([selfId])[0];
         if (!otherMember) {


### PR DESCRIPTION
The RoomTile gets remounted during logout due to the room stores being obliterated, however this causes the render() function to check if it should be showing custom status. If you have custom status enabled, and the person has a status set, the function errors due to no MatrixClient being available.

Fixes https://github.com/vector-im/riot-web/issues/9940