### PR TITLE
WIP: Oauth support

### DIFF
--- a/src/Oauth.js
+++ b/src/Oauth.js
@@ -1,0 +1,204 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Matrix from "matrix-js-sdk";
+
+import url from 'url';
+
+export default class Oauth {
+    constructor(hsUrl, isUrl, fallbackHsUrl, opts) {
+        this._hsUrl = hsUrl;
+        this._isUrl = isUrl;
+        this._fallbackHsUrl = fallbackHsUrl;
+        this._currentFlowIndex = 0;
+        this._flows = [];
+        this._defaultDeviceDisplayName = opts.defaultDeviceDisplayName;
+    }
+
+    getHomeserverUrl() {
+        return this._hsUrl;
+    }
+
+    getIdentityServerUrl() {
+        return this._isUrl;
+    }
+
+    setHomeserverUrl(hsUrl) {
+        this._hsUrl = hsUrl;
+    }
+
+    setIdentityServerUrl(isUrl) {
+        this._isUrl = isUrl;
+    }
+
+    /**
+     * Get a temporary MatrixClient, which can be used for login or register
+     * requests.
+     * @returns {MatrixClient}
+     */
+    _createTemporaryClient() {
+        return Matrix.createClient({
+            baseUrl: this._hsUrl,
+            idBaseUrl: this._isUrl,
+        });
+    }
+
+    getFlows() {
+        const self = this;
+        console.log("Oauth.js flows 1");
+
+        const client = this._createTemporaryClient();
+        return client.oauthFlows().then(function(result) {
+            console.log("Oauth.js flows 2");
+            console.log(result);
+            self._flows = result.providers;
+            self._flows.push({type: "m.oauth.mediawiki"});
+            self._currentFlowIndex = 0;
+            // technically the UI should display options for all flows for the
+            // user to then choose one, so return all the flows here.
+            return self._flows;
+        });
+    }
+
+    chooseFlow(flowIndex) {
+        this._currentFlowIndex = flowIndex;
+    }
+
+    getCurrentFlowStep() {
+        // technically the flow can have multiple steps, but no one does this
+        // for login so we can ignore it.
+        const flowStep = this._flows[this._currentFlowIndex];
+        return flowStep ? flowStep.type : null;
+    }
+
+    loginViaPassword(username, phoneCountry, phoneNumber, pass) {
+        const self = this;
+
+        const isEmail = username.indexOf("@") > 0;
+
+        let identifier;
+        if (phoneCountry && phoneNumber) {
+            identifier = {
+                type: 'm.id.phone',
+                country: phoneCountry,
+                number: phoneNumber,
+            };
+        } else if (isEmail) {
+            identifier = {
+                type: 'm.id.thirdparty',
+                medium: 'email',
+                address: username,
+            };
+        } else {
+            identifier = {
+                type: 'm.id.user',
+                user: username,
+            };
+        }
+
+        const loginParams = {
+            password: pass,
+            identifier: identifier,
+            initial_device_display_name: this._defaultDeviceDisplayName,
+        };
+
+        const tryFallbackHs = (originalError) => {
+            return sendLoginRequest(
+                self._fallbackHsUrl, this._isUrl, 'm.login.password', loginParams,
+            ).catch((fallbackError) => {
+                console.log("fallback HS login failed", fallbackError);
+                // throw the original error
+                throw originalError;
+            });
+        };
+
+        let originalLoginError = null;
+        return sendLoginRequest(
+            self._hsUrl, self._isUrl, 'm.login.password', loginParams,
+        ).catch((error) => {
+            originalLoginError = error;
+            if (error.httpStatus === 403) {
+                if (self._fallbackHsUrl) {
+                    return tryFallbackHs(originalLoginError);
+                }
+            }
+            throw originalLoginError;
+        }).catch((error) => {
+            console.log("Login failed", error);
+            throw error;
+        });
+    }
+
+    getSsoLoginUrl(loginType) {
+      const client = this._createTemporaryClient();
+      const parsedUrl = url.parse(window.location.href, true);
+
+      // XXX: at this point, the fragment will always be #/login, which is no
+      // use to anyone. Ideally, we would get the intended fragment from
+      // MatrixChat.screenAfterLogin so that you could follow #/room links etc
+      // through an SSO login.
+      parsedUrl.hash = "";
+
+      parsedUrl.query["homeserver"] = client.getHomeserverUrl();
+      parsedUrl.query["identityServer"] = client.getIdentityServerUrl();
+      return client.getSsoLoginUrl(url.format(parsedUrl), loginType);
+    }
+}
+
+
+/**
+ * Send a login request to the given server, and format the response
+ * as a MatrixClientCreds
+ *
+ * @param {string} hsUrl   the base url of the Homeserver used to log in.
+ * @param {string} isUrl   the base url of the default identity server
+ * @param {string} loginType the type of login to do
+ * @param {object} loginParams the parameters for the login
+ *
+ * @returns {MatrixClientCreds}
+ */
+export async function sendLoginRequest(hsUrl, isUrl, loginType, loginParams) {
+    const client = Matrix.createClient({
+        baseUrl: hsUrl,
+        idBaseUrl: isUrl,
+    });
+
+    const data = await client.login(loginType, loginParams);
+
+    const wellknown = data.well_known;
+    if (wellknown) {
+        if (wellknown["m.homeserver"] && wellknown["m.homeserver"]["base_url"]) {
+            hsUrl = wellknown["m.homeserver"]["base_url"];
+            console.log(`Overrode homeserver setting with ${hsUrl} from login response`);
+        }
+        if (wellknown["m.identity_server"] && wellknown["m.identity_server"]["base_url"]) {
+            // TODO: should we prompt here?
+            isUrl = wellknown["m.identity_server"]["base_url"];
+            console.log(`Overrode IS setting with ${isUrl} from login response`);
+        }
+    }
+
+    return {
+        homeserverUrl: hsUrl,
+        identityServerUrl: isUrl,
+        userId: data.user_id,
+        deviceId: data.device_id,
+        accessToken: data.access_token,
+    };
+}

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -100,6 +100,9 @@ const VIEWS = {
     // We are logged out (invalid token) but have our local state again. The user
     // should log back in to rehydrate the client.
     SOFT_LOGOUT: 8,
+
+    // we are showing the oauth view
+    OAUTH: 9,
 };
 
 // Actions that are redirected through the onboarding process prior to being
