### PR TITLE
Supply oobData to RoomPreviewBar

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1526,6 +1526,7 @@ module.exports = React.createClass({
                             error={this.state.roomLoadError}
                             loading={loading}
                             joining={this.state.joining}
+                            oobData={this.props.oobData}
                         />
                     </div>
                 );

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -238,9 +238,9 @@ module.exports = React.createClass({
             params: {
                 email: this.props.invitedEmail,
                 signurl: this.props.signUrl,
-                room_name: this.props.oobData.room_name,
-                room_avatar_url: this.props.oobData.avatarUrl,
-                inviter_name: this.props.oobData.inviterName,
+                room_name: this.props.oobData ? this.props.oobData.room_name : null,
+                room_avatar_url: this.props.oobData ? this.props.oobData.avatarUrl : null,
+                inviter_name: this.props.oobData ? this.props.oobData.inviterName : null,
             }
         };
     },

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -238,9 +238,9 @@ module.exports = React.createClass({
             params: {
                 email: this.props.invitedEmail,
                 signurl: this.props.signUrl,
-                room_name: this.props.oobData ? this.props.oobData.room_name : null,
-                room_avatar_url: this.props.oobData ? this.props.oobData.avatarUrl : null,
-                inviter_name: this.props.oobData ? this.props.oobData.inviterName : null,
+                room_name: this.props.oobData.room_name,
+                room_avatar_url: this.props.oobData.avatarUrl,
+                inviter_name: this.props.oobData.inviterName,
             }
         };
     },


### PR DESCRIPTION
Fixes the "buttons don't work" problem on https://github.com/vector-im/riot-web/issues/10114

Stack trace was "cannot read room_name of undefined", at these lines.