### PR TITLE
Iterate over all instances of variable/tag for _t substitutions

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -177,6 +177,10 @@ export function replaceByRegexes(text, mapping) {
     // If we insert any components we need to wrap the output in a span. React doesn't like just an array of components.
     let shouldWrapInSpan = false;
 
+    if (text === "You are now ignoring %(userId)s") {
+        debugger;
+    }
+
     for (const regexpString in mapping) {
         // TODO: Cache regexps
         const regexp = new RegExp(regexpString, "g");
@@ -233,11 +237,15 @@ export function replaceByRegexes(text, mapping) {
 
                 // add the text between prevMatch and this one
                 // or the end of the string if prevMatch is the last match
+                let tail;
                 if (match) {
                     const startIndex = prevMatch.index + prevMatch[0].length;
-                    parts.push(inputText.substr(startIndex, match.index - startIndex));
+                    tail = inputText.substr(startIndex, match.index - startIndex);
                 } else {
-                    parts.push(inputText.substr(prevMatch.index + prevMatch[0].length));
+                    tail = inputText.substr(prevMatch.index + prevMatch[0].length);
+                }
+                if (tail) {
+                    parts.push(tail);
                 }
             }
 

--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -177,10 +177,6 @@ export function replaceByRegexes(text, mapping) {
     // If we insert any components we need to wrap the output in a span. React doesn't like just an array of components.
     let shouldWrapInSpan = false;
 
-    if (text === "You are now ignoring %(userId)s") {
-        debugger;
-    }
-
     for (const regexpString in mapping) {
         // TODO: Cache regexps
         const regexp = new RegExp(regexpString, "g");

--- a/test/i18n-test/languageHandler-test.js
+++ b/test/i18n-test/languageHandler-test.js
@@ -73,12 +73,12 @@ describe('languageHandler', function() {
 
     it('multiple replacements of the same variable', function() {
         const text = '%(var1)s %(var1)s';
-        expect(languageHandler._t(text, { var1: 'val1' })).toBe('val1 val1');
+        expect(languageHandler.substitute(text, { var1: 'val1' })).toBe('val1 val1');
     });
 
     it('multiple replacements of the same tag', function() {
         const text = '<a>Click here</a> to join the discussion! <a>or here</a>';
-        expect(languageHandler._t(text, {}, { 'a': (sub) => `x${sub}x` }))
+        expect(languageHandler.substitute(text, {}, { 'a': (sub) => `x${sub}x` }))
             .toBe('xClick herex to join the discussion! xor herex');
     });
 });

--- a/test/i18n-test/languageHandler-test.js
+++ b/test/i18n-test/languageHandler-test.js
@@ -70,4 +70,15 @@ describe('languageHandler', function() {
         const text = '%(var1)s %(var2)s';
         expect(languageHandler._t(text, { var2: 'val2', var1: 'val1' })).toBe('val1 val2');
     });
+
+    it('multiple replacements of the same variable', function() {
+        const text = '%(var1)s %(var1)s';
+        expect(languageHandler._t(text, { var1: 'val1' })).toBe('val1 val1');
+    });
+
+    it('multiple replacements of the same tag', function() {
+        const text = '<a>Click here</a> to join the discussion! <a>or here</a>';
+        expect(languageHandler._t(text, {}, { 'a': (sub) => `x${sub}x` }))
+            .toBe('xClick herex to join the discussion! xor herex');
+    });
 });


### PR DESCRIPTION
Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#Finding_successive_matches

Fixes https://github.com/vector-im/riot-web/issues/9086

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>