### PR TITLE
On User.avatarUrl and User.displayName update top left menu

### DIFF
--- a/src/components/structures/TopLeftMenuButton.js
+++ b/src/components/structures/TopLeftMenuButton.js
@@ -62,8 +62,30 @@ export default class TopLeftMenuButton extends React.Component {
         };
     }
 
+    _onAvatarUrlChanged = (ev, user) => {
+        this.setState({
+            profileInfo: {
+                ...this.state.profileInfo,
+                avatarUrl: user.avatarUrl,
+            },
+        });
+    };
+
+    _onDisplayNameChanged = (ev, user) => {
+        this.setState({
+            profileInfo: {
+                ...this.state.profileInfo,
+                name: user.displayName,
+            },
+        });
+    };
+
     async componentDidMount() {
         this._dispatcherRef = dis.register(this.onAction);
+
+        const cli = MatrixClientPeg.get();
+        cli.on("User.avatarUrl", this._onAvatarUrlChanged);
+        cli.on("User.displayName", this._onDisplayNameChanged);
 
         try {
             const profileInfo = await this._getProfileInfo();
@@ -76,6 +98,12 @@ export default class TopLeftMenuButton extends React.Component {
 
     componentWillUnmount() {
         dis.unregister(this._dispatcherRef);
+
+        const cli = MatrixClientPeg.get();
+        if (cli) {
+            cli.removeListener("User.avatarUrl", this._onAvatarUrlChanged);
+            cli.removeListener("User.displayName", this._onDisplayNameChanged);
+        }
     }
 
     onAction = (payload) => {


### PR DESCRIPTION
So annoyingly this event in js-sdk seems like it'll only work on presence-enabled HSes:
https://github.com/matrix-org/matrix-js-sdk/blob/18655421923506225b12448d386db881c54edae0/src/models/user.js#L87-L94

Fixes https://github.com/vector-im/riot-web/issues/8570

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>