### PR TITLE
Remove lint comments about no-descending-specificity

### DIFF
--- a/res/css/structures/_AutoHideScrollbar.scss
+++ b/res/css/structures/_AutoHideScrollbar.scss
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/* This file has CSS for both native and non-native scrollbars in an
- * order that's fairly logic to read but violates stylelints descending
- * specificity rule, so turn it off for this file. It also duplicates
- * a selector to separate the hiding/showing from the sizing.
+/* This file has CSS for both native and non-native scrollbars in an order
+ * that's fairly logical to read but duplicates a selector to separate the
+ * hiding/showing from the sizing.
  */
-/* stylelint-disable no-descending-specificity, no-duplicate-selectors */
+/* stylelint-disable no-duplicate-selectors */
 
 /*
 1. for browsers that support native overlay auto-hiding scrollbars

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -135,9 +135,6 @@ limitations under the License.
     }
 }
 
-/* Ordering this block by specificity would require breaking it up into several
-   chunks, which seems like it would be more confusing to read. */
-/* stylelint-disable no-descending-specificity */
 .mx_DevTools_tgl-flip {
     + .mx_DevTools_tgl-btn {
         padding: 2px;
@@ -192,4 +189,3 @@ limitations under the License.
         }
     }
 }
-/* stylelint-enable no-descending-specificity */

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -148,9 +148,6 @@ limitations under the License.
     color: $greyed-fg-color;
 }
 
-/* Ordering this block by specificity would require breaking it up into several
-   chunks, which seems like it would be more confusing to read. */
-/* stylelint-disable no-descending-specificity */
 .mx_Field_valid {
     &.mx_Field,
     &.mx_Field:focus-within {
@@ -174,7 +171,6 @@ limitations under the License.
         color: $input-invalid-border-color;
     }
 }
-/* stylelint-enable no-descending-specificity */
 
 .mx_Field_tooltip {
     margin-top: -12px;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -561,9 +561,6 @@ div.mx_EventTile_notSent.mx_EventTile_redacted .mx_UnknownBody {
 
 /* end of overrides */
 
-/* Ordering this block by specificity would require breaking it up into several
-   chunks, which seems like it would be more confusing to read. */
-/* stylelint-disable no-descending-specificity */
 .mx_MatrixChat_useCompactLayout {
     .mx_EventTile {
         padding-top: 4px;
@@ -641,5 +638,3 @@ div.mx_EventTile_notSent.mx_EventTile_redacted .mx_UnknownBody {
         }
     }
 }
-
-/* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
We have disabled the `no-descending-specificity` stylelint rule, so we no longer
need these block comments.