### PR TITLE
Send MSISDN validation token to submit_url during registration

### DIFF
--- a/src/components/views/auth/InteractiveAuthEntryComponents.js
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.js
@@ -420,6 +420,7 @@ export const MsisdnAuthEntry = createReactClass({
     },
 
     componentWillMount: function() {
+        this._submitUrl = null;
         this._sid = null;
         this._msisdn = null;
         this._tokenBox = null;
@@ -442,6 +443,7 @@ export const MsisdnAuthEntry = createReactClass({
             this.props.clientSecret,
             1, // TODO: Multiple send attempts?
         ).then((result) => {
+            this._submitUrl = result.submit_url;
             this._sid = result.sid;
             this._msisdn = result.msisdn;
         });
@@ -462,9 +464,16 @@ export const MsisdnAuthEntry = createReactClass({
         });
 
         try {
-            const result = await this.props.matrixClient.submitMsisdnToken(
-                this._sid, this.props.clientSecret, this.state.token,
-            );
+            let result;
+            if (this._submitUrl) {
+                result = await this.props.matrixClient.submitMsisdnTokenOtherUrl(
+                    this._submitUrl, this._sid, this.props.clientSecret, this.state.token,
+                );
+            } else {
+                result = await this.props.matrixClient.submitMsisdnToken(
+                    this._sid, this.props.clientSecret, this.state.token,
+                );
+            }
             if (result.success) {
                 const creds = {
                     sid: this._sid,


### PR DESCRIPTION
Similar to previous changes for 3PID add, this changes registration with MSISDN
to also send tokens to `submit_url` when supplied.

Fixes https://github.com/vector-im/riot-web/issues/10939