### PR TITLE
Check for liveliness on submission when the server was previously dead

### DIFF
--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -149,6 +149,7 @@ module.exports = React.createClass({
         if (!this.state.serverIsAlive) {
             this.setState({busy: true});
             // Do a quick liveliness check on the URLs
+            let aliveAgain = true;
             try {
                 await AutoDiscoveryUtils.validateServerConfigWithStaticUrls(
                     this.props.serverConfig.hsUrl,
@@ -156,17 +157,16 @@ module.exports = React.createClass({
                 );
                 this.setState({serverIsAlive: true, errorText: ""});
             } catch (e) {
+                const componentState = AutoDiscoveryUtils.authComponentStateForError(e);
                 this.setState({
                     busy: false,
-                    ...AutoDiscoveryUtils.authComponentStateForError(e),
+                    ...componentState,
                 });
-                if (this.state.serverErrorIsFatal) {
-                    return; // Server is dead - do not continue.
-                }
+                aliveAgain = !componentState.serverErrorIsFatal;
             }
 
             // Prevent people from submitting their password when something isn't right.
-            if (!this.state.serverIsAlive) {
+            if (!aliveAgain) {
                 return;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10017

Specifically the `return` at the end of the diff fixes the problem, but it seems worthwhile to check for liveliness when we know the server has been dead in previous attempts.