### PR TITLE
Fix address type props to state conversion

### DIFF
--- a/src/components/views/dialogs/AddressPickerDialog.js
+++ b/src/components/views/dialogs/AddressPickerDialog.js
@@ -80,7 +80,7 @@ module.exports = createReactClass({
         let validAddressTypes = this.props.validAddressTypes;
         // Remove email from validAddressTypes if no IS is configured. It may be added at a later stage by the user
         if (!MatrixClientPeg.get().getIdentityServerUrl() && validAddressTypes.includes("email")) {
-            validAddressTypes = validAddressTypes.splice(validAddressTypes.indexOf("email"), 1);
+            validAddressTypes = validAddressTypes.filter(type => type !== "email");
         }
 
         return {


### PR DESCRIPTION
The address picker recently started tracking props and state versions of valid
address types separately
(https://github.com/matrix-org/matrix-react-sdk/pull/3408), where props
represents the maximal set of possible types and the state is the current
available types right now (since it can change while the dialog is open).

For the case where there is no a IS, a regression was introduced by that PR by
mutating the props in place instead returning a modified copy for the state.

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3408
Fixes https://github.com/vector-im/riot-web/issues/10878