### PR TITLE
Avoid visual glitch when terms appear for Integration Manager

### DIFF
--- a/res/css/views/dialogs/_TermsDialog.scss
+++ b/res/css/views/dialogs/_TermsDialog.scss
@@ -14,6 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+ * To avoid visual glitching of two modals stacking briefly, we customise the
+ * terms dialog sizing when it will appear for the integrations manager so that
+ * it gets the same basic size as the IM's own modal.
+ */
+.mx_TermsDialog_forIntegrationsManager .mx_Dialog {
+    width: 60%;
+    height: 70%;
+    box-sizing: border-box;
+}
+
 .mx_TermsDialog_termsTableHeader {
     font-weight: bold;
     text-align: left;
@@ -21,6 +32,7 @@ limitations under the License.
 
 .mx_TermsDialog_termsTable {
     font-size: 12px;
+    width: 100%;
 }
 
 .mx_TermsDialog_service, .mx_TermsDialog_summary {

--- a/src/Terms.js
+++ b/src/Terms.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import Promise from 'bluebird';
+import classNames from 'classnames';
 
 import MatrixClientPeg from './MatrixClientPeg';
 import sdk from './';
@@ -40,17 +41,6 @@ export class Service {
 }
 
 /**
- * Present a popup to the user prompting them to agree to terms and conditions
- *
- * @param {Service[]} services Object with keys 'serviceType', 'baseUrl', 'accessToken'
- * @returns {Promise} resolves when the user agreed to all necessary terms or rejects
- *     if they cancel.
- */
-export function presentTermsForServices(services) {
-    return startTermsFlow(services, dialogTermsInteractionCallback);
-}
-
-/**
  * Start a flow where the user is presented with terms & conditions for some services
  *
  * @param {Service[]} services Object with keys 'serviceType', 'baseUrl', 'accessToken'
@@ -61,7 +51,10 @@ export function presentTermsForServices(services) {
  * @returns {Promise} resolves when the user agreed to all necessary terms or rejects
  *     if they cancel.
  */
-export async function startTermsFlow(services, interactionCallback) {
+export async function startTermsFlow(
+    services,
+    interactionCallback = dialogTermsInteractionCallback,
+) {
     const termsPromises = services.map(
         (s) => MatrixClientPeg.get().getTerms(s.serviceType, s.baseUrl),
     );
@@ -160,7 +153,11 @@ export async function startTermsFlow(services, interactionCallback) {
     return Promise.all(agreePromises);
 }
 
-function dialogTermsInteractionCallback(policiesAndServicePairs, agreedUrls) {
+export function dialogTermsInteractionCallback(
+    policiesAndServicePairs,
+    agreedUrls,
+    extraClassNames,
+) {
     return new Promise((resolve, reject) => {
         console.log("Terms that need agreement", policiesAndServicePairs);
         const TermsDialog = sdk.getComponent("views.dialogs.TermsDialog");
@@ -175,6 +172,6 @@ function dialogTermsInteractionCallback(policiesAndServicePairs, agreedUrls) {
                 }
                 resolve(agreedUrls);
             },
-        });
+        }, classNames("mx_TermsDialog", extraClassNames));
     });
 }

--- a/src/components/views/dialogs/TermsDialog.js
+++ b/src/components/views/dialogs/TermsDialog.js
@@ -176,7 +176,7 @@ export default class TermsDialog extends React.PureComponent {
         }
 
         return (
-            <BaseDialog className='mx_TermsDialog'
+            <BaseDialog
                 fixedWidth={false}
                 onFinished={this._onCancelClick}
                 title={_t("Terms of Service")}

--- a/src/integrations/integrations.js
+++ b/src/integrations/integrations.js
@@ -17,7 +17,7 @@ limitations under the License.
 import sdk from "../index";
 import ScalarAuthClient from '../ScalarAuthClient';
 import Modal from '../Modal';
-import { TermsNotSignedError } from '../Terms';
+import { TermsNotSignedError, dialogTermsInteractionCallback } from '../Terms';
 
 export async function showIntegrationsManager(opts) {
     const IntegrationsManager = sdk.getComponent("views.settings.IntegrationsManager");
@@ -38,6 +38,7 @@ export async function showIntegrationsManager(opts) {
     }
 
     const scalarClient = new ScalarAuthClient();
+    scalarClient.setTermsInteractionCallback(integrationsTermsInteractionCallback);
     try {
         await scalarClient.connect();
         if (!scalarClient.hasCredentials()) {
@@ -62,4 +63,17 @@ export async function showIntegrationsManager(opts) {
     }
     close();
     Modal.createTrackedDialog('Integrations Manager', '', IntegrationsManager, props, "mx_IntegrationsManager");
+}
+
+/*
+ * To avoid visual glitching of two modals stacking briefly, we customise the
+ * terms dialog sizing when it will appear for the integrations manager so that
+ * it gets the same basic size as the IM's own modal.
+ */
+function integrationsTermsInteractionCallback(policiesAndServicePairs, agreedUrls) {
+    return dialogTermsInteractionCallback(
+        policiesAndServicePairs,
+        agreedUrls,
+        "mx_TermsDialog_forIntegrationsManager",
+    );
 }


### PR DESCRIPTION
This avoids a visual glitch where the Integration Manager portal would briefly
appear, but then be replaced by a smaller Terms dialog when there's something to
agree to.

To resolve this minimal code churn, this cheats a bit and customises the size of
the terms dialog to match the IM portal modal when terms are shown for IM
purposes.

Fixes https://github.com/vector-im/riot-web/issues/10386