### PR TITLE
Add label to rageshakes for React soft crashes

### DIFF
--- a/src/components/views/dialogs/BugReportDialog.js
+++ b/src/components/views/dialogs/BugReportDialog.js
@@ -2,6 +2,7 @@
 Copyright 2017 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
 Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -71,6 +72,7 @@ export default class BugReportDialog extends React.Component {
                 userText,
                 sendLogs: true,
                 progressCallback: this._sendProgressCallback,
+                label: this.props.label,
             }).then(() => {
                 if (!this._unmounted) {
                     this.props.onFinished(false);

--- a/src/components/views/elements/ErrorBoundary.js
+++ b/src/components/views/elements/ErrorBoundary.js
@@ -64,7 +64,9 @@ export default class ErrorBoundary extends React.PureComponent {
         if (!BugReportDialog) {
             return;
         }
-        Modal.createTrackedDialog('Bug Report Dialog', '', BugReportDialog, {});
+        Modal.createTrackedDialog('Bug Report Dialog', '', BugReportDialog, {
+            label: 'react-soft-crash',
+        });
     };
 
     render() {

--- a/src/rageshake/submit-rageshake.js
+++ b/src/rageshake/submit-rageshake.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,6 +80,10 @@ export default async function sendBugReport(bugReportEndpoint, opts) {
     if (client) {
         body.append('user_id', client.credentials.userId);
         body.append('device_id', client.deviceId);
+    }
+
+    if (opts.label) {
+        body.append('label', opts.label);
     }
 
     if (opts.sendLogs) {


### PR DESCRIPTION
This adds a label all rageshakes submitted via the React error boundary marking
them as soft crashes for triage.

Fixes https://github.com/vector-im/riot-web/issues/11072