### PR TITLE
Hide browser a11y outline on context menus

### DIFF
--- a/src/components/structures/ContextualMenu.js
+++ b/src/components/structures/ContextualMenu.js
@@ -167,6 +167,7 @@ export default class ContextualMenu extends React.Component {
 
         const menuClasses = classNames({
             'mx_ContextualMenu': true,
+            'mx_HiddenFocusable': true, // hide browser outline
             'mx_ContextualMenu_left': !hasChevron && position.left,
             'mx_ContextualMenu_right': !hasChevron && position.right,
             'mx_ContextualMenu_top': !hasChevron && position.top,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10926
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3454
Class introduced in https://github.com/matrix-org/matrix-react-sdk/pull/2994