### PR TITLE
Fix set integration manager tooltip

### DIFF
--- a/src/components/views/settings/SetIntegrationManager.js
+++ b/src/components/views/settings/SetIntegrationManager.js
@@ -124,7 +124,7 @@ export default class SetIntegrationManager extends React.Component {
                     id="mx_SetIntegrationManager_newUrl"
                     type="text" value={this.state.url} autoComplete="off"
                     onChange={this._onUrlChanged}
-                    tooltip={this._getTooltip()}
+                    tooltipContent={this._getTooltip()}
                 />
                 <AccessibleButton
                     kind="primary_sm"


### PR DESCRIPTION
The name of the prop changed in the original PR and this one didn't
get updated.