### PR TITLE
Get rid of warning of required prop

### DIFF
--- a/src/components/views/messages/EditHistoryMessage.js
+++ b/src/components/views/messages/EditHistoryMessage.js
@@ -36,7 +36,7 @@ export default class EditHistoryMessage extends React.PureComponent {
     static propTypes = {
         // the message event being edited
         mxEvent: PropTypes.instanceOf(MatrixEvent).isRequired,
-        previousEdit: PropTypes.instanceOf(MatrixEvent).isRequired,
+        previousEdit: PropTypes.instanceOf(MatrixEvent),
         isBaseEvent: PropTypes.bool,
     };
 


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/issues/10412 (this isn't the cause of the bug though).