### PR TITLE
Fix: file and notifications panel back-paginating forever.

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -18,6 +18,7 @@ limitations under the License.
     order: 2;
     flex: 1 1 0;
     overflow-y: auto;
+    display: flex;
 }
 
 .mx_FilePanel .mx_RoomView_messageListWrapper {

--- a/res/css/structures/_NotificationPanel.scss
+++ b/res/css/structures/_NotificationPanel.scss
@@ -18,6 +18,7 @@ limitations under the License.
     order: 2;
     flex: 1 1 0;
     overflow-y: auto;
+    display: flex;
 }
 
 .mx_NotificationPanel .mx_RoomView_messageListWrapper {

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -39,21 +39,8 @@ const FilePanel = createReactClass({
         };
     },
 
-    componentWillMount: function() {
+    componentDidMount: function() {
         this.updateTimelineSet(this.props.roomId);
-    },
-
-    componentWillReceiveProps: function(nextProps) {
-        if (nextProps.roomId !== this.props.roomId) {
-            // otherwise we race between re-rendering the TimelinePanel and setting the new timelineSet.
-            //
-            // FIXME: this race only happens because of the promise returned by getOrCreateFilter().
-            // We should only need to create the containsUrl filter once per login session, so in practice
-            // it shouldn't be being done here at all.  Then we could just update the timelineSet directly
-            // without resetting it first, and speed up room-change.
-            this.setState({ timelineSet: null });
-            this.updateTimelineSet(nextProps.roomId);
-        }
     },
 
     updateTimelineSet: function(roomId) {

--- a/src/components/structures/ScrollPanel.js
+++ b/src/components/structures/ScrollPanel.js
@@ -759,8 +759,10 @@ module.exports = createReactClass({
     _getMessagesHeight() {
         const itemlist = this.refs.itemlist;
         const lastNode = itemlist.lastElementChild;
+        const lastNodeBottom = lastNode ? lastNode.offsetTop + lastNode.clientHeight : 0;
+        const firstNodeTop = itemlist.firstElementChild ? itemlist.firstElementChild.offsetTop : 0;
         // 18 is itemlist padding
-        return (lastNode.offsetTop + lastNode.clientHeight) - itemlist.firstElementChild.offsetTop + (18 * 2);
+        return lastNodeBottom - firstNodeTop + (18 * 2);
     },
 
     _topFromBottom(node) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11323 & https://github.com/vector-im/riot-web/issues/11328

Also did some cleanups to prevent errors in the console, the real fix is making FilePanel and Notifications a flex container again, so the scrollpanel inside only takes the available height, and doesn't grow with their content.

I'm wondering when and how this broke... I'm guessing that the last change in that area was the UserInfo stuff, anything CSS changes that could have made the FilePanel and NotificationsPanel not being flex containers anymore @t3chguy ?