### PR TITLE
EditMessageComposer: disable Save button until a change has been made

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -114,7 +114,7 @@ export default class EditMessageComposer extends React.Component {
         this._editorRef = null;
 
         this.state = {
-            changed: false,
+            saveDisabled: true,
         };
     }
 
@@ -247,12 +247,12 @@ export default class EditMessageComposer extends React.Component {
     }
 
     _onChange = () => {
-        if (this.state.changed || !this._editorRef || !this._editorRef.isModified()) {
+        if (!this.state.saveDisabled || !this._editorRef || !this._editorRef.isModified()) {
             return;
         }
 
         this.setState({
-            changed: true,
+            saveDisabled: false,
         });
     };
 
@@ -269,7 +269,7 @@ export default class EditMessageComposer extends React.Component {
             />
             <div className="mx_EditMessageComposer_buttons">
                 <AccessibleButton kind="secondary" onClick={this._cancelEdit}>{_t("Cancel")}</AccessibleButton>
-                <AccessibleButton kind="primary" onClick={this._sendEdit} disabled={!this.state.changed}>
+                <AccessibleButton kind="primary" onClick={this._sendEdit} disabled={this.state.saveDisabled}>
                     {_t("Save")}
                 </AccessibleButton>
             </div>

--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -164,7 +164,7 @@ export default class EditMessageComposer extends React.Component {
         dis.dispatch({action: 'focus_composer'});
     }
 
-    _isModifiedOrSameAsOld(newContent) {
+    _isContentModified(newContent) {
         // if nothing has changed then bail
         const oldContent = this.props.editState.getEvent().getContent();
         if (!this._editorRef.isModified() ||
@@ -181,12 +181,14 @@ export default class EditMessageComposer extends React.Component {
         const editContent = createEditContent(this.model, editedEvent);
         const newContent = editContent["m.new_content"];
 
-        if (this._isModifiedOrSameAsOld(newContent)) {
+        // If content is modified then send an updated event into the room
+        if (this._isContentModified(newContent)) {
             const roomId = editedEvent.getRoomId();
             this._cancelPreviousPendingEdit();
             this.context.matrixClient.sendMessage(roomId, editContent);
         }
 
+        // close the event editing and focus composer
         dis.dispatch({action: "edit_event", event: null});
         dis.dispatch({action: 'focus_composer'});
     };


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10809

Also closes the edit event view if someone tries to send an edit which would not change the event at all, instead of doing nothing with no response to the user that their event would remain unchanged.

![10809](https://user-images.githubusercontent.com/2403652/64551712-9814cd80-d32d-11e9-9721-b3792a32c21d.gif)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>