### PR TITLE
Restrict green link colours to address picker dialog

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -281,12 +281,6 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
     box-shadow: 2px 15px 30px 0 $dialog-shadow-color;
     border-radius: 4px;
     overflow-y: auto;
-
-    a:link,
-    a:hover,
-    a:visited {
-        @mixin mx_Dialog_link;
-    }
 }
 
 .mx_Dialog_fixedWidth {

--- a/res/css/views/dialogs/_AddressPickerDialog.scss
+++ b/res/css/views/dialogs/_AddressPickerDialog.scss
@@ -1,6 +1,7 @@
 /*
 Copyright 2016 OpenMarket Ltd
 Copyright 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +15,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+.mx_AddressPickerDialog {
+    a:link,
+    a:hover,
+    a:visited {
+        @mixin mx_Dialog_link;
+    }
+}
 
 /* Using a textarea for this element, to circumvent autofill */
 .mx_AddressPickerDialog_input,


### PR DESCRIPTION
This changes to a more targeted selection of what becomes green (just the
actionable links in address picker).

Fixes https://github.com/vector-im/riot-web/issues/10703