### PR TITLE
Set the noreferrer attribute to links and images

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -167,6 +167,7 @@ const transformTags = { // custom to matrix
             }
         }
         attribs.rel = 'noopener'; // https://mathiasbynens.github.io/rel-noopener/
+        attribs.rel += ' noreferrer';
         return { tagName, attribs };
     },
     'img': function(tagName, attribs) {
@@ -181,6 +182,7 @@ const transformTags = { // custom to matrix
             attribs.width || 800,
             attribs.height || 600,
         );
+        attribs.rel = 'noreferrer';
         return { tagName, attribs };
     },
     'code': function(tagName, attribs) {

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -227,7 +227,7 @@ matrixLinkify.options = {
     },
 
     linkAttributes: {
-        rel: 'noopener',
+        rel: 'noopener noreferrer',
     },
 
     target: function(href, type) {


### PR DESCRIPTION
An alternative fix to vector-im/riot-web#6147 which for some reason
the PR vector-im/riot-web#6155 is not yet merged.

The key difference is that the riot-web PR vector-im/riot-web#6155
uses HTML meta header for noreferrer, while this one adds the
rel-attribute to include the noreferrer keyword in both user-created
links as well as links converted from incoming events.

I guess it's up to the maintainers then to pick and choose, but please
do ;).