### PR TITLE
Parse integration manager origins more sensibly

### DIFF
--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -557,20 +557,18 @@ const onMessage = function(event) {
     try {
         eventOriginUrl = new URL(event.origin);
     } catch (e) {
-        console.warn(`Message from IM with unparsable origin ${event.origin} ignored`);
-        return;
-    }
-    if (configUrl.origin !== eventOriginUrl.origin) {
-        console.warn(`Message from IM with invalid origin ${event.origin} ignored`);
         return;
     }
     // TODO -- Scalar postMessage API should be namespaced with event.data.api field
     // Fix following "if" statement to respond only to specific API messages.
     if (
+        configUrl.origin !== eventOriginUrl.origin ||
         !event.data.action ||
         event.data.api // Ignore messages with specific API set
     ) {
-        return; // don't log this - debugging APIs like to spam postMessage which floods the log otherwise
+        // don't log this - debugging APIs and browser add-ons like to spam
+        // postMessage which floods the log otherwise
+        return;
     }
 
     if (event.data.action === "close_scalar") {

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -549,13 +549,14 @@ const onMessage = function(event) {
     //
     // All strings start with the empty string, so for sanity return if the length
     // of the event origin is 0.
-    //
+    const url = SdkConfig.get().integrations_ui_url;
+    if (event.origin.length === 0 || !url.startsWith(event.origin + '/')) {
+        console.warn(`Message from IM with invalid origin ${event.origin} ignored`);
+        return;
+    }
     // TODO -- Scalar postMessage API should be namespaced with event.data.api field
     // Fix following "if" statement to respond only to specific API messages.
-    const url = SdkConfig.get().integrations_ui_url;
     if (
-        event.origin.length === 0 ||
-        !url.startsWith(event.origin + '/') ||
         !event.data.action ||
         event.data.api // Ignore messages with specific API set
     ) {

--- a/src/ScalarMessaging.js
+++ b/src/ScalarMessaging.js
@@ -546,11 +546,21 @@ const onMessage = function(event) {
     // This means the URL could contain a path (like /develop) and still be used
     // to validate event origins, which do not specify paths.
     // (See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)
-    //
-    // All strings start with the empty string, so for sanity return if the length
-    // of the event origin is 0.
-    const url = SdkConfig.get().integrations_ui_url;
-    if (event.origin.length === 0 || !url.startsWith(event.origin + '/')) {
+    let configUrl;
+    try {
+        configUrl = new URL(SdkConfig.get().integrations_ui_url);
+    } catch (e) {
+        // No integrations UI URL, ignore silently.
+        return;
+    }
+    let eventOriginUrl;
+    try {
+        eventOriginUrl = new URL(event.origin);
+    } catch (e) {
+        console.warn(`Message from IM with unparsable origin ${event.origin} ignored`);
+        return;
+    }
+    if (configUrl.origin !== eventOriginUrl.origin) {
         console.warn(`Message from IM with invalid origin ${event.origin} ignored`);
         return;
     }


### PR DESCRIPTION
This allows the configuration for `integrations_ui_url` to be more flexible. In
particular, it no longer matters whether you include a trailing slash after the
port, for example.