### PR TITLE
Track live events in timeline and use for read receipts and read markers

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -2,6 +2,7 @@
 Copyright 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 Copyright 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This changes the `TimelinePanel` to track live events (that have committed to
the server and been remote echoed) as well as the full list of events (which
includes pending events).

The code paths that advance read receipt and read markers are then changed to
only use the live events so that these cannot advance into pending events.

Fixes https://github.com/vector-im/riot-web/issues/9952