### PR TITLE
Fix weird scrollbar when devtools is in a narrow browser

### DIFF
--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -81,10 +81,6 @@ limitations under the License.
     padding: 10px;
 }
 
-.mx_DevTools_content .mx_Field_input {
-    display: inline-block;
-}
-
 .mx_DevTools_eventTypeStateKeyGroup {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/2403652/60288998-51f2c500-990d-11e9-8b3b-2a24616a851e.png)
After
![image](https://user-images.githubusercontent.com/2403652/60289007-57500f80-990d-11e9-9573-44b14c3187de.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>