### PR TITLE
Add IS access token callback

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -220,9 +220,7 @@ class MatrixClientPeg {
             fallbackICEServerAllowed: !!SettingsStore.getValue('fallbackICEServerAllowed'),
             verificationMethods: [verificationMethods.SAS],
             unstableClientRelationAggregation: true,
-            getIdentityAccessToken: () => {
-                return new IdentityAuthClient().getAccessToken();
-            },
+            identityServer: new IdentityAuthClient(),
         };
 
         this.matrixClient = createMatrixClient(opts);

--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -32,6 +32,7 @@ import Modal from './Modal';
 import {verificationMethods} from 'matrix-js-sdk/lib/crypto';
 import MatrixClientBackedSettingsHandler from "./settings/handlers/MatrixClientBackedSettingsHandler";
 import * as StorageManager from './utils/StorageManager';
+import IdentityAuthClient from './IdentityAuthClient';
 
 interface MatrixClientCreds {
     homeserverUrl: string,
@@ -219,6 +220,9 @@ class MatrixClientPeg {
             fallbackICEServerAllowed: !!SettingsStore.getValue('fallbackICEServerAllowed'),
             verificationMethods: [verificationMethods.SAS],
             unstableClientRelationAggregation: true,
+            getIdentityAccessToken: () => {
+                return new IdentityAuthClient().getAccessToken();
+            },
         };
 
         this.matrixClient = createMatrixClient(opts);


### PR DESCRIPTION
This passes a callback to the JS SDK which it can use to get IS access tokens
whenever needed for either talking to the IS directly or passing along to the
HS.

Fixes https://github.com/vector-im/riot-web/issues/10525
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1022