### PR TITLE
Treat rooms with pending events as read

### DIFF
--- a/src/Unread.js
+++ b/src/Unread.js
@@ -42,11 +42,6 @@ module.exports = {
     doesRoomHaveUnreadMessages: function(room) {
         const myUserId = MatrixClientPeg.get().credentials.userId;
 
-        // get the most recent read receipt sent by our account.
-        // N.B. this is NOT a read marker (RM, aka "read up to marker"),
-        // despite the name of the method :((
-        const readUpToId = room.getEventReadUpTo(myUserId);
-
         // as we don't send RRs for our own messages, make sure we special case that
         // if *we* sent the last message into the room, we consider it not unread!
         // Should fix: https://github.com/vector-im/riot-web/issues/3263
@@ -58,6 +53,11 @@ module.exports = {
             room.timeline[room.timeline.length - 1].sender.userId === myUserId) {
             return false;
         }
+
+        // get the most recent read receipt sent by our account.
+        // N.B. this is NOT a read marker (RM, aka "read up to marker"),
+        // despite the name of the method :((
+        const readUpToId = room.getEventReadUpTo(myUserId);
 
         // this just looks at whatever history we have, which if we've only just started
         // up probably won't be very much, so if the last couple of events are ones that

--- a/src/Unread.js
+++ b/src/Unread.js
@@ -42,6 +42,14 @@ module.exports = {
     doesRoomHaveUnreadMessages: function(room) {
         const myUserId = MatrixClientPeg.get().credentials.userId;
 
+        // If the room has pending events, assume that means you are active in
+        // the room, and so it should be treated as read. This also ensures that
+        // local echoes of pending events do not cause rooms to temporarily
+        // appear unread as in https://github.com/vector-im/riot-web/issues/9952.
+        if (room.getPendingEvents().length > 0) {
+            return false;
+        }
+
         // as we don't send RRs for our own messages, make sure we special case that
         // if *we* sent the last message into the room, we consider it not unread!
         // Should fix: https://github.com/vector-im/riot-web/issues/3263


### PR DESCRIPTION
This changes the room unread logic to mark any room with pending events as read,
under the assumption that you are active in the room. This also ensures that
local echoes of pending events do not cause rooms to temporarily appear unread.

Fixes https://github.com/vector-im/riot-web/issues/9952