### PR TITLE
SettingsFlag always run ToggleSwitch fully-controlled

### DIFF
--- a/src/components/views/elements/SettingsFlag.js
+++ b/src/components/views/elements/SettingsFlag.js
@@ -48,7 +48,7 @@ module.exports = createReactClass({
         if (this.props.group && !checked) return;
 
         if (!this.props.manualSave) this.save(checked);
-        else this.setState({ value: checked });
+        this.setState({ value: checked });
         if (this.props.onChange) this.props.onChange(checked);
     },
 

--- a/src/components/views/elements/SettingsFlag.js
+++ b/src/components/views/elements/SettingsFlag.js
@@ -62,13 +62,6 @@ module.exports = createReactClass({
     },
 
     render: function() {
-        const value = this.props.manualSave ? this.state.value : SettingsStore.getValueAt(
-            this.props.level,
-            this.props.name,
-            this.props.roomId,
-            this.props.isExplicit,
-        );
-
         const canChange = SettingsStore.canSetValue(this.props.name, this.props.roomId, this.props.level);
 
         let label = this.props.label;
@@ -78,7 +71,7 @@ module.exports = createReactClass({
         return (
             <div className="mx_SettingsFlag">
                 <span className="mx_SettingsFlag_label">{label}</span>
-                <ToggleSwitch checked={value} onChange={this.onChange} disabled={!canChange} aria-label={label} />
+                <ToggleSwitch checked={this.state.value} onChange={this.onChange} disabled={!canChange} aria-label={label} />
             </div>
         );
     },

--- a/src/components/views/elements/SettingsFlag.js
+++ b/src/components/views/elements/SettingsFlag.js
@@ -30,7 +30,6 @@ module.exports = createReactClass({
         label: PropTypes.string, // untranslated
         onChange: PropTypes.func,
         isExplicit: PropTypes.bool,
-        manualSave: PropTypes.bool,
     },
 
     getInitialState: function() {
@@ -47,7 +46,7 @@ module.exports = createReactClass({
     onChange: function(checked) {
         if (this.props.group && !checked) return;
 
-        if (!this.props.manualSave) this.save(checked);
+        this.save(checked);
         this.setState({ value: checked });
         if (this.props.onChange) this.props.onChange(checked);
     },


### PR DESCRIPTION
I do not understand why the value would ever come from the SettingsStore directly when we already had a copy of it. If Travis can explain why this is a thing that'd be great.

Fixes issue with preferences not toggling in v1.5.0-rc1

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>