### PR TITLE
Hide the change HS url button on SSO login flow if custom urls disabled

### DIFF
--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -567,6 +567,12 @@ module.exports = createReactClass({
 
     _renderSsoStep: function(url) {
         const SignInToText = sdk.getComponent('views.auth.SignInToText');
+
+        let onEditServerDetailsClick = null;
+        // If custom URLs are allowed, wire up the server details edit link.
+        if (PHASES_ENABLED && !SdkConfig.get()['disable_custom_urls']) {
+            onEditServerDetailsClick = this.onEditServerDetailsClick;
+        }
         // XXX: This link does *not* have a target="_blank" because single sign-on relies on
         // redirecting the user back to a URI once they're logged in. On the web, this means
         // we use the same window and redirect back to riot. On electron, this actually
@@ -578,7 +584,7 @@ module.exports = createReactClass({
         return (
             <div>
                 <SignInToText serverConfig={this.props.serverConfig}
-                    onEditServerDetailsClick={this.onEditServerDetailsClick} />
+                    onEditServerDetailsClick={onEditServerDetailsClick} />
 
                 <a href={url} className="mx_Login_sso_link mx_Login_submit">{ _t('Sign in with single sign-on') }</a>
             </div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10836

![image](https://user-images.githubusercontent.com/2403652/64738791-28970d80-d4e8-11e9-8f04-5939b4df9822.png)

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>