### PR TITLE
dont show remove button for original event in edit history

### DIFF
--- a/src/components/views/dialogs/MessageEditHistoryDialog.js
+++ b/src/components/views/dialogs/MessageEditHistoryDialog.js
@@ -107,11 +107,19 @@ export default class MessageEditHistoryDialog extends React.PureComponent {
         if (this.state.originalEvent && !this.state.nextBatch) {
             allEvents = allEvents.concat(this.state.originalEvent);
         }
+        const baseEventId = this.props.mxEvent.getId();
         allEvents.forEach(e => {
             if (!lastEvent || wantsDateSeparator(lastEvent.getDate(), e.getDate())) {
                 nodes.push(<li key={e.getTs() + "~"}><DateSeparator ts={e.getTs()} /></li>);
             }
-            nodes.push(<EditHistoryMessage key={e.getId()} mxEvent={e} isTwelveHour={this.state.isTwelveHour} />);
+            const isBaseEvent = e.getId() === baseEventId;
+            nodes.push((
+                <EditHistoryMessage
+                    key={e.getId()}
+                    isBaseEvent={isBaseEvent}
+                    mxEvent={e}
+                    isTwelveHour={this.state.isTwelveHour}
+                />));
             lastEvent = e;
         });
         return nodes;

--- a/src/components/views/messages/EditHistoryMessage.js
+++ b/src/components/views/messages/EditHistoryMessage.js
@@ -94,7 +94,7 @@ export default class EditHistoryMessage extends React.PureComponent {
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
         // hide the button when already redacted
         let redactButton;
-        if (!this.props.mxEvent.isRedacted()) {
+        if (!this.props.mxEvent.isRedacted() && !this.props.isBaseEvent) {
             redactButton = (
                 <AccessibleButton onClick={this._onRedactClick} disabled={!this.state.canRedact}>
                     {_t("Remove")}


### PR DESCRIPTION
the [latest synapse fixes](https://github.com/matrix-org/synapse/commits/anoa/edit_redacting) will redact relations when the base event is redacted. With this, if a user tries to redact the first message in the edit history, he would redact not only the first item in the history, but the whole message. This is not what one would reasonably expect given the UX, so disable it for now.