### PR TITLE
Fix: crash while canceling editing an event when no selection

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -210,9 +210,18 @@ export default class EditMessageComposer extends React.Component {
     }
 
     componentWillUnmount() {
+        // store caret and serialized parts in the
+        // editorstate so it can be restored when the remote echo event tile gets rendered
+        // in case we're currently editing a pending event
         const sel = document.getSelection();
-        const {caret} = getCaretOffsetAndText(this._editorRef, sel);
+        let caret;
+        if (sel.focusNode) {
+            caret = getCaretOffsetAndText(this._editorRef, sel).caret;
+        }
         const parts = this.model.serializeParts();
+        // if caret is undefined because for some reason there isn't a valid selection,
+        // then when mounting the editor again with the same editor state,
+        // it will set the cursor at the end.
         this.props.editState.setEditorState(caret, parts);
     }
 
@@ -239,7 +248,7 @@ export default class EditMessageComposer extends React.Component {
     _getInitialCaretPosition() {
         const {editState} = this.props;
         let caretPosition;
-        if (editState.hasEditorState()) {
+        if (editState.hasEditorState() && editState.getCaret()) {
             // if restoring state from a previous editor,
             // restore caret position from the state
             const caret = editState.getCaret();

--- a/src/editor/dom.js
+++ b/src/editor/dom.js
@@ -92,6 +92,10 @@ function getSelectionOffsetAndText(editor, selectionNode, selectionOffset) {
 // gets the caret position details, ignoring and adjusting to
 // the ZWS if you're typing in a caret node
 function getCaret(node, offsetToNode, offsetWithinNode) {
+    // if no node is selected, return an offset at the start
+    if (!node) {
+        return new DocumentOffset(0, false);
+    }
     let atNodeEnd = offsetWithinNode === node.textContent.length;
     if (node.nodeType === Node.TEXT_NODE && isCaretNode(node.parentElement)) {
         const zwsIdx = node.nodeValue.indexOf(CARET_NODE_CHAR);


### PR DESCRIPTION
Should fix https://github.com/vector-im/riot-web/issues/11110

Although I can't repro the problem.