### PR TITLE
Fix rounded corners for the formatting toolbar

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -41,6 +41,18 @@ limitations under the License.
         &:hover {
             border-color: $message-action-bar-hover-border-color;
         }
+
+        &:first-child {
+            border-radius: 3px 0 0 3px;
+        }
+
+        &:last-child {
+            border-radius: 0 3px 3px 0;
+        }
+
+        &:only-child {
+            border-radius: 3px;
+        }
     }
 
     .mx_MessageComposerFormatBar_button {


### PR DESCRIPTION
The formatting toolbar is meant to have rounded corners like the message action
bar.

<img width="207" alt="2019-11-08 at 17 42" src="https://user-images.githubusercontent.com/279572/68498860-cd676a00-024f-11ea-907b-368535c7eb1e.png">

Fixes https://github.com/vector-im/riot-web/issues/11203