### PR TITLE
Make the communities button behave more like a toggle

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -627,6 +627,22 @@ export default createReactClass({
             case 'view_invite':
                 showRoomInviteDialog(payload.roomId);
                 break;
+            case 'view_last_screen':
+                // This function does what we want, despite the name. The idea is that it shows
+                // the last room we were looking at or some reasonable default/guess. We don't
+                // have to worry about email invites or similar being re-triggered because the
+                // function will have cleared that state and not execute that path.
+                this._showScreenAfterLogin();
+                break;
+            case 'toggle_my_groups':
+                // We just dispatch the page change rather than have to worry about
+                // what the logic is for each of these branches.
+                if (this.state.page_type === PageTypes.MyGroups) {
+                    dis.dispatch({action: 'view_last_screen'});
+                } else {
+                    dis.dispatch({action: 'view_my_groups'});
+                }
+                break;
             case 'notifier_enabled': {
                     this.setState({showNotifierToolbar: Notifier.shouldShowToolbar()});
                 }

--- a/src/components/views/elements/GroupsButton.js
+++ b/src/components/views/elements/GroupsButton.js
@@ -22,7 +22,7 @@ import { _t } from '../../../languageHandler';
 const GroupsButton = function(props) {
     const ActionButton = sdk.getComponent('elements.ActionButton');
     return (
-        <ActionButton className="mx_GroupsButton" action="view_my_groups"
+        <ActionButton className="mx_GroupsButton" action="toggle_my_groups"
             label={_t("Communities")}
             size={props.size}
             tooltip={true}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10771

Clicking the button should toggle between your last page (room in our case) and the communities stuff.