### PR TITLE
Use alternate MSISDN submit URL when returned by HS

### DIFF
--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -200,7 +200,6 @@ export default class AddThreepid {
      */
     async haveMsisdnToken(msisdnToken) {
         const authClient = new IdentityAuthClient();
-        const identityAccessToken = await authClient.getAccessToken();
 
         let result;
         if (this.submitUrl) {
@@ -215,7 +214,7 @@ export default class AddThreepid {
                 this.sessionId,
                 this.clientSecret,
                 msisdnToken,
-                identityAccessToken,
+                await authClient.getAccessToken(),
             );
         }
         if (result.errcode) {
@@ -225,13 +224,11 @@ export default class AddThreepid {
         const identityServerDomain = MatrixClientPeg.get().idBaseUrl.split("://")[1];
         if (await MatrixClientPeg.get().doesServerSupportSeparateAddAndBind()) {
             if (this.bind) {
-                const authClient = new IdentityAuthClient();
-                const identityAccessToken = await authClient.getAccessToken();
                 await MatrixClientPeg.get().bindThreePid({
                     sid: this.sessionId,
                     client_secret: this.clientSecret,
                     id_server: identityServerDomain,
-                    id_access_token: identityAccessToken,
+                    id_access_token: await authClient.getAccessToken(),
                 });
             } else {
                 await MatrixClientPeg.get().addThreePidOnly({


### PR DESCRIPTION
This changes MSISDN token submission to send to an arbitrary URL (instead of the
current IS) when the HS provides such a URL.

Fixes vector-im/riot-web#10923
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1040