### PR TITLE
Correct case of propTypes property in ES6 React Components. React 16

### DIFF
--- a/src/components/structures/IndicatorScrollbar.js
+++ b/src/components/structures/IndicatorScrollbar.js
@@ -19,7 +19,7 @@ import PropTypes from "prop-types";
 import AutoHideScrollbar from "./AutoHideScrollbar";
 
 export default class IndicatorScrollbar extends React.Component {
-    static PropTypes = {
+    static propTypes = {
         // If true, the scrollbar will append mx_IndicatorScrollbar_leftOverflowIndicator
         // and mx_IndicatorScrollbar_rightOverflowIndicator elements to the list for positioning
         // by the parent element.

--- a/src/components/views/context_menus/GenericElementContextMenu.js
+++ b/src/components/views/context_menus/GenericElementContextMenu.js
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -26,7 +24,7 @@ import PropTypes from 'prop-types';
 
 
 export default class GenericElementContextMenu extends React.Component {
-    static PropTypes = {
+    static propTypes = {
         element: PropTypes.element.isRequired,
         // Function to be called when the parent window is resized
         // This can be used to reposition or close the menu on resize and

--- a/src/components/views/context_menus/GenericTextContextMenu.js
+++ b/src/components/views/context_menus/GenericTextContextMenu.js
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-'use strict';
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class GenericTextContextMenu extends React.Component {
-    static PropTypes = {
+    static propTypes = {
         message: PropTypes.string.isRequired,
     };
 


### PR DESCRIPTION
React 16 complains about the casing being invalid, probably works anyway but nice to keep it happy

Subset of https://github.com/matrix-org/matrix-react-sdk/pull/3270

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>