### PR TITLE
Send the correct UIA alongside the wrong UIA for backwards comaptibility

### DIFF
--- a/src/components/views/auth/InteractiveAuthEntryComponents.js
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.js
@@ -91,7 +91,13 @@ export const PasswordAuthEntry = React.createClass({
 
         this.props.submitAuthDict({
             type: PasswordAuthEntry.LOGIN_TYPE,
+            // TODO: Remove `user` once servers support proper UIA
+            // See https://github.com/vector-im/riot-web/issues/10312
             user: this.props.matrixClient.credentials.userId,
+            identifier: {
+                type: "m.id.user",
+                user: this.props.matrixClient.getUserId(),
+            },
             password: this.state.password,
         });
     },
@@ -463,7 +469,14 @@ export const MsisdnAuthEntry = React.createClass({
                 );
                 this.props.submitAuthDict({
                     type: MsisdnAuthEntry.LOGIN_TYPE,
+                    // TODO: Remove `threepid_creds` once servers support proper UIA
+                    // See https://github.com/vector-im/riot-web/issues/10312
                     threepid_creds: {
+                        sid: this._sid,
+                        client_secret: this.props.clientSecret,
+                        id_server: idServerParsedUrl.host,
+                    },
+                    threepidCreds: {
                         sid: this._sid,
                         client_secret: this.props.clientSecret,
                         id_server: idServerParsedUrl.host,

--- a/src/components/views/auth/InteractiveAuthEntryComponents.js
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.js
@@ -96,7 +96,7 @@ export const PasswordAuthEntry = React.createClass({
             user: this.props.matrixClient.credentials.userId,
             identifier: {
                 type: "m.id.user",
-                user: this.props.matrixClient.getUserId(),
+                user: this.props.matrixClient.credentials.userId,
             },
             password: this.state.password,
         });

--- a/src/components/views/dialogs/DeactivateAccountDialog.js
+++ b/src/components/views/dialogs/DeactivateAccountDialog.js
@@ -63,7 +63,13 @@ export default class DeactivateAccountDialog extends React.Component {
             // for this endpoint. In reality it could be any UI auth.
             const auth = {
                 type: 'm.login.password',
+                // TODO: Remove `user` once servers support proper UIA
+                // See https://github.com/vector-im/riot-web/issues/10312
                 user: MatrixClientPeg.get().credentials.userId,
+                identifier: {
+                    type: "m.id.user",
+                    user: MatrixClientPeg.get().credentials.userId,
+                },
                 password: this.state.password,
             };
             await MatrixClientPeg.get().deactivateAccount(auth, this.state.shouldErase);

--- a/test/components/views/dialogs/InteractiveAuthDialog-test.js
+++ b/test/components/views/dialogs/InteractiveAuthDialog-test.js
@@ -97,11 +97,14 @@ describe('InteractiveAuthDialog', function() {
             ReactTestUtils.Simulate.submit(formNode, {});
 
             expect(doRequest.callCount).toEqual(1);
-            expect(doRequest.calledWithExactly({
+            expect(doRequest.calledWithMatch({
                 session: "sess",
                 type: "m.login.password",
                 password: "s3kr3t",
-                user: "@user:id",
+                identifier: {
+                    type: "m.id.user",
+                    user: "@user:id",
+                },
             })).toBe(true);
             // let the request complete
             return Promise.delay(1);

--- a/test/components/views/dialogs/InteractiveAuthDialog-test.js
+++ b/test/components/views/dialogs/InteractiveAuthDialog-test.js
@@ -97,11 +97,10 @@ describe('InteractiveAuthDialog', function() {
             ReactTestUtils.Simulate.submit(formNode, {});
 
             expect(doRequest.callCount).toEqual(1);
-            expect(doRequest.calledWithExactly({
+            expect(doRequest.calledWithMatch({
                 session: "sess",
                 type: "m.login.password",
                 password: "s3kr3t",
-                user: "@user:id", // TODO: Remove this. See https://github.com/vector-im/riot-web/issues/10312
                 identifier: {
                     type: "m.id.user",
                     user: "@user:id",

--- a/test/components/views/dialogs/InteractiveAuthDialog-test.js
+++ b/test/components/views/dialogs/InteractiveAuthDialog-test.js
@@ -97,10 +97,11 @@ describe('InteractiveAuthDialog', function() {
             ReactTestUtils.Simulate.submit(formNode, {});
 
             expect(doRequest.callCount).toEqual(1);
-            expect(doRequest.calledWithMatch({
+            expect(doRequest.calledWithExactly({
                 session: "sess",
                 type: "m.login.password",
                 password: "s3kr3t",
+                user: "@user:id", // TODO: Remove this. See https://github.com/vector-im/riot-web/issues/10312
                 identifier: {
                     type: "m.id.user",
                     user: "@user:id",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10312