### PR TITLE
Fix registration with email + non-default HS

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -219,6 +219,18 @@ export default React.createClass({
         return {serverConfig: props};
     },
 
+    getRegisterServerProperties() {
+        const props = this.getServerProperties();
+        if (this.state.register_hs_url) {
+            props.hsUrl = this.state.register_hs_url;
+        }
+        if (this.state.register_is_url) {
+            props.isUrl = this.state.register_is_url;
+        }
+
+        return {serverConfig: props};
+    },
+
     componentWillMount: function() {
         SdkConfig.put(this.props.config);
 
@@ -1871,7 +1883,7 @@ export default React.createClass({
                     onLoggedIn={this.onRegistered}
                     onLoginClick={this.onLoginClick}
                     onServerConfigChange={this.onServerConfigChange}
-                    {...this.getServerProperties()}
+                    {...this.getRegisterServerProperties()}
                 />
             );
         }


### PR DESCRIPTION
We were ignoring the hs/is from the query parameters so after
clicking the link, the new client tried to use the wrong server.

Broken by https://github.com/matrix-org/matrix-react-sdk/pull/2941
Fixes https://github.com/vector-im/riot-web/issues/9659