### PR TITLE
Use a ternary operator instead of relying on AND semantics in EditHistoryDialog

### DIFF
--- a/src/components/views/dialogs/MessageEditHistoryDialog.js
+++ b/src/components/views/dialogs/MessageEditHistoryDialog.js
@@ -116,7 +116,7 @@ export default class MessageEditHistoryDialog extends React.PureComponent {
             nodes.push((
                 <EditHistoryMessage
                     key={e.getId()}
-                    previousEdit={!isBaseEvent && allEvents[i + 1]}
+                    previousEdit={!isBaseEvent ? allEvents[i + 1] : null}
                     isBaseEvent={isBaseEvent}
                     mxEvent={e}
                     isTwelveHour={this.state.isTwelveHour}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11334 (probably).

`allEvents` should never have a boolean in it, so given the stack trace and the code this is my best estimate for what the problem could be. I can't reproduce the problem.