### PR TITLE
Show m.room.create event before the ELS on room upgrade

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -411,6 +411,11 @@ module.exports = createReactClass({
                     readMarkerInSummary = true;
                 }
 
+                // If this m.room.create event should be shown (room upgrade) then show it before the summary
+                if (this._shouldShowEvent(mxEv)) {
+                    ret.push(...this._getTilesForEvent(prevEvent, mxEv, false));
+                }
+
                 const summarisedEvents = []; // Don't add m.room.create here as we don't want it inside the summary
                 for (;i + 1 < this.props.events.length; i++) {
                     const collapsedMxEv = this.props.events[i + 1];


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11463
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/3433

![image](https://user-images.githubusercontent.com/2403652/69418324-5f707780-0d12-11ea-8df8-b0b8a33a747b.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>