### PR TITLE
Reuse showRoom for onJoinClick so we join using alias if its available

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -390,12 +390,7 @@ module.exports = createReactClass({
 
     onJoinClick: function(ev, room) {
         this.props.onFinished();
-        MatrixClientPeg.get().joinRoom(room.room_id);
-        dis.dispatch({
-            action: 'view_room',
-            room_id: room.room_id,
-            joining: true,
-        });
+        this.showRoom(room, null, true);
         ev.stopPropagation();
     },
 

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -389,7 +389,6 @@ module.exports = createReactClass({
     },
 
     onJoinClick: function(ev, room) {
-        this.props.onFinished();
         this.showRoom(room, null, true);
         ev.stopPropagation();
     },


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10866
Seems to be caused by https://github.com/matrix-org/matrix-react-sdk/commit/7754e08d84005a1f7fe4544c5bdd665b304dcd2c#diff-c03ee7f6d50afc9c4fc20dc9d59e76c6
Which skips the existing logic for some reason.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>