### PR TITLE
Match identity server registration to the IS r0.3.0 spec

### DIFF
--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -183,8 +183,10 @@ export default class IdentityAuthClient {
     async registerForToken(check=true) {
         try {
             const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
-            const { access_token: identityAccessToken } =
+            // XXX: The spec is `token`, but we used `access_token` for a Sydent release.
+            const { access_token, token } =
                 await this._matrixClient.registerWithIdentityServer(hsOpenIdToken);
+            let identityAccessToken = token ? token : access_token;
             if (check) await this._checkToken(identityAccessToken);
             return identityAccessToken;
         } catch (e) {

--- a/src/IdentityAuthClient.js
+++ b/src/IdentityAuthClient.js
@@ -184,9 +184,9 @@ export default class IdentityAuthClient {
         try {
             const hsOpenIdToken = await MatrixClientPeg.get().getOpenIdToken();
             // XXX: The spec is `token`, but we used `access_token` for a Sydent release.
-            const { access_token, token } =
+            const { access_token: accessToken, token } =
                 await this._matrixClient.registerWithIdentityServer(hsOpenIdToken);
-            let identityAccessToken = token ? token : access_token;
+            const identityAccessToken = token ? token : accessToken;
             if (check) await this._checkToken(identityAccessToken);
             return identityAccessToken;
         } catch (e) {


### PR DESCRIPTION
The returned field is `token` for the spec, but we somehow got through with `access_token` on Sydent.

See also: https://github.com/matrix-org/sydent/pull/232