### PR TITLE
Consider cancelled verifications when mounting IncomingSasDialog

### DIFF
--- a/src/components/views/dialogs/IncomingSasDialog.js
+++ b/src/components/views/dialogs/IncomingSasDialog.js
@@ -34,9 +34,15 @@ export default class IncomingSasDialog extends React.Component {
     constructor(props) {
         super(props);
 
+        let phase = PHASE_START;
+        if (this.props.verifier.cancelled) {
+            console.log("Verifier was cancelled in the background.");
+            phase = PHASE_CANCELLED;
+        }
+
         this._showSasEvent = null;
         this.state = {
-            phase: PHASE_START,
+            phase: phase,
             sasVerified: false,
             opponentProfile: null,
             opponentProfileError: null,
@@ -44,13 +50,6 @@ export default class IncomingSasDialog extends React.Component {
         this.props.verifier.on('show_sas', this._onVerifierShowSas);
         this.props.verifier.on('cancel', this._onVerifierCancel);
         this._fetchOpponentProfile();
-    }
-
-    componentWillMount() {
-        if (this.props.verifier.cancelled) {
-            console.log("Verifier was cancelled in the background.");
-            this.setState({phase: PHASE_CANCELLED});
-        }
     }
 
     componentWillUnmount() {

--- a/src/components/views/dialogs/IncomingSasDialog.js
+++ b/src/components/views/dialogs/IncomingSasDialog.js
@@ -46,6 +46,13 @@ export default class IncomingSasDialog extends React.Component {
         this._fetchOpponentProfile();
     }
 
+    componentWillMount() {
+        if (this.props.verifier.cancelled) {
+            console.log("Verifier was cancelled in the background.");
+            this.setState({phase: PHASE_CANCELLED});
+        }
+    }
+
     componentWillUnmount() {
         if (this.state.phase !== PHASE_CANCELLED && this.state.phase !== PHASE_VERIFIED) {
             this.props.verifier.cancel('User cancel');


### PR DESCRIPTION
The cancellation can be because of a background problem, or because the user received another verification request from the same user. The cancel function does get called, however due to the speed of our dialog handling the state ends up being lost forever. Instead of trying to de-layer dialogs, this just fastforwards the whole dialog to "cancelled" on mount if required.

Fixes https://github.com/vector-im/riot-web/issues/10118
Fixes https://github.com/vector-im/riot-web/issues/9103 (or maybe just the js-sdk PR does? idk)
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/961**