### PR TITLE
Fix welcome user

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -51,6 +51,7 @@ interface MatrixClientCreds {
 class MatrixClientPeg {
     constructor() {
         this.matrixClient = null;
+        this._justRegisteredUserId = null;
 
         // These are the default options used when when the
         // client is started in 'start'. These can be altered
@@ -83,6 +84,31 @@ class MatrixClientPeg {
         this.matrixClient = null;
 
         MatrixActionCreators.stop();
+    }
+
+    /*
+     * If we've registered a user ID we set this to the ID of the
+     * user we've just registered. If they then go & log in, we
+     * can send them to the welcome user (obviously this doesn't
+     * guarentee they'll get a chat with the welcome user).
+     *
+     * @param {string} uid The user ID of the user we've just registered
+     */
+    setJustRegisteredUserId(uid) {
+        this._justRegisteredUserId = uid;
+    }
+
+    /*
+     * Returns true if the current user has just been registered by this
+     * client as determined by setJustRegisteredUserId()
+     *
+     * @returns {bool} True if user has just been registered
+     */
+    currentUserIsJustRegistered() {
+        return (
+            this.matrixClient &&
+            this.matrixClient.credentials.userId === this._justRegisteredUserId
+        );
     }
 
     /**

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1192,7 +1192,7 @@ export default React.createClass({
      */
     _onLoggedIn: async function() {
         this.setStateForNewView({ view: VIEWS.LOGGED_IN });
-        if (true || MatrixClientPeg.currentUserIsJustRegistered()) {
+        if (MatrixClientPeg.currentUserIsJustRegistered()) {
             MatrixClientPeg.setJustRegisteredUserId(null);
 
             if (this.props.config.welcomeUserId && getCurrentLanguage().startsWith("en")) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1191,9 +1191,14 @@ export default React.createClass({
                             return;
                         }
                     }
-                    // The user has just logged in after registering
+                    // We didn't rediret to the welcome user room, so show
+                    // the homepage.
                     dis.dispatch({action: 'view_home_page'});
                 });
+            } else {
+                // The user has just logged in after registering,
+                // so show the homepage.
+                dis.dispatch({action: 'view_home_page'});
             }
         } else {
             this._showScreenAfterLogin();

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -29,6 +29,7 @@ import * as ServerType from '../../views/auth/ServerTypeSelector';
 import AutoDiscoveryUtils, {ValidatedServerConfig} from "../../../utils/AutoDiscoveryUtils";
 import classNames from "classnames";
 import * as Lifecycle from '../../../Lifecycle';
+import MatrixClientPeg from "../../../MatrixClientPeg";
 
 // Phases
 // Show controls to configure server details
@@ -286,6 +287,8 @@ module.exports = React.createClass({
             });
             return;
         }
+
+        MatrixClientPeg.setJustRegisteredUserId(response.user_id);
 
         const newState = {
             doingUIAuth: false,


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/3101 meant we
don't get logged straight in after registering if using an email
address, but this was the point at which we made a chat with the
welcome user. Instead, set a flag in memory that we should try &
make a chat with the welcome user for that user ID if we get a
session for them.

Of course, if the user logs in on both tabs, this would mean each
would make a chat with the welcome user (although actually this
was a problem with the old code too). Check our m.direct to see if
we've started a chat with the welcome user before making one (which
also means we have to make sure the cached sync is up to date...
see comments).

Requires https://github.com/matrix-org/matrix-js-sdk/pull/956