### PR TITLE
 Handle associated event send failures

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -201,8 +201,12 @@ div.mx_EventTile_notSent.mx_EventTile_redacted .mx_UnknownBody {
 
 .mx_EventTile_highlight,
 .mx_EventTile_highlight .markdown-body
- {
-    color: $warning-color;
+{
+    color: $event-highlight-fg-color;
+
+    .mx_EventTile_line {
+        background-color: $event-highlight-bg-color;
+    }
 }
 
 .mx_EventTile_contextual {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -171,12 +171,19 @@ limitations under the License.
     opacity: 0.4;
 }
 
+div.mx_EventTile_notSent.mx_EventTile_redacted .mx_UnknownBody {
+    --lozenge-color: $event-notsent-color !important;
+    --lozenge-border-color: $event-notsent-color !important;
+}
+
 .mx_EventTile_notSent {
     color: $event-notsent-color;
 }
 
 .mx_EventTile_redacted .mx_EventTile_line .mx_UnknownBody,
 .mx_EventTile_redacted .mx_EventTile_reply .mx_UnknownBody {
+    --lozenge-color: $event-redacted-fg-color;
+    --lozenge-border-color: $event-redacted-border-color;
     display: block;
     width: 100%;
     height: 22px;
@@ -184,12 +191,12 @@ limitations under the License.
     border-radius: 11px;
     background: repeating-linear-gradient(
         -45deg,
-        $event-redacted-fg-color,
-        $event-redacted-fg-color 3px,
+        var(--lozenge-color),
+        var(--lozenge-color) 3px,
         transparent 3px,
         transparent 6px
     );
-    box-shadow: 0px 0px 3px $event-redacted-border-color inset;
+    box-shadow: 0px 0px 3px var(--lozenge-border-color) inset;
 }
 
 .mx_EventTile_highlight,

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -121,6 +121,9 @@ $event-sending-color: $text-secondary-color;
 $event-redacted-fg-color: #606060;
 $event-redacted-border-color: #000000;
 
+$event-highlight-fg-color: $warning-color;
+$event-highlight-bg-color: $event-selected-color;
+
 // event timestamp
 $event-timestamp-color: $text-secondary-color;
 

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -195,10 +195,12 @@ $panel-divider-color: #dee1f3;
 $widget-menu-bar-bg-color: $secondary-accent-color;
 
 // ********************
+
 // both $event-highlight-bg-color and $room-warning-bg-color share this value,
 // so to not make their order dependent on who depends on who, have a shared value
 // defined before both
 $yellow-background: #fff8e3;
+
 // event tile lifecycle
 $event-encrypting-color: #abddbc;
 $event-sending-color: #ddd;

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -195,11 +195,17 @@ $panel-divider-color: #dee1f3;
 $widget-menu-bar-bg-color: $secondary-accent-color;
 
 // ********************
-
+// both $event-highlight-bg-color and $room-warning-bg-color share this value,
+// so to not make their order dependent on who depends on who, have a shared value
+// defined before both
+$yellow-background: #fff8e3;
 // event tile lifecycle
 $event-encrypting-color: #abddbc;
 $event-sending-color: #ddd;
 $event-notsent-color: #f44;
+
+$event-highlight-fg-color: $warning-color;
+$event-highlight-bg-color: $yellow-background;
 
 // event redaction
 $event-redacted-fg-color: #e2e2e2;
@@ -244,7 +250,7 @@ $togglesw-ball-color: #fff;
 
 $progressbar-color: #000;
 
-$room-warning-bg-color: #fff8e3;
+$room-warning-bg-color: $yellow-background;
 
 $memberstatus-placeholder-color: $roomtile-name-color;
 

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -214,6 +214,9 @@ module.exports = React.createClass({
     // after an update to the contents of the panel, check that the scroll is
     // where it ought to be, and set off pagination requests if necessary.
     checkScroll: function() {
+        if (this.unmounted) {
+            return;
+        }
         this._restoreSavedScrollState();
         this.checkFillState();
     },

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -90,6 +90,11 @@ module.exports = React.createClass({
         this.closeMenu();
     },
 
+    onResendEditClick: function() {
+        Resend.resend(this.props.mxEvent.replacingEvent());
+        this.closeMenu();
+    },
+
     e2eInfoClicked: function() {
         this.props.e2eInfoCallback();
         this.closeMenu();
@@ -220,6 +225,8 @@ module.exports = React.createClass({
     render: function() {
         const mxEvent = this.props.mxEvent;
         const eventStatus = mxEvent.status;
+        const editEvent = mxEvent.replacingEvent();
+        const editStatus = editEvent && editEvent.status;
         let resendButton;
         let redactButton;
         let cancelButton;
@@ -238,6 +245,14 @@ module.exports = React.createClass({
             resendButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onResendClick}>
                     { _t('Resend') }
+                </div>
+            );
+        }
+
+        if (editStatus === EventStatus.NOT_SENT) {
+            resendButton = (
+                <div className="mx_MessageContextMenu_field" onClick={this.onResendEditClick}>
+                    { _t('Resend edit') }
                 </div>
             );
         }

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -95,6 +95,11 @@ module.exports = React.createClass({
         this.closeMenu();
     },
 
+    onResendRedactionClick: function() {
+        Resend.resend(this.props.mxEvent.localRedactionEvent());
+        this.closeMenu();
+    },
+
     e2eInfoClicked: function() {
         this.props.e2eInfoCallback();
         this.closeMenu();
@@ -225,8 +230,8 @@ module.exports = React.createClass({
     render: function() {
         const mxEvent = this.props.mxEvent;
         const eventStatus = mxEvent.status;
-        const editEvent = mxEvent.replacingEvent();
-        const editStatus = editEvent && editEvent.status;
+        const editStatus = mxEvent.replacingEvent() && mxEvent.replacingEvent().status;
+        const redactStatus = mxEvent.localRedactionEvent() && mxEvent.localRedactionEvent().status;
         let resendButton;
         let redactButton;
         let cancelButton;
@@ -253,6 +258,14 @@ module.exports = React.createClass({
             resendButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onResendEditClick}>
                     { _t('Resend edit') }
+                </div>
+            );
+        }
+
+        if (redactStatus === EventStatus.NOT_SENT) {
+            resendButton = (
+                <div className="mx_MessageContextMenu_field" onClick={this.onResendRedactionClick}>
+                    { _t('Resend removal') }
                 </div>
             );
         }

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -233,6 +233,8 @@ module.exports = React.createClass({
         const editStatus = mxEvent.replacingEvent() && mxEvent.replacingEvent().status;
         const redactStatus = mxEvent.localRedactionEvent() && mxEvent.localRedactionEvent().status;
         let resendButton;
+        let resendEditButton;
+        let resendRedactionButton;
         let redactButton;
         let cancelButton;
         let forwardButton;
@@ -255,7 +257,7 @@ module.exports = React.createClass({
         }
 
         if (editStatus === EventStatus.NOT_SENT) {
-            resendButton = (
+            resendEditButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onResendEditClick}>
                     { _t('Resend edit') }
                 </div>
@@ -263,7 +265,7 @@ module.exports = React.createClass({
         }
 
         if (redactStatus === EventStatus.NOT_SENT) {
-            resendButton = (
+            resendRedactionButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onResendRedactionClick}>
                     { _t('Resend removal') }
                 </div>
@@ -380,6 +382,9 @@ module.exports = React.createClass({
         return (
             <div className="mx_MessageContextMenu">
                 { resendButton }
+                { resendEditButton }
+                { resendReactionsButton }
+                { resendRedactionButton }
                 { redactButton }
                 { cancelButton }
                 { forwardButton }

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -269,29 +269,30 @@ module.exports = React.createClass({
 
         // status is SENT before remote-echo, null after
         const isSent = !eventStatus || eventStatus === EventStatus.SENT;
+        if (!mxEvent.isRedacted()) {
+            if (eventStatus === EventStatus.NOT_SENT) {
+                resendButton = (
+                    <div className="mx_MessageContextMenu_field" onClick={this.onResendClick}>
+                        { _t('Resend') }
+                    </div>
+                );
+            }
 
-        if (eventStatus === EventStatus.NOT_SENT) {
-            resendButton = (
-                <div className="mx_MessageContextMenu_field" onClick={this.onResendClick}>
-                    { _t('Resend') }
-                </div>
-            );
-        }
+            if (editStatus === EventStatus.NOT_SENT) {
+                resendEditButton = (
+                    <div className="mx_MessageContextMenu_field" onClick={this.onResendEditClick}>
+                        { _t('Resend edit') }
+                    </div>
+                );
+            }
 
-        if (editStatus === EventStatus.NOT_SENT) {
-            resendEditButton = (
-                <div className="mx_MessageContextMenu_field" onClick={this.onResendEditClick}>
-                    { _t('Resend edit') }
-                </div>
-            );
-        }
-
-        if (unsentReactionsCount !== 0) {
-            resendReactionsButton = (
-                <div className="mx_MessageContextMenu_field" onClick={this.onResendReactionsClick}>
-                    { _t('Resend %(unsentCount)s reactions', {unsentCount: unsentReactionsCount}) }
-                </div>
-            );
+            if (unsentReactionsCount !== 0) {
+                resendReactionsButton = (
+                    <div className="mx_MessageContextMenu_field" onClick={this.onResendReactionsClick}>
+                        { _t('Resend %(unsentCount)s reactions', {unsentCount: unsentReactionsCount}) }
+                    </div>
+                );
+            }
         }
 
         if (redactStatus === EventStatus.NOT_SENT) {

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -206,7 +206,10 @@ export default class MessageEditor extends React.Component {
     _cancelPreviousPendingEdit() {
         const originalEvent = this.props.editState.getEvent();
         const previousEdit = originalEvent.replacingEvent();
-        if (previousEdit && (previousEdit.status === EventStatus.QUEUED || previousEdit.status === EventStatus.NOT_SENT)) {
+        if (previousEdit && (
+            previousEdit.status === EventStatus.QUEUED ||
+            previousEdit.status === EventStatus.NOT_SENT
+        )) {
             this.context.matrixClient.cancelPendingEvent(previousEdit);
         }
     }

--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -206,7 +206,7 @@ export default class MessageEditor extends React.Component {
     _cancelPreviousPendingEdit() {
         const originalEvent = this.props.editState.getEvent();
         const previousEdit = originalEvent.replacingEvent();
-        if (previousEdit.status === EventStatus.QUEUED || previousEdit.status === EventStatus.NOT_SENT) {
+        if (previousEdit && (previousEdit.status === EventStatus.QUEUED || previousEdit.status === EventStatus.NOT_SENT)) {
             this.context.matrixClient.cancelPendingEvent(previousEdit);
         }
     }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -681,7 +681,7 @@ module.exports = withMatrixClient(React.createClass({
             </div> : null;
 
         let reactionsRow;
-        if (SettingsStore.isFeatureEnabled("feature_reactions")) {
+        if (SettingsStore.isFeatureEnabled("feature_reactions") && !isRedacted) {
             const ReactionsRow = sdk.getComponent('messages.ReactionsRow');
             reactionsRow = <ReactionsRow
                 mxEvent={this.props.mxEvent}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1303,7 +1303,7 @@
     "You cannot delete this message. (%(code)s)": "You cannot delete this message. (%(code)s)",
     "Resend": "Resend",
     "Resend edit": "Resend edit",
-    "Resend %(unsentCount)s reactions": "Resend %(unsentCount)s reactions",
+    "Resend %(unsentCount)s reaction(s)": "Resend %(unsentCount)s reaction(s)",
     "Resend removal": "Resend removal",
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1303,6 +1303,7 @@
     "You cannot delete this message. (%(code)s)": "You cannot delete this message. (%(code)s)",
     "Resend": "Resend",
     "Resend edit": "Resend edit",
+    "Resend removal": "Resend removal",
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",
     "Pin Message": "Pin Message",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1303,6 +1303,7 @@
     "You cannot delete this message. (%(code)s)": "You cannot delete this message. (%(code)s)",
     "Resend": "Resend",
     "Resend edit": "Resend edit",
+    "Resend %(unsentCount)s reactions": "Resend %(unsentCount)s reactions",
     "Resend removal": "Resend removal",
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1302,6 +1302,7 @@
     "Unable to reject invite": "Unable to reject invite",
     "You cannot delete this message. (%(code)s)": "You cannot delete this message. (%(code)s)",
     "Resend": "Resend",
+    "Resend edit": "Resend edit",
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",
     "Pin Message": "Pin Message",


### PR DESCRIPTION
Implements https://github.com/vector-im/riot-web/issues/10189
JS-SDK PR: https://github.com/matrix-org/matrix-js-sdk/pull/972

Below is a demo of:
 1. editing
 1. reacting
 1. removing
 1. cancelling (anything that is queued up, be it the event itself, or any associated event like an edit, reaction or redaction)

![send-failures](https://user-images.githubusercontent.com/274386/60526095-2c840380-9cdf-11e9-89ac-2597deddaffb.gif)

The multiple resend options in the context menu might not be the final UX, but this is a good start to gather feedback.

Also adds a background color to highlighted messages so they are distinguishable from send errors:

![image](https://user-images.githubusercontent.com/274386/60529587-6f95a500-9ce6-11e9-8f0f-64b338bd9d76.png)
