### PR TITLE
Move history with alt up/down regardless of where selection is

### DIFF
--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -1130,17 +1130,6 @@ export default class MessageComposerInput extends React.Component {
     onVerticalArrow = (e, up) => {
         if (e.ctrlKey || e.shiftKey || e.metaKey) return;
 
-        // selection must be collapsed
-        const selection = this.state.editorState.selection;
-        if (!selection.isCollapsed) return;
-        // and we must be at the edge of the document (up=start, down=end)
-        const document = this.state.editorState.document;
-        if (up) {
-            if (!selection.anchor.isAtStartOfNode(document)) return;
-        } else {
-            if (!selection.anchor.isAtEndOfNode(document)) return;
-        }
-
         const shouldSelectHistory = e.altKey;
         const shouldEditLastMessage = !e.altKey && up && !RoomViewStore.getQuotingEvent();
 
@@ -1152,6 +1141,17 @@ export default class MessageComposerInput extends React.Component {
                 e.preventDefault();
             }
         } else if (shouldEditLastMessage) {
+            // selection must be collapsed
+            const selection = this.state.editorState.selection;
+            if (!selection.isCollapsed) return;
+            // and we must be at the edge of the document (up=start, down=end)
+            const document = this.state.editorState.document;
+            if (up) {
+                if (!selection.anchor.isAtStartOfNode(document)) return;
+            } else {
+                if (!selection.anchor.isAtEndOfNode(document)) return;
+            }
+
             const editEvent = findEditableEvent(this.props.room, false);
             if (editEvent) {
                 // We're selecting history, so prevent the key event from doing anything else


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10325

![10325](https://user-images.githubusercontent.com/2403652/62041934-bc40a300-b1f4-11e9-82e5-30ef8f3cdd25.gif)


Has additional niceness that your selection gets persisted too, so you can refer back to an older message than return to your in-progress one without your caret being reset.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>