### PR TITLE
Relax identity server discovery error handling

### DIFF
--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -378,8 +378,19 @@ module.exports = createReactClass({
 
         // Do a quick liveliness check on the URLs
         try {
-            await AutoDiscoveryUtils.validateServerConfigWithStaticUrls(hsUrl, isUrl);
-            this.setState({serverIsAlive: true, errorText: ""});
+            const { warning } =
+                await AutoDiscoveryUtils.validateServerConfigWithStaticUrls(hsUrl, isUrl);
+            if (warning) {
+                this.setState({
+                    ...AutoDiscoveryUtils.authComponentStateForError(warning),
+                    errorText: "",
+                });
+            } else {
+                this.setState({
+                    serverIsAlive: true,
+                    errorText: "",
+                });
+            }
         } catch (e) {
             this.setState({
                 busy: false,


### PR DESCRIPTION
If discovery results in a warning for the identity server (as in can't be found
or is malformed), this allows you to continue signing in and shows the warning
above the form.

<img width="722" alt="2019-11-01 at 12 29" src="https://user-images.githubusercontent.com/279572/68025175-15ace800-fca4-11e9-87da-f199f42c7db4.png">

Fixes https://github.com/vector-im/riot-web/issues/11102