### PR TITLE
Cleanup: redacted reactions are removed here already

### DIFF
--- a/src/components/views/messages/ReactionDimension.js
+++ b/src/components/views/messages/ReactionDimension.js
@@ -85,9 +85,6 @@ export default class ReactionDimension extends React.PureComponent {
         let selectedReactionEvent = null;
         for (const option of options) {
             const reactionForOption = myReactions.find(mxEvent => {
-                if (mxEvent.isRedacted()) {
-                    return false;
-                }
                 return mxEvent.getRelation().key === option;
             });
             if (!reactionForOption) {


### PR DESCRIPTION
during beforeRedaction event before Relations.redaction is emitted
So this should not be needed.

Part of https://github.com/matrix-org/matrix-js-sdk/pull/947