### PR TITLE
New composer: force model update after IME composition finishes

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -152,6 +152,9 @@ export default class BasicMessageEditor extends React.Component {
 
     _onCompositionEnd = (event) => {
         this._isIMEComposing = false;
+        // some browsers (chromium) don't fire an input event after ending a composition
+        // so trigger a model update after the composition is done by calling the input handler
+        this._onInput({inputType: "insertCompositionText"});
     }
 
     _onInput = (event) => {


### PR DESCRIPTION
Related to https://github.com/vector-im/riot-web/issues/10646
As browsers are not consistent whether they fire an `input` event before or after the `compositionend` event.