### PR TITLE
Handle breadcrumbs, integration manager provisioning, and allowed widgets Riot settings

### DIFF
--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -283,6 +283,10 @@ export const SETTINGS = {
         supportedLevels: ['account'],
         default: true,
     },
+    "allowedWidgets": {
+        supportedLevels: ['room-account'],
+        default: {}, // none allowed
+    },
     "analyticsOptIn": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         displayName: _td('Send analytics data'),

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -279,6 +279,10 @@ export const SETTINGS = {
         supportedLevels: ['account'],
         default: [],
     },
+    "integration_provisioning": {
+        supportedLevels: ['account'],
+        default: true,
+    },
     "analyticsOptIn": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         displayName: _td('Send analytics data'),

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -279,7 +279,7 @@ export const SETTINGS = {
         supportedLevels: ['account'],
         default: [],
     },
-    "integration_provisioning": {
+    "integrationProvisioning": {
         supportedLevels: ['account'],
         default: true,
     },

--- a/src/settings/handlers/AccountSettingsHandler.js
+++ b/src/settings/handlers/AccountSettingsHandler.js
@@ -65,7 +65,7 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
             this._notifyBreadcrumbsUpdate(event);
         } else if (event.getType() === INTEG_PROVISIONING_EVENT_TYPE) {
             const val = event.getContent()['enabled'];
-            this._watchers.notifyUpdate("integration_provisioning", null, SettingLevel.ACCOUNT, val);
+            this._watchers.notifyUpdate("integrationProvisioning", null, SettingLevel.ACCOUNT, val);
         }
     }
 
@@ -93,7 +93,7 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         }
 
         // Special case integration manager provisioning
-        if (settingName === "integration_provisioning") {
+        if (settingName === "integrationProvisioning") {
             const content = this._getSettings(INTEG_PROVISIONING_EVENT_TYPE);
             return content ? content['enabled'] : null;
         }
@@ -132,7 +132,7 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         }
 
         // Special case integration manager provisioning
