### PR TITLE
Use same initial device name rules for SSO login as password login

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -286,7 +286,10 @@ export default createReactClass({
         // the first thing to do is to try the token params in the query-string
         // if the session isn't soft logged out (ie: is a clean session being logged in)
         if (!Lifecycle.isSoftLogout()) {
-            Lifecycle.attemptTokenLogin(this.props.realQueryParams).then((loggedIn) => {
+            Lifecycle.attemptTokenLogin(
+                this.props.realQueryParams,
+                this.props.defaultDeviceDisplayName,
+            ).then((loggedIn) => {
                 if (loggedIn) {
                     this.props.onTokenLoginCompleted();
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10881

![image](https://user-images.githubusercontent.com/2403652/65144012-4398de80-da0e-11e9-872e-7daa81410a35.png)
(bottom three devices created pre-fix)

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>