### PR TITLE
Look busy whilst requesting the email token

### DIFF
--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -97,7 +97,7 @@ export default React.createClass({
             sessionId: this.props.sessionId,
             clientSecret: this.props.clientSecret,
             emailSid: this.props.emailSid,
-            requestEmailToken: this.props.requestEmailToken,
+            requestEmailToken: this._requestEmailToken,
         });
 
         this._authLogic.attemptAuth().then((result) => {
@@ -132,6 +132,19 @@ export default React.createClass({
 
         if (this._intervalId !== null) {
             clearInterval(this._intervalId);
+        }
+    },
+
+    _requestEmailToken: async function(...args) {
+        this.setState({
+            busy: true,
+        });
+        try {
+            return await this.props.requestEmailToken(...args);
+        } finally {
+            this.setState({
+                busy: false,
+            });
         }
     },
 


### PR DESCRIPTION
We need to wait for it to finish before letting the user start
completing the steps since if it fails, we can't complete the auth.