### PR TITLE
Make uses of AddressPickerDialog static dialogs

### DIFF
--- a/src/GroupAddressPicker.js
+++ b/src/GroupAddressPicker.js
@@ -46,7 +46,7 @@ export function showGroupInviteDialog(groupId) {
 
                 _onGroupInviteFinished(groupId, addrs).then(resolve, reject);
             },
-        });
+        }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
     });
 }
 
@@ -81,7 +81,7 @@ export function showGroupAddRoomDialog(groupId) {
 
                 _onGroupAddRoomFinished(groupId, addrs, addRoomsPublicly).then(resolve, reject);
             },
-        });
+        }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
     });
 }
 

--- a/src/RoomInvite.js
+++ b/src/RoomInvite.js
@@ -62,7 +62,7 @@ export function showStartChatInviteDialog() {
         validAddressTypes,
         button: _t("Start Chat"),
         onFinished: _onStartDmFinished,
-    });
+    }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
 }
 
 export function showRoomInviteDialog(roomId) {
@@ -88,7 +88,7 @@ export function showRoomInviteDialog(roomId) {
         onFinished: (shouldInvite, addrs) => {
             _onRoomInviteFinished(roomId, shouldInvite, addrs);
         },
-    });
+    }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
 }
 
 /**

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -120,7 +120,7 @@ const CategoryRoomList = createReactClass({
                     });
                 });
             },
-        });
+        }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
     },
 
     render: function() {
@@ -297,7 +297,7 @@ const RoleUserList = createReactClass({
                     });
                 });
             },
-        });
+        }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
     },
 
     render: function() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10603

Static dialogs are ones that stay open underneath other dialogs, like the terms of service prompt. This is how user/room settings operate.

![image](https://user-images.githubusercontent.com/1190097/64634536-b2e15380-d3ba-11e9-9dbd-a710e502ba51.png)
