### PR TITLE
Improve Discovery section when no IS set

### DIFF
--- a/src/components/views/settings/SetIdServer.js
+++ b/src/components/views/settings/SetIdServer.js
@@ -95,8 +95,9 @@ export default class SetIdServer extends React.Component {
         }
 
         this.state = {
+            defaultIdServer,
             currentClientIdServer: MatrixClientPeg.get().getIdentityServerUrl(),
-            idServer: defaultIdServer,
+            idServer: "",
             error: null,
             busy: false,
             disconnectBusy: false,
@@ -265,7 +266,10 @@ export default class SetIdServer extends React.Component {
                 </span>
                 <Field label={_t("Identity Server")}
                     id="mx_SetIdServer_idServer"
-                    type="text" value={this.state.idServer} autoComplete="off"
+                    type="text"
+                    autoComplete="off"
+                    placeholder={this.state.defaultIdServer}
+                    value={this.state.idServer}
                     onChange={this._onIdentityServerChanged}
                     tooltipContent={this._getTooltip()}
                 />

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -189,13 +189,17 @@ export default class GeneralUserSettingsTab extends React.Component {
         const PhoneNumbers = sdk.getComponent("views.settings.discovery.PhoneNumbers");
         const SetIdServer = sdk.getComponent("views.settings.SetIdServer");
 
+        const threepidSection = this.state.haveIdServer ? <div>
+            <span className="mx_SettingsTab_subheading">{_t("Email addresses")}</span>
+            <EmailAddresses />
+
+            <span className="mx_SettingsTab_subheading">{_t("Phone numbers")}</span>
+            <PhoneNumbers />
+        </div> : null;
+
         return (
             <div className="mx_SettingsTab_section">
-                <span className="mx_SettingsTab_subheading">{_t("Email addresses")}</span>
-                <EmailAddresses />
-
-                <span className="mx_SettingsTab_subheading">{_t("Phone numbers")}</span>
-                <PhoneNumbers />
+                {threepidSection}
                 { /* has its own heading as it includes the current ID server */ }
                 <SetIdServer />
             </div>


### PR DESCRIPTION
This improves the Discovery section when no IS is set by hiding the 3PID areas and tweaking the IS placeholder behaviour.

<img width="581" alt="2019-08-19 at 14 16" src="https://user-images.githubusercontent.com/279572/63268719-b89cbb00-c28c-11e9-80bc-f9b46f04887d.png">

Fixes https://github.com/vector-im/riot-web/issues/10528