### PR TITLE
Fix HTML fallback in replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "diff-match-patch": "^1.0.4",
     "emojibase-data": "^4.0.2",
     "emojibase-regex": "^3.0.0",
+    "escape-html": "^1.0.3",
     "file-saver": "^1.3.3",
     "filesize": "3.5.6",
     "flux": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,7 +2862,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=


### PR DESCRIPTION
Correctly encode the `body` to avoid problems down the line. We also convert newlines to `<br/>` to better represent the message as a fallback.

Fixes https://github.com/vector-im/riot-web/issues/9413