### PR TITLE
Limit reactions row on initial display

### DIFF
--- a/res/css/views/messages/_ReactionsRow.scss
+++ b/res/css/views/messages/_ReactionsRow.scss
@@ -18,3 +18,17 @@ limitations under the License.
     margin: 6px 0;
     color: $primary-fg-color;
 }
+
+.mx_ReactionsRow_showAll {
+    text-decoration: none;
+    font-size: 10px;
+    font-weight: 600;
+    margin-left: 6px;
+    vertical-align: top;
+
+    &:hover,
+    &:link,
+    &:visited {
+        color: $accent-color;
+    }
+}

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -18,9 +18,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import sdk from '../../../index';
+import { _t } from '../../../languageHandler';
 import { isContentActionable } from '../../../utils/EventUtils';
 import { isSingleEmoji } from '../../../HtmlUtils';
 import MatrixClientPeg from '../../../MatrixClientPeg';
+
+// The maximum number of reactions to initially show on a message.
+const MAX_ITEMS_WHEN_LIMITED = 8;
 
 export default class ReactionsRow extends React.PureComponent {
     static propTypes = {
@@ -41,6 +45,7 @@ export default class ReactionsRow extends React.PureComponent {
 
         this.state = {
             myReactions: this.getMyReactions(),
+            showAll: false,
         };
     }
 
@@ -94,16 +99,22 @@ export default class ReactionsRow extends React.PureComponent {
         return [...myReactions.values()];
     }
 
+    onShowAllClick = () => {
+        this.setState({
+            showAll: true,
+        });
+    }
+
     render() {
         const { mxEvent, reactions } = this.props;
-        const { myReactions } = this.state;
+        const { myReactions, showAll } = this.state;
 
         if (!reactions || !isContentActionable(mxEvent)) {
             return null;
         }
 
         const ReactionsRowButton = sdk.getComponent('messages.ReactionsRowButton');
-        const items = reactions.getSortedAnnotationsByKey().map(([content, events]) => {
+        let items = reactions.getSortedAnnotationsByKey().map(([content, events]) => {
             if (!isSingleEmoji(content)) {
                 return null;
             }
@@ -125,10 +136,23 @@ export default class ReactionsRow extends React.PureComponent {
                 reactionEvents={events}
                 myReactionEvent={myReactionEvent}
             />;
-        });
+        }).filter(item => !!item);
+
+        let showAllLink;
+        if (items.length > MAX_ITEMS_WHEN_LIMITED && !showAll) {
+            items = items.slice(0, MAX_ITEMS_WHEN_LIMITED);
+            showAllLink = <a
+                className="mx_ReactionsRow_showAll"
+                href="#"
+                onClick={this.onShowAllClick}
+            >
+                {_t("Show all")}
+            </a>;
+        }
 
         return <div className="mx_ReactionsRow">
             {items}
+            {showAllLink}
         </div>;
     }
 }

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -141,10 +141,10 @@ export default class ReactionsRow extends React.PureComponent {
         // Show the first MAX_ITEMS if there are MAX_ITEMS + 1 or more items.
         // The "+ 1" ensure that the "show all" reveals something that takes up
         // more space than the button itself.
-        let showAllLink;
+        let showAllButton;
         if ((items.length > MAX_ITEMS_WHEN_LIMITED + 1) && !showAll) {
             items = items.slice(0, MAX_ITEMS_WHEN_LIMITED);
-            showAllLink = <a
+            showAllButton = <a
                 className="mx_ReactionsRow_showAll"
                 href="#"
                 onClick={this.onShowAllClick}
@@ -155,7 +155,7 @@ export default class ReactionsRow extends React.PureComponent {
 
         return <div className="mx_ReactionsRow">
             {items}
-            {showAllLink}
+            {showAllButton}
         </div>;
     }
 }

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -138,8 +138,11 @@ export default class ReactionsRow extends React.PureComponent {
             />;
         }).filter(item => !!item);
 
+        // Show the first MAX_ITEMS if there are MAX_ITEMS + 1 or more items.
+        // The "+ 1" ensure that the "show all" reveals something that takes up
+        // more space than the button itself.
         let showAllLink;
-        if (items.length > MAX_ITEMS_WHEN_LIMITED && !showAll) {
+        if ((items.length > MAX_ITEMS_WHEN_LIMITED + 1) && !showAll) {
             items = items.slice(0, MAX_ITEMS_WHEN_LIMITED);
             showAllLink = <a
                 className="mx_ReactionsRow_showAll"

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -944,6 +944,7 @@
     "Party Popper": "Party Popper",
     "Confused": "Confused",
     "Eyes": "Eyes",
+    "Show all": "Show all",
     "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>": "<reactors/><reactedWith>reacted with %(shortName)s</reactedWith>",
     "%(senderDisplayName)s changed the avatar for %(roomName)s": "%(senderDisplayName)s changed the avatar for %(roomName)s",
     "%(senderDisplayName)s removed the room avatar.": "%(senderDisplayName)s removed the room avatar.",


### PR DESCRIPTION
This limits the reactions row below messages to initially show at most 8 keys.
For those messages with more than that, a "Show all" option appears to reveal
all the keys.

<img width="491" alt="2019-06-27 at 13 22" src="https://user-images.githubusercontent.com/279572/60265849-a599ea00-98de-11e9-9dcf-d8c0710f38ff.png">

Fixes https://github.com/vector-im/riot-web/issues/9570