### PR TITLE
Be somewhat fuzzier when matching emojis to complete on space

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -533,10 +533,8 @@ export default class MessageComposerInput extends React.Component {
                 // The first matched group includes just the matched plaintext emoji
                 const emoticonMatch = REGEX_EMOTICON_WHITESPACE.exec(text.slice(0, currentStartOffset));
                 if (emoticonMatch) {
-                    const data = EMOJIBASE.find(e => {
-                        if (!e.emoticon) return false;
-                        return e.emoticon.toLowerCase() === emoticonMatch[1].toLowerCase().replace("-", "");
-                    });
+                    const query = emoticonMatch[1].toLowerCase().replace("-", "");
+                    const data = EMOJIBASE.find(e => e.emoticon ? e.emoticon.toLowerCase() === query : false);
 
                     // only perform replacement if we found a match, otherwise we would be not letting user type
                     if (data) {

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -533,21 +533,26 @@ export default class MessageComposerInput extends React.Component {
                 // The first matched group includes just the matched plaintext emoji
                 const emoticonMatch = REGEX_EMOTICON_WHITESPACE.exec(text.slice(0, currentStartOffset));
                 if (emoticonMatch) {
-                    const data = EMOJIBASE.find(e => e.emoticon === emoticonMatch[1]);
-                    const unicodeEmoji = data ? data.unicode : '';
-
-                    const range = Range.create({
-                        anchor: {
-                            key: editorState.startText.key,
-                            offset: currentStartOffset - emoticonMatch[1].length - 1,
-                        },
-                        focus: {
-                            key: editorState.startText.key,
-                            offset: currentStartOffset - 1,
-                        },
+                    const data = EMOJIBASE.find(e => {
+                        if (!e.emoticon) return false;
+                        return e.emoticon.toLowerCase() === emoticonMatch[1].toLowerCase().replace("-", "");
                     });
-                    change = change.insertTextAtRange(range, unicodeEmoji);
-                    editorState = change.value;
+
+                    // only perform replacement if we found a match, otherwise we would be not letting user type
+                    if (data) {
+                        const range = Range.create({
+                            anchor: {
+                                key: editorState.startText.key,
+                                offset: currentStartOffset - emoticonMatch[1].length - 1,
+                            },
+                            focus: {
+                                key: editorState.startText.key,
+                                offset: currentStartOffset - 1,
+                            },
+                        });
+                        change = change.insertTextAtRange(range, data.unicode);
+                        editorState = change.value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. If an emoji is not found in the json but matches the regex, don't remove what the user is typing.
2. Case insensitive comparison to emoticons in json
3. Strip `-` from emoticon matches, as the json contains 0 emoticons with `-` but some make sense, `:-D` -> `:D`

These may not be the most correct changes, but they seem to make the feature a lot more usable, and a lot more friendly so seem reasonable.

![9910](https://user-images.githubusercontent.com/2403652/59015490-029e0500-8837-11e9-9f60-0a651d85915f.gif)

Fixes https://github.com/vector-im/riot-web/issues/9910
Fixes https://github.com/vector-im/riot-web/issues/9945
Fixes https://github.com/vector-im/riot-web/issues/9921

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>