### PR TITLE
Fix React crash when using a non-default homeserver on soft logout

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -193,12 +193,19 @@ class MatrixClientPeg {
      * Throws an error if unable to deduce the homeserver name
      * (eg. if the user is not logged in)
      */
-    getHomeServerName() {
+    getHomeserverName() {
         const matches = /^@.+:(.+)$/.exec(this.matrixClient.credentials.userId);
         if (matches === null || matches.length < 1) {
             throw new Error("Failed to derive homeserver name from user ID!");
         }
         return matches[1];
+    }
+
+    /**
+     * @deprecated Use getHomeserverName() instead (correct spelling)
+     */
+    getHomeServerName() {
+        return this.getHomeserverName();
     }
 
     _createClient(creds: MatrixClientCreds) {

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -201,13 +201,6 @@ class MatrixClientPeg {
         return matches[1];
     }
 
-    /**
-     * @deprecated Use getHomeserverName() instead (correct spelling)
-     */
-    getHomeServerName() {
-        return this.getHomeserverName();
-    }
-
     _createClient(creds: MatrixClientCreds) {
         const aggregateRelations = SettingsStore.isFeatureEnabled("feature_reactions");
         const enableEdits = SettingsStore.isFeatureEnabled("feature_message_editing");

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -145,7 +145,7 @@ module.exports = React.createClass({
         // too. If it's changed, appending to the list will corrupt it.
         const my_next_batch = this.nextBatch;
         const opts = {limit: 20};
-        if (my_server != MatrixClientPeg.getHomeServerName()) {
+        if (my_server != MatrixClientPeg.getHomeserverName()) {
             opts.server = my_server;
         }
         if (this.state.instanceId) {

--- a/src/components/structures/auth/SoftLogout.js
+++ b/src/components/structures/auth/SoftLogout.js
@@ -37,7 +37,7 @@ export default class SoftLogout extends React.Component {
         const hsUrl = MatrixClientPeg.get().getHomeserverUrl();
         const domainName = hsUrl === defaultServerConfig.hsUrl
             ? defaultServerConfig.hsName
-            : MatrixClientPeg.get().getHomeServerName();
+            : MatrixClientPeg.getHomeserverName();
 
         const userId = MatrixClientPeg.get().getUserId();
         const user = MatrixClientPeg.get().getUser(userId);

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -37,7 +37,7 @@ export default class NetworkDropdown extends React.Component {
 
         this.inputTextBox = null;
 
-        const server = MatrixClientPeg.getHomeServerName();
+        const server = MatrixClientPeg.getHomeserverName();
         this.state = {
             expanded: false,
             selectedServer: server,
@@ -138,8 +138,8 @@ export default class NetworkDropdown extends React.Component {
             servers = servers.concat(roomDirectory.servers);
         }
 
-        if (!servers.includes(MatrixClientPeg.getHomeServerName())) {
-            servers.unshift(MatrixClientPeg.getHomeServerName());
+        if (!servers.includes(MatrixClientPeg.getHomeserverName())) {
+            servers.unshift(MatrixClientPeg.getHomeserverName());
         }
 
         // For our own HS, we can use the instance_ids given in the third party protocols
@@ -148,7 +148,7 @@ export default class NetworkDropdown extends React.Component {
         // we can only show the default room list.
         for (const server of servers) {
             options.push(this._makeMenuOption(server, null, true));
-            if (server === MatrixClientPeg.getHomeServerName()) {
+            if (server === MatrixClientPeg.getHomeserverName()) {
                 options.push(this._makeMenuOption(server, null, false));
                 if (this.props.protocols) {
                     for (const proto of Object.keys(this.props.protocols)) {


### PR DESCRIPTION
The function used exists on the peg, not the client. This commit also fixes the name of the function in a backwards compatible way.