### PR TITLE
Don't double translate labs settings

### DIFF
--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.js
@@ -32,7 +32,7 @@ export class LabsSettingToggle extends React.Component {
     };
 
     render() {
-        const label = _t(SettingsStore.getDisplayName(this.props.featureId));
+        const label = SettingsStore.getDisplayName(this.props.featureId);
         const value = SettingsStore.isFeatureEnabled(this.props.featureId);
         return <LabelledToggleSwitch value={value} label={label} onChange={this._onChange} />;
     }


### PR DESCRIPTION
SettingsStore.getDisplayName() already calls _t() for us.

Fixes https://github.com/vector-im/riot-web/issues/10586