### PR TITLE
Show read receipts on top of message

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -243,6 +243,7 @@ limitations under the License.
     height: 14px;
     top: 29px;
     user-select: none;
+    z-index: 1;
 }
 
 .mx_EventTile_continuation .mx_EventTile_readAvatars,


### PR DESCRIPTION
This allows you to view a long expanded set of read receipts even while hovering
a message.

<img width="622" alt="2019-06-06 at 13 57" src="https://user-images.githubusercontent.com/279572/59034833-e6648d00-8863-11e9-827e-1d9532023143.png">

Fixes https://github.com/vector-im/riot-web/issues/7608