### PR TITLE
Remove getBaseTheme 

### DIFF
--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -185,7 +185,10 @@ export default class GeneralUserSettingsTab extends React.Component {
         // The settings watcher doesn't fire until the echo comes back from the
         // server, so to make the theme change immediately we need to manually
         // do the dispatch now
-        dis.dispatch({action: 'recheck_theme'});
+        // XXX: The local echoed value appears to be unreliable, in particular
+        // when settings custom themes(!) so adding forceTheme to override
+        // the value from settings.
+        dis.dispatch({action: 'recheck_theme', forceTheme: newTheme});
     };
 
     _onUseSystemThemeChanged = (checked) => {

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -27,7 +27,7 @@ import LanguageDropdown from "../../../elements/LanguageDropdown";
 import AccessibleButton from "../../../elements/AccessibleButton";
 import DeactivateAccountDialog from "../../../dialogs/DeactivateAccountDialog";
 import PropTypes from "prop-types";
-import {enumerateThemes} from "../../../../../theme";
+import {enumerateThemes, ThemeWatcher} from "../../../../../theme";
 import PlatformPeg from "../../../../../PlatformPeg";
 import MatrixClientPeg from "../../../../../MatrixClientPeg";
 import sdk from "../../../../..";
@@ -50,6 +50,7 @@ export default class GeneralUserSettingsTab extends React.Component {
         this.state = {
             language: languageHandler.getCurrentLanguage(),
             theme: SettingsStore.getValueAt(SettingLevel.ACCOUNT, "theme"),
+            useSystemTheme: SettingsStore.getValueAt(SettingLevel.DEVICE, "use_system_theme"),
             haveIdServer: Boolean(MatrixClientPeg.get().getIdentityServerUrl()),
             serverSupportsSeparateAddAndBind: null,
             idServerHasUnsignedTerms: false,
@@ -177,15 +178,21 @@ export default class GeneralUserSettingsTab extends React.Component {
         // so remember what the value was before we tried to set it so we can revert
         const oldTheme = SettingsStore.getValue('theme');
         SettingsStore.setValue("theme", null, SettingLevel.ACCOUNT, newTheme).catch(() => {
-            dis.dispatch({action: 'set_theme', value: oldTheme});
+            dis.dispatch({action: 'recheck_theme'});
             this.setState({theme: oldTheme});
         });
         this.setState({theme: newTheme});
         // The settings watcher doesn't fire until the echo comes back from the
         // server, so to make the theme change immediately we need to manually
         // do the dispatch now
-        dis.dispatch({action: 'set_theme', value: newTheme});
+        dis.dispatch({action: 'recheck_theme'});
     };
+
+    _onUseSystemThemeChanged  = (checked) => {
+        this.setState({useSystemTheme: checked});
+        dis.dispatch({action: 'recheck_theme'});
+    }
+
 
     _onPasswordChangeError = (err) => {
         // TODO: Figure out a design that doesn't involve replacing the current dialog
@@ -297,11 +304,24 @@ export default class GeneralUserSettingsTab extends React.Component {
 
     _renderThemeSection() {
         const SettingsFlag = sdk.getComponent("views.elements.SettingsFlag");
+
+        const themeWatcher = new ThemeWatcher();
+        let systemThemeSection;
+        if (themeWatcher.isSystemThemeSupported()) {
+            systemThemeSection = <div>
+                <SettingsFlag name="use_system_theme" level={SettingLevel.DEVICE}
+                    onChange={this._onUseSystemThemeChanged}
+                />
+            </div>;
+        }
         return (
             <div className="mx_SettingsTab_section mx_GeneralUserSettingsTab_themeSection">
                 <span className="mx_SettingsTab_subheading">{_t("Theme")}</span>
+                {systemThemeSection}
                 <Field id="theme" label={_t("Theme")} element="select"
-                       value={this.state.theme} onChange={this._onThemeChange}>
+                       value={this.state.theme} onChange={this._onThemeChange}
+                       disabled={this.state.useSystemTheme}
+                >
                     {Object.entries(enumerateThemes()).map(([theme, text]) => {
                         return <option key={theme} value={theme}>{text}</option>;
                     })}

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -188,7 +188,7 @@ export default class GeneralUserSettingsTab extends React.Component {
         dis.dispatch({action: 'recheck_theme'});
     };
 
-    _onUseSystemThemeChanged  = (checked) => {
+    _onUseSystemThemeChanged = (checked) => {
         this.setState({useSystemTheme: checked});
         dis.dispatch({action: 'recheck_theme'});
     }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -363,6 +363,7 @@
     "Automatically replace plain text Emoji": "Automatically replace plain text Emoji",
     "Mirror local video feed": "Mirror local video feed",
     "Enable Community Filter Panel": "Enable Community Filter Panel",
+    "Match system theme": "Match system theme",
     "Allow Peer-to-Peer for 1:1 calls": "Allow Peer-to-Peer for 1:1 calls",
     "Send analytics data": "Send analytics data",
     "Never send encrypted messages to unverified devices from this device": "Never send encrypted messages to unverified devices from this device",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -275,6 +275,11 @@ export const SETTINGS = {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         default: [],
     },
+    "use_system_theme": {
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        default: true,
+        displayName: _td("Match system theme"),
+    },
     "webRtcAllowPeerToPeer": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         displayName: _td('Allow Peer-to-Peer for 1:1 calls'),

--- a/src/theme.js
+++ b/src/theme.js
@@ -66,6 +66,7 @@ export class ThemeWatcher {
     }
 
     // XXX: forceTheme param aded here as local echo appears to be unreliable
+    // https://github.com/vector-im/riot-web/issues/11443
     recheck(forceTheme) {
         const oldTheme = this._currentTheme;
         this._currentTheme = forceTheme === undefined ? this.getEffectiveTheme() : forceTheme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -19,7 +19,71 @@ import {_t} from "./languageHandler";
 
 export const DEFAULT_THEME = "light";
 import Tinter from "./Tinter";
+import dis from "./dispatcher";
 import SettingsStore from "./settings/SettingsStore";
+
+export class ThemeWatcher {
+    static _instance = null;
+
+    constructor() {
+        this._themeWatchRef = null;
+        this._systemThemeWatchRef = null;
+        this._dispatcherRef = null;
+
+        // we have both here as each may either match or not match, so by having both
+        // we can get the tristate of dark/light/unsupported
+        this._preferDark = global.matchMedia("(prefers-color-scheme: dark)");
+        this._preferLight = global.matchMedia("(prefers-color-scheme: light)");
+
+        this._currentTheme = this.getEffectiveTheme();
+    }
+
+    start() {
+        this._themeWatchRef = SettingsStore.watchSetting("theme", null, this._onChange);
+        this._systemThemeWatchRef = SettingsStore.watchSetting("use_system_theme", null, this._onChange);
+        this._preferDark.addEventListener('change', this._onChange);
+        this._preferLight.addEventListener('change', this._onChange);
+        this._dispatcherRef = dis.register(this._onAction);
+    }
+
+    stop() {
+        this._preferDark.removeEventListener('change', this._onChange);
+        this._preferLight.removeEventListener('change', this._onChange);
+        SettingsStore.unwatchSetting(this._systemThemeWatchRef);
+        SettingsStore.unwatchSetting(this._themeWatchRef);
+        dis.unregister(this._dispatcherRef);
+    }
+
+    _onChange = () => {
+        this.recheck();
+    }
+
+    _onAction = (payload) => {
+        if (payload.action === 'recheck_theme') {
+            this.recheck();
+        }
+    }
+
+    recheck() {
+        const oldTheme = this._currentTheme;
+        this._currentTheme = this.getEffectiveTheme();
+        if (oldTheme !== this._currentTheme) {
+            setTheme(this._currentTheme);
+        }
+    }
+
+    getEffectiveTheme() {
+        if (SettingsStore.getValue('use_system_theme')) {
+            if (this._preferDark.matches) return 'dark';
+            if (this._preferLight.matches) return 'light';
+        }
+        return SettingsStore.getValue('theme');
+    }
+
+    isSystemThemeSupported() {
+        return this._preferDark || this._preferLight;
+    }
+}
 
 export function enumerateThemes() {
     const BUILTIN_THEMES = {
@@ -83,7 +147,8 @@ export function getBaseTheme(theme) {
  */
 export function setTheme(theme) {
     if (!theme) {
-        theme = SettingsStore.getValue("theme");
+        const themeWatcher = new ThemeWatcher();
+        theme = themeWatcher.getEffectiveTheme();
     }
     let stylesheetName = theme;
     if (theme.startsWith("custom-")) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -60,13 +60,15 @@ export class ThemeWatcher {
 
     _onAction = (payload) => {
         if (payload.action === 'recheck_theme') {
-            this.recheck();
+            // XXX forceTheme
+            this.recheck(payload.forceTheme);
         }
     }
 
-    recheck() {
+    // XXX: forceTheme param aded here as local echo appears to be unreliable
+    recheck(forceTheme) {
         const oldTheme = this._currentTheme;
-        this._currentTheme = this.getEffectiveTheme();
+        this._currentTheme = forceTheme === undefined ? this.getEffectiveTheme() : forceTheme;
         if (oldTheme !== this._currentTheme) {
             setTheme(this._currentTheme);
         }

--- a/src/theme.js
+++ b/src/theme.js
@@ -128,27 +128,13 @@ function getCustomTheme(themeName) {
 }
 
 /**
- * Gets the underlying theme name for the given theme. This is usually the theme or
- * CSS resource that the theme relies upon to load.
- * @param {string} theme The theme name to get the base of.
- * @returns {string} The base theme (typically "light" or "dark").
- */
-export function getBaseTheme(theme) {
-    if (!theme) return "light";
-    if (theme.startsWith("custom-")) {
-        const customTheme = getCustomTheme(theme.substr(7));
-        return customTheme.is_dark ? "dark-custom" : "light-custom";
-    }
-
-    return theme; // it's probably a base theme
-}
-
-/**
  * Called whenever someone changes the theme
+ * Async function that returns once the theme has been set
+ * (ie. the CSS has been loaded)
  *
  * @param {string} theme new theme
  */
-export function setTheme(theme) {
+export async function setTheme(theme) {
     if (!theme) {
         const themeWatcher = new ThemeWatcher();
         theme = themeWatcher.getEffectiveTheme();
@@ -190,38 +176,41 @@ export function setTheme(theme) {
 
     styleElements[stylesheetName].disabled = false;
 
-    const switchTheme = function() {
-        // we re-enable our theme here just in case we raced with another
-        // theme set request as per https://github.com/vector-im/riot-web/issues/5601.
-        // We could alternatively lock or similar to stop the race, but
-        // this is probably good enough for now.
-        styleElements[stylesheetName].disabled = false;
-        Object.values(styleElements).forEach((a) => {
-            if (a == styleElements[stylesheetName]) return;
-            a.disabled = true;
-        });
-        Tinter.setTheme(theme);
-    };
+    return new Promise((resolve) => {
+        const switchTheme = function() {
+            // we re-enable our theme here just in case we raced with another
+            // theme set request as per https://github.com/vector-im/riot-web/issues/5601.
+            // We could alternatively lock or similar to stop the race, but
+            // this is probably good enough for now.
+            styleElements[stylesheetName].disabled = false;
+            Object.values(styleElements).forEach((a) => {
+                if (a == styleElements[stylesheetName]) return;
+                a.disabled = true;
+            });
+            Tinter.setTheme(theme);
+            resolve();
+        };
 
-    // turns out that Firefox preloads the CSS for link elements with
-    // the disabled attribute, but Chrome doesn't.
+        // turns out that Firefox preloads the CSS for link elements with
+        // the disabled attribute, but Chrome doesn't.
 
-    let cssLoaded = false;
+        let cssLoaded = false;
 
-    styleElements[stylesheetName].onload = () => {
-        switchTheme();
-    };
+        styleElements[stylesheetName].onload = () => {
+            switchTheme();
+        };
 
-    for (let i = 0; i < document.styleSheets.length; i++) {
-        const ss = document.styleSheets[i];
-        if (ss && ss.href === styleElements[stylesheetName].href) {
-            cssLoaded = true;
-            break;
+        for (let i = 0; i < document.styleSheets.length; i++) {
+            const ss = document.styleSheets[i];
+            if (ss && ss.href === styleElements[stylesheetName].href) {
+                cssLoaded = true;
+                break;
+            }
         }
-    }
 
-    if (cssLoaded) {
-        styleElements[stylesheetName].onload = undefined;
-        switchTheme();
-    }
+        if (cssLoaded) {
+            styleElements[stylesheetName].onload = undefined;
+            switchTheme();
+        }
+    });
 }


### PR DESCRIPTION
This was only used by vector/index.js, in the code removed by
vector-im/riot-web#11445

React SDK does a very similar thing in setTheme but also gets the
rest of the custom theme name.

Requires vector-im/riot-web#11445