### PR TITLE
Disable MSISDN registration if the homeserver doesn't support it

### DIFF
--- a/src/components/views/auth/RegistrationForm.js
+++ b/src/components/views/auth/RegistrationForm.js
@@ -447,7 +447,8 @@ module.exports = React.createClass({
     _showPhoneNumber() {
         const threePidLogin = !SdkConfig.get().disable_3pid_login;
         const haveIs = Boolean(this.props.serverConfig.isUrl);
-        if (!threePidLogin || (this.props.serverRequiresIdServer && !haveIs) || !this._authStepIsUsed('m.login.msisdn')) {
+        const haveRequiredIs = this.props.serverRequiresIdServer && !haveIs;
+        if (!threePidLogin || haveRequiredIs || !this._authStepIsUsed('m.login.msisdn')) {
             return false;
         }
         return true;

--- a/src/components/views/auth/RegistrationForm.js
+++ b/src/components/views/auth/RegistrationForm.js
@@ -447,7 +447,7 @@ module.exports = React.createClass({
     _showPhoneNumber() {
         const threePidLogin = !SdkConfig.get().disable_3pid_login;
         const haveIs = Boolean(this.props.serverConfig.isUrl);
-        if (!threePidLogin || !haveIs || !this._authStepIsUsed('m.login.msisdn')) {
+        if (!threePidLogin || (this.props.serverRequiresIdServer && !haveIs) || !this._authStepIsUsed('m.login.msisdn')) {
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10599 (I think?)

I'm failing to understand the full scope of the issue, but similar checks to this are already all over password reset and settings - it was just registration that missed it for msisdn only. 