### PR TITLE
Fix login type selector border

### DIFF
--- a/res/css/structures/auth/_Login.scss
+++ b/res/css/structures/auth/_Login.scss
@@ -83,11 +83,7 @@ limitations under the License.
 }
 
 .mx_Login_type_label {
-    flex-grow: 1;
-}
-
-.mx_Login_type_dropdown {
-    min-width: 200px;
+    flex: 1;
 }
 
 .mx_Login_underlinedServerName {

--- a/src/components/views/auth/PasswordLogin.js
+++ b/src/components/views/auth/PasswordLogin.js
@@ -312,7 +312,6 @@ export default class PasswordLogin extends React.Component {
                 <div className="mx_Login_type_container">
                     <label className="mx_Login_type_label">{ _t('Sign in with') }</label>
                     <Field
-                        className="mx_Login_type_dropdown"
                         id="mx_PasswordLogin_type"
                         element="select"
                         value={this.state.loginType}


### PR DESCRIPTION
This fixes a regression in the login type selector's border and placement.

<img width="399" alt="2019-07-02 at 15 09" src="https://user-images.githubusercontent.com/279572/60519512-a0bca800-9cdb-11e9-8698-6b90a481304c.png">

Fixes https://github.com/vector-im/riot-web/issues/10223