### PR TITLE
Tweak privacy settings copy and whitespace

### DIFF
--- a/res/css/views/settings/_SetIntegrationManager.scss
+++ b/res/css/views/settings/_SetIntegrationManager.scss
@@ -30,5 +30,4 @@ limitations under the License.
 .mx_SetIntegrationManager > .mx_SettingsTab_heading > .mx_SettingsTab_subheading {
     display: inline-block;
     padding-left: 5px;
-    font-size: 14px;
 }

--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -24,6 +24,10 @@ limitations under the License.
     color: $primary-fg-color;
 }
 
+.mx_SettingsTab_heading:nth-child(n + 2) {
+    margin-top: 30px;
+}
+
 .mx_SettingsTab_subheading {
     font-size: 16px;
     display: block;
@@ -37,9 +41,8 @@ limitations under the License.
 .mx_SettingsTab_subsectionText {
     color: $settings-subsection-fg-color;
     font-size: 14px;
-    padding-bottom: 12px;
     display: block;
-    margin: 0 100px 0 0; // Align with the rest of the view
+    margin: 10px 100px 10px 0; // Align with the rest of the view
 }
 
 .mx_SettingsTab_section .mx_SettingsFlag {
@@ -68,9 +71,14 @@ limitations under the License.
 }
 
 .mx_SettingsTab .mx_SettingsTab_subheading:nth-child(n + 2) {
+    // TODO: This `nth-child(n + 2)` isn't working very well since many sections
+    // add intermediate elements (mostly because our version of React requires
+    // them) which throws off the numbering and results in many subheading
+    // missing margins.
+    // See also https://github.com/vector-im/riot-web/issues/10554
     // These views have a lot of the same repetitive information on it, so
     // give them more visual distinction between the sections.
-    margin-top: 30px;
+    margin-top: 25px;
 }
 
 .mx_SettingsTab a {

--- a/src/components/views/settings/SetIdServer.js
+++ b/src/components/views/settings/SetIdServer.js
@@ -263,7 +263,7 @@ export default class SetIdServer extends React.Component {
                 <span className="mx_SettingsTab_subsectionText">
                     {bodyText}
                 </span>
-                <Field label={_t("Identity Server")}
+                <Field label={_t("Enter a new identity server")}
                     id="mx_SetIdServer_idServer"
                     type="text" value={this.state.idServer} autoComplete="off"
                     onChange={this._onIdentityServerChanged}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -557,6 +557,7 @@
     "Identity Server": "Identity Server",
     "You are not currently using an identity server. To discover and be discoverable by existing contacts you know, add one below.": "You are not currently using an identity server. To discover and be discoverable by existing contacts you know, add one below.",
     "Disconnecting from your identity server will mean you won't be discoverable by other users and you won't be able to invite others by email or phone.": "Disconnecting from your identity server will mean you won't be discoverable by other users and you won't be able to invite others by email or phone.",
+    "Enter a new identity server": "Enter a new identity server",
     "Change": "Change",
     "Failed to update integration manager": "Failed to update integration manager",
     "Integration manager offline or not accessible.": "Integration manager offline or not accessible.",


### PR DESCRIPTION
A few assorted changes that get us a bit closer to the privacy settings designs. A more holistic look is expected to happen in https://github.com/vector-im/riot-web/issues/10554.

<img width="699" alt="2019-08-19 at 15 49" src="https://user-images.githubusercontent.com/279572/63275220-03bccb00-c299-11e9-8b00-614aaecc9730.png">
