### PR TITLE
Don't infinite loop on server change

### DIFF
--- a/src/components/views/auth/ServerConfig.js
+++ b/src/components/views/auth/ServerConfig.js
@@ -82,7 +82,12 @@ export default class ServerConfig extends React.PureComponent {
         // Always try and use the defaults first
         const defaultConfig: ValidatedServerConfig = SdkConfig.get()["validated_server_config"];
         if (defaultConfig.hsUrl === hsUrl && defaultConfig.isUrl === isUrl) {
-            this.setState({busy: false, errorText: ""});
+            this.setState({
+                hsUrl: defaultConfig.hsUrl,
+                isUrl: defaultConfig.isUrl,
+                busy: false,
+                errorText: "",
+            });
             this.props.onServerConfigChange(defaultConfig);
             return defaultConfig;
         }


### PR DESCRIPTION
ServerConfig assumed that the state was already correct when
checking the given urls against the default, but that is not
neccessarily the case (eg. the validation can return a different
url to what the user entered). This would cause an infinite loop
because it would keep firing onServerConfigChange to change to
the desired URLs but the state would never change.

Fixes part of https://github.com/vector-im/riot-web/issues/10666