### PR TITLE
Use overflow on MemberInfo name/mxid so that the back button stays

### DIFF
--- a/res/css/views/rooms/_MemberInfo.scss
+++ b/res/css/views/rooms/_MemberInfo.scss
@@ -43,6 +43,8 @@ limitations under the License.
 
 .mx_MemberInfo_name h2 {
     flex: 1;
+    overflow-x: auto;
+    max-height: 50px;
 }
 
 .mx_MemberInfo h2 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2403652/59385906-44f6a300-8d5d-11e9-9849-af79858ace10.png)

Opted for vertical scroll-ability just in case someone wants to see the entire thing

Fixes https://github.com/vector-im/riot-web/issues/9879

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>