### PR TITLE
Fix integration manager not updating when set

### DIFF
--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -233,7 +233,9 @@ export default class WidgetUtils {
         };
 
         const client = MatrixClientPeg.get();
-        const userWidgets = WidgetUtils.getUserWidgets();
+        // Get the current widgets and clone them before we modify them, otherwise
+        // we'll modify the content of the old event.
+        const userWidgets = JSON.parse(JSON.stringify(WidgetUtils.getUserWidgets()));
 
         // Delete existing widget with ID
         try {


### PR DESCRIPTION
setUserWidget was modifying the content of the old event itself,
so when `waitForUserWidget()` checked the content to see if it was
there yet, it was, but because the echo hadn't come back, the
IntegrationManager hadn't rebuilt its list.

In other news, its terrifying that we can just accidentally modify
the content of an event in the store. I'm going to make a js-sdk
PR that freezes the content and see what breaks...

Fixes https://github.com/vector-im/riot-web/issues/10977