### PR TITLE
Support RTL language in message composer

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -566,6 +566,7 @@ export default class BasicMessageEditor extends React.Component {
                 aria-haspopup="listbox"
                 aria-expanded={Boolean(this.state.autoComplete)}
                 aria-activedescendant={completionIndex >= 0 ? generateCompletionDomId(completionIndex) : undefined}
+                dir="auto"
             />
         </div>);
     }


### PR DESCRIPTION
Add `dir=auto` attribute to support RTL langauges properly in message composer. 