### PR TITLE
Replace React.PropTypes with usage of the `prop-types` package

### DIFF
--- a/src/components/structures/CompatibilityPage.js
+++ b/src/components/structures/CompatibilityPage.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
-
-const React = require('react');
+import React from 'react';
+import PropTypes from 'prop-types';
 import { _t } from '../../languageHandler';
 
 module.exports = React.createClass({
     displayName: 'CompatibilityPage',
     propTypes: {
-        onAccept: React.PropTypes.func,
+        onAccept: PropTypes.func,
     },
 
     getDefaultProps: function() {

--- a/src/components/structures/RightPanel.js
+++ b/src/components/structures/RightPanel.js
@@ -3,6 +3,7 @@ Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 Copyright 2017 New Vector Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,9 +31,9 @@ import GroupStore from '../../stores/GroupStore';
 export default class RightPanel extends React.Component {
     static get propTypes() {
         return {
-            roomId: React.PropTypes.string, // if showing panels for a given room, this is set
-            groupId: React.PropTypes.string, // if showing panels for a given group, this is set
-            user: React.PropTypes.object,
+            roomId: PropTypes.string, // if showing panels for a given room, this is set
+            groupId: PropTypes.string, // if showing panels for a given group, this is set
+            user: PropTypes.object,
         };
     }
 

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +26,7 @@ const sdk = require('../../index');
 const dis = require('../../dispatcher');
 
 import { linkifyAndSanitizeHtml } from '../../HtmlUtils';
+import PropTypes from 'prop-types';
 import Promise from 'bluebird';
 import { _t } from '../../languageHandler';
 import { instanceForInstanceId, protocolNameForInstanceId } from '../../utils/DirectoryUtils';
@@ -41,8 +43,8 @@ module.exports = React.createClass({
     displayName: 'RoomDirectory',
 
     propTypes: {
-        config: React.PropTypes.object,
-        onFinished: React.PropTypes.func.isRequired,
+        config: PropTypes.object,
+        onFinished: PropTypes.func.isRequired,
     },
 
     getDefaultProps: function() {
@@ -65,7 +67,7 @@ module.exports = React.createClass({
     },
 
     childContextTypes: {
-        matrixClient: React.PropTypes.object,
+        matrixClient: PropTypes.object,
     },
 
     getChildContext: function() {

--- a/src/components/structures/UserView.js
+++ b/src/components/structures/UserView.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@ limitations under the License.
 */
 
 import React from "react";
+import PropTypes from "prop-types";
 import Matrix from "matrix-js-sdk";
 import MatrixClientPeg from "../../MatrixClientPeg";
 import sdk from "../../index";
@@ -24,7 +26,7 @@ import { _t } from '../../languageHandler';
 export default class UserView extends React.Component {
     static get propTypes() {
         return {
-            userId: React.PropTypes.string,
+            userId: PropTypes.string,
         };
     }
 

--- a/src/components/views/dialogs/BugReportDialog.js
+++ b/src/components/views/dialogs/BugReportDialog.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import sdk from '../../../index';
 import SdkConfig from '../../../SdkConfig';
 import Modal from '../../../Modal';
@@ -200,5 +202,5 @@ export default class BugReportDialog extends React.Component {
 }
 
 BugReportDialog.propTypes = {
-    onFinished: React.PropTypes.func.isRequired,
+    onFinished: PropTypes.func.isRequired,
 };

--- a/src/components/views/dialogs/ChangelogDialog.js
+++ b/src/components/views/dialogs/ChangelogDialog.js
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 Aviral Dasgupta
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import sdk from '../../../index';
 import request from 'browser-request';
 import { _t } from '../../../languageHandler';
@@ -99,7 +101,7 @@ export default class ChangelogDialog extends React.Component {
 }
 
 ChangelogDialog.propTypes = {
-    version: React.PropTypes.string.isRequired,
-    newVersion: React.PropTypes.string.isRequired,
-    onFinished: React.PropTypes.func.isRequired,
+    version: PropTypes.string.isRequired,
+    newVersion: PropTypes.string.isRequired,
+    onFinished: PropTypes.func.isRequired,
 };

--- a/src/components/views/dialogs/SetPasswordDialog.js
+++ b/src/components/views/dialogs/SetPasswordDialog.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 Vector Creations Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import sdk from '../../../index';
 import { _t } from '../../../languageHandler';
 import Modal from '../../../Modal';
@@ -63,7 +65,7 @@ const WarmFuzzy = function(props) {
 export default React.createClass({
     displayName: 'SetPasswordDialog',
     propTypes: {
-        onFinished: React.PropTypes.func.isRequired,
+        onFinished: PropTypes.func.isRequired,
     },
 
     getInitialState: function() {

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 OpenMarket Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@ limitations under the License.
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 import {instanceForInstanceId} from '../../../utils/DirectoryUtils';
 
@@ -241,10 +243,10 @@ export default class NetworkDropdown extends React.Component {
 }
 
 NetworkDropdown.propTypes = {
-    onOptionChange: React.PropTypes.func.isRequired,
-    protocols: React.PropTypes.object,
+    onOptionChange: PropTypes.func.isRequired,
+    protocols: PropTypes.object,
     // The room directory config. May have a 'servers' key that is a list of server names to include in the dropdown
-    config: React.PropTypes.object,
+    config: PropTypes.object,
 };
 
 NetworkDropdown.defaultProps = {

--- a/src/components/views/elements/Dropdown.js
+++ b/src/components/views/elements/Dropdown.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,7 +59,7 @@ class MenuOption extends React.Component {
 
 MenuOption.propTypes = {
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(React.PropTypes.node),
+      PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
     highlighted: PropTypes.bool,

--- a/src/components/views/elements/ImageView.js
+++ b/src/components/views/elements/ImageView.js
@@ -17,7 +17,8 @@ limitations under the License.
 
 'use strict';
 
-const React = require('react');
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const MatrixClientPeg = require('../../../MatrixClientPeg');
 
@@ -30,19 +31,19 @@ import { _t } from '../../../languageHandler';
 
 export default class ImageView extends React.Component {
     static propTypes = {
-        src: React.PropTypes.string.isRequired, // the source of the image being displayed
-        name: React.PropTypes.string, // the main title ('name') for the image
-        link: React.PropTypes.string, // the link (if any) applied to the name of the image
-        width: React.PropTypes.number, // width of the image src in pixels
-        height: React.PropTypes.number, // height of the image src in pixels
-        fileSize: React.PropTypes.number, // size of the image src in bytes
-        onFinished: React.PropTypes.func.isRequired, // callback when the lightbox is dismissed
+        src: PropTypes.string.isRequired, // the source of the image being displayed
+        name: PropTypes.string, // the main title ('name') for the image
+        link: PropTypes.string, // the link (if any) applied to the name of the image
+        width: PropTypes.number, // width of the image src in pixels
+        height: PropTypes.number, // height of the image src in pixels
+        fileSize: PropTypes.number, // size of the image src in bytes
+        onFinished: PropTypes.func.isRequired, // callback when the lightbox is dismissed
 
         // the event (if any) that the Image is displaying. Used for event-specific stuff like
         // redactions, senders, timestamps etc.  Other descriptors are taken from the explicit
         // properties above, which let us use lightboxes to display images which aren't associated
         // with events.
-        mxEvent: React.PropTypes.object,
+        mxEvent: PropTypes.object,
     };
 
     constructor(props) {

--- a/src/components/views/elements/Tooltip.js
+++ b/src/components/views/elements/Tooltip.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2019 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ limitations under the License.
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import dis from '../../../dispatcher';
 import classNames from 'classnames';
 
@@ -28,15 +30,15 @@ module.exports = React.createClass({
 
     propTypes: {
         // Class applied to the element used to position the tooltip
-        className: React.PropTypes.string,
+        className: PropTypes.string,
         // Class applied to the tooltip itself
-        tooltipClassName: React.PropTypes.string,
+        tooltipClassName: PropTypes.string,
         // Whether the tooltip is visible or hidden.
         // The hidden state allows animating the tooltip away via CSS.
         // Defaults to visible if unset.
-        visible: React.PropTypes.bool,
+        visible: PropTypes.bool,
         // the react element to put into the tooltip
-        label: React.PropTypes.node,
+        label: PropTypes.node,
     },
 
     getDefaultProps() {

--- a/src/components/views/elements/UserSelector.js
+++ b/src/components/views/elements/UserSelector.js
@@ -25,7 +25,7 @@ module.exports = React.createClass({
 
     propTypes: {
         onChange: PropTypes.func,
-        selected_users: PropTypes.arrayOf(React.PropTypes.string),
+        selected_users: PropTypes.arrayOf(PropTypes.string),
     },
 
     getDefaultProps: function() {

--- a/src/components/views/globals/NewVersionBar.js
+++ b/src/components/views/globals/NewVersionBar.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,9 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import sdk from '../../../index';
 import Modal from '../../../Modal';
 import PlatformPeg from '../../../PlatformPeg';
@@ -33,9 +33,9 @@ function checkVersion(ver) {
 
 export default React.createClass({
     propTypes: {
-        version: React.PropTypes.string.isRequired,
-        newVersion: React.PropTypes.string.isRequired,
-        releaseNotes: React.PropTypes.string,
+        version: PropTypes.string.isRequired,
+        newVersion: PropTypes.string.isRequired,
+        releaseNotes: PropTypes.string,
     },
 
     displayReleaseNotes: function(releaseNotes) {

--- a/src/components/views/globals/UpdateCheckBar.js
+++ b/src/components/views/globals/UpdateCheckBar.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Michael Telatynski <7t3chguy@gmail.com>
+Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { _t } from '../../../languageHandler';
 import PlatformPeg from '../../../PlatformPeg';
 import AccessibleButton from '../../../components/views/elements/AccessibleButton';
 
 export default React.createClass({
     propTypes: {
-        status: React.PropTypes.string.isRequired,
+        status: PropTypes.string.isRequired,
         // Currently for error detail but will be usable for download progress
         // once that is a thing that squirrel passes through electron.
-        detail: React.PropTypes.string,
+        detail: PropTypes.string,
     },
 
     getDefaultProps: function() {

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -2,6 +2,7 @@
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 New Vector Ltd
 Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -131,7 +132,7 @@ module.exports = withMatrixClient(React.createClass({
         onHeightChanged: PropTypes.func,
 
         /* a list of read-receipts we should show. Each object has a 'roomMember' and 'ts'. */
-        readReceipts: PropTypes.arrayOf(React.PropTypes.object),
+        readReceipts: PropTypes.arrayOf(PropTypes.object),
 
         /* opaque readreceipt info for each userId; used by ReadReceiptMarker
          * to manage its animations. Should be an empty object when the room

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -18,6 +18,7 @@ import SettingsStore from "../../../src/settings/SettingsStore";
 
 const React = require('react');
 const ReactDOM = require("react-dom");
+import PropTypes from "prop-types";
 const TestUtils = require('react-addons-test-utils');
 const expect = require('expect');
 import sinon from 'sinon';
@@ -40,7 +41,7 @@ const room = new Matrix.Room();
 // wrap MessagePanel with a component which provides the MatrixClient in the context.
 const WrappedMessagePanel = React.createClass({
     childContextTypes: {
-        matrixClient: React.PropTypes.object,
+        matrixClient: PropTypes.object,
     },
 
     getChildContext: function() {


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/6410