### PR TITLE
New composer: make command detection not break with pill candidates in command

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.js
+++ b/src/components/views/rooms/SendMessageComposer.js
@@ -163,10 +163,7 @@ export default class SendMessageComposer extends React.Component {
 
     _isSlashCommand() {
         const parts = this.model.parts;
-        const isPlain = parts.reduce((isPlain, part) => {
-            return isPlain && (part.type === "command" || part.type === "plain" || part.type === "newline");
-        }, true);
-        return isPlain && parts.length > 0 && parts[0].text.startsWith("/");
+        return parts.length && parts[0].type === "command";
     }
 
     async _runSlashCommand() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10706

The bug was caused by typing #something or :something which would insert a pill candidate, at which point the command detection would not consider the message a command anymore.

Now only the first part should be of type `command` and any part can follow.