### PR TITLE
Perform a local rejection for failed invite rejections,

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -489,13 +489,13 @@ export default React.createClass({
                                 if (error.httpStatus === 404) {
                                     const room = cli.getRoom(payload.room_id);
                                     if (room && room.getMyMembership() === "invite") {
-                                        return cli.store.getSavedSync().then((data) => {
+                                        return cli.store.getNextBatchToken().then((nextBatch) => {
                                             this.state.room.updateMyMembership("leave");
                                             cli.store.setSyncData({
                                                 rooms: {
                                                     leave: {[payload.room_id]: {}},
                                                 },
-                                                next_batch: data.nextBatch,
+                                                next_batch: nextBatch,
                                             });
                                             return Promise.resolve();
                                         });

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1274,13 +1274,13 @@ module.exports = React.createClass({
             // if rejecting invite fails, perform a local-rejection because Synapse does not send it down sync-stream
             // TODO improve this condition once 404 on /leave is actually specced
             if (error.httpStatus === 404 && this.state.room && this.state.room.getMyMembership() === "invite") {
-                return cli.store.getSavedSync().then((data) => {
+                return cli.store.getNextBatchToken().then((nextBatch) => {
                     this.state.room.updateMyMembership("leave");
                     cli.store.setSyncData({
                         rooms: {
                             leave: {[this.state.roomId]: {}},
                         },
-                        next_batch: data.nextBatch,
+                        next_batch: nextBatch,
                     });
                     return Promise.resolve();
                 });


### PR DESCRIPTION
which synapse does not send its own local-rejection down sync

Fixes https://github.com/vector-im/riot-web/issues/3743
![3743](https://user-images.githubusercontent.com/2403652/60416943-06733c00-9bd7-11e9-978e-8b73a171521c.gif)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>