### PR TITLE
Fix quick reactions to be aligned with other emoji

### DIFF
--- a/res/css/views/emojipicker/_EmojiPicker.scss
+++ b/res/css/views/emojipicker/_EmojiPicker.scss
@@ -221,7 +221,6 @@ limitations under the License.
 
 .mx_EmojiPicker_quick {
     flex-direction: column;
-    align-items: start;
     justify-content: space-around;
 }
 


### PR DESCRIPTION
This uses center alignment for quick reactions as well, so that they line up
with the larger emoji categories above.

![image](https://user-images.githubusercontent.com/279572/67682273-dff7be80-f986-11e9-988f-cb66b9596257.png)
