### PR TITLE
Introduce RoomContext for sharing state between RoomView and children

### DIFF
--- a/src/components/views/messages/MessageActionBar.js
+++ b/src/components/views/messages/MessageActionBar.js
@@ -145,12 +145,10 @@ export default class MessageActionBar extends React.PureComponent {
         let editButton;
 
         if (isContentActionable(this.props.mxEvent)) {
-            // `context` can be null in tests that use a subtree of components
-            // that don't create the context.
-            if (!this.context || !this.context.room || this.context.room.canReact) {
+            if (this.context.room.canReact) {
                 reactButton = this.renderReactButton();
             }
-            if (!this.context || !this.context.room || this.context.room.canReply) {
+            if (this.context.room.canReply) {
                 replyButton = <span className="mx_MessageActionBar_maskButton mx_MessageActionBar_replyButton"
                     title={_t("Reply")}
                     onClick={this.onReplyClick}

--- a/src/components/views/messages/MessageActionBar.js
+++ b/src/components/views/messages/MessageActionBar.js
@@ -145,10 +145,12 @@ export default class MessageActionBar extends React.PureComponent {
         let editButton;
 
         if (isContentActionable(this.props.mxEvent)) {
-            if (this.context.room.canReact) {
+            // `context` can be null in tests that use a subtree of components
+            // that don't create the context.
+            if (!this.context || !this.context.room || this.context.room.canReact) {
                 reactButton = this.renderReactButton();
             }
-            if (this.context.room.canReply) {
+            if (!this.context || !this.context.room || this.context.room.canReply) {
                 replyButton = <span className="mx_MessageActionBar_maskButton mx_MessageActionBar_replyButton"
                     title={_t("Reply")}
                     onClick={this.onReplyClick}

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -41,11 +41,16 @@ const room = new Matrix.Room();
 const WrappedMessagePanel = React.createClass({
     childContextTypes: {
         matrixClient: React.PropTypes.object,
+        room: React.PropTypes.object,
     },
 
     getChildContext: function() {
         return {
             matrixClient: client,
+            room: {
+                canReact: true,
+                canReply: true,
+            },
         };
     },
 


### PR DESCRIPTION
and pull canReact/canReply state up to RoomView to get rid of all the event listeners

Fixes https://github.com/vector-im/riot-web/issues/10456

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>