### PR TITLE
Hide/show presence based on capabilities per MSC1862

### DIFF
--- a/src/components/views/rooms/MemberInfo.js
+++ b/src/components/views/rooms/MemberInfo.js
@@ -89,6 +89,17 @@ module.exports = withMatrixClient(React.createClass({
         cli.on("RoomMember.membership", this.onRoomMemberMembership);
         cli.on("accountData", this.onAccountData);
 
+        const enablePresenceByHsUrl = SdkConfig.get()["enable_presence_by_hs_url"];
+        this._showPresence = true;
+        if (enablePresenceByHsUrl && enablePresenceByHsUrl[cli.baseUrl] !== undefined) {
+            this._showPresence = enablePresenceByHsUrl[cli.baseUrl];
+        }
+        cli.getCapabilities().then((caps) => {
+            if (!caps["m.presence"]) {
+                return;
+            }
+            this._showPresence = caps["m.presence"]["receive_enabled"];
+        });
         this._checkIgnoreState();
     },
 
@@ -922,15 +933,8 @@ module.exports = withMatrixClient(React.createClass({
         const powerLevelEvent = room ? room.currentState.getStateEvents("m.room.power_levels", "") : null;
         const powerLevelUsersDefault = powerLevelEvent ? powerLevelEvent.getContent().users_default : 0;
 
-        const enablePresenceByHsUrl = SdkConfig.get()["enable_presence_by_hs_url"];
-        const hsUrl = this.props.matrixClient.baseUrl;
-        let showPresence = true;
-        if (enablePresenceByHsUrl && enablePresenceByHsUrl[hsUrl] !== undefined) {
-            showPresence = enablePresenceByHsUrl[hsUrl];
-        }
-
         let presenceLabel = null;
-        if (showPresence) {
+        if (this._showPresence) {
             const PresenceLabel = sdk.getComponent('rooms.PresenceLabel');
             presenceLabel = <PresenceLabel activeAgo={presenceLastActiveAgo}
                 currentlyActive={presenceCurrentlyActive}

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -55,11 +55,16 @@ module.exports = React.createClass({
         }
         cli.on("Room", this.onRoom); // invites & joining after peek
         const enablePresenceByHsUrl = SdkConfig.get()["enable_presence_by_hs_url"];
-        const hsUrl = MatrixClientPeg.get().baseUrl;
         this._showPresence = true;
-        if (enablePresenceByHsUrl && enablePresenceByHsUrl[hsUrl] !== undefined) {
-            this._showPresence = enablePresenceByHsUrl[hsUrl];
+        if (enablePresenceByHsUrl && enablePresenceByHsUrl[cli.baseUrl] !== undefined) {
+            this._showPresence = enablePresenceByHsUrl[cli.baseUrl];
         }
+        cli.getCapabilities().then((caps) => {
+            if (!caps["m.presence"]) {
+                return;
+            }
+            this._showPresence = caps["m.presence"]["receive_enabled"];
+        });
     },
 
     _listenForMembersChanges: function() {


### PR DESCRIPTION
This is currently a simple implementation which overrides  the config value of `enable_presence_by_hs_url` with the response given looking at /capabilities `m.presence`.

https://github.com/matrix-org/matrix-doc/pull/1862