### PR TITLE
Add support for IS v2 API with authentication

### DIFF
--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -111,12 +111,12 @@ export default class AddThreepid {
      */
     async haveMsisdnToken(msisdnToken) {
         const authClient = new IdentityAuthClient();
-        const isAccessToken = await authClient.getAccessToken();
+        const identityAccessToken = await authClient.getAccessToken();
         const result = await MatrixClientPeg.get().submitMsisdnToken(
             this.sessionId,
             this.clientSecret,
             msisdnToken,
-            isAccessToken,
+            identityAccessToken,
         );
         if (result.errcode) {
             throw result;

--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import MatrixClientPeg from './MatrixClientPeg';
 import { _t } from './languageHandler';
+import IdentityAuthClient from './IdentityAuthClient';
 
 /**
  * Allows a user to add a third party identifier to their homeserver and,
@@ -103,14 +104,19 @@ export default class AddThreepid {
     /**
      * Takes a phone number verification code as entered by the user and validates
      * it with the ID server, then if successful, adds the phone number.
-     * @param {string} token phone number verification code as entered by the user
+     * @param {string} msisdnToken phone number verification code as entered by the user
      * @return {Promise} Resolves if the phone number was added. Rejects with an object
      * with a "message" property which contains a human-readable message detailing why
      * the request failed.
      */
-    async haveMsisdnToken(token) {
+    async haveMsisdnToken(msisdnToken) {
+        const authClient = new IdentityAuthClient();
+        const isAccessToken = await authClient.getAccessToken();
         const result = await MatrixClientPeg.get().submitMsisdnToken(
-            this.sessionId, this.clientSecret, token,
+            this.sessionId,
+            this.clientSecret,
+            msisdnToken,
+            isAccessToken,
         );
         if (result.errcode) {
             throw result;

--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -108,19 +108,19 @@ export default class AddThreepid {
      * with a "message" property which contains a human-readable message detailing why
      * the request failed.
      */
-    haveMsisdnToken(token) {
-        return MatrixClientPeg.get().submitMsisdnToken(
+    async haveMsisdnToken(token) {
+        const result = await MatrixClientPeg.get().submitMsisdnToken(
             this.sessionId, this.clientSecret, token,
-        ).then((result) => {
-            if (result.errcode) {
-                throw result;
-            }
-            const identityServerDomain = MatrixClientPeg.get().idBaseUrl.split("://")[1];
-            return MatrixClientPeg.get().addThreePid({
-                sid: this.sessionId,
-                client_secret: this.clientSecret,
-                id_server: identityServerDomain,
-            }, this.bind);
-        });
+        );
+        if (result.errcode) {
+            throw result;
+        }
+
+        const identityServerDomain = MatrixClientPeg.get().idBaseUrl.split("://")[1];
+        return MatrixClientPeg.get().addThreePid({
+            sid: this.sessionId,
+            client_secret: this.clientSecret,
+            id_server: identityServerDomain,
+        }, this.bind);
     }
 }

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -19,6 +19,7 @@ import MatrixClientPeg from './MatrixClientPeg';
 export default class IdentityAuthClient {
     constructor() {
         this.accessToken = null;
+        this.authEnabled = true;
     }
 
     hasCredentials() {
@@ -27,34 +28,52 @@ export default class IdentityAuthClient {
 
     // Returns a promise that resolves to the access_token string from the IS
     async getAccessToken() {
+        if (!this.authEnabled) {
+            // The current IS doesn't support authentication
+            return null;
+        }
+
         let token = this.accessToken;
         if (!token) {
             token = window.localStorage.getItem("mx_is_access_token");
         }
 
         if (!token) {
-            return this.registerForToken();
+            token = await this.registerForToken();
+            this.accessToken = token;
+            window.localStorage.setItem("mx_is_access_token", token);
         }
 
         try {
-            return await this._checkToken(token);
+            await this._checkToken(token);
         } catch (e) {
-            return await this.registerForToken();
+            // Retry in case token expired
+            token = await this.registerForToken();
+            this.accessToken = token;
+            window.localStorage.setItem("mx_is_access_token", token);
         }
+
+        return token;
     }
 
     _checkToken(token) {
         // TODO: Test current API token via /account endpoint
-        return token;
     }
 
     async registerForToken() {
-        const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
-        const { access_token: isAccessToken } =
-            await MatrixClientPeg.get().registerWithIdentityServer(hsOpenIdToken);
-        await this._checkToken(isAccessToken);
-        this.accessToken = isAccessToken;
-        window.localStorage.setItem("mx_is_access_token", isAccessToken);
-        return isAccessToken;
+        try {
+            const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
+            const { access_token: isAccessToken } =
+                await MatrixClientPeg.get().registerWithIdentityServer(hsOpenIdToken);
+            await this._checkToken(isAccessToken);
+            return isAccessToken;
+        } catch (err) {
+            if (err.cors === "rejected" || err.httpStatus === 404) {
+                // Assume IS only supports deprecated v1 API for now
+                // TODO: Remove this path once v2 is only supported version
+                console.warn("IS doesn't support v2 auth");
+                this.authEnabled = false;
+            }
+        }
     }
 }

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -58,8 +58,13 @@ export default class IdentityAuthClient {
 
     _checkToken(token) {
         // TODO: Test current API token via `/account` endpoint
+
         // At the moment, Sydent doesn't implement `/account`, so we can't use
         // that yet. We could try a lookup for a null address perhaps...?
+        // Sydent doesn't currently expire tokens, but we should still be testing
+        // them in any case.
+        // See also https://github.com/vector-im/riot-web/issues/10452.
+
         // In any case, we should ensure the token in `localStorage` is cleared
         // appropriately. We already clear storage on sign out, but we'll need
         // additional clearing when changing ISes in settings as part of future

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -63,10 +63,10 @@ export default class IdentityAuthClient {
     async registerForToken() {
         try {
             const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
-            const { access_token: isAccessToken } =
+            const { access_token: identityAccessToken } =
                 await MatrixClientPeg.get().registerWithIdentityServer(hsOpenIdToken);
-            await this._checkToken(isAccessToken);
-            return isAccessToken;
+            await this._checkToken(identityAccessToken);
+            return identityAccessToken;
         } catch (err) {
             if (err.cors === "rejected" || err.httpStatus === 404) {
                 // Assume IS only supports deprecated v1 API for now

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import MatrixClientPeg from './MatrixClientPeg';
+
+export default class IdentityAuthClient {
+    constructor() {
+        this.accessToken = null;
+    }
+
+    hasCredentials() {
+        return this.accessToken != null; // undef or null
+    }
+
+    // Returns a promise that resolves to the access_token string from the IS
+    async getAccessToken() {
+        let token = this.accessToken;
+        if (!token) {
+            token = window.localStorage.getItem("mx_is_access_token");
+        }
+
+        if (!token) {
+            return this.registerForToken();
+        }
+
+        try {
+            return await this._checkToken(token);
+        } catch (e) {
+            return await this.registerForToken();
+        }
+    }
+
+    _checkToken(token) {
+        // TODO: Test current API token via /account endpoint
+        return token;
+    }
+
+    async registerForToken() {
+        const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
+        const { access_token: isAccessToken } =
+            await MatrixClientPeg.get().registerWithIdentityServer(hsOpenIdToken);
+        await this._checkToken(isAccessToken);
+        this.accessToken = isAccessToken;
+        window.localStorage.setItem("mx_is_access_token", isAccessToken);
+        return isAccessToken;
+    }
+}

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -77,6 +77,7 @@ export default class IdentityAuthClient {
             if (err.cors === "rejected" || err.httpStatus === 404) {
                 // Assume IS only supports deprecated v1 API for now
                 // TODO: Remove this path once v2 is only supported version
+                // See https://github.com/vector-im/riot-web/issues/10443
                 console.warn("IS doesn't support v2 auth");
                 this.authEnabled = false;
             }

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -57,7 +57,13 @@ export default class IdentityAuthClient {
     }
 
     _checkToken(token) {
-        // TODO: Test current API token via /account endpoint
+        // TODO: Test current API token via `/account` endpoint
+        // At the moment, Sydent doesn't implement `/account`, so we can't use
+        // that yet. We could try a lookup for a null address perhaps...?
+        // In any case, we should ensure the token in `localStorage` is cleared
+        // appropriately. We already clear storage on sign out, but we'll need
+        // additional clearing when changing ISes in settings as part of future
+        // privacy work.
     }
 
     async registerForToken() {

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -69,6 +69,7 @@ export default class IdentityAuthClient {
         // appropriately. We already clear storage on sign out, but we'll need
         // additional clearing when changing ISes in settings as part of future
         // privacy work.
+        // See also https://github.com/vector-im/riot-web/issues/10455.
     }
 
     async registerForToken() {

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -513,7 +513,13 @@ module.exports = React.createClass({
         if (cancelled) return null;
 
         try {
-            const lookup = await MatrixClientPeg.get().lookupThreePid(medium, address);
+            const hsAccountToken = await MatrixClientPeg.get().getOpenIdToken();
+            if (cancelled) return null;
+
+            const isAccountToken = await MatrixClientPeg.get().registerWithIdentityServer(hsAccountToken);
+            if (cancelled) return null;
+
+            const lookup = await MatrixClientPeg.get().lookupThreePid(medium, address, undefined, isAccountToken);
             if (cancelled || lookup === null || !lookup.mxid) return null;
 
             const profile = await MatrixClientPeg.get().getProfileInfo(lookup.mxid);

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -520,7 +520,12 @@ module.exports = React.createClass({
             const isAccessToken = await authClient.getAccessToken();
             if (cancelled) return null;
 
-            const lookup = await MatrixClientPeg.get().lookupThreePid(medium, address, undefined, isAccessToken);
+            const lookup = await MatrixClientPeg.get().lookupThreePid(
+                medium,
+                address,
+                undefined /* callback */,
+                isAccessToken,
+            );
             if (cancelled || lookup === null || !lookup.mxid) return null;
 
             const profile = await MatrixClientPeg.get().getProfileInfo(lookup.mxid);

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -517,14 +517,14 @@ module.exports = React.createClass({
 
         try {
             const authClient = new IdentityAuthClient();
-            const isAccessToken = await authClient.getAccessToken();
+            const identityAccessToken = await authClient.getAccessToken();
             if (cancelled) return null;
 
             const lookup = await MatrixClientPeg.get().lookupThreePid(
                 medium,
                 address,
                 undefined /* callback */,
-                isAccessToken,
+                identityAccessToken,
             );
             if (cancelled || lookup === null || !lookup.mxid) return null;
 

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -2,6 +2,7 @@
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017, 2018, 2019 New Vector Ltd
 Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,13 +19,15 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { _t, _td } from '../../../languageHandler';
 import sdk from '../../../index';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 import Promise from 'bluebird';
 import { addressTypes, getAddressType } from '../../../UserAddress.js';
 import GroupStore from '../../../stores/GroupStore';
-import * as Email from "../../../email";
+import * as Email from '../../../email';
+import IdentityAuthClient from '../../../IdentityAuthClient';
 
 const TRUNCATE_QUERY_LIST = 40;
 const QUERY_USER_DIRECTORY_DEBOUNCE_MS = 200;
@@ -513,13 +516,11 @@ module.exports = React.createClass({
         if (cancelled) return null;
 
         try {
-            const hsAccountToken = await MatrixClientPeg.get().getOpenIdToken();
+            const authClient = new IdentityAuthClient();
+            const isAccessToken = await authClient.getAccessToken();
             if (cancelled) return null;
 
-            const isAccountToken = await MatrixClientPeg.get().registerWithIdentityServer(hsAccountToken);
-            if (cancelled) return null;
-
-            const lookup = await MatrixClientPeg.get().lookupThreePid(medium, address, undefined, isAccountToken);
+            const lookup = await MatrixClientPeg.get().lookupThreePid(medium, address, undefined, isAccessToken);
             if (cancelled || lookup === null || !lookup.mxid) return null;
 
             const profile = await MatrixClientPeg.get().getProfileInfo(lookup.mxid);

--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -74,12 +74,11 @@ module.exports = React.createClass({
 
     getInitialState: function() {
         return {
-            error: false,
-
+            // Whether to show an error message because of an invalid address
+            invalidAddressError: false,
             // List of UserAddressType objects representing
             // the list of addresses we're going to invite
             selectedList: [],
-
             // Whether a search is ongoing
             busy: false,
             // An error message generated during the user directory search
@@ -451,7 +450,7 @@ module.exports = React.createClass({
         }
         this.setState({
             suggestedList,
-            error: false,
+            invalidAddressError: false,
         }, () => {
             if (this.addressSelector) this.addressSelector.moveSelectionTop();
         });
@@ -495,7 +494,7 @@ module.exports = React.createClass({
             selectedList,
             suggestedList: [],
             query: "",
-            error: hasError ? true : this.state.error,
+            invalidAddressError: hasError ? true : this.state.invalidAddressError,
         });
         if (this._cancelThreepidLookup) this._cancelThreepidLookup();
         return hasError ? null : selectedList;
@@ -543,6 +542,9 @@ module.exports = React.createClass({
             });
         } catch (e) {
             console.error(e);
+            this.setState({
+                searchError: _t('Something went wrong!'),
+            });
         }
     },
 
@@ -610,7 +612,7 @@ module.exports = React.createClass({
 
         let error;
         let addressSelector;
-        if (this.state.error) {
+        if (this.state.invalidAddressError) {
             const validTypeDescriptions = this.props.validAddressTypes.map((t) => _t(addressTypeName[t]));
             error = <div className="mx_AddressPickerDialog_error">
                 { _t("You have entered an invalid address.") }

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -104,21 +104,21 @@ module.exports = React.createClass({
         }
     },
 
-    _checkInvitedEmail: function() {
+    _checkInvitedEmail: async function() {
         // If this is an invite and we've been told what email
         // address was invited, fetch the user's list of Threepids
         // so we can check them against the one that was invited
         if (this.props.inviterName && this.props.invitedEmail) {
             this.setState({busy: true});
-            MatrixClientPeg.get().lookupThreePid(
-                'email', this.props.invitedEmail,
-            ).finally(() => {
-                this.setState({busy: false});
-            }).done((result) => {
+            try {
+                const result = await MatrixClientPeg.get().lookupThreePid(
+                    'email', this.props.invitedEmail,
+                );
                 this.setState({invitedEmailMxid: result.mxid});
-            }, (err) => {
+            } catch (err) {
                 this.setState({threePidFetchError: err});
-            });
+            }
+            this.setState({busy: false});
         }
     },
 

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -25,6 +25,7 @@ import MatrixClientPeg from '../../../MatrixClientPeg';
 import dis from '../../../dispatcher';
 import classNames from 'classnames';
 import { _t } from '../../../languageHandler';
+import IdentityAuthClient from '../../../IdentityAuthClient';
 
 const MessageCase = Object.freeze({
     NotLoggedIn: "NotLoggedIn",
@@ -111,8 +112,13 @@ module.exports = React.createClass({
         if (this.props.inviterName && this.props.invitedEmail) {
             this.setState({busy: true});
             try {
+                const authClient = new IdentityAuthClient();
+                const isAccessToken = await authClient.getAccessToken();
                 const result = await MatrixClientPeg.get().lookupThreePid(
-                    'email', this.props.invitedEmail,
+                    'email',
+                    this.props.invitedEmail,
+                    undefined /* callback */,
+                    isAccessToken,
                 );
                 this.setState({invitedEmailMxid: result.mxid});
             } catch (err) {

--- a/src/components/views/rooms/RoomPreviewBar.js
+++ b/src/components/views/rooms/RoomPreviewBar.js
@@ -113,12 +113,12 @@ module.exports = React.createClass({
             this.setState({busy: true});
             try {
                 const authClient = new IdentityAuthClient();
-                const isAccessToken = await authClient.getAccessToken();
+                const identityAccessToken = await authClient.getAccessToken();
                 const result = await MatrixClientPeg.get().lookupThreePid(
                     'email',
                     this.props.invitedEmail,
                     undefined /* callback */,
-                    isAccessToken,
+                    identityAccessToken,
                 );
                 this.setState({invitedEmailMxid: result.mxid});
             } catch (err) {


### PR DESCRIPTION
This adds support for the IS v2 API in all existing IS usages. A new auth client object checks for an IS token as needed. All IS call sites pass along the token.

This will fall back to v1 APIs if v2 is not supported for the moment, but this will eventually be removed once servers are updated.

Implements part of [MSC2140](https://github.com/matrix-org/matrix-doc/pull/2140)
Fixes https://github.com/vector-im/riot-web/issues/10408
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1002