### PR TITLE
Fix favicon/title badge count

### DIFF
--- a/src/RoomNotifs.js
+++ b/src/RoomNotifs.js
@@ -35,6 +35,27 @@ function _shouldShowMentionBadge(roomNotifState) {
     return roomNotifState !== MUTE;
 }
 
+export function countRoomsWithNotif(rooms) {
+    return rooms.reduce((result, room, index) => {
+        const roomNotifState = getRoomNotifsState(room.roomId);
+        const highlight = room.getUnreadNotificationCount('highlight') > 0;
+        const notificationCount = room.getUnreadNotificationCount();
+
+        const notifBadges = notificationCount > 0 && _shouldShowNotifBadge(roomNotifState);
+        const mentionBadges = highlight && _shouldShowMentionBadge(roomNotifState);
+        const isInvite = room.hasMembershipState(MatrixClientPeg.get().credentials.userId, 'invite');
+        const badges = notifBadges || mentionBadges || isInvite;
+
+        if (badges) {
+            result.count++;
+            if (highlight) {
+                result.highlight = true;
+            }
+        }
+        return result;
+    }, {count: 0, highlight: false});
+}
+
 export function aggregateNotificationCount(rooms) {
     return rooms.reduce((result, room, index) => {
         const roomNotifState = getRoomNotifsState(room.roomId);

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -54,6 +54,7 @@ import ResizeNotifier from "../../utils/ResizeNotifier";
 import { ValidatedServerConfig } from "../../utils/AutoDiscoveryUtils";
 import AutoDiscoveryUtils from "../../utils/AutoDiscoveryUtils";
 import DMRoomMap from '../../utils/DMRoomMap';
+import { countRoomsWithNotif } from '../../RoomNotifs';
 
 // Disable warnings for now: we use deprecated bluebird functions
 // and need to migrate, but they spam the console with warnings.
@@ -1749,19 +1750,7 @@ export default React.createClass({
     },
 
     updateStatusIndicator: function(state, prevState) {
-        let notifCount = 0;
-
-        const rooms = MatrixClientPeg.get().getRooms();
-        for (let i = 0; i < rooms.length; ++i) {
-            if (rooms[i].hasMembershipState(MatrixClientPeg.get().credentials.userId, 'invite')) {
-                notifCount++;
-            } else if (rooms[i].getUnreadNotificationCount()) {
-                // if we were summing unread notifs:
-                // notifCount += rooms[i].getUnreadNotificationCount();
-                // instead, we just count the number of rooms with notifs.
-                notifCount++;
-            }
-        }
+        let notifCount = countRoomsWithNotif(MatrixClientPeg.get().getRooms()).count;
 
         if (PlatformPeg.get()) {
             PlatformPeg.get().setErrorStatus(state === 'ERROR');

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1750,7 +1750,7 @@ export default React.createClass({
     },
 
     updateStatusIndicator: function(state, prevState) {
-        let notifCount = countRoomsWithNotif(MatrixClientPeg.get().getRooms()).count;
+        const notifCount = countRoomsWithNotif(MatrixClientPeg.get().getRooms()).count;
 
         if (PlatformPeg.get()) {
             PlatformPeg.get().setErrorStatus(state === 'ERROR');


### PR DESCRIPTION
This was using a separate function (in MatrixChat) that didn't
take into account whether we were supposed to be hiding the badge
for rooms so would include notifs that were hidden everywhere else.

Also make it a function & put it in RoomNotifs with all its friends.

Fixes https://github.com/vector-im/riot-web/issues/3060