### PR TITLE
Only Destroy the expected persistent widget, not *ANY*

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -154,10 +154,9 @@ export default class AppTile extends React.Component {
         // Widget action listeners
         dis.unregister(this.dispatcherRef);
 
-        const canPersist = this.props.whitelistCapabilities.includes('m.always_on_screen');
         // if it's not remaining on screen, get rid of the PersistedElement container
-        if (canPersist && !ActiveWidgetStore.getWidgetPersistence(this.props.id)) {
-            ActiveWidgetStore.destroyPersistentWidget();
+        if (!ActiveWidgetStore.getWidgetPersistence(this.props.id)) {
+            ActiveWidgetStore.destroyPersistentWidget(this.props.id);
             const PersistedElement = sdk.getComponent("elements.PersistedElement");
             PersistedElement.destroyElement(this._persistKey);
         }
@@ -429,7 +428,7 @@ export default class AppTile extends React.Component {
         this.setState({hasPermissionToLoad: false});
 
         // Force the widget to be non-persistent
-        ActiveWidgetStore.destroyPersistentWidget();
+        ActiveWidgetStore.destroyPersistentWidget(this.props.id);
         const PersistedElement = sdk.getComponent("elements.PersistedElement");
         PersistedElement.destroyElement(this._persistKey);
     }

--- a/src/stores/ActiveWidgetStore.js
+++ b/src/stores/ActiveWidgetStore.js
@@ -67,11 +67,12 @@ class ActiveWidgetStore extends EventEmitter {
         if (ev.getType() !== 'im.vector.modular.widgets') return;
 
         if (ev.getStateKey() === this._persistentWidgetId) {
-            this.destroyPersistentWidget();
+            this.destroyPersistentWidget(this._persistentWidgetId);
         }
     }
 
-    destroyPersistentWidget() {
+    destroyPersistentWidget(id) {
+        if (id !== this._persistentWidgetId) return;
         const toDeleteId = this._persistentWidgetId;
 
         this.setWidgetPersistence(toDeleteId, false);


### PR DESCRIPTION
This fixes all cases of https://github.com/vector-im/riot-web/issues/9878
but may leave some things not cleaned up properly. Persistent widgets are really a bit magic :(((

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>