### PR TITLE
Fix regression on widget panel edit button

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -266,7 +266,7 @@ export default class AppTile extends React.Component {
             // TODO: Open the right manager for the widget
             IntegrationManagers.sharedInstance().getPrimaryManager().open(
                 this.props.room,
-                this.props.type,
+                'type_' + this.props.type,
                 this.props.id,
             );
         }


### PR DESCRIPTION
Due to commit https://github.com/matrix-org/matrix-react-sdk/commit/ffa49df8892fa5377312dce28adb721326a9009e
the parameters for the call to open a widget in edit mode from the
widget panel in a room has broken. The `screen` parameter needs
to be prefixed with `type_` as it was before.

This corresponds to parameters supplied when creating the URL when
opening a widget in edit mode through Scalar screens.

Signed-off-by: Jason Robinson <jasonr@matrix.org>