### PR TITLE
Move read marker past invisible events

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -747,6 +747,7 @@ const TimelinePanel = React.createClass({
         const lastDisplayedIndex = this._getLastDisplayedEventIndex({
             allowPartial: true,
             ignoreEchoes: true,
+            allowEventsWithoutTiles: true,
         });
 
         if (lastDisplayedIndex === null) {

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -738,14 +738,8 @@ const TimelinePanel = React.createClass({
         // move the RM to *after* the message at the bottom of the screen. This
         // avoids a problem whereby we never advance the RM if there is a huge
         // message which doesn't fit on the screen.
-        //
-        // But ignore local echoes for this - they have a temporary event ID
-        // and we'll get confused when their ID changes and we can't figure out
-        // where the RM is pointing to. The read marker will be invisible for
-        // now anyway, so this doesn't really matter.
         const lastDisplayedIndex = this._getLastDisplayedEventIndex({
             allowPartial: true,
-            ignoreEchoes: true,
         });
 
         if (lastDisplayedIndex === null) {
@@ -1128,7 +1122,6 @@ const TimelinePanel = React.createClass({
     _getLastDisplayedEventIndex: function(opts) {
         opts = opts || {};
         const ignoreOwn = opts.ignoreOwn || false;
-        const ignoreEchoes = opts.ignoreEchoes || false;
         const allowPartial = opts.allowPartial || false;
 
         const messagePanel = this.refs.messagePanel;
@@ -1175,7 +1168,7 @@ const TimelinePanel = React.createClass({
                 adjacentInvisibleEventCount = 0;
             }
 
-            const shouldIgnore = (ignoreEchoes && ev.status) || // local echo
+            const shouldIgnore = !!ev.status || // local echo
                 (ignoreOwn && ev.sender && ev.sender.userId == myUserId);   // own message
             const isWithoutTile = !EventTile.haveTileForEvent(ev) || shouldHideEvent(ev);
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -658,7 +658,6 @@ const TimelinePanel = React.createClass({
 
         const lastReadEventIndex = this._getLastDisplayedEventIndex({
             ignoreOwn: true,
-            allowEventsWithoutTiles: true,
         });
         if (lastReadEventIndex === null) {
             shouldSendRR = false;
@@ -747,7 +746,6 @@ const TimelinePanel = React.createClass({
         const lastDisplayedIndex = this._getLastDisplayedEventIndex({
             allowPartial: true,
             ignoreEchoes: true,
-            allowEventsWithoutTiles: true,
         });
 
         if (lastDisplayedIndex === null) {
@@ -1132,7 +1130,6 @@ const TimelinePanel = React.createClass({
         const ignoreOwn = opts.ignoreOwn || false;
         const ignoreEchoes = opts.ignoreEchoes || false;
         const allowPartial = opts.allowPartial || false;
-        const allowEventsWithoutTiles = opts.allowEventsWithoutTiles || false;
 
         const messagePanel = this.refs.messagePanel;
         if (messagePanel === undefined) return null;
@@ -1153,8 +1150,7 @@ const TimelinePanel = React.createClass({
             return false;
         };
 
-        // if allowEventsWithoutTiles is enabled, we keep track
-        // of how many of the adjacent events didn't have a tile
+        // We keep track of how many of the adjacent events didn't have a tile
         // but should have the read receipt moved past them, so
         // we can include those once we find the last displayed (visible) event.
         // The counter is not started for events we don't want
@@ -1183,7 +1179,7 @@ const TimelinePanel = React.createClass({
                 (ignoreOwn && ev.sender && ev.sender.userId == myUserId);   // own message
             const isWithoutTile = !EventTile.haveTileForEvent(ev) || shouldHideEvent(ev);
 
-            if (allowEventsWithoutTiles && (isWithoutTile || !node)) {
+            if (isWithoutTile || !node) {
                 // don't start counting if the event should be ignored,
                 // but continue counting if we were already so the offset
                 // to the previous invisble event that didn't need to be ignored


### PR DESCRIPTION
Doesn't really fix any issue, but a nice clean-up (I came across while looking at https://github.com/vector-im/riot-web/issues/9889) to keep it symmetrical with how read receipts are moved.