### PR TITLE
Fix the scrollbar in the community bar

### DIFF
--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -63,9 +63,8 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: 5px;
 
-    height: calc(100% - 5px);
+    height: 100%;
 }
 .mx_TagPanel .mx_TagPanel_tagTileContainer > div {
     height: 40px;

--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -65,7 +65,7 @@ limitations under the License.
     align-items: center;
     margin-top: 5px;
 
-    height: 100%;
+    height: calc(100% - 5px);
 }
 .mx_TagPanel .mx_TagPanel_tagTileContainer > div {
     height: 40px;


### PR DESCRIPTION
Currently the scrollbar is always visible because the inner container is 5px bigger in height than the outer container. This is hereby fixed.