### PR TITLE
Fix reply fallback being included in edit m.new_content

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -75,7 +75,7 @@ function createEditContent(model, editedEvent) {
 
     const newContent = {
         "msgtype": isEmote ? "m.emote" : "m.text",
-        "body": plainPrefix + body,
+        "body": body,
     };
     const contentBody = {
         msgtype: newContent.msgtype,
@@ -85,7 +85,7 @@ function createEditContent(model, editedEvent) {
     const formattedBody = htmlSerializeIfNeeded(model, {forceHTML: isReply});
     if (formattedBody) {
         newContent.format = "org.matrix.custom.html";
-        newContent.formatted_body = htmlPrefix + formattedBody;
+        newContent.formatted_body = formattedBody;
         contentBody.format = newContent.format;
         contentBody.formatted_body = `${htmlPrefix} * ${formattedBody}`;
     }


### PR DESCRIPTION
This pull request removes the reply fallback from the `m.new_content` object in edits. It is still kept in the edit fallback.

Fixes vector-im/riot-web#11129