### PR TITLE
Fix softcrash if editing silly events

### DIFF
--- a/src/utils/EventUtils.js
+++ b/src/utils/EventUtils.js
@@ -52,6 +52,7 @@ export function canEditContent(mxEvent) {
     const content = mxEvent.getOriginalContent();
     const {msgtype} = content;
     return (msgtype === "m.text" || msgtype === "m.emote") &&
+        content.body && typeof content.body === 'string' &&
         mxEvent.getSender() === MatrixClientPeg.get().getUserId();
 }
 


### PR DESCRIPTION
If you sent an event with a body of the empty json object, riot
would then softcrash when you pressed the up arrow because it
would try to treat a json object as a string and run split on it.

This fix makes those events non-editable