### PR TITLE
Fix double date separator for room upgrade tiles

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -416,7 +416,8 @@ export default class MessagePanel extends React.Component {
 
                 // If this m.room.create event should be shown (room upgrade) then show it before the summary
                 if (this._shouldShowEvent(mxEv)) {
-                    ret.push(...this._getTilesForEvent(prevEvent, mxEv, false));
+                    // pass in the mxEv as prevEvent as well so no extra DateSeparator is rendered
+                    ret.push(...this._getTilesForEvent(mxEv, mxEv, false));
                 }
 
                 const summarisedEvents = []; // Don't add m.room.create here as we don't want it inside the summary


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11468