### PR TITLE
Add Custom CSS Feature

### DIFF
--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -142,7 +142,7 @@ export default class GeneralUserSettingsTab extends React.Component {
 
     _saveCustomCss = (e) => {
         SettingsStore.setValue("customCss", null, SettingLevel.DEVICE, this.state.customCss).then(() => {
-            PlatformPeg.get().reload();
+            document.getElementById("customcss_container").innerHTML = this.state.customCss;
         });
     };
 

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -49,6 +49,7 @@ export default class GeneralUserSettingsTab extends React.Component {
         this.state = {
             language: languageHandler.getCurrentLanguage(),
             theme: SettingsStore.getValueAt(SettingLevel.ACCOUNT, "theme"),
+            customCss: SettingsStore.getValueAt(SettingLevel.DEVICE, "customCss"),
             haveIdServer: Boolean(MatrixClientPeg.get().getIdentityServerUrl()),
             serverRequiresIdServer: null,
             idServerHasUnsignedTerms: false,
@@ -133,6 +134,16 @@ export default class GeneralUserSettingsTab extends React.Component {
         SettingsStore.setValue("theme", null, SettingLevel.ACCOUNT, newTheme);
         this.setState({theme: newTheme});
         dis.dispatch({action: 'set_theme', value: newTheme});
+    };
+
+    _onCustomCssChange = (e) => {
+        this.setState({customCss: e.target.value});
+    };
+
+    _saveCustomCss = (e) => {
+        SettingsStore.setValue("customCss", null, SettingLevel.DEVICE, this.state.customCss).then(() => {
+            PlatformPeg.get().reload();
+        });
     };
 
     _onPasswordChangeError = (err) => {
@@ -244,6 +255,18 @@ export default class GeneralUserSettingsTab extends React.Component {
                     })}
                 </Field>
                 <SettingsFlag name="useCompactLayout" level={SettingLevel.ACCOUNT} />
+
+                <span className="mx_SettingsTab_subheading">{_t("Custom CSS")}</span>
+                <Field
+                    element="textarea"
+                    id="customCss"
+                    value={this.state.customCss}
+                    onChange={this._onCustomCssChange.bind(this)}
+                    />
+
+                <AccessibleButton onClick={this._saveCustomCss} kind="primary">
+                    {_t("Save")}
+                </AccessibleButton>
             </div>
         );
     }

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -246,7 +246,7 @@ export const SETTINGS = {
         controller: new ThemeController(),
     },
     "customCss": {
-        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: null,
     },
     "webRtcAllowPeerToPeer": {

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -245,6 +245,10 @@ export const SETTINGS = {
         default: "light",
         controller: new ThemeController(),
     },
+    "customCss": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        default: null,
+    },
     "webRtcAllowPeerToPeer": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         displayName: _td('Allow Peer-to-Peer for 1:1 calls'),


### PR DESCRIPTION
Linked PR: https://github.com/vector-im/riot-web/pull/10707

This PR implements a Custom CSS-Stylesheet Feature within the User-Settings Menu. 
There is a Textarea where Users can put their CSS Overrides into.
This will be stored in the SettingsStore and loaded/injected into the Interface. 

Its a pragmatic hack and should be replaced with a real Theming Engine in the Future. :-)

But for now this enables Theming Experiments and visual impaired Persons to modify the Interface for their needs.

Will fix #7316



Signed-off-by: Frank Isemann <frank@isemann.name>