### PR TITLE
Take adjacent invisible events into account for read receipt, even if any but first should be ignored.

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -1153,11 +1153,11 @@ const TimelinePanel = React.createClass({
         };
 
         // if allowEventsWithoutTiles is enabled, we keep track
-        // of how many of the adjacent events were invisible (because no tile)
-        // but should have the read receipt moved past, so
+        // of how many of the adjacent events didn't have a tile
+        // but should have the read receipt moved past them, so
         // we can include those once we find the last displayed (visible) event.
-        // The counter is cleared when we ignore an event we don't want
-        // to send a read receipt for (our own events, local echos)
+        // The counter is not started for events we don't want
+        // to send a read receipt for (our own events, local echos).
         let adjacentInvisibleEventCount = 0;
         // Use `liveEvents` here because we don't want the read marker or read
         // receipt to advance into pending events.
@@ -1167,15 +1167,14 @@ const TimelinePanel = React.createClass({
             const node = messagePanel.getNodeForEventId(ev.getId());
             const isInView = isNodeInView(node);
 
-            // the event at i + adjacentInvisibleEventCount should
-            // not be ignored, and it considered the first in view (at the bottom)
-            // because  i is the first one in view and the adjacent ones are invisible,
-            // so return this without further ado.
+            // when we've reached the first visible event, and the previous
+            // events were all invisible (with the first one not being ignored),
+            // return the index of the first invisible event.
             if (isInView && adjacentInvisibleEventCount !== 0) {
                 return i + adjacentInvisibleEventCount;
             } else {
                 if (node && !isInView) {
-                    // has node but not in view, so adjacent invisible events don't count
+                    // has node but not in view, so reset adjacent invisible events
                     adjacentInvisibleEventCount = 0;
                 }
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -1172,34 +1172,33 @@ const TimelinePanel = React.createClass({
             // return the index of the first invisible event.
             if (isInView && adjacentInvisibleEventCount !== 0) {
                 return i + adjacentInvisibleEventCount;
-            } else {
-                if (node && !isInView) {
-                    // has node but not in view, so reset adjacent invisible events
-                    adjacentInvisibleEventCount = 0;
-                }
+            }
+            if (node && !isInView) {
+                // has node but not in view, so reset adjacent invisible events
+                adjacentInvisibleEventCount = 0;
+            }
 
-                const shouldIgnore = (ignoreEchoes && ev.status) || // local echo
-                    (ignoreOwn && ev.sender && ev.sender.userId == myUserId);   // own message
-                const isWithoutTile = !EventTile.haveTileForEvent(ev) || shouldHideEvent(ev);
+            const shouldIgnore = (ignoreEchoes && ev.status) || // local echo
+                (ignoreOwn && ev.sender && ev.sender.userId == myUserId);   // own message
+            const isWithoutTile = !EventTile.haveTileForEvent(ev) || shouldHideEvent(ev);
 
-                if (allowEventsWithoutTiles && (isWithoutTile || !node)) {
-                    // don't start counting if the event should be ignored,
-                    // but continue counting if we were already so the offset
-                    // to the previous invisble event that didn't need to be ignored
-                    // doesn't get messed up
-                    if (!shouldIgnore || (shouldIgnore && adjacentInvisibleEventCount !== 0)) {
-                        ++adjacentInvisibleEventCount;
-                    }
-                    continue;
+            if (allowEventsWithoutTiles && (isWithoutTile || !node)) {
+                // don't start counting if the event should be ignored,
+                // but continue counting if we were already so the offset
+                // to the previous invisble event that didn't need to be ignored
+                // doesn't get messed up
+                if (!shouldIgnore || (shouldIgnore && adjacentInvisibleEventCount !== 0)) {
+                    ++adjacentInvisibleEventCount;
                 }
+                continue;
+            }
 
-                if (shouldIgnore) {
-                    continue;
-                }
+            if (shouldIgnore) {
+                continue;
+            }
 
-                if (isInView) {
-                    return i;
-                }
+            if (isInView) {
+                return i;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10314

This changes the algorithm to determine the last event in the viewport that should have a read receipt sent for it. It goes backwards in the timeline (like it did before) and keeps track of how many invisible events there were (with the first one not being your own or a local echo) prior to the first visible one. It then returns the first invisible adjacent one it found, so the read receipt gets set for it.

Tested this to:
 - [x] fix the issue (can repro before and not after)
 - [x] basic receipt use cases still work with this (sending last visible, ignoring own)

![read-edit](https://user-images.githubusercontent.com/274386/61216068-0a857a80-a6fc-11e9-8ccf-21a779275e3a.png)

Let me know if I can make the comments any clearer.

@jryans already had [a brief review on the first (now rebased) commit](https://github.com/matrix-org/matrix-react-sdk/commit/546e79e15f62ad299c20f4ea97819b747f15b68f), and I replied to his comments there.