### PR TITLE
Remove unneeded help about identity servers

### DIFF
--- a/src/components/views/auth/CustomServerDialog.js
+++ b/src/components/views/auth/CustomServerDialog.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,11 +34,6 @@ module.exports = createReactClass({
                         "Matrix servers by specifying a different homeserver URL. This " +
                         "allows you to use this app with an existing Matrix account on a " +
                         "different homeserver.",
-                    )}</p>
-                    <p>{_t(
-                        "You can also set a custom identity server, but you won't be " +
-                        "able to invite users by email address, or be invited by email " +
-                        "address yourself.",
                     )}</p>
                 </div>
                 <div className="mx_Dialog_buttons">

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1496,7 +1496,6 @@
     "This homeserver would like to make sure you are not a robot.": "This homeserver would like to make sure you are not a robot.",
     "Custom Server Options": "Custom Server Options",
     "You can use the custom server options to sign into other Matrix servers by specifying a different homeserver URL. This allows you to use this app with an existing Matrix account on a different homeserver.": "You can use the custom server options to sign into other Matrix servers by specifying a different homeserver URL. This allows you to use this app with an existing Matrix account on a different homeserver.",
-    "You can also set a custom identity server, but you won't be able to invite users by email address, or be invited by email address yourself.": "You can also set a custom identity server, but you won't be able to invite users by email address, or be invited by email address yourself.",
     "To continue, please enter your password.": "To continue, please enter your password.",
     "Missing captcha public key in homeserver configuration. Please report this to your homeserver administrator.": "Missing captcha public key in homeserver configuration. Please report this to your homeserver administrator.",
     "Please review and accept all of the homeserver's policies": "Please review and accept all of the homeserver's policies",


### PR DESCRIPTION
The custom server path no longer shows an identity server field (for modern
homeservers), so it's confusing to have the help dialog reference it.

Part of https://github.com/vector-im/riot-web/issues/11236