### PR TITLE
Restore thumbs after variation selector removal

### DIFF
--- a/src/HtmlUtils.js
+++ b/src/HtmlUtils.js
@@ -53,7 +53,6 @@ const ZWJ_REGEX = new RegExp("\u200D|\u2003", "g");
 const WHITESPACE_REGEX = new RegExp("\\s", "g");
 
 const BIGEMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})+$`, 'i');
-const SINGLE_EMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})$`, 'i');
 
 const COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
@@ -73,16 +72,28 @@ function mightContainEmoji(str) {
 }
 
 /**
+ * Find emoji data in emojibase by character.
+ *
+ * @param {String} char The emoji character
+ * @return {Object} The emoji data
+ */
+export function findEmojiData(char) {
+    // Check against both the char and the char with an empty variation selector
+    // appended because that's how emojibase stores its base emojis which have
+    // variations.
+    // See also https://github.com/vector-im/riot-web/issues/9785.
+    const emptyVariation = char + VARIATION_SELECTOR;
+    return EMOJIBASE.find(e => e.unicode === char || e.unicode === emptyVariation);
+}
+
+/**
  * Returns the shortcode for an emoji character.
  *
  * @param {String} char The emoji character
  * @return {String} The shortcode (such as :thumbup:)
  */
 export function unicodeToShortcode(char) {
-    // Check against both the char and the char with an empty variation selector appended because that's how
-    // emoji-base stores its base emojis which have variations. https://github.com/vector-im/riot-web/issues/9785
-    const emptyVariation = char + VARIATION_SELECTOR;
-    const data = EMOJIBASE.find(e => e.unicode === char || e.unicode === emptyVariation);
+    const data = findEmojiData(char);
     return (data && data.shortcodes ? `:${data.shortcodes[0]}:` : '');
 }
 

--- a/src/components/views/emojipicker/EmojiPicker.js
+++ b/src/components/views/emojipicker/EmojiPicker.js
@@ -48,7 +48,14 @@ const DATA_BY_CATEGORY = {
 };
 const DATA_BY_EMOJI = {};
 
+const VARIATION_SELECTOR = String.fromCharCode(0xFE0F);
 EMOJIBASE.forEach(emoji => {
+    if (emoji.unicode.includes(VARIATION_SELECTOR)) {
+        // Clone data into variation-less version
+        emoji = Object.assign({}, emoji, {
+            unicode: emoji.unicode.replace(VARIATION_SELECTOR, ""),
+        });
+    }
     DATA_BY_EMOJI[emoji.unicode] = emoji;
     const categoryId = EMOJIBASE_CATEGORY_IDS[emoji.group];
     if (DATA_BY_CATEGORY.hasOwnProperty(categoryId)) {
@@ -82,7 +89,10 @@ class EmojiPicker extends React.Component {
             viewportHeight: 280,
         };
 
-        this.recentlyUsed = recent.get().map(unicode => DATA_BY_EMOJI[unicode]);
+        // Convert recent emoji characters to emoji data, removing unknowns.
+        this.recentlyUsed = recent.get()
+            .map(unicode => DATA_BY_EMOJI[unicode])
+            .filter(data => !!data);
         this.memoizedDataByCategory = {
             recent: this.recentlyUsed,
             ...DATA_BY_CATEGORY,

--- a/src/components/views/emojipicker/QuickReactions.js
+++ b/src/components/views/emojipicker/QuickReactions.js
@@ -16,17 +16,19 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import EMOJIBASE from 'emojibase-data/en/compact.json';
 
 import sdk from '../../../index';
 import { _t } from '../../../languageHandler';
+import { findEmojiData } from '../../../HtmlUtils';
 
-const QUICK_REACTIONS = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"];
-EMOJIBASE.forEach(emoji => {
-    const index = QUICK_REACTIONS.indexOf(emoji.unicode);
-    if (index !== -1) {
-        QUICK_REACTIONS[index] = emoji;
+const QUICK_REACTIONS = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"].map(emoji => {
+    const data = findEmojiData(emoji);
+    if (!data) {
+        throw new Error(`Emoji ${emoji} doesn't exist in emojibase`);
     }
+    // Prefer our unicode value for quick reactions (which does not have
+    // variation selectors).
+    return Object.assign({}, data, { unicode: emoji });
 });
 
 class QuickReactions extends React.Component {


### PR DESCRIPTION
This more thorough change adjusts emoji processing to deal with variation
selectors appropriately and revives the missing thumbs.

<img width="397" alt="2019-11-07 at 17 49" src="https://user-images.githubusercontent.com/279572/68413969-3505b280-0187-11ea-9881-0ee166e1da66.png">

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3598
Fixes https://github.com/vector-im/riot-web/issues/11344