### PR TITLE
Change read markers to use CSS transitions

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -221,6 +221,9 @@ hr.mx_RoomView_myReadMarker {
     position: relative;
     top: -1px;
     z-index: 1;
+    transition: width 400ms easeInSine 1s, opacity 400ms easeInSine 1s;
+    width: 99%;
+    opacity: 1;
 }
 
 .mx_RoomView_callStatusBar .mx_UploadBar_uploadProgressInner {


### PR DESCRIPTION
Removes one of the two places we use Velocity, so we're one step
closer to getting rid of it for good.

Should therefore fix the fact that Velocity is leaking data entries
and therefore `<hr>` elements.

Hopefully also makes the logic in getEventTiles incrementally simpler,
if still somwewhat byzantine.

Requires https://github.com/vector-im/riot-web/pull/11521