### PR TITLE
Append keyshare request dialogs instead of replacing the current dialog

### DIFF
--- a/src/KeyRequestHandler.js
+++ b/src/KeyRequestHandler.js
@@ -125,7 +125,7 @@ export default class KeyRequestHandler {
         };
 
         const KeyShareDialog = sdk.getComponent("dialogs.KeyShareDialog");
-        Modal.createTrackedDialog('Key Share', 'Process Next Request', KeyShareDialog, {
+        Modal.appendTrackedDialog('Key Share', 'Process Next Request', KeyShareDialog, {
             matrixClient: this._matrixClient,
             userId: userId,
             deviceId: deviceId,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8798

By default, Modal dialogs are put up front. For this particular dialog we don't need to deal with it right away, therefore it can wait.