### PR TITLE
Hide Remove button in message editing history if you don't have permission to redact

### DIFF
--- a/src/components/views/messages/EditHistoryMessage.js
+++ b/src/components/views/messages/EditHistoryMessage.js
@@ -102,9 +102,9 @@ export default class EditHistoryMessage extends React.PureComponent {
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
         // hide the button when already redacted
         let redactButton;
-        if (!this.props.mxEvent.isRedacted() && !this.props.isBaseEvent) {
+        if (!this.props.mxEvent.isRedacted() && !this.props.isBaseEvent && this.state.canRedact) {
             redactButton = (
-                <AccessibleButton onClick={this._onRedactClick} disabled={!this.state.canRedact}>
+                <AccessibleButton onClick={this._onRedactClick}>
                     {_t("Remove")}
                 </AccessibleButton>
             );


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10366
Fixes https://github.com/vector-im/riot-web/issues/10292