### PR TITLE
Dont wrap text in room directory buttons

### DIFF
--- a/res/css/structures/_RoomDirectory.scss
+++ b/res/css/structures/_RoomDirectory.scss
@@ -107,6 +107,7 @@ limitations under the License.
 .mx_RoomDirectory_join, .mx_RoomDirectory_preview {
     width: 80px;
     text-align: center;
+    white-space: nowrap;
 }
 
 .mx_RoomDirectory_name {


### PR DESCRIPTION
This broke again with https://github.com/matrix-org/matrix-react-sdk/pull/3427

Turns out we do need `nowrap` for the room directory (I thought I did it originally for the explore button), so adding it back with a limited scope.

![image](https://user-images.githubusercontent.com/274386/64790569-cf6dbf00-d565-11e9-8bfc-6c2fbbd393c6.png)
