### PR TITLE
Re-enable register button

### DIFF
--- a/res/css/structures/auth/_Login.scss
+++ b/res/css/structures/auth/_Login.scss
@@ -30,6 +30,7 @@ limitations under the License.
 
 .mx_Login_submit:disabled {
     opacity: 0.3;
+    cursor: default;
 }
 
 .mx_AuthBody a.mx_Login_sso_link:link,

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -180,7 +180,10 @@ module.exports = React.createClass({
                 serverConfig.hsUrl,
                 serverConfig.isUrl,
             );
-            this.setState({serverIsAlive: true});
+            this.setState({
+                serverIsAlive: true,
+                serverErrorIsFatal: false,
+            });
         } catch (e) {
             this.setState({
                 busy: false,


### PR DESCRIPTION
Register button disabling is done via serverErrorIsFatal so we need
to reset this on a successful validation.

Fixes https://github.com/vector-im/riot-web/issues/10029