### PR TITLE
Show terms modal when inviting by email

### DIFF
--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as Matrix from 'matrix-js-sdk';
+import { SERVICE_TYPES } from 'matrix-js-sdk';
 
 import MatrixClientPeg from './MatrixClientPeg';
 import { Service, startTermsFlow } from './Terms';
@@ -66,7 +66,7 @@ export default class IdentityAuthClient {
             if (e.errcode === "M_TERMS_NOT_SIGNED") {
                 console.log("Identity Server requires new terms to be agreed to");
                 await startTermsFlow([new Service(
-                    Matrix.SERVICE_TYPES.IS,
+                    SERVICE_TYPES.IS,
                     MatrixClientPeg.get().idBaseUrl,
                     token,
                 )]);


### PR DESCRIPTION
This invokes the terms modal flow when inviting someone by email. Entering an
email triggers a lookup to the IS, and if it has terms you need to agree to,
then a separate modal is shown to complete this activity. You then come back to
invite screen after agreeing to the terms.

![email-invite-terms](https://user-images.githubusercontent.com/279572/62312017-ffb14080-b484-11e9-8e96-b2b51da97ed5.gif)

Fixes https://github.com/vector-im/riot-web/issues/10093