### PR TITLE
Truncate debug logs at the start, not the end

### DIFF
--- a/src/rageshake/rageshake.js
+++ b/src/rageshake/rageshake.js
@@ -258,7 +258,7 @@ class IndexedDBLogStore {
             const objectStore = db.transaction("logs", "readonly").objectStore("logs");
 
             return new Promise((resolve, reject) => {
-                const query = objectStore.index("id").openCursor(IDBKeyRange.only(id), 'next');
+                const query = objectStore.index("id").openCursor(IDBKeyRange.only(id), 'prev');
                 let lines = '';
                 query.onerror = (event) => {
                     reject(new Error("Query failed: " + event.target.errorCode));
@@ -269,10 +269,10 @@ class IndexedDBLogStore {
                         resolve(lines);
                         return; // end of results
                     }
-                    lines += cursor.value.lines;
-                    if (lines.length >= MAX_LOG_SIZE) {
+                    if (lines.length + cursor.value.lines.length >= MAX_LOG_SIZE && lines.length > 0) {
                         resolve(lines);
                     } else {
+                        lines = cursor.value.lines + lines;
                         cursor.continue();
                     }
                 };


### PR DESCRIPTION
We left out later parts if we exceeded the maximum log size, which
was deeply unhelpful since the problem almost certainly happened
just before the user hit the 'submit debug logs' button.

Instead, iterate backwards through the fragments and prepend them,
leaving off the earlier ones if we run over the size.

Also, check we're not going to run over the size before adding
the fragment so we might actually stick to the maximum log size.

May fix https://github.com/vector-im/riot-web/issues/10951