### PR TITLE
New composer: dont allow sending empty messages

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.js
+++ b/src/components/views/rooms/SendMessageComposer.js
@@ -203,6 +203,9 @@ export default class SendMessageComposer extends React.Component {
     }
 
     _sendMessage() {
+        if (this.model.isEmpty) {
+            return;
+        }
         if (!containsEmote(this.model) && this._isSlashCommand()) {
             this._runSlashCommand();
         } else {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10698

This still allows messages with just whitespace to be sent, but that's the same as what we had before.