### PR TITLE
Fix unit tests: Use correct ShallowRenderer and updated lolex

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "matrix-mock-request": "^1.2.3",
     "matrix-react-test-utils": "^0.2.2",
     "mocha": "^5.0.5",
+    "react-test-renderer": "^16.9.0",
     "require-json": "0.0.1",
     "rimraf": "^2.4.3",
     "sinon": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "isomorphic-fetch": "^2.2.1",
     "linkifyjs": "^2.1.6",
     "lodash": "^4.17.14",
-    "lolex": "2.3.2",
+    "lolex": "4.2",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
     "optimist": "^0.6.1",
     "pako": "^1.0.5",

--- a/test/components/views/elements/MemberEventListSummary-test.js
+++ b/test/components/views/elements/MemberEventListSummary-test.js
@@ -112,7 +112,7 @@ describe('MemberEventListSummary', function() {
             threshold: 3,
         };
 
-        const renderer = ReactTestUtils.createRenderer();
+        const renderer = testUtils.getRenderer();
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 
@@ -134,7 +134,7 @@ describe('MemberEventListSummary', function() {
             threshold: 3,
         };
 
-        const renderer = ReactTestUtils.createRenderer();
+        const renderer = testUtils.getRenderer();
         renderer.render(<MemberEventListSummary {...props} />);
         const result = renderer.getRenderOutput();
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -9,6 +9,7 @@ import dis from '../src/dispatcher';
 import jssdk from 'matrix-js-sdk';
 import {makeType} from "../src/utils/TypeUtils";
 import {ValidatedServerConfig} from "../src/utils/AutoDiscoveryUtils";
+import ShallowRenderer from 'react-test-renderer/shallow';
 const MatrixEvent = jssdk.MatrixEvent;
 
 /**
@@ -31,6 +32,10 @@ export function beforeEach(context) {
     console.log(new Array(1 + desc.length).join("="));
 }
 
+export function getRenderer() {
+    // Old: ReactTestUtils.createRenderer();
+    return new ShallowRenderer();
+}
 
 /**
  * Stub out the MatrixClient, and configure the MatrixClientPeg object to

--- a/yarn.lock
+++ b/yarn.lock
@@ -6404,6 +6404,11 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -6430,6 +6435,16 @@ react-redux@^5.0.6:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-test-renderer@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
+  integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.9.0"
+    scheduler "^0.15.0"
 
 react-transition-group@^1.2.0:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,10 +4930,10 @@ loglevel@1.6.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-lolex@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
-  integrity sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==
+lolex@4.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 lolex@^2.4.2:
   version "2.7.5"


### PR DESCRIPTION
An alternative to https://github.com/matrix-org/matrix-react-sdk/pull/3452

The `ReactTestUtils` renderer doesn't exist anymore, so we need to use a `ShallowRenderer` from React.

See https://github.com/sinonjs/lolex/issues/136 for the lolex issue.

We don't use fake timers, but we do use lolex's clock, which probably causes the same thing. Jumping from 2.x to 4.x looks largely compatible - tests pass.