### PR TITLE
Take server-side aggregation into account for timestamp on (edited) tooltip

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -364,11 +364,11 @@ module.exports = React.createClass({
         let editedTooltip;
         if (this.state.editedMarkerHovered) {
             const Tooltip = sdk.getComponent('elements.Tooltip');
-            const editEvent = this.props.mxEvent.replacingEvent();
-            const date = editEvent && formatDate(editEvent.getDate());
+            const date = this.props.mxEvent.replacingEventDate();
+            const dateString = date && formatDate(date);
             editedTooltip = <Tooltip
                 tooltipClassName="mx_Tooltip_timeline"
-                label={_t("Edited at %(date)s. Click to view edits.", {date})}
+                label={_t("Edited at %(date)s. Click to view edits.", {date: dateString})}
             />;
         }
         return (


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/9834
Needs https://github.com/matrix-org/matrix-js-sdk/pull/984

![ssa](https://user-images.githubusercontent.com/274386/60877057-92671280-a22c-11e9-8022-1e1a1d117847.png)
