### PR TITLE
Prevent autocomplete on paste, and verserev-ing text before and after :

### DIFF
--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -280,6 +280,7 @@ export default class MessageEditor extends React.Component {
     }
 
     componentWillUnmount() {
+        this._editorRef.removeEventListener("input", this._onInput, true);
         const sel = document.getSelection();
         const {caret} = getCaretOffsetAndText(this._editorRef, sel);
         const parts = this.model.serializeParts();
@@ -292,6 +293,9 @@ export default class MessageEditor extends React.Component {
         this._updateEditorState();
         // initial caret position
         this._initializeCaret();
+        // attach input listener by hand so React doesn't proxy the events,
+        // as the proxied event doesn't support inputType, which we need.
+        this._editorRef.addEventListener("input", this._onInput, true);
         this._editorRef.focus();
     }
 
@@ -359,7 +363,6 @@ export default class MessageEditor extends React.Component {
                     className="mx_MessageEditor_editor"
                     contentEditable="true"
                     tabIndex="1"
-                    onInput={this._onInput}
                     onKeyDown={this._onKeyDown}
                     ref={ref => this._editorRef = ref}
                     aria-label={_t("Edit message")}

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -219,6 +219,9 @@ export default class EditorModel {
      * inserts `str` into the model at `pos`.
      * @param {Object} pos
      * @param {string} str
+     * @param {Object} options
+     * @param {bool} options.validate Whether characters will be validated by the part.
+     *                                Validating allows the inserted text to be parsed according to the part rules.
      * @return {Number} how far from position (in characters) the insertion ended.
      * This can be more than the length of `str` when crossing non-editable parts, which are skipped.
      */

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -244,6 +244,10 @@ export default class EditorModel {
                 addLen += part.text.length - offset;
                 index += 1;
             }
+        } else if (index < 0) {
+            // if position was not found (index: -1, as happens for empty editor)
+            // reset it to insert as first part
+            index = 0;
         }
         while (str) {
             const newPart = this._partCreator.createPartForInput(str);

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -69,7 +69,7 @@ class BasePart {
 
     // inserts str at offset if all the characters in str were accepted, otherwise don't do anything
     // return whether the str was accepted or not.
-    insertAll(offset, str) {
+    validateAndInsert(offset, str) {
         for (let i = 0; i < str.length; ++i) {
             const chr = str.charAt(i);
             if (!this.acceptsInsertion(chr)) {
@@ -80,6 +80,16 @@ class BasePart {
         const afterInsert = this._text.substr(offset);
         this._text = beforeInsert + str + afterInsert;
         return true;
+    }
+
+    insert(offset, str) {
+        if (this.canEdit) {
+            const beforeInsert = this._text.substr(0, offset);
+            const afterInsert = this._text.substr(offset);
+            this._text = beforeInsert + str + afterInsert;
+            return true;
+        }
+        return false;
     }
 
     createAutoComplete() {}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9818
Fixes https://github.com/vector-im/riot-web/issues/9985

Don't open autocomplete when pasting or dropping text.

Also, when pasting a link into an empty editor, we were inserting parts at index -1 (as the position was not found), and then 0, so the second pill-candidate part (:..) would be prepended to the first plain part (https). That is fixed, but also wouldn't happen anymore since pasting doesn't trigger autocomplete anymore, so you only create one plain part, no pill-candidate.

I couldn't reproduce with the exact steps in https://github.com/vector-im/riot-web/issues/9985 anymore, but suspect part of it might have been solved with the caret work I did before.