### PR TITLE
A11Y fixes in the Left Panel

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -48,10 +48,14 @@ limitations under the License.
 
 .mx_LeftPanel {
     flex: 1;
-    overflow-x: hidden;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
     min-height: 0;
+}
+
+.mx_LeftPanel .mx_LeftPanel_Rooms {
+    flex: 1 1 0;
 }
 
 .mx_LeftPanel .mx_AppTile_mini {

--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -48,14 +48,10 @@ limitations under the License.
 
 .mx_LeftPanel {
     flex: 1;
-    overflow: hidden;
+    overflow-x: hidden;
     display: flex;
     flex-direction: column;
     min-height: 0;
-}
-
-.mx_LeftPanel .mx_LeftPanel_Rooms {
-    flex: 1 1 0;
 }
 
 .mx_LeftPanel .mx_AppTile_mini {

--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -272,6 +272,7 @@ const LeftPanel = createReactClass({
                 <aside className="mx_LeftPanel dark-panel">
                     <TopLeftMenuButton collapsed={this.props.collapsed} />
                     { breadcrumbs }
+                    <CallPreview ConferenceHandler={VectorConferenceHandler} />
                     <div className="mx_LeftPanel_Rooms" onKeyDown={this._onKeyDown} onFocus={this._onFocus} onBlur={this._onBlur}>
                         <div className="mx_LeftPanel_exploreAndFilterRow">
                             { exploreButton }
@@ -284,7 +285,6 @@ const LeftPanel = createReactClass({
                             searchFilter={this.state.searchFilter}
                             ConferenceHandler={VectorConferenceHandler} />
                     </div>
-                    <CallPreview ConferenceHandler={VectorConferenceHandler} />
                 </aside>
             </div>
         );

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -324,6 +324,7 @@ const RoomSubList = createReactClass({
                     aria-expanded={!isCollapsed}
                     inputRef={this._headerButton}
                     role="treeitem"
+                    aria-level="1"
                 >
                     { chevron }
                     <span>{this.props.label}</span>

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -346,8 +346,15 @@ export default class RoomBreadcrumbs extends React.Component {
             }
 
             return (
-                <AccessibleButton className={classes} key={r.room.roomId} onClick={() => this._viewRoom(r.room, i)}
-                    onMouseEnter={() => this._onMouseEnter(r.room)} onMouseLeave={() => this._onMouseLeave(r.room)}>
+                <AccessibleButton
+                    className={classes}
+                    key={r.room.roomId}
+                    onClick={() => this._viewRoom(r.room, i)}
+                    onMouseEnter={() => this._onMouseEnter(r.room)}
+                    onMouseLeave={() => this._onMouseLeave(r.room)}
+                    aria-label={_t("Room %(name)s", {name: r.room.name})}
+                    role="listitem"
+                >
                     <RoomAvatar room={r.room} width={32} height={32} />
                     {badge}
                     {dmIndicator}
@@ -356,10 +363,16 @@ export default class RoomBreadcrumbs extends React.Component {
             );
         });
         return (
-            <IndicatorScrollbar ref="scroller" className="mx_RoomBreadcrumbs"
-                trackHorizontalOverflow={true} verticalScrollsHorizontally={true}>
-                { avatars }
-            </IndicatorScrollbar>
+            <div role="list" aria-orientation="horizontal" aria-roledescription={_t("Recent rooms.")}>
+                <IndicatorScrollbar
+                    ref="scroller"
+                    className="mx_RoomBreadcrumbs"
+                    trackHorizontalOverflow={true}
+                    verticalScrollsHorizontally={true}
+                >
+                    { avatars }
+                </IndicatorScrollbar>
+            </div>
         );
     }
 }

--- a/src/components/views/rooms/RoomBreadcrumbs.js
+++ b/src/components/views/rooms/RoomBreadcrumbs.js
@@ -363,7 +363,7 @@ export default class RoomBreadcrumbs extends React.Component {
             );
         });
         return (
-            <div role="list" aria-orientation="horizontal" aria-roledescription={_t("Recent rooms.")}>
+            <div role="list" aria-orientation="horizontal" aria-roledescription={_t("Recent rooms")}>
                 <IndicatorScrollbar
                     ref="scroller"
                     className="mx_RoomBreadcrumbs"

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -896,6 +896,8 @@
     "Seen by %(displayName)s (%(userName)s) at %(dateTime)s": "Seen by %(displayName)s (%(userName)s) at %(dateTime)s",
     "Replying": "Replying",
     "Direct Chat": "Direct Chat",
+    "Room %(name)s": "Room %(name)s",
+    "Recent rooms": "Recent rooms",
     "No rooms to show": "No rooms to show",
     "Unnamed room": "Unnamed room",
     "World readable": "World readable",


### PR DESCRIPTION
+ Specify the aria-level for the headers on the room list tree
+ Make breadcrumbs tab accessible and specify aria-labels to match hover tooltips
+ Move Jitsi widget to above Explore/Filter, it was previously in the middle of the room list + filtering widget which broke natural tab ordering
+ Remove some tab traps, only introduce them for arrow key navigation, allowing more natural tabbing around for accessibility

![image](https://user-images.githubusercontent.com/2403652/67391000-a6454300-f595-11e9-9d9b-b3f8e000ae7f.png)
