### PR TITLE
Allow diplayed reaction values to contain anything

### DIFF
--- a/res/css/views/messages/_ReactionsRowButton.scss
+++ b/res/css/views/messages/_ReactionsRowButton.scss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .mx_ReactionsRowButton {
-    display: inline-block;
+    display: inline-flex;
     height: 20px;
     line-height: 21px;
     margin-right: 6px;
@@ -34,4 +34,12 @@ limitations under the License.
         background-color: $reaction-row-button-selected-bg-color;
         border-color: $reaction-row-button-selected-border-color;
     }
+}
+
+.mx_ReactionsRowButton_content {
+    max-width: 100px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding-right: 4px;
 }

--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -66,17 +66,8 @@ const VARIATION_SELECTOR = String.fromCharCode(0xFE0F);
  * need emojification.
  * unicodeToImage uses this function.
  */
-export function mightContainEmoji(str) {
+function mightContainEmoji(str) {
     return SURROGATE_PAIR_PATTERN.test(str) || SYMBOL_PATTERN.test(str);
-}
-
-/**
- * Returns true if the string definitely contains a single emoji.
- * @param {String} str String to test
- * @return {Boolean}
- */
-export function isSingleEmoji(str) {
-    return mightContainEmoji(str) && SINGLE_EMOJI_REGEX.test(str);
 }
 
 /**

--- a/src/components/views/messages/ReactionsRow.js
+++ b/src/components/views/messages/ReactionsRow.js
@@ -20,7 +20,6 @@ import PropTypes from 'prop-types';
 import sdk from '../../../index';
 import { _t } from '../../../languageHandler';
 import { isContentActionable } from '../../../utils/EventUtils';
-import { isSingleEmoji } from '../../../HtmlUtils';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 
 // The maximum number of reactions to initially show on a message.
@@ -115,9 +114,6 @@ export default class ReactionsRow extends React.PureComponent {
 
         const ReactionsRowButton = sdk.getComponent('messages.ReactionsRowButton');
         let items = reactions.getSortedAnnotationsByKey().map(([content, events]) => {
-            if (!isSingleEmoji(content)) {
-                return null;
-            }
             const count = events.size;
             if (!count) {
                 return null;

--- a/src/components/views/messages/ReactionsRowButton.js
+++ b/src/components/views/messages/ReactionsRowButton.js
@@ -101,7 +101,12 @@ export default class ReactionsRowButton extends React.PureComponent {
             onMouseOver={this.onMouseOver}
             onMouseOut={this.onMouseOut}
         >
-            {content} {count}
+            <span className="mx_ReactionsRowButton_content">
+                {content}
+            </span>
+            <span className="mx_ReactionsRowButton_count">
+                {count}
+            </span>
             {tooltip}
         </span>;
     }


### PR DESCRIPTION
This removes the requirement that reactions be a single emoji value. As a compromise to keep some amount of visual sanity, the width is clamped to be at most 100px.

<img width="299" alt="2019-07-05 at 16 16" src="https://user-images.githubusercontent.com/279572/60731970-c39bc600-9f40-11e9-911f-7684736cf21b.png">

Fixes https://github.com/vector-im/riot-web/issues/10256