### PR TITLE
truncate long display names in timeline headings

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -56,13 +56,17 @@ limitations under the License.
     color: $primary-fg-color;
     font-size: 14px;
     display: inline-block; /* anti-zalgo, with overflow hidden */
-    overflow-y: hidden;
+    overflow: hidden;
     cursor: pointer;
     padding-left: 65px; /* left gutter */
     padding-bottom: 0px;
     padding-top: 0px;
     margin: 0px;
     line-height: 17px;
+    /* the next three lines, along with overflow hidden, truncate long display names */
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: calc(100% - 65px);
 }
 
 .mx_EventTile .mx_SenderProfile .mx_Flair {


### PR DESCRIPTION
partial fix for vector-im/riot-web#5739

Note: I have not rebuilt Riot with this change yet, because yarn currently hates me, so this is untested.  Whoever reviews this should probably give it a try first.