### PR TITLE
Update code style for our 90 char life

### DIFF
--- a/code_style.md
+++ b/code_style.md
@@ -22,7 +22,7 @@ number throgh from the original code to the final application.
 General Style
 -------------
 - 4 spaces to indent, for consistency with Matrix Python.
-- 120 columns per line, but try to keep JavaScript code around the 80 column mark.
+- 120 columns per line, but try to keep JavaScript code around the 90 column mark.
   Inline JSX in particular can be nicer with more columns per line.
 - No trailing whitespace at end of lines.
 - Don't indent empty lines.


### PR DESCRIPTION
We've been using 90 chars for JS code for quite a while now, but for some
reason, the code style guide hasn't admitted that, so this adjusts it to match
ESLint settings.