### PR TITLE
/plain command to bypass markdown conversion

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -118,7 +118,15 @@ export const CommandMap = {
         },
         category: CommandCategories.messages,
     }),
-
+    plain: new Command({
+        name: 'plain',
+        args: '<message>',
+        description: _td('Sends a message as plain text, without interpreting it as markdown'),
+        runFn: function(roomId, messages) {
+            return success(MatrixClientPeg.get().sendTextMessage(roomId, messages));
+        },
+        category: CommandCategories.messages,
+    }),
     ddg: new Command({
         name: 'ddg',
         args: '<query>',

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -141,6 +141,7 @@
     "Other": "Other",
     "Usage": "Usage",
     "Prepends ¯\\_(ツ)_/¯ to a plain-text message": "Prepends ¯\\_(ツ)_/¯ to a plain-text message",
+    "Sends a message as plain text, without interpreting it as markdown": "Sends a message as plain text, without interpreting it as markdown",
     "Searches DuckDuckGo for results": "Searches DuckDuckGo for results",
     "/ddg is not a command": "/ddg is not a command",
     "To use it, just wait for autocomplete results to load and tab through them.": "To use it, just wait for autocomplete results to load and tab through them.",


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/10721