### PR TITLE
Fix dialog button border colours

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -380,7 +380,7 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
 
     // flip colours for the secondary ones
     font-weight: 600;
-    border: 1px solid $accent-color !important;
+    border: 1px solid $accent-color;
     color: $accent-color;
     background-color: $button-secondary-bg-color;
 }


### PR DESCRIPTION
This corrects dialog button borders to match other buttons by removing the green
border from disabled and danger states.

<img width="288" alt="danger-dialog" src="https://user-images.githubusercontent.com/279572/62290966-90265b80-b45a-11e9-9ebd-c7584767c00e.png">
<img width="269" alt="disabled-dialog" src="https://user-images.githubusercontent.com/279572/62290972-91578880-b45a-11e9-9b5c-1112ef8fa531.png">

Fixes https://github.com/vector-im/riot-web/issues/10310