### PR TITLE
Raise action bar above read marker

### DIFF
--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -26,6 +26,7 @@ limitations under the License.
     top: -18px;
     right: 8px;
     user-select: none;
+    z-index: 1;
 
     > * {
         display: inline-block;

--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -26,6 +26,7 @@ limitations under the License.
     top: -18px;
     right: 8px;
     user-select: none;
+    // Ensure the action bar appears above over things, like the read marker.
     z-index: 1;
 
     > * {


### PR DESCRIPTION
Use `z-index` to ensure the action bar appears above over things, like the read
marker.

Fixes https://github.com/vector-im/riot-web/issues/9619