### PR TITLE
Check for a message type before assuming it is a room message

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -556,10 +556,10 @@ module.exports = createReactClass({
 
         // Info messages are basically information about commands processed on a room
         const isBubbleMessage = eventType.startsWith("m.key.verification") ||
-            (eventType === "m.room.message" && msgtype.startsWith("m.key.verification"));
+            (eventType === "m.room.message" && msgtype && msgtype.startsWith("m.key.verification"));
         let isInfoMessage = (
             !isBubbleMessage && eventType !== 'm.room.message' &&
-            eventType !== 'm.sticker' && eventType != 'm.room.create'
+            eventType !== 'm.sticker' && eventType !== 'm.room.create'
         );
 
         let tileHandler = getHandlerTile(this.props.mxEvent);


### PR DESCRIPTION
Redacted messages do not have message types, despite being room messages. 

Fixes https://github.com/vector-im/riot-web/issues/11352

Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/3601

Click-to-ping being broken (as mentioned by https://github.com/vector-im/riot-web/issues/11353) is a side effect of the react stack falling over. Once one room crashes, click-to-ping is broken everywhere.