### PR TITLE
Update ServerTypeSelector for new matrix.org CS API URL

### DIFF
--- a/src/components/views/auth/ServerTypeSelector.js
+++ b/src/components/views/auth/ServerTypeSelector.js
@@ -35,7 +35,7 @@ export const TYPES = {
         logo: () => <img src={require('../../../../res/img/matrix-org-bw-logo.svg')} />,
         description: () => _t('Join millions for free on the largest public server'),
         serverConfig: makeType(ValidatedServerConfig, {
-            hsUrl: "https://matrix.org",
+            hsUrl: "https://matrix-client.matrix.org",
             hsName: "matrix.org",
             hsNameIsDifferent: false,
             isUrl: "https://vector.im",


### PR DESCRIPTION
This was missed in https://github.com/vector-im/riot-web/pull/11112 and causes problems where matrix.org isn't pre-selected.