### PR TITLE
Use setBusy interface of js-sdk interactive auth

### DIFF
--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -93,7 +93,7 @@ export default React.createClass({
         this._authLogic = new InteractiveAuth({
             authData: this.props.authData,
             doRequest: this._requestCallback,
-            setBusy: this._setBusy,
+            busyChanged: this._onBusyChanged,
             inputs: this.props.inputs,
             stateUpdated: this._authStateUpdated,
             matrixClient: this.props.matrixClient,
@@ -175,7 +175,7 @@ export default React.createClass({
         return this.props.makeRequest(auth);
     },
 
-    _setBusy: function(busy) {
+    _onBusyChanged: function(busy) {
         // if we've started doing stuff, reset the error messages
         if (busy) {
             this.setState({

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -23,6 +23,8 @@ import PropTypes from 'prop-types';
 
 import {getEntryComponentForLoginType} from '../views/auth/InteractiveAuthEntryComponents';
 
+import sdk from '../../index';
+
 export default React.createClass({
     displayName: 'InteractiveAuth',
 
@@ -90,7 +92,8 @@ export default React.createClass({
         this._unmounted = false;
         this._authLogic = new InteractiveAuth({
             authData: this.props.authData,
-            doRequest: this._requestCallback,
+            doRequest: this.props.makeRequest,
+            setBusy: this._setBusy,
             inputs: this.props.inputs,
             stateUpdated: this._authStateUpdated,
             matrixClient: this.props.matrixClient,
@@ -165,27 +168,19 @@ export default React.createClass({
         });
     },
 
-    _requestCallback: function(auth, background) {
-        const makeRequestPromise = this.props.makeRequest(auth);
-
-        // if it's a background request, just do it: we don't want
-        // it to affect the state of our UI.
-        if (background) return makeRequestPromise;
-
-        // otherwise, manage the state of the spinner and error messages
-        this.setState({
-            busy: true,
-            errorText: null,
-            stageErrorText: null,
-        });
-        return makeRequestPromise.finally(() => {
-            if (this._unmounted) {
-                return;
-            }
+    _setBusy: function(busy) {
+        // if we've started doing stuff, reset the error messages
+        if (busy) {
+            this.setState({
+                busy: true,
+                errorText: null,
+                stageErrorText: null,
+            });
+        } else {
             this.setState({
                 busy: false,
             });
-        });
+        }
     },
 
     _setFocus: function() {
@@ -200,7 +195,14 @@ export default React.createClass({
 
     _renderCurrentStage: function() {
         const stage = this.state.authStage;
-        if (!stage) return null;
+        if (!stage) {
+            if (this.state.busy) {
+                const Loader = sdk.getComponent("elements.Spinner");
+                return <Loader />;
+            } else {
+                return null;
+            }
+        }
 
         const StageComponent = getEntryComponentForLoginType(stage);
         return (

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -92,7 +92,7 @@ export default React.createClass({
         this._unmounted = false;
         this._authLogic = new InteractiveAuth({
             authData: this.props.authData,
-            doRequest: this.props.makeRequest,
+            doRequest: this._requestCallback,
             setBusy: this._setBusy,
             inputs: this.props.inputs,
             stateUpdated: this._authStateUpdated,
@@ -166,6 +166,13 @@ export default React.createClass({
         }, () => {
             if (oldStage != stageType) this._setFocus();
         });
+    },
+
+    _requestCallback: function(auth) {
+        // This wrapper just exists because the js-sdk passes a second
+        // 'busy' param for backwards compat. This throws the tests off
+        // so discard it here.
+        return this.props.makeRequest(auth);
     },
 
     _setBusy: function(busy) {


### PR DESCRIPTION
This helps to make sure we only do one auth request at a time.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/951