### PR TITLE
React 16: use shallow-renderer for tests instead of react-dom/test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "matrix-mock-request": "^1.2.3",
     "matrix-react-test-utils": "^0.2.2",
     "mocha": "^5.0.5",
+    "react-test-renderer": "^16.9.0",
     "require-json": "0.0.1",
     "rimraf": "^2.4.3",
     "sinon": "^5.0.7",

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -12,8 +12,6 @@ const MemberEventListSummary = testUtils.wrapInMatrixClientContext(
 );
 
 describe('MemberEventListSummary', function() {
-    let sandbox;
-
     // Generate dummy event tiles for use in simulating an expanded MELS
     const generateTiles = (events) => {
         return events.map((e) => {
@@ -89,7 +87,7 @@ describe('MemberEventListSummary', function() {
 
     beforeEach(function(done) {
         testUtils.beforeEach(this);
-        sandbox = testUtils.stubClient();
+        testUtils.stubClient();
 
         languageHandler.setLanguage('en').done(done);
         languageHandler.setMissingEntryGenerator(function(key) {
@@ -98,7 +96,7 @@ describe('MemberEventListSummary', function() {
     });
 
     afterEach(function() {
-        sandbox.restore();
+        testUtils.restore();
     });
 
     it('renders expanded events if there are less than props.threshold', function() {

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -1,6 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import sdk from 'matrix-react-sdk';
 import * as languageHandler from '../../../../src/languageHandler';
 import * as testUtils from '../../../test-utils';
@@ -112,7 +113,7 @@ describe('MemberEventListSummary', function() {
             threshold: 3,
         };
 
-        const renderer = ReactTestUtils.createRenderer();
+        const renderer = new ShallowRenderer();
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 
@@ -134,7 +135,7 @@ describe('MemberEventListSummary', function() {
             threshold: 3,
         };
 
-        const renderer = ReactTestUtils.createRenderer();
+        const renderer = new ShallowRenderer();
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 

--- a/test/components/views/rooms/MemberList-test.js
+++ b/test/components/views/rooms/MemberList-test.js
@@ -26,7 +26,6 @@ describe('MemberList', () => {
     }
 
     let parentDiv = null;
-    let sandbox = null;
     let client = null;
     let root = null;
     let clock = null;
@@ -39,7 +38,7 @@ describe('MemberList', () => {
 
     beforeEach(function() {
         TestUtils.beforeEach(this);
-        sandbox = TestUtils.stubClient(sandbox);
+        TestUtils.stubClient();
         client = MatrixClientPeg.get();
         client.hasLazyLoadMembersEnabled = () => false;
 
@@ -116,7 +115,7 @@ describe('MemberList', () => {
             parentDiv.remove();
             parentDiv = null;
         }
-        sandbox.restore();
+        TestUtils.restore();
 
         clock.uninstall();
 

--- a/test/components/views/rooms/MessageComposerInput-test.js
+++ b/test/components/views/rooms/MessageComposerInput-test.js
@@ -23,14 +23,13 @@ function addTextToDraft(text) {
 
 xdescribe('MessageComposerInput', () => {
     let parentDiv = null,
-        sandbox = null,
         client = null,
         mci = null,
         room = testUtils.mkStubRoom('!DdJkzRliezrwpNebLk:matrix.org');
 
     beforeEach(function() {
         testUtils.beforeEach(this);
-        sandbox = testUtils.stubClient(sandbox);
+        testUtils.stubClient();
         client = MatrixClientPeg.get();
         client.credentials = {userId: '@me:domain.com'};
 
@@ -55,7 +54,7 @@ xdescribe('MessageComposerInput', () => {
                 parentDiv.remove();
                 parentDiv = null;
             }
-            sandbox.restore();
+            testUtils.restore();
             done();
         });
     });

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -31,7 +31,6 @@ describe('RoomList', () => {
     }
 
     let parentDiv = null;
-    let sandbox = null;
     let client = null;
     let root = null;
     const myUserId = '@me:domain';
@@ -46,7 +45,7 @@ describe('RoomList', () => {
 
     beforeEach(function() {
         TestUtils.beforeEach(this);
-        sandbox = TestUtils.stubClient(sandbox);
+        TestUtils.stubClient();
         client = MatrixClientPeg.get();
         client.credentials = {userId: myUserId};
         //revert this to prototype method as the test-utils monkey-patches this to return a hardcoded value
@@ -112,7 +111,7 @@ describe('RoomList', () => {
             parentDiv.remove();
             parentDiv = null;
         }
-        sandbox.restore();
+        TestUtils.restore();
 
         clock.uninstall();
 

--- a/test/i18n-test/languageHandler-test.js
+++ b/test/i18n-test/languageHandler-test.js
@@ -5,17 +5,15 @@ import * as languageHandler from '../../src/languageHandler';
 const testUtils = require('../test-utils');
 
 describe('languageHandler', function() {
-    let sandbox;
-
     beforeEach(function(done) {
         testUtils.beforeEach(this);
-        sandbox = testUtils.stubClient();
+        testUtils.stubClient();
 
         languageHandler.setLanguage('en').done(done);
     });
 
     afterEach(function() {
-        sandbox.restore();
+        testUtils.restore();
     });
 
     it('translates a string to german', function() {

--- a/test/matrix-to-test.js
+++ b/test/matrix-to-test.js
@@ -63,16 +63,14 @@ function mockRoom(roomId, members, serverACL) {
 }
 
 describe('matrix-to', function() {
-    let sandbox;
-
     beforeEach(function() {
         testUtils.beforeEach(this);
-        sandbox = testUtils.stubClient();
+        testUtils.stubClient();
         peg.get().credentials = { userId: "@test:example.com" };
     });
 
     afterEach(function() {
-        sandbox.restore();
+        testUtils.restore();
     });
 
     it('should pick no candidate servers when the room has no members', function() {

--- a/test/stores/RoomViewStore-test.js
+++ b/test/stores/RoomViewStore-test.js
@@ -1,6 +1,5 @@
 import expect from 'expect';
 
-import dis from '../../src/dispatcher';
 import RoomViewStore from '../../src/stores/RoomViewStore';
 
 
@@ -12,11 +11,9 @@ import Promise from 'bluebird';
 const dispatch = testUtils.getDispatchForStore(RoomViewStore);
 
 describe('RoomViewStore', function() {
-    let sandbox;
-
     beforeEach(function() {
         testUtils.beforeEach(this);
-        sandbox = testUtils.stubClient();
+        testUtils.stubClient();
         peg.get().credentials = { userId: "@test:example.com" };
 
         // Reset the state of the store
@@ -24,7 +21,7 @@ describe('RoomViewStore', function() {
     });
 
     afterEach(function() {
-        sandbox.restore();
+        testUtils.restore();
     });
 
     it('can be used to view a room by ID and join', function(done) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -39,12 +39,8 @@ export function beforeEach(context) {
  * TODO: once the components are updated to get their MatrixClients from
  * the react context, we can get rid of this and just inject a test client
  * via the context instead.
- *
- * @returns {sinon.Sandbox}; remember to call sandbox.restore afterwards.
  */
 export function stubClient() {
-    const sandbox = sinon.createSandbox();
-
     const client = createTestClient();
 
     // stub out the methods in MatrixClientPeg
@@ -53,12 +49,15 @@ export function stubClient() {
     // so we do this for each method
     const methods = ['get', 'unset', 'replaceUsingCreds'];
     for (let i = 0; i < methods.length; i++) {
-        sandbox.stub(peg, methods[i]);
+        sinon.stub(peg, methods[i]);
     }
     // MatrixClientPeg.get() is called a /lot/, so implement it with our own
     // fast stub function rather than a sinon stub
     peg.get = function() { return client; };
-    return sandbox;
+}
+
+export function restore() {
+    sinon.restore();
 }
 
 /**

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -43,7 +43,7 @@ export function beforeEach(context) {
  * @returns {sinon.Sandbox}; remember to call sandbox.restore afterwards.
  */
 export function stubClient() {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     const client = createTestClient();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6404,6 +6404,11 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -6430,6 +6435,16 @@ react-redux@^5.0.6:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-test-renderer@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
+  integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.9.0"
+    scheduler "^0.15.0"
 
 react-transition-group@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

It got moved out of react-dom/test-utils at some point