### PR TITLE
Auto-replace emoticons with emojis in new composer

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -78,7 +78,8 @@ export default class BasicMessageEditor extends React.Component {
     _replaceEmoticon = (caret, inputType, diff) => {
         const {model} = this.props;
         const range = model.startRange(caret);
-        // expand range max 8 characters backwards from caret
+        // expand range max 8 characters backwards from caret,
+        // as a space to look for an emoticon
         let n = 8;
         range.expandBackwardsWhile((index, offset) => {
             const part = model.parts[index];
@@ -90,8 +91,14 @@ export default class BasicMessageEditor extends React.Component {
             const query = emoticonMatch[1].toLowerCase().replace("-", "");
             const data = EMOJIBASE.find(e => e.emoticon ? e.emoticon.toLowerCase() === query : false);
             if (data) {
-                // + 1 because index is reported without preceding space
-                range.moveStart(emoticonMatch.index + 1);
+                const hasPrecedingSpace = emoticonMatch[0][0] === " ";
+                // we need the range to only comprise of the emoticon
+                // because we'll replace the whole range with an emoji,
+                // so move the start forward to the start of the emoticon.
+                // Take + 1 because index is reported without the possible preceding space.
+                range.moveStart(emoticonMatch.index + (hasPrecedingSpace ? 1 : 0));
+                // this returns the amount of added/removed characters during the replace
+                // so the caret position can be adjusted.
                 return range.replace([this.props.model.partCreator.plain(data.unicode + " ")]);
             }
         }

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -25,6 +25,11 @@ import {autoCompleteCreator} from '../../../editor/parts';
 import {renderModel} from '../../../editor/render';
 import {Room} from 'matrix-js-sdk';
 import TypingStore from "../../../stores/TypingStore";
+import EMOJIBASE from 'emojibase-data/en/compact.json';
+import SettingsStore from "../../../settings/SettingsStore";
+import EMOTICON_REGEX from 'emojibase-regex/emoticon';
+
+const REGEX_EMOTICON_WHITESPACE = new RegExp('(?:^|\\s)(' + EMOTICON_REGEX.source + ')\\s$');
 
 const IS_MAC = navigator.platform.indexOf("Mac") !== -1;
 
@@ -68,6 +73,28 @@ export default class BasicMessageEditor extends React.Component {
         this._editorRef = null;
         this._autocompleteRef = null;
         this._modifiedFlag = false;
+    }
+
+    _replaceEmoticon = (caret, inputType, diff) => {
+        const {model} = this.props;
+        const range = model.startRange(caret);
+        // expand range max 8 characters backwards from caret
+        let n = 8;
+        range.expandBackwardsWhile((index, offset) => {
+            const part = model.parts[index];
+            n -= 1;
+            return n >= 0 && (part.type === "plain" || part.type === "pill-candidate");
+        });
+        const emoticonMatch = REGEX_EMOTICON_WHITESPACE.exec(range.text);
+        if (emoticonMatch) {
+            const query = emoticonMatch[1].toLowerCase().replace("-", "");
+            const data = EMOJIBASE.find(e => e.emoticon ? e.emoticon.toLowerCase() === query : false);
+            if (data) {
+                // + 1 because index is reported without preceding space
+                range.moveStart(emoticonMatch.index + 1);
+                return range.replace([this.props.model.partCreator.plain(data.unicode + " ")]);
+            }
+        }
     }
 
     _updateEditorState = (caret, inputType, diff) => {
@@ -262,6 +289,9 @@ export default class BasicMessageEditor extends React.Component {
     componentDidMount() {
         const model = this.props.model;
         model.setUpdateCallback(this._updateEditorState);
+        if (SettingsStore.getValue('MessageComposerInput.autoReplaceEmoji')) {
+            model.setTransformCallback(this._replaceEmoticon);
+        }
         const partCreator = model.partCreator;
         // TODO: does this allow us to get rid of EditorStateTransfer?
         // not really, but we could not serialize the parts, and just change the autoCompleter

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -32,7 +32,7 @@ import Range from "./range";
  * @param {string?} inputType the inputType of the DOM input event
  * @param {object?} diff an object with `removed` and `added` strings
  * @return {Number?} addedLen how many characters were added/removed (-) before the caret during the transformation step.
-                     This is used to adjust the caret position.
+ *    This is used to adjust the caret position.
  */
 
 export default class EditorModel {
@@ -47,7 +47,8 @@ export default class EditorModel {
         this._updateInProgress = false;
     }
 
-    /** Set a callback for the transformation step.
+    /**
+     * Set a callback for the transformation step.
      * While processing an update, right before calling the update callback,
      * a transform callback can be called, which serves to do modifications
      * on the model that can span multiple parts. Also see `startRange()`.
@@ -57,7 +58,8 @@ export default class EditorModel {
         this._transformCallback = transformCallback;
     }
 
-    /** Set a callback for rerendering the model after it has been updated.
+    /**
+     * Set a callback for rerendering the model after it has been updated.
      * @param {ModelCallback} updateCallback
      */
     setUpdateCallback(updateCallback) {

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -19,6 +19,13 @@ import {diffAtCaret, diffDeletion} from "./diff";
 import DocumentPosition from "./position";
 import Range from "./range";
 
+/**
+ * @callback ModelCallback
+ * @param {DocumentPosition?} caretPosition the position where the caret should be position
+ * @param {string?} inputType the inputType of the DOM input event
+ * @param {object?} diff an object with `removed` and `added` strings
+ */
+
  /**
  * @callback TransformCallback
  * @param {DocumentPosition?} caretPosition the position where the caret should be position
@@ -50,6 +57,9 @@ export default class EditorModel {
         this._transformCallback = transformCallback;
     }
 
+    /** Set a callback for rerendering the model after it has been updated.
+     * @param {ModelCallback} updateCallback
+     */
     setUpdateCallback(updateCallback) {
         this._updateCallback = updateCallback;
     }
@@ -376,6 +386,11 @@ export default class EditorModel {
         return new DocumentPosition(index, totalOffset - currentOffset);
     }
 
+    /**
+     * Starts a range, which can span across multiple parts, to find and replace text.
+     * @param {DocumentPosition} position where to start the range
+     * @return {Range}
+     */
     startRange(position) {
         return new Range(this, position);
     }

--- a/src/editor/model.js
+++ b/src/editor/model.js
@@ -183,9 +183,7 @@ export default class EditorModel {
         this._setActivePart(newPosition, canOpenAutoComplete);
         if (this._transformCallback) {
             const transformAddedLen = this._transform(newPosition, inputType, diff);
-            if (transformAddedLen !== 0) {
-                newPosition = this.positionForOffset(caretOffset + transformAddedLen, true);
-            }
+            newPosition = this.positionForOffset(caretOffset + transformAddedLen, true);
         }
         this._updateInProgress = false;
         this._updateCallback(newPosition, inputType, diff);

--- a/src/editor/position.js
+++ b/src/editor/position.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default class DocumentPosition {
+    constructor(index, offset) {
+        this._index = index;
+        this._offset = offset;
+    }
+
+    get index() {
+        return this._index;
+    }
+
+    get offset() {
+        return this._offset;
+    }
+
+    compare(otherPos) {
+        if (this._index === otherPos._index) {
+            return this._offset - otherPos._offset;
+        } else {
+            return this._index - otherPos._index;
+        }
+    }
+}

--- a/src/editor/position.js
+++ b/src/editor/position.js
@@ -35,4 +35,73 @@ export default class DocumentPosition {
             return this._index - otherPos._index;
         }
     }
+
+    iteratePartsBetween(other, model, callback) {
+        if (this.index === -1 || other.index === -1) {
+            return;
+        }
+        const [startPos, endPos] = this.compare(other) < 0 ? [this, other] : [other, this];
+        if (startPos.index === endPos.index) {
+            callback(model.parts[this.index], startPos.offset, endPos.offset);
+        } else {
+            const firstPart = model.parts[startPos.index];
+            callback(firstPart, startPos.offset, firstPart.text.length);
+            for (let i = startPos.index + 1; i < endPos.index; ++i) {
+                const part = model.parts[i];
+                callback(part, 0, part.text.length);
+            }
+            const lastPart = model.parts[endPos.index];
+            callback(lastPart, 0, endPos.offset);
+        }
+    }
+
+    forwardsWhile(model, predicate) {
+        if (this.index === -1) {
+            return this;
+        }
+
+        let {index, offset} = this;
+        const {parts} = model;
+        while (index < parts.length) {
+            const part = parts[index];
+            while (offset < part.text.length) {
+                if (!predicate(index, offset, part)) {
+                    return new DocumentPosition(index, offset);
+                }
+                offset += 1;
+            }
+            // end reached
+            if (index === (parts.length - 1)) {
+                return new DocumentPosition(index, offset);
+            } else {
+                index += 1;
+                offset = 0;
+            }
+        }
+    }
+
+    backwardsWhile(model, predicate) {
+        if (this.index === -1) {
+            return this;
+        }
+
+        let {index, offset} = this;
+        const parts = model.parts;
+        while (index >= 0) {
+            const part = parts[index];
+            while (offset > 0) {
+                if (!predicate(index, offset - 1, part)) {
+                    return new DocumentPosition(index, offset);
+                }
+                offset -= 1;
+            }
+            // start reached
+            if (index === 0) {
+                return new DocumentPosition(index, offset);
+            } else {
+                index -= 1;
+                offset = parts[index].text.length;
+            }
+        }
+    }
 }

--- a/src/editor/range.js
+++ b/src/editor/range.js
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default class Range {
+    constructor(model, startPosition, endPosition = startPosition) {
+        this._model = model;
+        this._start = startPosition;
+        this._end = endPosition;
+    }
+
+    moveStart(delta) {
+        this._start = this._start.forwardsWhile(this._model, () => {
+            delta -= 1;
+            return delta >= 0;
+        });
+    }
+
+    expandBackwardsWhile(predicate) {
+        this._start = this._start.backwardsWhile(this._model, predicate);
+    }
+
+    get text() {
+        let text = "";
+        this._start.iteratePartsBetween(this._end, this._model, (part, startIdx, endIdx) => {
+            const t = part.text.substring(startIdx, endIdx);
+            text = text + t;
+        });
+        return text;
+    }
+
+    replace(parts) {
+        const newLength = parts.reduce((sum, part) => sum + part.text.length, 0);
+        let oldLength = 0;
+        this._start.iteratePartsBetween(this._end, this._model, (part, startIdx, endIdx) => {
+            oldLength += endIdx - startIdx;
+        });
+        this._model.replaceRange(this._start, this._end, parts);
+        return newLength - oldLength;
+    }
+}

--- a/test/editor/position-test.js
+++ b/test/editor/position-test.js
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import expect from 'expect';
+import EditorModel from "../../src/editor/model";
+import {createPartCreator} from "./mock";
+
+function createRenderer() {
+    const render = (c) => {
+        render.caret = c;
+        render.count += 1;
+    };
+    render.count = 0;
+    render.caret = null;
+    return render;
+}
+
+describe('editor/position', function() {
+    it('move first position backward in empty model', function() {
+        const model = new EditorModel([], createPartCreator(), createRenderer());
+        const pos = model.positionForOffset(0, true);
+        const pos2 = pos.backwardsWhile(model, () => true);
+        expect(pos).toBe(pos2);
+    });
+    it('move first position forwards in empty model', function() {
+        const model = new EditorModel([], createPartCreator(), createRenderer());
+        const pos = model.positionForOffset(0, true);
+        const pos2 = pos.forwardsWhile(() => true);
+        expect(pos).toBe(pos2);
+    });
+    it('move forwards within one part', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain("hello")], pc, createRenderer());
+        const pos = model.positionForOffset(1);
+        let n = 3;
+        const pos2 = pos.forwardsWhile(model, () => { n -= 1; return n >= 0; });
+        expect(pos2.index).toBe(0);
+        expect(pos2.offset).toBe(4);
+    });
+    it('move forwards crossing to other part', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain("hello"), pc.plain(" world")], pc, createRenderer());
+        const pos = model.positionForOffset(4);
+        let n = 3;
+        const pos2 = pos.forwardsWhile(model, () => { n -= 1; return n >= 0; });
+        expect(pos2.index).toBe(1);
+        expect(pos2.offset).toBe(2);
+    });
+    it('move backwards within one part', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain("hello")], pc, createRenderer());
+        const pos = model.positionForOffset(4);
+        let n = 3;
+        const pos2 = pos.backwardsWhile(model, () => { n -= 1; return n >= 0; });
+        expect(pos2.index).toBe(0);
+        expect(pos2.offset).toBe(1);
+    });
+    it('move backwards crossing to other part', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain("hello"), pc.plain(" world")], pc, createRenderer());
+        const pos = model.positionForOffset(7);
+        let n = 3;
+        const pos2 = pos.backwardsWhile(model, () => { n -= 1; return n >= 0; });
+        expect(pos2.index).toBe(0);
+        expect(pos2.offset).toBe(4);
+    });
+});

