### PR TITLE
fix font smoothing to match figma

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -30,6 +30,11 @@ body {
     color: $primary-fg-color;
     border: 0px;
     margin: 0px;
+
+    // needed to match the designs correctly on macOS
+    // see https://github.com/vector-im/riot-web/issues/11425
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 pre, code {


### PR DESCRIPTION
as per https://github.com/vector-im/riot-web/issues/11425

with apologies to https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/ :/