### PR TITLE
Fix alignment of add email/phone number inputs in settings

### DIFF
--- a/res/css/views/settings/tabs/user/_GeneralUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_GeneralUserSettingsTab.scss
@@ -23,8 +23,8 @@ limitations under the License.
     margin-top: 0;
 }
 
-.mx_GeneralUserSettingsTab_accountSection > .mx_EmailAddresses,
-.mx_GeneralUserSettingsTab_accountSection > .mx_PhoneNumbers,
+.mx_GeneralUserSettingsTab_accountSection .mx_EmailAddresses,
+.mx_GeneralUserSettingsTab_accountSection .mx_PhoneNumbers,
 .mx_GeneralUserSettingsTab_languageInput {
     margin-right: 100px; // Align with the other fields on the page
 }


### PR DESCRIPTION
The components were pushed a layer deeper into the DOM, so the CSS wasn't matching.

## Before:
![image](https://user-images.githubusercontent.com/1190097/62895244-b0cc9c00-bd0b-11e9-9ed4-0b73ed401c40.png)


## After:
![image](https://user-images.githubusercontent.com/1190097/62895170-85e24800-bd0b-11e9-95a0-5a75299e4187.png)
