### PR TITLE
Don't load guest sessions on post-registration login link

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -99,7 +99,9 @@ export async function loadSession(opts) {
                 guest: true,
             }, true).then(() => true);
         }
-        const success = await _restoreFromLocalStorage(Boolean(opts.ignoreGuest));
+        const success = await _restoreFromLocalStorage({
+            ignoreGuest: Boolean(opts.ignoreGuest),
+        });
         if (success) {
             return true;
         }
@@ -275,7 +277,9 @@ export function getLocalStorageSessionVars() {
 //      The plan is to gradually move the localStorage access done here into
 //      SessionStore to avoid bugs where the view becomes out-of-sync with
 //      localStorage (e.g. isGuest etc.)
-async function _restoreFromLocalStorage(ignoreGuest) {
+async function _restoreFromLocalStorage(opts) {
+    const ignoreGuest = opts.ignoreGuest;
+
     if (!localStorage) {
         return false;
     }

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -66,6 +66,9 @@ import TypingStore from "./stores/TypingStore";
  * @params {string} opts.guestIsUrl: homeserver URL. Only used if enableGuest is
  *     true; defines the IS to use.
  *
+ * @params {bool} opts.ignoreGuest: If the stored session is a guest account, ignore
+ *     it and don't load it.
+ *
  * @returns {Promise} a promise which resolves when the above process completes.
  *     Resolves to `true` if we ended up starting a session, or `false` if we
  *     failed.
@@ -96,7 +99,7 @@ export async function loadSession(opts) {
                 guest: true,
             }, true).then(() => true);
         }
-        const success = await _restoreFromLocalStorage();
+        const success = await _restoreFromLocalStorage(Boolean(opts.ignoreGuest));
         if (success) {
             return true;
         }
@@ -272,7 +275,7 @@ export function getLocalStorageSessionVars() {
 //      The plan is to gradually move the localStorage access done here into
 //      SessionStore to avoid bugs where the view becomes out-of-sync with
 //      localStorage (e.g. isGuest etc.)
-async function _restoreFromLocalStorage() {
+async function _restoreFromLocalStorage(ignoreGuest) {
     if (!localStorage) {
         return false;
     }
@@ -280,6 +283,11 @@ async function _restoreFromLocalStorage() {
     const {hsUrl, isUrl, accessToken, userId, deviceId, isGuest} = getLocalStorageSessionVars();
 
     if (accessToken && userId && hsUrl) {
+        if (ignoreGuest && isGuest) {
+            console.log("Ignoring stored guest account: " + userId);
+            return false;
+        }
+
         console.log(`Restoring session for ${userId}`);
         await _doSetLoggedIn({
             userId: userId,

--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -438,7 +438,7 @@ module.exports = React.createClass({
     _onLoginClickWithCheck: async function(ev) {
         ev.preventDefault();
 
-        const sessionLoaded = await Lifecycle.loadSession({});
+        const sessionLoaded = await Lifecycle.loadSession({ignoreGuest: true});
         if (!sessionLoaded) {
             // ok fine, there's still no session: really go to the login page
             this.props.onLoginClick();


### PR DESCRIPTION
If guest access was enabled, clicking the login link on the 'registration
completed' page would just load the guest account you had before registering.

Fixes https://github.com/vector-im/riot-web/issues/10482