### PR TITLE
Don't mark a room as unread when someone adds an alias

### DIFF
--- a/src/Unread.js
+++ b/src/Unread.js
@@ -34,6 +34,8 @@ module.exports = {
             return false;
         } else if (ev.getType() == 'm.room.message' && ev.getContent().msgtype == 'm.notify') {
             return false;
+        } else if (ev.getType() == 'm.room.aliases' || ev.getType() == 'm.room.canonical_alias') {
+            return false;
         }
         const EventTile = sdk.getComponent('rooms.EventTile');
         return EventTile.haveTileForEvent(ev);


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/2321#issuecomment-508526884

Really annoying when rooms like #homeowners:matrix.org get marked as unread when there aren't any new messages
