### PR TITLE
Abort scroll updates when already unmounted

### DIFF
--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -677,6 +677,11 @@ module.exports = createReactClass({
             debuglog("updateHeight getting straight to business, no scrolling going on.");
         }
 
+        // We might have unmounted since the timer finished, so abort if so.
+        if (this.unmounted) {
+            return;
+        }
+
         const sn = this._getScrollNode();
         const itemlist = this.refs.itemlist;
         const contentHeight = this._getMessagesHeight();


### PR DESCRIPTION
This checks whether we're unmounted before updating scroll state, as we use
async functions and timeouts in this area.

Fixes https://github.com/vector-im/riot-web/issues/11150