### PR TITLE
Lift 3PID state management up to Settings tab

### DIFF
--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -65,7 +65,7 @@ export default class IdentityAuthClient {
     }
 
     // Returns a promise that resolves to the access_token string from the IS
-    async getAccessToken(check=true) {
+    async getAccessToken({ check = true } = {}) {
         if (!this.authEnabled) {
             // The current IS doesn't support authentication
             return null;

--- a/src/boundThreepids.js
+++ b/src/boundThreepids.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import IdentityAuthClient from './IdentityAuthClient';
 
-export async function getThreepidBindStatus(client, filterMedium) {
+export async function getThreepidsWithBindStatus(client, filterMedium) {
     const userId = client.getUserId();
 
     let { threepids } = await client.getThreePids();
@@ -24,7 +24,8 @@ export async function getThreepidBindStatus(client, filterMedium) {
         threepids = threepids.filter((a) => a.medium === filterMedium);
     }
 
-    if (threepids.length > 0) {
+    // Check bind status assuming we have an IS and terms are agreed
+    if (threepids.length > 0 && client.getIdentityServerUrl()) {
         // TODO: Handle terms agreement
         // See https://github.com/vector-im/riot-web/issues/10522
         const authClient = new IdentityAuthClient();

--- a/src/boundThreepids.js
+++ b/src/boundThreepids.js
@@ -25,7 +25,7 @@ export async function getThreepidsWithBindStatus(client, filterMedium) {
     }
 
     // Check bind status assuming we have an IS and terms are agreed
-    if (threepids.length > 0 && client.getIdentityServerUrl()) {
+    if (threepids.length > 0 && !!client.getIdentityServerUrl()) {
         try {
             const authClient = new IdentityAuthClient();
             const identityAccessToken = await authClient.getAccessToken({ check: false });

--- a/src/components/views/settings/SetIdServer.js
+++ b/src/components/views/settings/SetIdServer.js
@@ -22,7 +22,7 @@ import sdk from '../../../index';
 import MatrixClientPeg from "../../../MatrixClientPeg";
 import Modal from '../../../Modal';
 import dis from "../../../dispatcher";
-import { getThreepidBindStatus } from '../../../boundThreepids';
+import { getThreepidsWithBindStatus } from '../../../boundThreepids';
 import IdentityAuthClient from "../../../IdentityAuthClient";
 import {SERVICE_TYPES} from "matrix-js-sdk";
 import {abbreviateUrl, unabbreviateUrl} from "../../../utils/UrlUtils";
@@ -249,7 +249,7 @@ export default class SetIdServer extends React.Component {
     };
 
     async _showServerChangeWarning({ title, unboundMessage, button }) {
-        const threepids = await getThreepidBindStatus(MatrixClientPeg.get());
+        const threepids = await getThreepidsWithBindStatus(MatrixClientPeg.get());
 
         const boundThreepids = threepids.filter(tp => tp.bound);
         let message;

--- a/src/components/views/settings/account/EmailAddresses.js
+++ b/src/components/views/settings/account/EmailAddresses.js
@@ -23,8 +23,8 @@ import Field from "../../elements/Field";
 import AccessibleButton from "../../elements/AccessibleButton";
 import * as Email from "../../../../email";
 import AddThreepid from "../../../../AddThreepid";
-const sdk = require('../../../../index');
-const Modal = require("../../../../Modal");
+import sdk from '../../../../index';
+import Modal from '../../../../Modal';
 
 /*
 TODO: Improve the UX for everything in here.
@@ -113,11 +113,15 @@ export class ExistingEmailAddress extends React.Component {
 }
 
 export default class EmailAddresses extends React.Component {
-    constructor() {
-        super();
+    static propTypes = {
+        emails: PropTypes.array.isRequired,
+        onEmailsChange: PropTypes.func.isRequired,
+    }
+
+    constructor(props) {
+        super(props);
 
         this.state = {
-            emails: [],
             verifying: false,
             addTask: null,
             continueDisabled: false,
@@ -125,16 +129,9 @@ export default class EmailAddresses extends React.Component {
         };
     }
 
-    componentWillMount(): void {
-        const client = MatrixClientPeg.get();
-
-        client.getThreePids().then((addresses) => {
-            this.setState({emails: addresses.threepids.filter((a) => a.medium === 'email')});
-        });
-    }
-
     _onRemoved = (address) => {
-        this.setState({emails: this.state.emails.filter((e) => e !== address)});
+        const emails = this.props.emails.filter((e) => e !== address);
+        this.props.onEmailsChange(emails);
     };
 
     _onChangeNewEmailAddress = (e) => {
@@ -184,12 +181,16 @@ export default class EmailAddresses extends React.Component {
         this.state.addTask.checkEmailLinkClicked().then(() => {
             const email = this.state.newEmailAddress;
             this.setState({
-                emails: [...this.state.emails, {address: email, medium: "email"}],
                 addTask: null,
                 continueDisabled: false,
                 verifying: false,
                 newEmailAddress: "",
             });
+            const emails = [
+                ...this.props.emails,
+                { address: email, medium: "email" },
+            ];
+            this.props.onEmailsChange(emails);
         }).catch((err) => {
             this.setState({continueDisabled: false});
             if (err.errcode !== 'M_THREEPID_AUTH_FAILED') {
@@ -204,7 +205,7 @@ export default class EmailAddresses extends React.Component {
     };
 
     render() {
-        const existingEmailElements = this.state.emails.map((e) => {
+        const existingEmailElements = this.props.emails.map((e) => {
             return <ExistingEmailAddress email={e} onRemoved={this._onRemoved} key={e.address} />;
         });
 

--- a/src/components/views/settings/discovery/EmailAddresses.js
+++ b/src/components/views/settings/discovery/EmailAddresses.js
@@ -23,7 +23,6 @@ import MatrixClientPeg from "../../../../MatrixClientPeg";
 import sdk from '../../../../index';
 import Modal from '../../../../Modal';
 import AddThreepid from '../../../../AddThreepid';
-import { getThreepidBindStatus } from '../../../../boundThreepids';
 
 /*
 TODO: Improve the UX for everything in here.
@@ -187,27 +186,14 @@ export class EmailAddress extends React.Component {
 }
 
 export default class EmailAddresses extends React.Component {
-    constructor() {
-        super();
-
-        this.state = {
-            loaded: false,
-            emails: [],
-        };
-    }
-
-    async componentWillMount() {
-        const client = MatrixClientPeg.get();
-
-        const emails = await getThreepidBindStatus(client, 'email');
-
-        this.setState({ emails });
+    static propTypes = {
+        emails: PropTypes.array.isRequired,
     }
 
     render() {
         let content;
-        if (this.state.emails.length > 0) {
-            content = this.state.emails.map((e) => {
+        if (this.props.emails.length > 0) {
+            content = this.props.emails.map((e) => {
                 return <EmailAddress email={e} key={e.address} />;
             });
         } else {

--- a/src/components/views/settings/discovery/EmailAddresses.js
+++ b/src/components/views/settings/discovery/EmailAddresses.js
@@ -58,6 +58,11 @@ export class EmailAddress extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        const { bound } = nextProps.email;
+        this.setState({ bound });
+    }
+
     async changeBinding({ bind, label, errorTitle }) {
         const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
         const { medium, address } = this.props.email;

--- a/src/components/views/settings/discovery/PhoneNumbers.js
+++ b/src/components/views/settings/discovery/PhoneNumbers.js
@@ -23,7 +23,6 @@ import MatrixClientPeg from "../../../../MatrixClientPeg";
 import sdk from '../../../../index';
 import Modal from '../../../../Modal';
 import AddThreepid from '../../../../AddThreepid';
-import { getThreepidBindStatus } from '../../../../boundThreepids';
 
 /*
 TODO: Improve the UX for everything in here.
@@ -206,27 +205,14 @@ export class PhoneNumber extends React.Component {
 }
 
 export default class PhoneNumbers extends React.Component {
-    constructor() {
-        super();
-
-        this.state = {
-            loaded: false,
-            msisdns: [],
-        };
-    }
-
-    async componentWillMount() {
-        const client = MatrixClientPeg.get();
-
-        const msisdns = await getThreepidBindStatus(client, 'msisdn');
-
-        this.setState({ msisdns });
+    static propTypes = {
+        msisdns: PropTypes.array.isRequired,
     }
 
     render() {
         let content;
-        if (this.state.msisdns.length > 0) {
-            content = this.state.msisdns.map((e) => {
+        if (this.props.msisdns.length > 0) {
+            content = this.props.msisdns.map((e) => {
                 return <PhoneNumber msisdn={e} key={e.address} />;
             });
         } else {

--- a/src/components/views/settings/discovery/PhoneNumbers.js
+++ b/src/components/views/settings/discovery/PhoneNumbers.js
@@ -50,6 +50,11 @@ export class PhoneNumber extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        const { bound } = nextProps.msisdn;
+        this.setState({ bound });
+    }
+
     async changeBinding({ bind, label, errorTitle }) {
         const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
         const { medium, address } = this.props.msisdn;

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -110,7 +110,7 @@ export default class GeneralUserSettingsTab extends React.Component {
         // By starting the terms flow we get the logic for checking which terms the user has signed
         // for free. So we might as well use that for our own purposes.
         const authClient = new IdentityAuthClient();
-        const idAccessToken = await authClient.getAccessToken(/*check=*/false);
+        const idAccessToken = await authClient.getAccessToken({ check: false });
         startTermsFlow([new Service(
             SERVICE_TYPES.IS,
             MatrixClientPeg.get().getIdentityServerUrl(),

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -72,14 +72,7 @@ export default class GeneralUserSettingsTab extends React.Component {
         const serverRequiresIdServer = await cli.doesServerRequireIdServerParam();
         this.setState({serverRequiresIdServer});
 
-        // Check to see if terms need accepting
-        this._checkTerms();
-
-        // Need to get 3PIDs generally for Account section and possibly also for
-        // Discovery (assuming we have an IS and terms are agreed).
-        const threepids = await getThreepidsWithBindStatus(cli);
-        this.setState({ emails: threepids.filter((a) => a.medium === 'email') });
-        this.setState({ msisdns: threepids.filter((a) => a.medium === 'msisdn') });
+        this._getThreepidState();
     }
 
     componentWillUnmount() {
@@ -89,7 +82,7 @@ export default class GeneralUserSettingsTab extends React.Component {
     _onAction = (payload) => {
         if (payload.action === 'id_server_changed') {
             this.setState({haveIdServer: Boolean(MatrixClientPeg.get().getIdentityServerUrl())});
-            this._checkTerms();
+            this._getThreepidState();
         }
     };
 
@@ -99,6 +92,19 @@ export default class GeneralUserSettingsTab extends React.Component {
 
     _onMsisdnsChange = (msisdns) => {
         this.setState({ msisdns });
+    }
+
+    async _getThreepidState() {
+        const cli = MatrixClientPeg.get();
+
+        // Check to see if terms need accepting
+        this._checkTerms();
+
+        // Need to get 3PIDs generally for Account section and possibly also for
+        // Discovery (assuming we have an IS and terms are agreed).
+        const threepids = await getThreepidsWithBindStatus(cli);
+        this.setState({ emails: threepids.filter((a) => a.medium === 'email') });
+        this.setState({ msisdns: threepids.filter((a) => a.medium === 'msisdn') });
     }
 
     async _checkTerms() {


### PR DESCRIPTION
This pulls the 3PID state management in Settings up to a single location so that
the Account and Discovery sections now work from a single list that updates
immediately.

Fixes vector-im/riot-web#10519