### PR TITLE
Add a button to mark all rooms as read

### DIFF
--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
@@ -84,9 +84,9 @@ export default class HelpUserSettingsTab extends React.Component {
         MatrixClientPeg.get().getRooms().forEach(function(element) {
             MatrixClientPeg.get().sendReadReceipt(function(evs) {
                 return evs[evs.length - 1]
-            }(element.getLiveTimeline()._events), {})
-        })
-    }
+            }(element.getLiveTimeline()._events), {});
+        });
+    };
 
     _onBugReport = (e) => {
         const BugReportDialog = sdk.getComponent("dialogs.BugReportDialog");

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
@@ -80,6 +80,14 @@ export default class HelpUserSettingsTab extends React.Component {
         });
     };
 
+    _onMarkAllRoomsAsRead = (e) => {
+        MatrixClientPeg.get().getRooms().forEach(function(element) {
+            MatrixClientPeg.get().sendReadReceipt(function(evs) {
+                return evs[evs.length - 1]
+            }(element.getLiveTimeline()._events), {})
+        })
+    }
+
     _onBugReport = (e) => {
         const BugReportDialog = sdk.getComponent("dialogs.BugReportDialog");
         if (!BugReportDialog) {
@@ -230,6 +238,11 @@ export default class HelpUserSettingsTab extends React.Component {
                         <div className='mx_HelpUserSettingsTab_debugButton'>
                             <AccessibleButton onClick={this._onClearCacheAndReload} kind='danger'>
                                 {_t("Clear cache and reload")}
+                            </AccessibleButton>
+                        </div>
+                        <div className='mx_HelpUserSettingsTab_debugButton'>
+                            <AccessibleButton onClick={this._onMarkAllRoomsAsRead} kind='danger'>
+                                {_t("Mark all rooms as read")}
                             </AccessibleButton>
                         </div>
                     </div>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -631,6 +631,7 @@
     "If you've submitted a bug via GitHub, debug logs can help us track down the problem. Debug logs contain application usage data including your username, the IDs or aliases of the rooms or groups you have visited and the usernames of other users. They do not contain messages.": "If you've submitted a bug via GitHub, debug logs can help us track down the problem. Debug logs contain application usage data including your username, the IDs or aliases of the rooms or groups you have visited and the usernames of other users. They do not contain messages.",
     "Submit debug logs": "Submit debug logs",
     "Clear cache and reload": "Clear cache and reload",
+    "Mark all rooms as read": "Mark all rooms as read",
     "FAQ": "FAQ",
     "Versions": "Versions",
     "matrix-react-sdk version:": "matrix-react-sdk version:",


### PR DESCRIPTION
![Screen Shot 2019-11-26 at 4 09 47 PM](https://user-images.githubusercontent.com/5855073/69676816-2d8b4800-1067-11ea-948d-c776d0163c28.png)

Helps with https://github.com/vector-im/riot-web/issues/850 but it would be nice to add a `Shift + Escape` keyboard shortcut like Slack

Workaround for https://github.com/vector-im/riot-web/issues/3060