### PR TITLE
Show server details on login for unreachable homeserver

### DIFF
--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -386,7 +386,11 @@ module.exports = createReactClass({
                 ...AutoDiscoveryUtils.authComponentStateForError(e),
             });
             if (this.state.serverErrorIsFatal) {
-                return; // Server is dead - do not continue.
+                // Server is dead: show server details prompt instead
+                this.setState({
+                    phase: PHASE_SERVER_DETAILS,
+                });
+                return;
             }
         }
 


### PR DESCRIPTION
This fixes the login page to be more helpful when the current homeserver is
unreachable: it reveals the server change field, so you have some chance to
progress forward.

<img width="732" alt="2019-11-14 at 15 15" src="https://user-images.githubusercontent.com/279572/68870492-e0b48280-06f2-11ea-915e-2491e2fb6ac1.png">

Fixes https://github.com/vector-im/riot-web/issues/11077