### PR TITLE
Fix linkify imports

### DIFF
--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -243,4 +243,4 @@ matrixLinkify.options = {
     },
 };
 
-module.exports = matrixLinkify;
+export default matrixLinkify;

--- a/src/utils/permalinks/Permalinks.js
+++ b/src/utils/permalinks/Permalinks.js
@@ -20,7 +20,7 @@ import utils from 'matrix-js-sdk/lib/utils';
 import SpecPermalinkConstructor, {baseUrl as matrixtoBaseUrl} from "./SpecPermalinkConstructor";
 import PermalinkConstructor, {PermalinkParts} from "./PermalinkConstructor";
 import RiotPermalinkConstructor from "./RiotPermalinkConstructor";
-import * as matrixLinkify from "../../linkify-matrix";
+import matrixLinkify from "../../linkify-matrix";
 
 const SdkConfig = require("../../SdkConfig");
 


### PR DESCRIPTION
VECTOR_URL_PATTERN was 'undefined' inside Permalinks.tryTransformPermalinkToLocalHref()