-        if (settingName === "integration_provisioning") {
+        if (settingName === "integrationProvisioning") {
             const content = this._getSettings(INTEG_PROVISIONING_EVENT_TYPE) || {};
             content['enabled'] = newValue;
             return MatrixClientPeg.get().setAccountData(INTEG_PROVISIONING_EVENT_TYPE, content);

--- a/src/settings/handlers/AccountSettingsHandler.js
+++ b/src/settings/handlers/AccountSettingsHandler.js
@@ -23,6 +23,8 @@ const BREADCRUMBS_LEGACY_EVENT_TYPE = "im.vector.riot.breadcrumb_rooms";
 const BREADCRUMBS_EVENT_TYPE = "im.vector.setting.breadcrumbs";
 const BREADCRUMBS_EVENT_TYPES = [BREADCRUMBS_LEGACY_EVENT_TYPE, BREADCRUMBS_EVENT_TYPE];
 
+const INTEG_PROVISIONING_EVENT_TYPE = "im.vector.setting.integration_provisioning";
+
 /**
  * Gets and sets settings at the "account" level for the current user.
  * This handler does not make use of the roomId parameter.
@@ -61,6 +63,9 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
             }
         } else if (BREADCRUMBS_EVENT_TYPES.includes(event.getType())) {
             this._notifyBreadcrumbsUpdate(event);
+        } else if (event.getType() === INTEG_PROVISIONING_EVENT_TYPE) {
+            let val = event.getContent()['enabled'];
+            this._watchers.notifyUpdate("integration_provisioning", null, SettingLevel.ACCOUNT, val);
         }
     }
 
@@ -85,6 +90,12 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
             }
 
             return content && content['recent_rooms'] ? content['recent_rooms'] : [];
+        }
+
+        // Special case integration manager provisioning
+        if (settingName === "integration_provisioning") {
+            const content = this._getSettings(INTEG_PROVISIONING_EVENT_TYPE);
+            return content ? content['enabled'] : null;
         }
 
         const settings = this._getSettings() || {};
@@ -118,6 +129,13 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
 
             content['recent_rooms'] = newValue;
             return MatrixClientPeg.get().setAccountData(BREADCRUMBS_EVENT_TYPE, content);
+        }
+
+        // Special case integration manager provisioning
+        if (settingName === "integration_provisioning") {
+            const content = this._getSettings(INTEG_PROVISIONING_EVENT_TYPE) || {};
+            content['enabled'] = newValue;
+            return MatrixClientPeg.get().setAccountData(INTEG_PROVISIONING_EVENT_TYPE, content);
         }
 
         const content = this._getSettings() || {};

--- a/src/settings/handlers/AccountSettingsHandler.js
+++ b/src/settings/handlers/AccountSettingsHandler.js
@@ -19,7 +19,9 @@ import MatrixClientPeg from '../../MatrixClientPeg';
 import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandler";
 import {SettingLevel} from "../SettingsStore";
 
-const BREADCRUMBS_EVENT_TYPE = "im.vector.riot.breadcrumb_rooms";
+const BREADCRUMBS_LEGACY_EVENT_TYPE = "im.vector.riot.breadcrumb_rooms";
+const BREADCRUMBS_EVENT_TYPE = "im.vector.setting.breadcrumbs";
+const BREADCRUMBS_EVENT_TYPES = [BREADCRUMBS_LEGACY_EVENT_TYPE, BREADCRUMBS_EVENT_TYPE];
 
 /**
  * Gets and sets settings at the "account" level for the current user.
@@ -57,9 +59,8 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
                 const val = event.getContent()[settingName];
                 this._watchers.notifyUpdate(settingName, null, SettingLevel.ACCOUNT, val);
             }
-        } else if (event.getType() === BREADCRUMBS_EVENT_TYPE) {
-            const val = event.getContent()['rooms'] || [];
-            this._watchers.notifyUpdate("breadcrumb_rooms", null, SettingLevel.ACCOUNT, val);
+        } else if (BREADCRUMBS_EVENT_TYPES.includes(event.getType())) {
+            this._notifyBreadcrumbsUpdate(event);
         }
     }
 
@@ -75,8 +76,15 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
 
         // Special case for breadcrumbs
         if (settingName === "breadcrumb_rooms") {
-            const content = this._getSettings(BREADCRUMBS_EVENT_TYPE) || {};
-            return content['rooms'] || [];
+            let content = this._getSettings(BREADCRUMBS_EVENT_TYPE);
+            if (!content || !content['recent_rooms']) {
+                content = this._getSettings(BREADCRUMBS_LEGACY_EVENT_TYPE);
+
+                // This is a bit of a hack, but it makes things slightly easier
+                if (content) content['recent_rooms'] = content['rooms'];
+            }
+
+            return content && content['recent_rooms'] ? content['recent_rooms'] : [];
         }
 
         const settings = this._getSettings() || {};
@@ -102,8 +110,13 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
 
         // Special case for breadcrumbs
         if (settingName === "breadcrumb_rooms") {
-            const content = this._getSettings(BREADCRUMBS_EVENT_TYPE) || {};
-            content['rooms'] = newValue;
+            // We read the value first just to make sure we preserve whatever random keys might be present.
+            let content = this._getSettings(BREADCRUMBS_EVENT_TYPE);
+            if (!content || !content['recent_rooms']) {
+                content = this._getSettings(BREADCRUMBS_LEGACY_EVENT_TYPE);
+            }
+
+            content['recent_rooms'] = newValue;
             return MatrixClientPeg.get().setAccountData(BREADCRUMBS_EVENT_TYPE, content);
         }
 
@@ -128,5 +141,20 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         const event = cli.getAccountData(eventType);
         if (!event || !event.getContent()) return null;
         return event.getContent();
+    }
+
+    _notifyBreadcrumbsUpdate(event) {
+        let val = [];
+        if (event.getType() === BREADCRUMBS_LEGACY_EVENT_TYPE) {
+            // This seems fishy - try and get the event for the new rooms
+            const newType = this._getSettings(BREADCRUMBS_EVENT_TYPE);
+            if (newType) val = newType['recent_rooms'];
+            else val = event.getContent()['rooms'];
+        } else if (event.getType() === BREADCRUMBS_EVENT_TYPE) {
+            val = event.getContent()['recent_rooms'];
+        } else {
+            return; // for sanity, not because we expect to be here.
+        }
+        this._watchers.notifyUpdate("breadcrumb_rooms", null, SettingLevel.ACCOUNT, val || []);
     }
 }

--- a/src/settings/handlers/AccountSettingsHandler.js
+++ b/src/settings/handlers/AccountSettingsHandler.js
@@ -64,7 +64,7 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         } else if (BREADCRUMBS_EVENT_TYPES.includes(event.getType())) {
             this._notifyBreadcrumbsUpdate(event);
         } else if (event.getType() === INTEG_PROVISIONING_EVENT_TYPE) {
-            let val = event.getContent()['enabled'];
+            const val = event.getContent()['enabled'];
             this._watchers.notifyUpdate("integration_provisioning", null, SettingLevel.ACCOUNT, val);
         }
     }

--- a/src/settings/handlers/RoomAccountSettingsHandler.js
+++ b/src/settings/handlers/RoomAccountSettingsHandler.js
@@ -108,7 +108,7 @@ export default class RoomAccountSettingsHandler extends MatrixClientBackedSettin
 
         // Special case allowed widgets
         if (settingName === "allowedWidgets") {
-            return return MatrixClientPeg.get().setRoomAccountData(roomId, ALLOWED_WIDGETS_EVENT_TYPE, newValue);
+            return MatrixClientPeg.get().setRoomAccountData(roomId, ALLOWED_WIDGETS_EVENT_TYPE, newValue);
         }
 
         const content = this._getSettings(roomId) || {};

--- a/src/settings/handlers/RoomAccountSettingsHandler.js
+++ b/src/settings/handlers/RoomAccountSettingsHandler.js
@@ -19,6 +19,8 @@ import MatrixClientPeg from '../../MatrixClientPeg';
 import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandler";
 import {SettingLevel} from "../SettingsStore";
 
+const ALLOWED_WIDGETS_EVENT_TYPE = "im.vector.setting.allowed_widgets";
+
 /**
  * Gets and sets settings at the "room-account" level for the current user.
  */
@@ -58,6 +60,8 @@ export default class RoomAccountSettingsHandler extends MatrixClientBackedSettin
                 const val = event.getContent()[settingName];
                 this._watchers.notifyUpdate(settingName, roomId, SettingLevel.ROOM_ACCOUNT, val);
             }
+        } else if (event.getType() === ALLOWED_WIDGETS_EVENT_TYPE) {
+            this._watchers.notifyUpdate("allowedWidgets", roomId, SettingLevel.ROOM_ACCOUNT, event.getContent());
         }
     }
 
