### PR TITLE
Fix bug where rooms would not appear when filtering

### DIFF
--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -67,6 +67,9 @@ const RoomSubList = createReactClass({
             // some values to get LazyRenderList starting
             scrollerHeight: 800,
             scrollTop: 0,
+            // React 16's getDerivedStateFromProps(props, state) doesn't give the previous props so
+            // we have to store the length of the list here so we can see if it's changed or not...
+            listLength: null,
         };
     },
 
@@ -79,9 +82,18 @@ const RoomSubList = createReactClass({
         };
     },
 
-    componentWillMount: function() {
+    componentDidMount: function() {
         this._headerButton = createRef();
         this.dispatcherRef = dis.register(this.onAction);
+    },
+
+    statics: {
+        getDerivedStateFromProps: function(props, state) {
+            return {
+                listLength: props.list.length,
+                scrollTop: props.list.length === state.listLength ? state.scrollTop : 0,
+            };
+        },
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
We need to reset the scroll offset otherwise the component may be
scrolled past the only content it has (Chrome just corrected the
scroll offset but Firefox scrolled it anyway).

NB. Introducing the new deriveStateFromProps method seems to
means that react no longer calls componentWillMount so I've
had to change it to componentDidMount (which it should have
been anyway).

Fixes https://github.com/vector-im/riot-web/issues/11263