### PR TITLE
Message editing: deserialize headers from html back to markdown

### DIFF
--- a/src/editor/deserialize.js
+++ b/src/editor/deserialize.js
@@ -71,8 +71,20 @@ function parseCodeBlock(n, partCreator) {
     return parts;
 }
 
+function parseHeader(el, partCreator) {
+    const depth = parseInt(el.nodeName.substr(1), 10);
+    return partCreator.plain("#".repeat(depth) + " ");
+}
+
 function parseElement(n, partCreator, state) {
     switch (n.nodeName) {
+        case "H1":
+        case "H2":
+        case "H3":
+        case "H4":
+        case "H5":
+        case "H6":
+            return parseHeader(n, partCreator);
         case "A":
             return parseLink(n, partCreator);
         case "BR":


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10602

![mdheaders](https://user-images.githubusercontent.com/274386/64121125-73e54980-cd8d-11e9-8528-48af856e4d6b.gif)
