### PR TITLE
Fix draw order when hovering composer format buttons

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -40,6 +40,7 @@ limitations under the License.
 
         &:hover {
             border-color: $message-action-bar-hover-border-color;
+            z-index: 1;
         }
 
         &:first-child {


### PR DESCRIPTION
This ensures all 4 sides of a button show the hover border colour as intended.

<img width="289" alt="2019-11-11 at 10 24" src="https://user-images.githubusercontent.com/279572/68580230-d33a9680-046d-11ea-841d-7dcd92b27029.png">

Another part of https://github.com/vector-im/riot-web/issues/11203