### PR TITLE
Add some logging/recovery for lost rooms

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -515,7 +515,21 @@ class RoomListStore extends Store {
             }
 
             if (count !== 1) {
-                console.warn(`!! Room ${room.roomId} inserted ${count} times`);
+                console.warn(`!! Room ${room.roomId} inserted ${count} times to ${targetTag}`);
+            }
+
+            // This is a workaround for https://github.com/vector-im/riot-web/issues/11303
+            // The logging is to try and identify what happened exactly.
+            if (count === 0) {
+                // Something went very badly wrong - try to recover the room.
+                // We don't bother checking how the target list is ordered - we're expecting
+                // to just insert it.
+                console.warn(`!! Recovering ${room.roomId} for tag ${targetTag} at position 0`);
+                if (!listsClone[targetTag]) {
+                    console.warn(`!! List for tag ${targetTag} does not exist - creating`);
+                    listsClone[targetTag] = [];
+                }
+                listsClone[targetTag].splice(0, 0, {room, category});
             }
         }
 


### PR DESCRIPTION
Zero inserts is not normal, so we apply the same recovery technique from the categorization logic above this block: insert it to be the very first room and hope that someone complains that the room is ordered incorrectly.

There's some additional logging to try and identify what went wrong because it should definitely be inserted. The `!== 1` check is not supposed to be called, ever.

Logging for https://github.com/vector-im/riot-web/issues/11303