### PR TITLE
Fix registration after fail-fast 

### DIFF
--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -177,7 +177,10 @@ module.exports = React.createClass({
             );
             this.setState({serverIsAlive: true});
         } catch (e) {
-            this.setState(AutoDiscoveryUtils.authComponentStateForError(e, "register"));
+            this.setState({
+                busy: false,
+                ...AutoDiscoveryUtils.authComponentStateForError(e, "register"),
+            });
             if (this.state.serverErrorIsFatal) {
                 return; // Server is dead - do not continue.
             }
@@ -455,6 +458,8 @@ module.exports = React.createClass({
                 emailSid={this.props.idSid}
                 poll={true}
             />;
+        } else if (!this.state.matrixClient && !this.state.busy) {
+            return null;
         } else if (this.state.busy || !this.state.flows) {
             return <div className="mx_AuthBody_spinner">
                 <Spinner />

--- a/test/components/structures/auth/Registration-test.js
+++ b/test/components/structures/auth/Registration-test.js
@@ -69,9 +69,11 @@ describe('Registration', function() {
 
         const root = render();
 
-        // Set non-empty flows to get past the loading spinner
+        // Set non-empty flow & matrixClient to get past the loading spinner
         root.setState({
             flows: [],
+            matrixClient: {},
+            busy: false,
         });
 
         const form = ReactTestUtils.findRenderedComponentWithType(


### PR DESCRIPTION
The lineness checks meant that we could no longer assume we always
had a matrix client, so don't assume we do.

Fixes vector-im/riot-web#10011