### PR TITLE
Undo/redo support for new editor

### DIFF
--- a/src/components/views/elements/MessageEditor.js
+++ b/src/components/views/elements/MessageEditor.js
@@ -315,9 +315,7 @@ export default class MessageEditor extends React.Component {
     componentDidMount() {
         this._createEditorModel();
         // initial render of model
-        this._updateEditorState();
-        // initial caret position
-        this._initializeCaret();
+        this._updateEditorState(this._getInitialCaretPosition());
         // attach input listener by hand so React doesn't proxy the events,
         // as the proxied event doesn't support inputType, which we need.
         this._editorRef.addEventListener("input", this._onInput, true);
@@ -350,7 +348,7 @@ export default class MessageEditor extends React.Component {
         );
     }
 
-    _initializeCaret() {
+    _getInitialCaretPosition() {
         const {editState} = this.props;
         let caretPosition;
         if (editState.hasEditorState()) {
@@ -362,7 +360,7 @@ export default class MessageEditor extends React.Component {
             // otherwise, set it at the end
             caretPosition = this.model.getPositionAtEnd();
         }
-        setCaretPosition(this._editorRef, this.model, caretPosition);
+        return caretPosition;
     }
 
     render() {

--- a/src/editor/history.js
+++ b/src/editor/history.js
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+export const MAX_STEP_LENGTH = 10;
+
 export default class HistoryManager {
     constructor() {
         this._stack = [];
@@ -30,9 +32,8 @@ export default class HistoryManager {
                 return true;
             }
             if (diff.added) {
-                // only append after every 5th keystroke while typing
                 this._newlyTypedCharCount += diff.added.length;
-                return this._newlyTypedCharCount > 5;
+                return this._newlyTypedCharCount > MAX_STEP_LENGTH;
             }
         } else {
             return true;

--- a/src/editor/history.js
+++ b/src/editor/history.js
@@ -1,0 +1,101 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default class HistoryManager {
+    constructor() {
+        this._stack = [];
+        this._newlyTypedCharCount = 0;
+        this._currentIndex = -1;
+        this._changedSinceLastPush = false;
+        this._lastCaret = null;
+    }
+
+    _shouldPush(inputType, diff) {
+        if (inputType === "insertText") {
+            if (diff.removed) {
+                // always append when removing text
+                return true;
+            }
+            if (diff.added) {
+                // only append after every 5th keystroke while typing
+                this._newlyTypedCharCount += diff.added.length;
+                return this._newlyTypedCharCount > 5;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    _pushState(model, caret) {
+        // remove all steps after current step
+        while (this._currentIndex < (this._stack.length - 1)) {
+            this._stack.pop();
+        }
+        const parts = model.serializeParts();
+        this._stack.push({parts, caret});
+        this._currentIndex = this._stack.length - 1;
+        this._lastCaret = null;
+        this._changedSinceLastPush = false;
+        this._newlyTypedCharCount = 0;
+    }
+
+    // needs to persist parts and caret position
+    tryPush(model, caret, inputType, diff) {
+        // ignore state restoration echos.
+        // these respect the inputType values of the input event,
+        // but are actually passed in from MessageEditor calling model.reset()
+        // in the keydown event handler.
+        if (inputType === "historyUndo" || inputType === "historyRedo") {
+            return false;
+        }
+        const shouldPush = this._shouldPush(inputType, diff);
+        if (shouldPush) {
+            this._pushState(model, caret);
+        } else {
+            this._lastCaret = caret;
+            this._changedSinceLastPush = true;
+        }
+        return shouldPush;
+    }
+
+    canUndo() {
+        return this._currentIndex >= 1 || this._changedSinceLastPush;
+    }
+
+    canRedo() {
+        return this._currentIndex < (this._stack.length - 1);
+    }
+
+    // returns state that should be applied to model
+    undo(model) {
+        if (this.canUndo()) {
+            if (this._changedSinceLastPush) {
+                this._pushState(model, this._lastCaret);
+            }
+            this._currentIndex -= 1;
+            return this._stack[this._currentIndex];
+        }
+    }
+
+    // returns state that should be applied to model
+    redo() {
+        if (this.canRedo()) {
+            this._changedSinceLastPush = false;
+            this._currentIndex += 1;
+            return this._stack[this._currentIndex];
+        }
+    }
+}

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -107,7 +107,7 @@ export default class EditorModel {
         const caretOffset = diff.at - removedOffsetDecrease + addedLen;
         const newPosition = this.positionForOffset(caretOffset, true);
         this._setActivePart(newPosition, canOpenAutoComplete);
-        this._updateCallback(newPosition);
+        this._updateCallback(newPosition, inputType, diff);
     }
 
     _setActivePart(pos, canOpenAutoComplete) {

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -90,6 +90,11 @@ export default class EditorModel {
         }
     }
 
+    reset(serializedParts, caret, inputType) {
+        this._parts = serializedParts.map(p => this._partCreator.deserializePart(p));
+        this._updateCallback(caret, inputType);
+    }
+
     update(newValue, inputType, caret) {
         const diff = this._diff(newValue, inputType, caret);
         const position = this.positionForOffset(diff.at, caret.atNodeEnd);

--- a/src/editor/render.js
+++ b/src/editor/render.js
@@ -176,7 +176,7 @@ export function renderModel(editor, model) {
         }
     });
     if (lines.length) {
-        removeNextSiblings(editor.children[lines.length]);
+        removeNextSiblings(editor.children[lines.length - 1]);
     } else {
         removeChildren(editor);
     }

--- a/test/editor/history-test.js
+++ b/test/editor/history-test.js
@@ -79,6 +79,33 @@ describe('editor/history', function() {
         expect(history.canUndo()).toEqual(false);
         expect(keystrokeCount).toEqual(MAX_STEP_LENGTH + 1); // +1 before we type before checking
     });
+    it('history step is added at word boundary', function() {
+        const history = new HistoryManager();
+        const model = {serializeParts: () => parts.slice()};
+        const parts = ["h"];
+        let diff = {added: "h"};
+        expect(history.tryPush(model, {}, "insertText", diff)).toEqual(false);
+        diff = {added: "i"};
+        parts[0] = "hi";
+        expect(history.tryPush(model, {}, "insertText", diff)).toEqual(false);
+        diff = {added: " "};
+        parts[0] = "hi ";
+        const spaceCaret = {};
+        expect(history.tryPush(model, spaceCaret, "insertText", diff)).toEqual(true);
+        diff = {added: "y"};
+        parts[0] = "hi y";
+        expect(history.tryPush(model, {}, "insertText", diff)).toEqual(false);
+        diff = {added: "o"};
+        parts[0] = "hi yo";
+        expect(history.tryPush(model, {}, "insertText", diff)).toEqual(false);
+        diff = {added: "u"};
+        parts[0] = "hi you";
+
+        expect(history.canUndo()).toEqual(true);
+        const undoResult = history.undo(model);
+        expect(undoResult.caret).toEqual(spaceCaret);
+        expect(undoResult.parts).toEqual(["hi "]);
+    });
     it('keystroke that didn\'t add a step can undo', function() {
         const history = new HistoryManager();
         const parts = ["hello"];

--- a/test/editor/history-test.js
+++ b/test/editor/history-test.js
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import expect from 'expect';
+import HistoryManager from "../../src/editor/history";
+
+describe('editor/history', function() {
+    it('push, then undo', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        const caret1 = {};
+        const result1 = history.tryPush(model, caret1);
+        expect(result1).toEqual(true);
+        parts[0] = "hello world";
+        history.tryPush(model, {});
+        expect(history.canUndo()).toEqual(true);
+        const undoState = history.undo(model);
+        expect(undoState.caret).toEqual(caret1);
+        expect(undoState.parts).toEqual(["hello"]);
+        expect(history.canUndo()).toEqual(false);
+    });
+    it('push, undo, then redo', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        history.tryPush(model, {});
+        parts[0] = "hello world";
+        const caret2 = {};
+        history.tryPush(model, caret2);
+        history.undo(model);
+        expect(history.canRedo()).toEqual(true);
+        const redoState = history.redo();
+        expect(redoState.caret).toEqual(caret2);
+        expect(redoState.parts).toEqual(["hello world"]);
+        expect(history.canRedo()).toEqual(false);
+        expect(history.canUndo()).toEqual(true);
+    });
+    it('push, undo, push, ensure you can`t redo', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        history.tryPush(model, {});
+        parts[0] = "hello world";
+        history.tryPush(model, {});
+        history.undo(model);
+        parts[0] = "hello world!!";
+        history.tryPush(model, {});
+        expect(history.canRedo()).toEqual(false);
+    });
+    it('not every keystroke stores a history step', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        const firstCaret = {};
+        history.tryPush(model, firstCaret);
+        const diff = {added: "o"};
+        let keystrokeCount = 0;
+        do {
+            parts[0] = parts[0] + diff.added;
+            keystrokeCount += 1;
+        } while (!history.tryPush(model, {}, "insertText", diff));
+        const undoState = history.undo(model);
+        expect(undoState.caret).toEqual(firstCaret);
+        expect(undoState.parts).toEqual(["hello"]);
+        expect(history.canUndo()).toEqual(false);
+        expect(keystrokeCount).toBeGreaterThan(2);
+        expect(keystrokeCount).toBeLessThan(20);
+    });
+    it('keystroke that didn\'t add a step can undo', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        const firstCaret = {};
+        history.tryPush(model, {});
+        parts[0] = "helloo";
+        const result = history.tryPush(model, {}, "insertText", {added: "o"});
+        expect(result).toEqual(false);
+        expect(history.canUndo()).toEqual(true);
+        const undoState = history.undo(model);
+        expect(undoState.caret).toEqual(firstCaret);
+        expect(undoState.parts).toEqual(["hello"]);
+    });
+    it('undo after keystroke that didn\'t add a step is able to redo', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        history.tryPush(model, {});
+        parts[0] = "helloo";
+        const caret = {last: true};
+        history.tryPush(model, caret, "insertText", {added: "o"});
+        history.undo(model);
+        expect(history.canRedo()).toEqual(true);
+        const redoState = history.redo();
+        expect(redoState.caret).toEqual(caret);
+        expect(redoState.parts).toEqual(["helloo"]);
+    });
+    it('overwriting text always stores a step', function() {
+        const history = new HistoryManager();
+        const parts = ["hello"];
+        const model = {serializeParts: () => parts.slice()};
+        const firstCaret = {};
+        history.tryPush(model, firstCaret);
+        const diff = {at: 1, added: "a", removed: "e"};
+        const result = history.tryPush(model, {}, "insertText", diff);
+        expect(result).toEqual(true);
+    });
+});

--- a/test/editor/history-test.js
+++ b/test/editor/history-test.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import expect from 'expect';
-import HistoryManager from "../../src/editor/history";
+import HistoryManager, {MAX_STEP_LENGTH} from "../../src/editor/history";
 
 describe('editor/history', function() {
     it('push, then undo', function() {
@@ -77,8 +77,7 @@ describe('editor/history', function() {
         expect(undoState.caret).toEqual(firstCaret);
         expect(undoState.parts).toEqual(["hello"]);
         expect(history.canUndo()).toEqual(false);
-        expect(keystrokeCount).toBeGreaterThan(2);
-        expect(keystrokeCount).toBeLessThan(20);
+        expect(keystrokeCount).toEqual(MAX_STEP_LENGTH + 1); // +1 before we type before checking
     });
     it('keystroke that didn\'t add a step can undo', function() {
         const history = new HistoryManager();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9831

The algorithm when to push history steps might still need a bit of fine-tuning. Right now it always pushes on every change, apart from when typing (and not overwriting), then it pushes a step on every 5th typed character.

![editor-history](https://user-images.githubusercontent.com/274386/62282669-775c7c80-b43f-11e9-8fab-6f87aadeb0ad.gif)
