### PR TITLE
Focus context menus so screen readers can find them

### DIFF
--- a/src/components/structures/ContextualMenu.js
+++ b/src/components/structures/ContextualMenu.js
@@ -20,6 +20,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import {focusCapturedRef} from "../../utils/Accessibility";
 
 // Shamelessly ripped off Modal.js.  There's probably a better way
 // of doing reusable widgets like dialog boxes & menus where we go and
@@ -82,6 +83,9 @@ export default class ContextualMenu extends React.Component {
     collectContextMenuRect(element) {
         // We don't need to clean up when unmounting, so ignore
         if (!element) return;
+
+        // For screen readers to find the thing
+        focusCapturedRef(element);
 
         this.setState({
             contextMenuRect: element.getBoundingClientRect(),
@@ -206,7 +210,7 @@ export default class ContextualMenu extends React.Component {
         // FIXME: If a menu uses getDefaultProps it clobbers the onFinished
         // property set here so you can't close the menu from a button click!
         return <div className={className} style={{...position, ...wrapperStyle}}>
-            <div className={menuClasses} style={menuStyle} ref={this.collectContextMenuRect}>
+            <div className={menuClasses} style={menuStyle} ref={this.collectContextMenuRect} tabIndex={0}>
                 { chevron }
                 <ElementClass {...props} onFinished={props.closeMenu} onResize={props.windowResize} />
             </div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10899

The `tabIndex` is required to make the thing actually focusable. This is the same trick employed in https://github.com/matrix-org/matrix-react-sdk/pull/2994

----

Legend for the demos below:
* Blue outline is Windows Narrator (a relatively unintelligent screen reader, but still helpful).
* Red/Orange are CSS hacks to figure out what is going on:
  ```css
  :hover {
    /* orange */
    background-color: rgba(255, 165, 0, 0.5) !important;
  }
  :focus {
    /* red */
    background-color: rgba(255, 0, 0, 0.5) !important;
  }
  ```

Video (may need to download - has audio): https://t2bot.io/_matrix/media/r0/download/t2l.io/6c5c0245ef554f332817f16c81564375b8c44861

Gif form (no audio, obviously):
![ctxmenu mp4](https://user-images.githubusercontent.com/1190097/65081860-d2035680-d961-11e9-9694-f7b4c8df1c49.gif)
