### PR TITLE
EventIndex: Move the checkpoint loading logic into the init method.

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -35,7 +35,12 @@ export default class EventIndex {
 
     async init() {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
+
         await indexManager.initEventIndex();
+        console.log("EventIndex: Successfully initialized the event index");
+
+        this.crawlerCheckpoints = await indexManager.loadCheckpoints();
+        console.log("EventIndex: Loaded checkpoints", this.crawlerCheckpoints);
 
         this.registerListeners();
     }
@@ -61,14 +66,6 @@ export default class EventIndex {
 
     onSync = async (state, prevState, data) => {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
-
-        if (prevState === null && state === "PREPARED") {
-            // Load our stored checkpoints, if any.
-            this.crawlerCheckpoints = await indexManager.loadCheckpoints();
-            console.log("EventIndex: Loaded checkpoints",
-                        this.crawlerCheckpoints);
-            return;
-        }
 
         if (prevState === "PREPARED" && state === "SYNCING") {
             const addInitialCheckpoints = async () => {

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -55,8 +55,6 @@ class EventIndexPeg {
             return false;
         }
 
-        console.log("EventIndex: Successfully initialized the event index");
-
         this.index = index;
 
         return true;


### PR DESCRIPTION
The checkpoints don't seem to be loaded anymore in the onSync method,
the reason why this has stopped working is left unexplored since loading
the checkpoints makes most sense during the initialization step anyways.