### PR TITLE
Fix autocomplete for editing being broken

### DIFF
--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -349,7 +349,7 @@ class PillCandidatePart extends PlainPart {
     }
 }
 
-export function autoCompleteCreator(updateQuery, getAutocompleterComponent) {
+export function autoCompleteCreator(getAutocompleterComponent, updateQuery) {
     return (partCreator) => {
         return (updateCallback) => {
             return new AutocompleteWrapperModel(


### PR DESCRIPTION
This is called from `MessageEditor::_createEditorModel` (line 335), where the reverse parameter order is assumed.