### PR TITLE
Check content and content.users in power levels

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -416,7 +416,8 @@ function textForEncryptionEvent(event) {
 // Currently will only display a change if a user's power level is changed
 function textForPowerEvent(event) {
     const senderName = event.sender ? event.sender.name : event.getSender();
-    if (!event.getPrevContent() || !event.getPrevContent().users) {
+    if (!event.getPrevContent() || !event.getPrevContent().users ||
+        !event.getContent() || !event.getContent().users) {
         return '';
     }
     const userDefault = event.getContent().users_default || 0;


### PR DESCRIPTION
This prevents Riot from crashing as described in the related ticket, but setting the power levels to a non-sensical value obviously strips you as an admin from your ability to set the power levels again to something else, but that's not an issue with Riot.