### PR TITLE
Guard against falsy names in getInitialLetter

### DIFF
--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -67,7 +67,7 @@ module.exports = {
      * @return {string} the first letter
      */
     getInitialLetter(name) {
-        if (name.length < 1) {
+        if (!name || name.length < 1) {
             return undefined;
         }
 

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -67,7 +67,12 @@ module.exports = {
      * @return {string} the first letter
      */
     getInitialLetter(name) {
-        if (!name || name.length < 1) {
+        if (!name) {
+            // XXX: We should find out what causes the name to sometimes be falsy.
+            console.trace("`name` argument to `getInitialLetter` not supplied");
+            return undefined;
+        }
+        if (name.length < 1) {
             return undefined;
         }
 


### PR DESCRIPTION
This ensures we check for a falsy name in `getInitialLetter` instead of throwing
errors. We should perhaps also fix whatever other issues have led to the input
being undefined in the first place, but for now we leave this for another day.

Hopefully helps with https://github.com/vector-im/riot-web/issues/10983