### PR TITLE
Keep widget URL in permission screen to one line

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -310,7 +311,7 @@ form.mx_Custom_Widget_Form div {
 }
 
 .mx_AppPermissionWarningText {
-    max-width: 400px;
+    max-width: 90%;
     margin: 10px auto 10px auto;
     color: $primary-fg-color;
 }
@@ -321,7 +322,12 @@ form.mx_Custom_Widget_Form div {
 }
 
 .mx_AppPermissionWarningTextURL {
+    display: inline-block;
+    max-width: 100%;
     color: $accent-color;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .mx_AppPermissionButton {

--- a/src/components/views/elements/AppPermission.js
+++ b/src/components/views/elements/AppPermission.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 Vector Creations Ltd
 Copyright 2018, 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -67,7 +68,10 @@ export default class AppPermission extends React.Component {
                     <img src={require("../../../../res/img/feather-customised/warning-triangle.svg")} alt={_t('Warning!')} />
                 </div>
                 <div className='mx_AppPermissionWarningText'>
-                    <span className='mx_AppPermissionWarningTextLabel'>{ _t('Do you want to load widget from URL:') }</span> <span className='mx_AppPermissionWarningTextURL'>{ this.state.curlBase }</span>
+                    <span className='mx_AppPermissionWarningTextLabel'>{_t('Do you want to load widget from URL:')}</span>
+                    <span className='mx_AppPermissionWarningTextURL'
+                        title={this.state.curlBase}
+                    >{this.state.curlBase}</span>
                     { e2eWarningText }
                     { cookieWarning }
                 </div>

--- a/src/components/views/elements/AppPermission.js
+++ b/src/components/views/elements/AppPermission.js
@@ -1,3 +1,20 @@
+/*
+Copyright 2017 Vector Creations Ltd
+Copyright 2018, 2019 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import url from 'url';


### PR DESCRIPTION
This keeps the widget URL to one line max, so that the allow button will always
be visible. The full URL can be viewed by hovering.

<img width="977" alt="2019-07-23 at 18 17" src="https://user-images.githubusercontent.com/279572/61732709-1fa27f00-ad76-11e9-9e68-4b0230e5ef84.png">

Fixes https://github.com/vector-im/riot-web/issues/10402