### PR TITLE
Fix room upgrade warning being chopped off and a spelling mistake

### DIFF
--- a/res/css/views/rooms/_RoomUpgradeWarningBar.scss
+++ b/res/css/views/rooms/_RoomUpgradeWarningBar.scss
@@ -15,17 +15,22 @@ limitations under the License.
 */
 
 .mx_RoomUpgradeWarningBar {
+    max-height: 235px;
+    background-color: $preview-bar-bg-color;
+    padding-left: 20px;
+    padding-right: 20px;
+    overflow: scroll;
+}
+
+.mx_RoomUpgradeWarningBar_wrapped {
+    width: 100%;
+    height: 100%;
+    display: flex;
     text-align: center;
-    height: 235px;
-    background-color: $event-selected-color;
     align-items: center;
     flex-direction: column;
     justify-content: center;
-    display: flex;
-    background-color: $preview-bar-bg-color;
     -webkit-align-items: center;
-    padding-left: 20px;
-    padding-right: 20px;
 }
 
 .mx_RoomUpgradeWarningBar_header {

--- a/src/components/views/dialogs/RoomUpgradeDialog.js
+++ b/src/components/views/dialogs/RoomUpgradeDialog.js
@@ -92,7 +92,7 @@ export default React.createClass({
                 <p>
                     {_t(
                         "Upgrading this room requires closing down the current " +
-                        "instance of the room and creating a new room it its place. " +
+                        "instance of the room and creating a new room in its place. " +
                         "To give room members the best possible experience, we will:",
                     )}
                 </p>

--- a/src/components/views/rooms/RoomUpgradeWarningBar.js
+++ b/src/components/views/rooms/RoomUpgradeWarningBar.js
@@ -97,20 +97,22 @@ module.exports = React.createClass({
 
         return (
             <div className="mx_RoomUpgradeWarningBar">
-                <div className="mx_RoomUpgradeWarningBar_header">
-                    {_t(
-                        "This room is running room version <roomVersion />, which this homeserver has " +
-                        "marked as <i>unstable</i>.",
-                        {},
-                        {
-                            "roomVersion": () => <code>{this.props.room.getVersion()}</code>,
-                            "i": (sub) => <i>{sub}</i>,
-                        },
-                    )}
-                </div>
-                {doUpgradeWarnings}
-                <div className="mx_RoomUpgradeWarningBar_small">
-                    {_t("Only room administrators will see this warning")}
+                <div className="mx_RoomUpgradeWarningBar_wrapped">
+                    <div className="mx_RoomUpgradeWarningBar_header">
+                        {_t(
+                            "This room is running room version <roomVersion />, which this homeserver has " +
+                            "marked as <i>unstable</i>.",
+                            {},
+                            {
+                                "roomVersion": () => <code>{this.props.room.getVersion()}</code>,
+                                "i": (sub) => <i>{sub}</i>,
+                            },
+                        )}
+                    </div>
+                    {doUpgradeWarnings}
+                    <div className="mx_RoomUpgradeWarningBar_small">
+                        {_t("Only room administrators will see this warning")}
+                    </div>
                 </div>
             </div>
         );

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1204,7 +1204,7 @@
     "The room upgrade could not be completed": "The room upgrade could not be completed",
     "Upgrade this room to version %(version)s": "Upgrade this room to version %(version)s",
     "Upgrade Room Version": "Upgrade Room Version",
-    "Upgrading this room requires closing down the current instance of the room and creating a new room it its place. To give room members the best possible experience, we will:": "Upgrading this room requires closing down the current instance of the room and creating a new room it its place. To give room members the best possible experience, we will:",
+    "Upgrading this room requires closing down the current instance of the room and creating a new room in its place. To give room members the best possible experience, we will:": "Upgrading this room requires closing down the current instance of the room and creating a new room in its place. To give room members the best possible experience, we will:",
     "Create a new room with the same name, description and avatar": "Create a new room with the same name, description and avatar",
     "Update any local room aliases to point to the new room": "Update any local room aliases to point to the new room",
     "Stop users from speaking in the old version of the room, and post a message advising users to move to the new room": "Stop users from speaking in the old version of the room, and post a message advising users to move to the new room",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9603

Squished:
![image](https://user-images.githubusercontent.com/1190097/60135765-ad7f5000-975f-11e9-8c15-d4f295d2fc0c.png)

Unsquished:
![image](https://user-images.githubusercontent.com/1190097/60135778-b2dc9a80-975f-11e9-8b2c-7682dca94fb8.png)

(note: I hacked my Riot to make version 1 be flagged as unstable)