### PR TITLE
Update existing 3PID management UX

### DIFF
--- a/res/css/views/settings/_EmailAddresses.scss
+++ b/res/css/views/settings/_EmailAddresses.scss
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 .mx_ExistingEmailAddress {
+    display: flex;
+    align-items: center;
     margin-bottom: 5px;
 }
 
@@ -24,14 +26,12 @@ limitations under the License.
     vertical-align: middle;
 }
 
-.mx_ExistingEmailAddress_email {
-    vertical-align: middle;
-}
-
+.mx_ExistingEmailAddress_email,
 .mx_ExistingEmailAddress_promptText {
+    flex: 1;
     margin-right: 10px;
 }
 
 .mx_ExistingEmailAddress_confirmBtn {
-    margin-right: 5px;
+    margin-left: 5px;
 }

--- a/res/css/views/settings/_PhoneNumbers.scss
+++ b/res/css/views/settings/_PhoneNumbers.scss
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 .mx_ExistingPhoneNumber {
+    display: flex;
+    align-items: center;
     margin-bottom: 5px;
 }
 
@@ -24,16 +26,14 @@ limitations under the License.
     vertical-align: middle;
 }
 
-.mx_ExistingPhoneNumber_address {
-    vertical-align: middle;
-}
-
+.mx_ExistingPhoneNumber_address,
 .mx_ExistingPhoneNumber_promptText {
+    flex: 1;
     margin-right: 10px;
 }
 
 .mx_ExistingPhoneNumber_confirmBtn {
-    margin-right: 5px;
+    margin-left: 5px;
 }
 
 .mx_PhoneNumbers_input {

--- a/src/components/views/settings/EmailAddresses.js
+++ b/src/components/views/settings/EmailAddresses.js
@@ -102,9 +102,10 @@ export class ExistingEmailAddress extends React.Component {
 
         return (
             <div className="mx_ExistingEmailAddress">
-                <img src={require("../../../../res/img/feather-customised/cancel.svg")} width={14} height={14}
-                     onClick={this._onRemove} className="mx_ExistingEmailAddress_delete" alt={_t("Remove")} />
                 <span className="mx_ExistingEmailAddress_email">{this.props.email.address}</span>
+                <AccessibleButton onClick={this._onRemove} kind="danger_sm">
+                    {_t("Remove")}
+                </AccessibleButton>
             </div>
         );
     }

--- a/src/components/views/settings/PhoneNumbers.js
+++ b/src/components/views/settings/PhoneNumbers.js
@@ -97,9 +97,10 @@ export class ExistingPhoneNumber extends React.Component {
 
         return (
             <div className="mx_ExistingPhoneNumber">
-                <img src={require("../../../../res/img/feather-customised/cancel.svg")} width={14} height={14}
-                     onClick={this._onRemove} className="mx_ExistingPhoneNumber_delete" alt={_t("Remove")} />
                 <span className="mx_ExistingPhoneNumber_address">+{this.props.msisdn.address}</span>
+                <AccessibleButton onClick={this._onRemove} kind="danger_sm">
+                    {_t("Remove")}
+                </AccessibleButton>
             </div>
         );
     }


### PR DESCRIPTION
This tweaks the appearance of the existing 3PID management UX to use a different
style for the remove button. This styling will more closely match the soon to be
added 3PID discovery settings.

<img width="585" alt="email-address-section" src="https://user-images.githubusercontent.com/279572/62476752-84f76680-b79f-11e9-9d95-766a3d819967.png">

Part of https://github.com/vector-im/riot-web/issues/10159