### PR TITLE
Disable left/right arrow navigating completions for now

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -682,14 +682,6 @@ export default class MessageComposerInput extends React.Component {
         if (this.autocomplete.countCompletions() > 0) {
             if (!(ev.ctrlKey || ev.shiftKey || ev.altKey || ev.metaKey)) {
                 switch (ev.keyCode) {
-                    case KeyCode.LEFT:
-                        this.autocomplete.moveSelection(-1);
-                        ev.preventDefault();
-                        return true;
-                    case KeyCode.RIGHT:
-                        this.autocomplete.moveSelection(+1);
-                        ev.preventDefault();
-                        return true;
                     case KeyCode.UP:
                         this.autocomplete.moveSelection(-1);
                         ev.preventDefault();


### PR DESCRIPTION
as the autocomplete is now very eager to appear, this breaks
caret navigation when typing e.g. anything with a colon.

Ideally, we should make the AC less eager to appear,
but this is a quick fix for now.

Related to https://github.com/vector-im/riot-web/issues/10116