### PR TITLE
Fix email invites address-match checking

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1551,6 +1551,7 @@ module.exports = React.createClass({
                             joining={this.state.joining}
                             inviterName={inviterName}
                             invitedEmail={invitedEmail}
+                            oobData={this.props.oobData}
                             room={this.state.room}
                         />
                     </div>
@@ -1681,6 +1682,7 @@ module.exports = React.createClass({
                                 joining={this.state.joining}
                                 inviterName={inviterName}
                                 invitedEmail={invitedEmail}
+                                oobData={this.props.oobData}
                                 canPreview={this.state.canPeek}
                                 room={this.state.room}
                 />

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -54,6 +54,9 @@ module.exports = React.createClass({
         // If invited by 3rd party invite, the email address the invite was sent to
         invitedEmail: PropTypes.string,
 
+        // For third party invites, information passed about the room out-of-band
+        oobData: PropTypes.object,
+
         // A standard client/server API error object. If supplied, indicates that the
         // caller was unable to fetch details about the room for the given reason.
         error: PropTypes.object,
@@ -87,6 +90,16 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
+        this._checkInvitedEmail();
+    },
+
+    componentDidUpdate: function(prevProps, prevState) {
+        if (this.props.invitedEmail !== prevProps.invitedEmail || this.props.inviterName !== prevProps.inviterName) {
+            this._checkInvitedEmail();
+        }
+    },
+
+    _checkInvitedEmail: function() {
         // If this is an invite and we've been told what email
         // address was invited, fetch the user's list of Threepids
         // so we can check them against the one that was invited
@@ -335,7 +348,7 @@ module.exports = React.createClass({
             }
             case MessageCase.Invite: {
                 const RoomAvatar = sdk.getComponent("views.avatars.RoomAvatar");
-                const avatar = <RoomAvatar room={this.props.room} />;
+                const avatar = <RoomAvatar room={this.props.room} oobData={this.props.oobData} />;
 
                 const inviteMember = this._getInviteMember();
                 let inviterElement;


### PR DESCRIPTION
Riot was always saying the email address that the invite was sent
to was not associated with your account.

Two fixes here:
 1. We mounted RoomPreviewBar with no invitedEmail prop and then
    changed the prop later, but RoomPreviewBar only checked for it
    on mount. Make sure we re-check when the props change.
 2. Pass oobData through RoomPreviewBar because we need to pass it
    to the RoomAvatar for 3pid invites.

https://github.com/vector-im/riot-web/issues/9816