### PR TITLE
Now that part of spacing is padding, make it smaller when collapsed

### DIFF
--- a/res/css/structures/_RoomSubList.scss
+++ b/res/css/structures/_RoomSubList.scss
@@ -151,6 +151,7 @@ limitations under the License.
     .mx_RoomSubList_labelContainer {
         margin-right: 8px;
         margin-left: 2px;
+        padding: 0;
     }
 
     .mx_RoomSubList_addRoom {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11339

![image](https://user-images.githubusercontent.com/2403652/68380515-eab11100-0147-11ea-8cea-62dccdb1b44f.png)

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>