### PR TITLE
Fix: only hide clear filter button when blurred & no more search term

### DIFF
--- a/src/components/structures/SearchBox.js
+++ b/src/components/structures/SearchBox.js
@@ -126,7 +126,7 @@ module.exports = createReactClass({
         if (this.props.collapsed) {
             return null;
         }
-        const clearButton = !this.state.blurred ?
+        const clearButton = (!this.state.blurred || this.state.searchTerm) ?
             (<AccessibleButton key="button"
                     className="mx_SearchBox_closeButton"
                     onClick={ () => {this._clearSearch("button"); } }>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10842

The bug occurred because clicking the x would cause a blur event to fire first, it would hide the x button, and then the click even would never fire. This fixes it by keeping the x button on blur if there is still text, which is a good thing to do anyway.