### PR TITLE
Guard against misconfigured homeservers when adding / binding phone numbers

### DIFF
--- a/src/AddThreepid.js
+++ b/src/AddThreepid.js
@@ -236,6 +236,8 @@ export default class AddThreepid {
      */
     async haveMsisdnToken(msisdnToken) {
         const authClient = new IdentityAuthClient();
+        const supportsSeparateAddAndBind =
+            await MatrixClientPeg.get().doesServerSupportSeparateAddAndBind();
 
         let result;
         if (this.submitUrl) {
@@ -245,19 +247,21 @@ export default class AddThreepid {
                 this.clientSecret,
                 msisdnToken,
             );
-        } else {
+        } else if (this.bind || !supportsSeparateAddAndBind) {
             result = await MatrixClientPeg.get().submitMsisdnToken(
                 this.sessionId,
                 this.clientSecret,
                 msisdnToken,
                 await authClient.getAccessToken(),
             );
+        } else {
+            throw new Error("The add / bind with MSISDN flow is misconfigured");
         }
         if (result.errcode) {
             throw result;
         }
 
-        if (await MatrixClientPeg.get().doesServerSupportSeparateAddAndBind()) {
+        if (supportsSeparateAddAndBind) {
             if (this.bind) {
                 await MatrixClientPeg.get().bindThreePid({
                     sid: this.sessionId,

--- a/src/components/views/auth/InteractiveAuthEntryComponents.js
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.js
@@ -475,22 +475,26 @@ export const MsisdnAuthEntry = createReactClass({
         });
 
         try {
+            const requiresIdServerParam =
+                await this.props.matrixClient.doesServerRequireIdServerParam();
             let result;
             if (this._submitUrl) {
                 result = await this.props.matrixClient.submitMsisdnTokenOtherUrl(
                     this._submitUrl, this._sid, this.props.clientSecret, this.state.token,
                 );
-            } else {
+            } else if (requiresIdServerParam) {
                 result = await this.props.matrixClient.submitMsisdnToken(
                     this._sid, this.props.clientSecret, this.state.token,
                 );
+            } else {
+                throw new Error("The registration with MSISDN flow is misconfigured");
             }
             if (result.success) {
                 const creds = {
                     sid: this._sid,
                     client_secret: this.props.clientSecret,
                 };
-                if (await this.props.matrixClient.doesServerRequireIdServerParam()) {
+                if (requiresIdServerParam) {
                     const idServerParsedUrl = url.parse(
                         this.props.matrixClient.getIdentityServerUrl(),
                     );


### PR DESCRIPTION
This ensures we only fallback to submitting MSISDN tokens to the identity server
when we expect to do. Unexpected cases will now throw an error.

Fixes https://github.com/vector-im/riot-web/issues/10936