### PR TITLE
change Modal async/await signature to use raw promises

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -274,7 +274,7 @@ class ModalManager {
         this._reRender();
         return {
             close: closeDialog,
-            then: (resolve, reject) => onFinishedProm.then(resolve, reject),
+            finished: onFinishedProm,
         };
     }
 
@@ -285,7 +285,7 @@ class ModalManager {
         this._reRender();
         return {
             close: closeDialog,
-            then: (resolve, reject) => onFinishedProm.then(resolve, reject),
+            finished: onFinishedProm,
         };
     }
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -935,7 +935,7 @@ export default React.createClass({
         const CreateRoomDialog = sdk.getComponent('dialogs.CreateRoomDialog');
         const modal = Modal.createTrackedDialog('Create Room', '', CreateRoomDialog);
 
-        const [shouldCreate, name, noFederate] = await modal;
+        const [shouldCreate, name, noFederate] = await modal.finished;
         if (shouldCreate) {
             const createOpts = {};
             if (name) createOpts.name = name;


### PR DESCRIPTION
The signature from the previous PR irked me, it only supported async/await or Promises via Promise.resolve, but given that underneath it uses Promises anyway then might as well expose it more explicitly

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>