### PR TITLE
Improve API and interactivity of new tooltip

### DIFF
--- a/src/components/views/elements/InteractiveTooltip.js
+++ b/src/components/views/elements/InteractiveTooltip.js
@@ -35,16 +35,8 @@ function getOrCreateContainer() {
 
 function isInRect(x, y, rect, buffer = 10) {
     const { top, right, bottom, left } = rect;
-
-    if (x < (left - buffer) || x > (right + buffer)) {
-        return false;
-    }
-
-    if (y < (top - buffer) || y > (bottom + buffer)) {
-        return false;
-    }
-
-    return true;
+    return x >= (left - buffer) && x <= (right + buffer)
+        && y >= (top - buffer) && y <= (bottom + buffer);
 }
 
 /*


### PR DESCRIPTION
This reworks the API the `InteractiveTooltip` component so that it's more
natural to use just like other React components. You can now supply the target
component as a child and the tooltip content as a prop.

In addition, this tweaks the interactivity to keep the tooltip on screen until
you move the mouse away from the tooltip and its target.

![tooltip-interaction](https://user-images.githubusercontent.com/279572/60036189-887ad680-96a6-11e9-8651-c63322ddf5fd.gif)

Part of https://github.com/vector-im/riot-web/issues/9753
Part of https://github.com/vector-im/riot-web/issues/9716