### PR TITLE
Fix: editor tests

### DIFF
--- a/test/editor/deserialize-test.js
+++ b/test/editor/deserialize-test.js
@@ -208,9 +208,9 @@ describe('editor/deserialize', function() {
             expect(parts.length).toBe(5);
             expect(parts[0]).toStrictEqual({type: "plain", text: "1. Start"});
             expect(parts[1]).toStrictEqual({type: "newline", text: "\n"});
-            expect(parts[2]).toStrictEqual({type: "plain", text: "1. Continue"});
+            expect(parts[2]).toStrictEqual({type: "plain", text: "2. Continue"});
             expect(parts[3]).toStrictEqual({type: "newline", text: "\n"});
-            expect(parts[4]).toStrictEqual({type: "plain", text: "1. Finish"});
+            expect(parts[4]).toStrictEqual({type: "plain", text: "3. Finish"});
         });
         it('mx-reply is stripped', function() {
             const html = "<mx-reply>foo</mx-reply>bar";


### PR DESCRIPTION
adjust list item numbers in test that are now preserved