### PR TITLE
Use the state variable for the password when deactivating

### DIFF
--- a/src/components/views/dialogs/DeactivateAccountDialog.js
+++ b/src/components/views/dialogs/DeactivateAccountDialog.js
@@ -64,13 +64,13 @@ export default class DeactivateAccountDialog extends React.Component {
             const auth = {
                 type: 'm.login.password',
                 user: MatrixClientPeg.get().credentials.userId,
-                password: this._passwordField.value,
+                password: this.state.password,
             };
             await MatrixClientPeg.get().deactivateAccount(auth, this.state.shouldErase);
         } catch (err) {
             let errStr = _t('Unknown error');
             // https://matrix.org/jira/browse/SYN-744
-            if (err.httpStatus == 401 || err.httpStatus == 403) {
+            if (err.httpStatus === 401 || err.httpStatus === 403) {
                 errStr = _t('Incorrect password');
                 Velocity(this._passwordField, "callout.shake", 300);
             }


### PR DESCRIPTION
The `Field` is controlled, so we should be using the state. Otherwise the value is undefined, which means we don't supply the required auth.

Fixes https://github.com/vector-im/riot-web/issues/10302
Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/3071