### PR TITLE
Fix autocomplete delay text field not accepting text

### DIFF
--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -66,6 +66,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
             autoLaunchSupported: false,
             minimizeToTray: true,
             minimizeToTraySupported: false,
+            autocompleteDelay: SettingsStore.getValueAt(SettingLevel.DEVICE, 'autocompleteDelay').toString(10),
         };
     }
 
@@ -98,6 +99,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
     };
 
     _onAutocompleteDelayChange = (e) => {
+        this.setState({autocompleteDelay: e.target.value});
         SettingsStore.setValue("autocompleteDelay", null, SettingLevel.DEVICE, e.target.value);
     };
 
@@ -139,7 +141,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
                     {minimizeToTrayOption}
                     {autoLaunchOption}
                     <Field id={"autocompleteDelay"} label={_t('Autocomplete delay (ms)')} type='number'
-                           value={SettingsStore.getValueAt(SettingLevel.DEVICE, 'autocompleteDelay').toString(10)}
+                           value={this.state.autocompleteDelay}
                            onChange={this._onAutocompleteDelayChange} />
                 </div>
             </div>


### PR DESCRIPTION
SettingsStore.setValue is async (fire&forget) however getValueAt is cached. Theory was supposed to be that getValueAt local echos, however the animation loop of React is probably just too fast to actually make the local echo happen.

Fixes https://github.com/vector-im/riot-web/issues/9907