### PR TITLE
Don't assume that diffs will have an appropriate child node

### DIFF
--- a/src/utils/MessageDiffUtils.js
+++ b/src/utils/MessageDiffUtils.js
@@ -77,6 +77,8 @@ function findRefNodes(root, route, isAddition) {
     const end = isAddition ? route.length - 1 : route.length;
     for (let i = 0; i < end; ++i) {
         refParentNode = refNode;
+        // Lists don't have appropriate child nodes we can use.
+        if (!refNode.childNodes[route[i]]) continue;
         refNode = refNode.childNodes[route[i]];
     }
     return {refNode, refParentNode};


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11497

This is a regression from react-sdk v1.5.0 where the diff feature was added in the first place. It only affects lists.

Note: lists look a bit weird after this change, but it seems like a better option than exploding.
![image](https://user-images.githubusercontent.com/1190097/69753632-43edde00-1111-11ea-8ba9-8d39adf0358f.png)
