### PR TITLE
Fix field styling regression

### DIFF
--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -59,7 +59,7 @@ limitations under the License.
     }
 
     .mx_Field_labelAlwaysTopLeft label,
-    .mx_Field select + label, /* Always show a select's label on top to not collide with the value */,
+    .mx_Field select + label /* Always show a select's label on top to not collide with the value */,
     .mx_Field input:focus + label,
     .mx_Field input:not(:placeholder-shown) + label,
     .mx_Field textarea:focus + label,

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -111,7 +111,7 @@ limitations under the License.
 }
 
 .mx_Field_labelAlwaysTopLeft label,
-.mx_Field select + label, /* Always show a select's label on top to not collide with the value */,
+.mx_Field select + label /* Always show a select's label on top to not collide with the value */,
 .mx_Field input:focus + label,
 .mx_Field input:not(:placeholder-shown) + label,
 .mx_Field textarea:focus + label,


### PR DESCRIPTION
The extra comma in the selectors caused this rule set to be ignored.

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3200
Fixes https://github.com/vector-im/riot-web/issues/10311