### PR TITLE
Remove variation selectors from quick reactions

### DIFF
--- a/src/components/views/emojipicker/QuickReactions.js
+++ b/src/components/views/emojipicker/QuickReactions.js
@@ -21,7 +21,7 @@ import EMOJIBASE from 'emojibase-data/en/compact.json';
 import sdk from '../../../index';
 import { _t } from '../../../languageHandler';
 
-const QUICK_REACTIONS = ["👍️", "👎️", "😄", "🎉", "😕", "❤️", "🚀", "👀"];
+const QUICK_REACTIONS = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"];
 EMOJIBASE.forEach(emoji => {
     const index = QUICK_REACTIONS.indexOf(emoji.unicode);
     if (index !== -1) {


### PR DESCRIPTION
This fixes a regression introduced by the full emoji picker which inserted empty
variation selectors in the thumbs up / down quick reactions. Since this makes
them different characters, it would cause us to not aggregate thumbs from web
vs. mobile together.

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3554
Fixes https://github.com/vector-im/riot-web/issues/11335