### PR TITLE
Handle null from TimelinePanel.getScrollState in RoomView _getScrollState

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1417,7 +1417,8 @@ module.exports = createReactClass({
 
         const scrollState = messagePanel.getScrollState();
 
-        if (scrollState.stuckAtBottom) {
+        // getScrollState on TimelinePanel *may* return null, so guard against that
+        if (!scrollState || scrollState.stuckAtBottom) {
             // we don't really expect to be in this state, but it will
             // occasionally happen when no scroll state has been set on the
             // messagePanel (ie, we didn't have an initial event (so it's


### PR DESCRIPTION
Based on rageshake from M on mozilla-test, should fix https://github.com/vector-im/riot-web/issues/11032

~Could not reproduce locally so *untested*~

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>