### PR TITLE
New composer: put display name in user pill text fallback instead of mxid

### DIFF
--- a/src/editor/serialize.js
+++ b/src/editor/serialize.js
@@ -54,7 +54,7 @@ export function textSerialize(model) {
                 return text + part.text;
             case "room-pill":
             case "user-pill":
-                return text + `${part.resourceId}`;
+                return text + `${part.text}`;
         }
     }, "");
 }


### PR DESCRIPTION
Fixes a cause of https://github.com/vector-im/riot-web/issues/10682
See if this helps with https://github.com/vector-im/riot-web/issues/10681 as well