### PR TITLE
Remove 3PID binding during registration

### DIFF
--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -403,14 +403,9 @@ module.exports = React.createClass({
         // clicking the email link.
         let inhibitLogin = Boolean(this.state.formVals.email);
 
-        // Only send the bind params if we're sending username / pw params
+        // Only send inhibitLogin if we're sending username / pw params
         // (Since we need to send no params at all to use the ones saved in the
         // session).
-        const bindThreepids = this.state.formVals.password ? {
-            email: true,
-            msisdn: true,
-        } : {};
-        // Likewise inhibitLogin
         if (!this.state.formVals.password) inhibitLogin = null;
 
         return this.state.matrixClient.register(
@@ -418,7 +413,7 @@ module.exports = React.createClass({
             this.state.formVals.password,
             undefined, // session id: included in the auth dict already
             auth,
-            bindThreepids,
+            null,
             null,
             inhibitLogin,
         );


### PR DESCRIPTION
This disables 3PID binding at registration time, so users won't be discoverable
by 3PID by default. Instead, new discovery controls in settings allow you to
opt-in.

Fixes https://github.com/vector-im/riot-web/issues/10424