### PR TITLE
ChatCreateOrReuse show only rooms both you and the other party still in

### DIFF
--- a/src/components/views/dialogs/ChatCreateOrReuseDialog.js
+++ b/src/components/views/dialogs/ChatCreateOrReuseDialog.js
@@ -52,7 +52,12 @@ export default class ChatCreateOrReuseDialog extends React.Component {
         const tiles = [];
         for (const roomId of dmRooms) {
             const room = client.getRoom(roomId);
-            if (room) {
+            if (room && room.getMyMembership() === "join") {
+                const member = room.getMember(this.props.userId);
+                if (!member || member.membership !== "join") {
+                    continue;
+                }
+
                 const isInvite = room.getMyMembership() === "invite";
                 const highlight = room.getUnreadNotificationCount('highlight') > 0 || isInvite;
                 tiles.push(


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/2403652/61252145-7d224480-a754-11e9-88eb-46fe4126920a.png)
After
![image](https://user-images.githubusercontent.com/2403652/61252400-53b5e880-a755-11e9-84e4-bf964949e1e8.png)

Fixes https://github.com/vector-im/riot-web/issues/10218

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>