### PR TITLE
Fix: stop propagation click handler for <TR> doesn't run

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -368,25 +368,27 @@ module.exports = createReactClass({
         }
     },
 
-    onPreviewClick: function(room) {
+    onPreviewClick: function(ev, room) {
         this.props.onFinished();
         dis.dispatch({
             action: 'view_room',
             room_id: room.room_id,
             should_peek: true,
         });
+        ev.stopPropagation();
     },
 
-    onViewClick: function(room) {
+    onViewClick: function(ev, room) {
         this.props.onFinished();
         dis.dispatch({
             action: 'view_room',
             room_id: room.room_id,
             should_peek: false,
         });
+        ev.stopPropagation();
     },
 
-    onJoinClick: function(room) {
+    onJoinClick: function(ev, room) {
         this.props.onFinished();
         MatrixClientPeg.get().joinRoom(room.room_id);
         dis.dispatch({
@@ -394,6 +396,7 @@ module.exports = createReactClass({
             room_id: room.room_id,
             joining: true,
         });
+        ev.stopPropagation();
     },
 
     onCreateRoomClick: function(room) {
@@ -457,16 +460,16 @@ module.exports = createReactClass({
 
         if (room.world_readable && !hasJoinedRoom) {
             previewButton = (
-                <AccessibleButton kind="secondary" onClick={() => this.onPreviewClick(room)}>{_t("Preview")}</AccessibleButton>
+                <AccessibleButton kind="secondary" onClick={(ev) => this.onPreviewClick(ev, room)}>{_t("Preview")}</AccessibleButton>
             );
         }
         if (hasJoinedRoom) {
             joinOrViewButton = (
-                <AccessibleButton kind="secondary" onClick={() => this.onViewClick(room)}>{_t("View")}</AccessibleButton>
+                <AccessibleButton kind="secondary" onClick={(ev) => this.onViewClick(ev, room)}>{_t("View")}</AccessibleButton>
             );
         } else if (!isGuest || room.guest_can_join) {
             joinOrViewButton = (
-                <AccessibleButton kind="primary" onClick={() => this.onJoinClick(room)}>{_t("Join")}</AccessibleButton>
+                <AccessibleButton kind="primary" onClick={(ev) => this.onJoinClick(ev, room)}>{_t("Join")}</AccessibleButton>
             );
         }
 


### PR DESCRIPTION
Looking at https://buildkite.com/matrix-dot-org/matrix-react-sdk/builds/2365#9df91931-f901-44cb-9372-45afb8058d67 it looks like, at least in the e2e tests in the room directory, the TR click handler for that room is also running and trying to preview the room after clicking the join button. The "can't preview" screen should go away once the join completes though, so can't be the lone cause of the test failure, but having multiple click handlers run when clicking join seems suboptimal in any case. I've tried to reproduce this, and wasn't able though.