--- a/test/editor/range-test.js
+++ b/test/editor/range-test.js
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import expect from 'expect';
+import EditorModel from "../../src/editor/model";
+import {createPartCreator} from "./mock";
+
+function createRenderer() {
+    const render = (c) => {
+        render.caret = c;
+        render.count += 1;
+    };
+    render.count = 0;
+    render.caret = null;
+    return render;
+}
+
+const pillChannel = "#riot-dev:matrix.org";
+
+describe('editor/range', function() {
+    it('range on empty model', function() {
+        const renderer = createRenderer();
+        const pc = createPartCreator();
+        const model = new EditorModel([], pc, renderer);
+        const range = model.startRange(model.positionForOffset(0, true));  // after "world"
+        let called = false;
+        range.expandBackwardsWhile(chr => {
+            called = true;
+            return true;
+        });
+        expect(called).toBe(false);
+        expect(range.text).toBe("");
+    });
+    it('range replace within a part', function() {
+        const renderer = createRenderer();
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain("hello world!!!!")], pc, renderer);
+        const range = model.startRange(model.positionForOffset(11));  // after "world"
+        range.expandBackwardsWhile((index, offset) => model.parts[index].text[offset] !== " ");
+        expect(range.text).toBe("world");
+        range.replace([pc.roomPill(pillChannel)]);
+        console.log({parts: JSON.stringify(model.serializeParts())});
+        expect(model.parts[0].type).toBe("plain");
+        expect(model.parts[0].text).toBe("hello ");
+        expect(model.parts[1].type).toBe("room-pill");
+        expect(model.parts[1].text).toBe(pillChannel);
+        expect(model.parts[2].type).toBe("plain");
+        expect(model.parts[2].text).toBe("!!!!");
+        expect(model.parts.length).toBe(3);
+        expect(renderer.count).toBe(1);
+    });
+    it('range replace across parts', function() {
+        const renderer = createRenderer();
+        const pc = createPartCreator();
+        const model = new EditorModel([
+            pc.plain("try to re"),
+            pc.plain("pla"),
+            pc.plain("ce "),
+            pc.plain("me"),
+        ], pc, renderer);
+        const range = model.startRange(model.positionForOffset(14));  // after "replace"
+        range.expandBackwardsWhile((index, offset) => model.parts[index].text[offset] !== " ");
+        expect(range.text).toBe("replace");
+        console.log("range.text", {text: range.text});
+        range.replace([pc.roomPill(pillChannel)]);
+        expect(model.parts[0].type).toBe("plain");
+        expect(model.parts[0].text).toBe("try to ");
+        expect(model.parts[1].type).toBe("room-pill");
+        expect(model.parts[1].text).toBe(pillChannel);
+        expect(model.parts[2].type).toBe("plain");
+        expect(model.parts[2].text).toBe(" me");
+        expect(model.parts.length).toBe(3);
+        expect(renderer.count).toBe(1);
+    });
+});


### PR DESCRIPTION
Implements https://github.com/vector-im/riot-web/issues/10629

To support auto-replacing emoticons, which can span multiple parts, the model gains support for a transform step where a range can be opened on the model, and replace with other parts. This is used to find and replace emoticons.

![emoticons](https://user-images.githubusercontent.com/274386/63697467-7d5e3700-c80c-11e9-92ac-1a5cba72d15c.gif)
