### PR TITLE
Fix persisted widgets getting stuck at loading screens

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -36,6 +36,7 @@ import classNames from 'classnames';
 import {IntegrationManagers} from "../../../integrations/IntegrationManagers";
 import SettingsStore, {SettingLevel} from "../../../settings/SettingsStore";
 import {createMenu} from "../../structures/ContextualMenu";
+import PersistedElement from "./PersistedElement";
 
 const ALLOWED_APP_URL_SCHEMES = ['https:', 'http:'];
 const ENABLE_REACT_PERF = false;
@@ -247,7 +248,8 @@ export default class AppTile extends React.Component {
                 this.setScalarToken();
             }
         } else if (nextProps.show && !this.props.show) {
-            if (this.props.waitForIframeLoad) {
+            // We assume that persisted widgets are loaded and don't need a spinner.
+            if (this.props.waitForIframeLoad && !PersistedElement.isMounted(this._persistKey)) {
                 this.setState({
                     loading: true,
                 });
@@ -652,12 +654,7 @@ export default class AppTile extends React.Component {
                     appTileBody = (
                         <div className={appTileBodyClass + (this.state.loading ? 'mx_AppLoading' : '')}>
                             { this.state.loading && loadingElement }
-                            { /*
-                                The "is" attribute in the following iframe tag is needed in order to enable rendering of the
-                                "allow" attribute, which is unknown to react 15.
-                            */ }
                             <iframe
-                                is
                                 allow={iframeFeatures}
                                 ref="appFrame"
                                 src={this._getSafeUrl()}


### PR DESCRIPTION
The widget itself is rendered underneath the loading screen, so we just have to disable the loading state.

This commit also removes the "is" attribute because React 16 includes unknown attributes: https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html

Fixes https://github.com/vector-im/riot-web/issues/11536