### PR TITLE
New composer: ensure undo history is persisted before applying formatting

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -437,6 +437,7 @@ export default class BasicMessageEditor extends React.Component {
         if (range.length === 0) {
             return;
         }
+        this.historyManager.ensureLastChangesPushed(this.props.model);
         switch (action) {
             case "bold":
                 formatInline(range, "**");

--- a/src/editor/history.js
+++ b/src/editor/history.js
@@ -106,6 +106,12 @@ export default class HistoryManager {
         return shouldPush;
     }
 
+    ensureLastChangesPushed(model) {
+        if (this._changedSinceLastPush) {
+            this._pushState(model, this._lastCaret);
+        }
+    }
+
     canUndo() {
         return this._currentIndex >= 1 || this._changedSinceLastPush;
     }
@@ -117,9 +123,7 @@ export default class HistoryManager {
     // returns state that should be applied to model
     undo(model) {
         if (this.canUndo()) {
-            if (this._changedSinceLastPush) {
-                this._pushState(model, this._lastCaret);
-            }
+            this.ensureLastChangesPushed(model);
             this._currentIndex -= 1;
             return this._stack[this._currentIndex];
         }


### PR DESCRIPTION
Based off https://github.com/matrix-org/matrix-react-sdk/pull/3389

As we don't store the history on every keystroke while typing, we need to make sure that the editor state is stored in the undo history before applying formatting.