### PR TITLE
Breadcrumbs: only show after having joined at least 10 rooms

### DIFF
--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -29,6 +29,7 @@ import DMRoomMap from "../../../utils/DMRoomMap";
 import {_t} from "../../../languageHandler";
 
 const MAX_ROOMS = 20;
+const MIN_ROOMS_BEFORE_ENABLED = 10;
 
 export default class RoomBreadcrumbs extends React.Component {
     constructor(props) {
@@ -159,7 +160,7 @@ export default class RoomBreadcrumbs extends React.Component {
         const joinedRoomCount = client.getRooms().reduce((count, r) => {
             return count + (r.getMyMembership() === "join" ? 1 : 0);
         }, 0);
-        return joinedRoomCount >= 10;
+        return joinedRoomCount >= MIN_ROOMS_BEFORE_ENABLED;
     }
 
     _loadRoomIds(roomIds) {


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/10775

![breadcrumbs-after-10](https://user-images.githubusercontent.com/274386/64782945-08059c80-d556-11e9-89c6-58b13ee0b9e6.gif)