@@ -511,6 +514,20 @@ export default createReactClass({
                     view: VIEWS.LOGIN,
                 });
                 this.notifyNewScreen('login');
+                break;
+            case 'start_oauth':
+                console.info("start oauth");
+                if (Lifecycle.isSoftLogout()) {
+                    this._onSoftLogout();
+                    break;
+                }
+                if (payload.screenAfterLogin) {
+                    this._screenAfterLogin = payload.screenAfterLogin;
+                }
+                this.setStateForNewView({
+                    view: VIEWS.OAUTH,
+                });
+                this.notifyNewScreen('oauth');
                 break;
             case 'start_post_registration':
                 this.setState({
@@ -1519,6 +1536,11 @@ export default createReactClass({
                 action: 'start_login',
                 params: params,
             });
+        } else if (screen == 'oauth') {
+            dis.dispatch({
+                action: 'start_oauth',
+                params: params,
+            });
         } else if (screen == 'forgot_password') {
             dis.dispatch({
                 action: 'start_password_recovery',
@@ -1912,6 +1934,19 @@ export default createReactClass({
             const Login = sdk.getComponent('structures.auth.Login');
             view = (
                 <Login
+                    onLoggedIn={Lifecycle.setLoggedIn}
+                    onRegisterClick={this.onRegisterClick}
+                    fallbackHsUrl={this.getFallbackHsUrl()}
+                    defaultDeviceDisplayName={this.props.defaultDeviceDisplayName}
+                    onForgotPasswordClick={this.onForgotPasswordClick}
+                    onServerConfigChange={this.onServerConfigChange}
+                    {...this.getServerProperties()}
+                />
+            );
+        } else if (this.state.view === VIEWS.OAUTH) {
+            const Oauth = sdk.getComponent('structures.auth.Oauth');
+            view = (
+                <Oauth
                     onLoggedIn={Lifecycle.setLoggedIn}
                     onRegisterClick={this.onRegisterClick}
                     fallbackHsUrl={this.getFallbackHsUrl()}

--- a/src/components/structures/auth/Oauth.js
+++ b/src/components/structures/auth/Oauth.js
@@ -1,0 +1,414 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
+Copyright 2018, 2019 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import {_t, _td} from '../../../languageHandler';
+import sdk from '../../../index';
+import Oauth from '../../../Oauth';
+import SdkConfig from '../../../SdkConfig';
+import AutoDiscoveryUtils, {ValidatedServerConfig} from "../../../utils/AutoDiscoveryUtils";
+import classNames from "classnames";
+
+// Phases
+// Show controls to configure server details
+const PHASE_SERVER_DETAILS = 0;
+// Show the appropriate login flow(s) for the server
+const PHASE_LOGIN = 1;
+
+// Enable phases for login
+const PHASES_ENABLED = true;
+
+// These are used in several places, and come from the js-sdk's autodiscovery
+// stuff. We define them here so that they'll be picked up by i18n.
+_td("Invalid homeserver discovery response");
+_td("Failed to get autodiscovery configuration from server");
+_td("Invalid base_url for m.homeserver");
+_td("Homeserver URL does not appear to be a valid Matrix homeserver");
+_td("Invalid identity server discovery response");
+_td("Invalid base_url for m.identity_server");
+_td("Identity server URL does not appear to be a valid identity server");
+_td("General failure");
+
+/**
+ * A wire component which glues together login UI components and Login logic
+ */
+module.exports = createReactClass({
+    displayName: 'Login',
+
+    propTypes: {
+        onLoggedIn: PropTypes.func.isRequired,
+
+        // If true, the component will consider itself busy.
+        busy: PropTypes.bool,
+
+        // Secondary HS which we try to log into if the user is using
+        // the default HS but login fails. Useful for migrating to a
+        // different homeserver without confusing users.
+        fallbackHsUrl: PropTypes.string,
+
+        defaultDeviceDisplayName: PropTypes.string,
+
+        // login shouldn't know or care how registration, password recovery,
+        // etc is done.
+        onRegisterClick: PropTypes.func.isRequired,
+        onForgotPasswordClick: PropTypes.func,
+        onServerConfigChange: PropTypes.func.isRequired,
+
+        serverConfig: PropTypes.instanceOf(ValidatedServerConfig).isRequired,
+    },
+
+    getInitialState: function() {
+        return {
+            busy: false,
+            errorText: null,
+            loginIncorrect: false,
+            canTryLogin: true, // can we attempt to log in or are there validation errors?
+
+            // used for preserving form values when changing homeserver
+            username: "",
+            phoneCountry: null,
+            phoneNumber: "",
+
+            // Phase of the overall login dialog.
+            phase: PHASE_LOGIN,
+            // The current login flow, such as password, SSO, etc.
+            currentFlow: null, // we need to load the flows from the server
+
+            // We perform liveliness checks later, but for now suppress the errors.
+            // We also track the server dead errors independently of the regular errors so
+            // that we can render it differently, and override any other error the user may
+            // be seeing.
+            serverIsAlive: true,
+            serverErrorIsFatal: false,
+            serverDeadError: "",
+        };
+    },
+
+    componentWillMount: function() {
+        this._unmounted = false;
+
+        this._stepRendererMap = {
+            'm.oauth.mediawiki': this._renderOauthStep,
+        };
+
+        this._initLoginLogic();
+    },
+
+    componentWillUnmount: function() {
+        this._unmounted = true;
+    },
+
+    componentWillReceiveProps(newProps) {
+        if (newProps.serverConfig.hsUrl === this.props.serverConfig.hsUrl &&
+            newProps.serverConfig.isUrl === this.props.serverConfig.isUrl) return;
+
+        // Ensure that we end up actually logging in to the right place
+        this._initLoginLogic(newProps.serverConfig.hsUrl, newProps.serverConfig.isUrl);
+    },
+
+    onPasswordLoginError: function(errorText) {
+        this.setState({
+            errorText,
+            loginIncorrect: Boolean(errorText),
+        });
+    },
+
+    isBusy: function() {
+        return this.state.busy || this.props.busy;
+    },
+
+    async onServerDetailsNextPhaseClick() {
+        this.setState({
+            phase: PHASE_LOGIN,
+        });
+    },
+
+    onEditServerDetailsClick(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this.setState({
+            phase: PHASE_SERVER_DETAILS,
+        });
+    },
+
+    _initLoginLogic: async function(hsUrl, isUrl) {
+        hsUrl = hsUrl || this.props.serverConfig.hsUrl;
+        isUrl = isUrl || this.props.serverConfig.isUrl;
+
+        let isDefaultServer = false;
+        if (this.props.serverConfig.isDefault
+            && hsUrl === this.props.serverConfig.hsUrl
+            && isUrl === this.props.serverConfig.isUrl) {
+            isDefaultServer = true;
+        }
+
+        const fallbackHsUrl = isDefaultServer ? this.props.fallbackHsUrl : null;
+
+        // Replace with new Oauth()
+        // was new Login
+        const loginLogic = new Oauth(hsUrl, isUrl, fallbackHsUrl, {
+            defaultDeviceDisplayName: this.props.defaultDeviceDisplayName,
+        });
+        this._loginLogic = loginLogic;
+
+        this.setState({
+            busy: true,
+            currentFlow: null, // reset flow
+            loginIncorrect: false,
+        });
+
+        // Do a quick liveliness check on the URLs
+        try {
+            await AutoDiscoveryUtils.validateServerConfigWithStaticUrls(hsUrl, isUrl);
+            this.setState({serverIsAlive: true, errorText: ""});
+        } catch (e) {
+            this.setState({
+                busy: false,
+                ...AutoDiscoveryUtils.authComponentStateForError(e),
+            });
+            if (this.state.serverErrorIsFatal) {
+                return; // Server is dead - do not continue.
+            }
+        }
+
+        loginLogic.getFlows().then((flows) => {
+            console.log("auth/Oauth.js: loginLogic");
+            console.log(flows);
+            // look for a flow where we understand all of the steps.
+            for (let i = 0; i < flows.length; i++ ) {
+                if (!this._isSupportedFlow(flows[i])) {
+                    continue;
+                }
+
+                // we just pick the first flow where we support all the
+                // steps. (we don't have a UI for multiple logins so let's skip
+                // that for now).
+                loginLogic.chooseFlow(i);
+                this.setState({
+                    currentFlow: this._getCurrentFlowStep(),
+                });
+                return;
+            }
+            // we got to the end of the list without finding a suitable
+            // flow.
+            this.setState({
+                errorText: _t(
+                    "This homeserver doesn't offer any login flows which are " +
+                        "supported by this client.",
+                ),
+            });
+        }, (err) => {
+            this.setState({
+                errorText: this._errorTextFromError(err),
+                loginIncorrect: false,
+                canTryLogin: false,
+            });
+        }).finally(() => {
+            this.setState({
+                busy: false,
+            });
+        }).done();
+    },
+
+    _isSupportedFlow: function(flow) {
+        // technically the flow can have multiple steps, but no one does this
+        // for login and loginLogic doesn't support it so we can ignore it.
+        if (!this._stepRendererMap[flow.type]) {
+            console.log("Skipping flow", flow, "due to unsupported login type", flow.type);
+            return false;
+        }
+        return true;
+    },
+
+    _getCurrentFlowStep: function() {
+        return this._loginLogic ? this._loginLogic.getCurrentFlowStep() : null;
+    },
+
+    _errorTextFromError(err) {
+        let errCode = err.errcode;
+        if (!errCode && err.httpStatus) {
+            errCode = "HTTP " + err.httpStatus;
+        }
+
+        let errorText = _t("Error: Problem communicating with the given homeserver.") +
+                (errCode ? " (" + errCode + ")" : "");
+
+        if (err.cors === 'rejected') {
+            if (window.location.protocol === 'https:' &&
+                (this.props.serverConfig.hsUrl.startsWith("http:") ||
+                 !this.props.serverConfig.hsUrl.startsWith("http"))
+            ) {
+                errorText = <span>
+                    { _t("Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar. " +
+                        "Either use HTTPS or <a>enable unsafe scripts</a>.", {},
+                        {
+                            'a': (sub) => {
+                                return <a target="_blank" rel="noopener"
+                                    href="https://www.google.com/search?&q=enable%20unsafe%20scripts"
+                                >
+                                    { sub }
+                                </a>;
+                            },
+                        },
+                    ) }
+                </span>;
+            } else {
+                errorText = <span>
+                    { _t("Can't connect to homeserver - please check your connectivity, ensure your " +
+                        "<a>homeserver's SSL certificate</a> is trusted, and that a browser extension " +
+                        "is not blocking requests.", {},
+                        {
+                            'a': (sub) => {
+                                return <a target="_blank" rel="noopener" href={this.props.serverConfig.hsUrl}>
+                                    { sub }
+                                </a>;
+                            },
+                        },
+                    ) }
+                </span>;
+            }
+        }
+
+        return errorText;
+    },
+
+    renderServerComponent() {
+        const ServerConfig = sdk.getComponent("auth.ServerConfig");
+
+        if (SdkConfig.get()['disable_custom_urls']) {
+            return null;
+        }
+
+        if (PHASES_ENABLED && this.state.phase !== PHASE_SERVER_DETAILS) {
+            return null;
+        }
+
+        const serverDetailsProps = {};
+        if (PHASES_ENABLED) {
+            serverDetailsProps.onAfterSubmit = this.onServerDetailsNextPhaseClick;
+            serverDetailsProps.submitText = _t("Next");
+            serverDetailsProps.submitClass = "mx_Login_submit";
+        }
+
+        return <ServerConfig
+            serverConfig={this.props.serverConfig}
+            onServerConfigChange={this.props.onServerConfigChange}
+            delayTimeMs={250}
+            {...serverDetailsProps}
+        />;
+    },
+
+    renderLoginComponentForStep() {
+        if (PHASES_ENABLED && this.state.phase !== PHASE_LOGIN) {
+            return null;
+        }
+
+        const step = this.state.currentFlow;
+
+        if (!step) {
+            return null;
+        }
+
+        const stepRenderer = this._stepRendererMap[step];
+
+        if (stepRenderer) {
+            return stepRenderer();
+        }
+
+        return null;
+    },
+
+    _renderOauthStep: function() {
+        const OauthLogin = sdk.getComponent('auth.OauthLogin');
+
+        let onEditServerDetailsClick = null;
+        // If custom URLs are allowed, wire up the server details edit link.
+        if (PHASES_ENABLED && !SdkConfig.get()['disable_custom_urls']) {
+            onEditServerDetailsClick = this.onEditServerDetailsClick;
+        }
+
+        return (
+            <OauthLogin
+               onEditServerDetailsClick={onEditServerDetailsClick}
+               serverConfig={this.props.serverConfig}
+            />
+        );
+    },
+
+    render: function() {
+        const Loader = sdk.getComponent("elements.Spinner");
+        const AuthPage = sdk.getComponent("auth.AuthPage");
+        const AuthHeader = sdk.getComponent("auth.AuthHeader");
+        const AuthBody = sdk.getComponent("auth.AuthBody");
+        const OauthLogin = sdk.getComponent('auth.OauthLogin');
+        const loader = this.isBusy() ? <div className="mx_Login_loader"><Loader /></div> : null;
+
+        const errorText = this.state.errorText;
+
+        let errorTextSection;
+        if (errorText) {
+            errorTextSection = (
+                <div className="mx_Login_error">
+                    { errorText }
+                </div>
+            );
+        }
+
+        let serverDeadSection;
+        if (!this.state.serverIsAlive) {
+            const classes = classNames({
+                "mx_Login_error": true,
+                "mx_Login_serverError": true,
+                "mx_Login_serverErrorNonFatal": !this.state.serverErrorIsFatal,
+            });
+            serverDeadSection = (
+                <div className={classes}>
+                    {this.state.serverDeadError}
+                </div>
+            );
+        }
+
+        let onEditServerDetailsClick = null;
+        // If custom URLs are allowed, wire up the server details edit link.
+        if (PHASES_ENABLED && !SdkConfig.get()['disable_custom_urls']) {
+            onEditServerDetailsClick = this.onEditServerDetailsClick;
+        }
+
+        return (
+            <AuthPage>
+                <AuthHeader />
+                <AuthBody>
+                    <h2>
+                        {_t('Sign in using OAuth')}
+                        {loader}
+                    </h2>
+                    { errorTextSection }
+                    { serverDeadSection }
+                    { this.renderServerComponent() }
+                    <OauthLogin
+                        onSubmit={this.onPasswordLogin}
+                        onEditServerDetailsClick={onEditServerDetailsClick}
+                        serverConfig={this.props.serverConfig}
+                    />
+                </AuthBody>
+            </AuthPage>
+        );
+    },
+});

--- a/src/components/views/auth/OauthButton.js
+++ b/src/components/views/auth/OauthButton.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 New Vector
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SdkConfig from "../../../SdkConfig";
+import {getCurrentLanguage} from "../../../languageHandler";
+import SettingsStore, {SettingLevel} from "../../../settings/SettingsStore";
+import PlatformPeg from "../../../PlatformPeg";
+import sdk from '../../../index';
+import React from 'react';
+
+function onChange(newLang) {
+    if (getCurrentLanguage() !== newLang) {
+        SettingsStore.setValue("language", null, SettingLevel.DEVICE, newLang);
+        PlatformPeg.get().reload();
+    }
+}
+
+export default function OauthButton() {
+    if (SdkConfig.get()['disable_login_language_selector']) return <div />;
+
+    const OauthButton = sdk.getComponent('views.elements.OauthButton');
+    return <OauthButton className="mx_AuthBody_language"
+        onOptionChange={onChange}
+        value={getCurrentLanguage()}
+    />;
+}

--- a/src/components/views/auth/OauthLogin.js
+++ b/src/components/views/auth/OauthLogin.js
@@ -1,0 +1,56 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
+Copyright 2019 New Vector Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import sdk from '../../../index';
+import {ValidatedServerConfig} from "../../../utils/AutoDiscoveryUtils";
+
+/**
+ * A UI component that displays OAuth login buttons
+ */
+export default class OauthLogin extends React.Component {
+    static propTypes = {
+        onSubmit: PropTypes.func.isRequired,
+        onEditServerDetailsClick: PropTypes.func,
+        serverConfig: PropTypes.instanceOf(ValidatedServerConfig).isRequired,
+    };
+
+    static defaultProps = {
+        onEditServerDetailsClick: null,
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const SignInToText = sdk.getComponent('views.auth.SignInToText');
+
+        return (
+            <div>
+                <SignInToText serverConfig={this.props.serverConfig}
+                    onEditServerDetailsClick={this.props.onEditServerDetailsClick} />
+                <button className="mx_Login_submit" onClick={this.props.onSubmit}>
+                    Mediawiki
+                </button>
+            </div>
+        );
+    }
+}

--- a/src/components/views/auth/Welcome.js
+++ b/src/components/views/auth/Welcome.js
@@ -33,12 +33,21 @@ export default class Welcome extends React.PureComponent {
             pageUrl = 'welcome.html';
         }
 
+        let oauthButton = '';
+
+        if (SdkConfig.get().show_oauth) {
+            const OauthButton = sdk.getComponent('auth.OauthButton');
+            console.log("show aouth");
+            oauthButton = <OauthButton />;
+        }
+
         return (
             <AuthPage>
                 <div className="mx_Welcome">
                     <EmbeddedPage className="mx_WelcomePage"
                         url={pageUrl}
                     />
+                    {oauthButton}
                     <LanguageSelector />
                 </div>
             </AuthPage>

--- a/src/components/views/elements/OauthButton.js
+++ b/src/components/views/elements/OauthButton.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 Marcel Radzio (MTRNord)
+Copyright 2017 Vector Creations Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class OauthButton extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            searchQuery: '',
+            langs: null,
+        };
+    }
+
+    render() {
+        return <div className="mx_ButtonRow">
+            <a href="#/oauth"
+               className="mx_ButtonParent mx_ButtonFullWidth mx_ButtonOAuth mx_Button_iconSignIn"
+            >
+                <div className="mx_ButtonLabel">OAuth</div>
+            </a>
+        </div>;
+    }
+}
+
+OauthButton.propTypes = {
+    className: PropTypes.string,
+    onOptionChange: PropTypes.func.isRequired,
+    value: PropTypes.string,
+};

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -314,6 +314,7 @@
     "Show timestamps in 12 hour format (e.g. 2:30pm)": "Show timestamps in 12 hour format (e.g. 2:30pm)",
     "Signed Out": "Signed Out",
     "Sign in": "Sign in",
+    "Sign in using OAuth": "Sign in using OAuth",
     "Sign out": "Sign out",
     "%(count)s of your messages have not been sent.|other": "Some of your messages have not been sent.",
     "Someone": "Someone",


### PR DESCRIPTION
Issue: https://github.com/vector-im/riot-web/issues/4610

This adds a button to the welcome screen:

![welcome_screen](https://user-images.githubusercontent.com/6953323/69007192-eac8c200-093a-11ea-9109-d9e8d86432c2.png)

This leads to a page similar to the login screen where the plan is to list the supported Oauth providers:

![oauth_screen](https://user-images.githubusercontent.com/6953323/69007208-2d8a9a00-093b-11ea-8b1c-6c5ecb172f13.png)

Part of these pull requests:
- matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/1073
- riot-web: https://github.com/vector-im/riot-web/pull/11401
- synapse: https://github.com/matrix-org/synapse/pull/6371