### PR TITLE
Enable reactions and edits by default

### DIFF
--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -118,13 +118,13 @@ export const SETTINGS = {
         isFeature: true,
         displayName: _td("Edit messages after they have been sent (refresh to apply changes)"),
         supportedLevels: LEVELS_FEATURE,
-        default: false,
+        default: true,
     },
     "feature_reactions": {
         isFeature: true,
         displayName: _td("React to messages with emoji (refresh to apply changes)"),
         supportedLevels: LEVELS_FEATURE,
-        default: false,
+        default: true,
     },
     "MessageComposerInput.suggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,

--- a/src/settings/handlers/DeviceSettingsHandler.js
+++ b/src/settings/handlers/DeviceSettingsHandler.js
@@ -122,7 +122,10 @@ export default class DeviceSettingsHandler extends SettingsHandler {
         }
 
         const value = localStorage.getItem("mx_labs_feature_" + featureName);
-        return value === "true";
+        if (value === "true") return true;
+        if (value === "false") return false;
+        // Try to read the next config level for the feature.
+        return null;
     }
 
     _writeFeature(featureName, enabled) {


### PR DESCRIPTION
This enables reactions and edits by default, assuming you don't have any local
device settings that would disable them.

Fixes https://github.com/vector-im/riot-web/issues/10281