### PR TITLE
Fix soft crash on room join

### DIFF
--- a/src/components/structures/MainSplit.js
+++ b/src/components/structures/MainSplit.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,9 +80,12 @@ export default class MainSplit extends React.Component {
         const wasPanelSet = this.props.panel && !prevProps.panel;
         const wasPanelCleared = !this.props.panel && prevProps.panel;
 
-        if (wasExpanded || wasPanelSet) {
+        if (this.resizeContainer && (wasExpanded || wasPanelSet)) {
+            // The resizer can only be created when **both** expanded and the panel is
+            // set. Once both are true, the container ref will mount, which is required
+            // for the resizer to work.
             this._createResizer();
-        } else if (wasCollapsed || wasPanelCleared) {
+        } else if (this.resizer && (wasCollapsed || wasPanelCleared)) {
             this.resizer.detach();
             this.resizer = null;
         }

--- a/src/resizer/resizer.js
+++ b/src/resizer/resizer.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +32,9 @@ export default class Resizer {
     // TODO move vertical/horizontal to config option/container class
     // as it doesn't make sense to mix them within one container/Resizer
     constructor(container, distributorCtor, config) {
+        if (!container) {
+            throw new Error("Resizer requires a non-null `container` arg");
+        }
         this.container = container;
         this.distributorCtor = distributorCtor;
         this.config = config;


### PR DESCRIPTION
This fixes a soft crash that can happen on room join if you keep the right panel
open (which is the default). The `MainSplit` component was not properly testing
for the edge cases of when the resize container would be mounted.

Fixes https://github.com/vector-im/riot-web/issues/10997