### PR TITLE
re-add missing case of codepath

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -1076,6 +1076,7 @@ const TimelinePanel = createReactClass({
         if (timeline) {
             // This is a hot-path optimization by skipping a promise tick
             // by repeating a no-op sync branch in TimelineSet.getTimelineForEvent & MatrixClient.getEventTimeline
+            this._timelineWindow.load(eventId, INITIAL_SIZE); // in this branch this method will happen in sync time
             onLoaded();
         } else {
             const prom = this._timelineWindow.load(eventId, INITIAL_SIZE);


### PR DESCRIPTION
With getting rid of bluebirds the js-sdk initFields method didn't end up getting called. Could not hit this issue so guessing atm

Should fix https://github.com/vector-im/riot-web/issues/11412