### PR TITLE
Breadcrumbs: show placeholder for empty slot

### DIFF
--- a/res/css/views/rooms/_RoomBreadcrumbs.scss
+++ b/res/css/views/rooms/_RoomBreadcrumbs.scss
@@ -22,6 +22,19 @@ limitations under the License.
     display: flex;
     flex-direction: row;
 
+    // repeating circles as empty placeholders
+    background:
+        radial-gradient(
+            circle at center,
+            $breadcrumb-placeholder-bg-color,
+            $breadcrumb-placeholder-bg-color 15px,
+            transparent 16px
+        );
+    background-size: 36px;
+    background-position: 6px -1px;
+    background-repeat: repeat-x;
+
+
     // Autohide the scrollbar
     overflow-x: hidden;
     &:hover {

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -170,6 +170,8 @@ $tooltip-timeline-fg-color: #ffffff;
 $interactive-tooltip-bg-color: $base-color;
 $interactive-tooltip-fg-color: #ffffff;
 
+$breadcrumb-placeholder-bg-color: #272c35;
+
 // ***** Mixins! *****
 
 @define-mixin mx_DialogButton {

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -288,6 +288,8 @@ $tooltip-timeline-fg-color: #ffffff;
 $interactive-tooltip-bg-color: #27303a;
 $interactive-tooltip-fg-color: #ffffff;
 
+$breadcrumb-placeholder-bg-color: #e8eef5;
+
 // ***** Mixins! *****
 
 @define-mixin mx_DialogButton {


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/10775

![breadcrumb-empty-placeholders](https://user-images.githubusercontent.com/274386/64785000-ece95b80-d55a-11e9-92a7-366ecec22889.gif)

![breadcrumbs-placeholder-dark](https://user-images.githubusercontent.com/274386/64785005-f07ce280-d55a-11e9-91b2-e42c420e18c7.png)

Freestyled the color for dark mode, lmk if you want to change it @nadonomy 

The repeating circle is visible just before the first room, but the contrast with the background is low enough for it to be hard to notice I think.