### PR TITLE
Add option to disable typing notifications 

### DIFF
--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -22,6 +22,7 @@ import WhoIsTyping from '../../../WhoIsTyping';
 import Timer from '../../../utils/Timer';
 import MatrixClientPeg from '../../../MatrixClientPeg';
 import MemberAvatar from '../avatars/MemberAvatar';
+import SettingsStore from '../../../settings/SettingsStore';
 
 module.exports = createReactClass({
     displayName: 'WhoIsTypingTile',
@@ -194,6 +195,7 @@ module.exports = createReactClass({
 
     render: function() {
         let usersTyping = this.state.usersTyping;
+        const showTypingNotifications = SettingsStore.getValue("showTypingNotifications", this.props.room.roomId)
         const stoppedUsersOnTimer = Object.keys(this.state.delayedStopTypingTimers)
             .map((userId) => this.props.room.getMember(userId));
         // append the users that have been reported not typing anymore
@@ -208,7 +210,7 @@ module.exports = createReactClass({
             usersTyping,
             this.props.whoIsTypingLimit,
         );
-        if (!typingString) {
+        if (!typingString || !showTypingNotifications) {
             return (<div className="mx_WhoIsTypingTile_empty" />);
         }
 

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -29,6 +29,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
         'MessageComposerInput.autoReplaceEmoji',
         'MessageComposerInput.suggestEmoji',
         'sendTypingNotifications',
+        'showTypingNotifications',
     ];
 
     static TIMELINE_SETTINGS = [

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -349,6 +349,7 @@
     "Show avatars in user and room mentions": "Show avatars in user and room mentions",
     "Enable big emoji in chat": "Enable big emoji in chat",
     "Send typing notifications": "Send typing notifications",
+    "Show typing notifications": "Show typing notifications",
     "Automatically replace plain text Emoji": "Automatically replace plain text Emoji",
     "Mirror local video feed": "Mirror local video feed",
     "Enable Community Filter Panel": "Enable Community Filter Panel",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -224,6 +224,12 @@ export const SETTINGS = {
         default: true,
         invertedSettingName: 'dontSendTypingNotifications',
     },
+    "showTypingNotifications": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td("Show typing notifications"),
+        default: true,
+        invertedSettingName: 'dontShowTypingNotifications',
+    },
     "MessageComposerInput.autoReplaceEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Automatically replace plain text Emoji'),


### PR DESCRIPTION
Resolves [this riot-im issue](https://github.com/vector-im/riot-web/issues/7283).

Signed-off-by: Lukas Schwarz <ghub@posteo.se>


