### PR TITLE
Fix: formatbar appearing below other elements 

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -23,6 +23,9 @@ limitations under the License.
     border-radius: 4px;
     background-color: $message-action-bar-bg-color;
     user-select: none;
+    // equal to z-index of mx_ReplyPreview and mx_RoomView_statusArea (1000)
+    // but as it appears after them in the DOM, will appear on top.
+    z-index: 1000;
 
     &.mx_MessageComposerFormatBar_shown {
         display: block;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10780
Fixes https://github.com/vector-im/riot-web/issues/10912

More specifically, the room status bar and reply preview.

![image](https://user-images.githubusercontent.com/274386/65424407-057b3080-ddfb-11e9-930d-8d1b0697d825.png)

![formatbarzindex](https://user-images.githubusercontent.com/274386/65424426-11ff8900-ddfb-11e9-87bb-70ef419711bf.gif)