@@ -79,6 +83,11 @@ export default class RoomAccountSettingsHandler extends MatrixClientBackedSettin
             return this._getSettings(roomId, "org.matrix.room.color_scheme");
         }
 
+        // Special case allowed widgets
+        if (settingName === "allowedWidgets") {
+            return this._getSettings(roomId, ALLOWED_WIDGETS_EVENT_TYPE);
+        }
+
         const settings = this._getSettings(roomId) || {};
         return settings[settingName];
     }
@@ -95,6 +104,11 @@ export default class RoomAccountSettingsHandler extends MatrixClientBackedSettin
         if (settingName === "roomColor") {
             // The new value should match our requirements, we just need to store it in the right place.
             return MatrixClientPeg.get().setRoomAccountData(roomId, "org.matrix.room.color_scheme", newValue);
+        }
+
+        // Special case allowed widgets
+        if (settingName === "allowedWidgets") {
+            return return MatrixClientPeg.get().setRoomAccountData(roomId, ALLOWED_WIDGETS_EVENT_TYPE, newValue);
         }
 
         const content = this._getSettings(roomId) || {};


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11260

Breadcrumbs are a bit special and have a fallback mechanic to them. The integration manager provisioning setting is just present to show how one would implement such a thing in Riot's granular settings structure - it is not hooked up. Hooking it up is for a different issue. Allowed widgets are in the same boat as integration manager provisioning.