### PR TITLE
Add new agreed URLs to account data instead of overwriting

### DIFF
--- a/src/Terms.js
+++ b/src/Terms.js
@@ -119,7 +119,8 @@ export async function startTermsFlow(
     if (unagreedPoliciesAndServicePairs.length > 0) {
         const newlyAgreedUrls = await interactionCallback(unagreedPoliciesAndServicePairs, [...agreedUrlSet]);
         console.log("User has agreed to URLs", newlyAgreedUrls);
-        agreedUrlSet = new Set(newlyAgreedUrls);
+        // Merge with previously agreed URLs
+        newlyAgreedUrls.forEach(url => agreedUrlSet.add(url));
     } else {
         console.log("User has already agreed to all required policies");
     }


### PR DESCRIPTION
This changes terms account data storage to always add, rather than setting only
the current set of displayed URLs.

Fixes https://github.com/vector-im/riot-web/issues/10755