### PR TITLE
Explicitly check for modifier keydown events before focusing composer

### DIFF
--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -349,7 +349,8 @@ const LoggedInView = React.createClass({
 
         let handled = false;
         const ctrlCmdOnly = isOnlyCtrlOrCmdKeyEvent(ev);
-        const hasModifier = ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey;
+        const hasModifier = ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey ||
+            ev.key === "Alt" || ev.key === "Control" || ev.key === "Meta" || ev.key === "Shift";
 
         switch (ev.keyCode) {
             case KeyCode.PAGE_UP:


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/issues/10390#issuecomment-522914495 for context:

> Hmm, I indeed [see](https://danburzo.github.io/input-methods/index.html) (Linux, Gnome & Wayland) a keyboard event for just pressing `Control` on Chromium but not Firefox. If they `ctrlKey` flag isn't set on this event, it would explain things, but for me this flag is set. I'm adding some extra checks to not refocus when just pressing a modifier key, regardless of the state of the modifier flags. Let's see if that helps.

This is an attempt to fix that issue. See https://www.w3.org/TR/uievents-key/#keys-modifier for key constants.