### PR TITLE
Ensure the settings page accurately represents theme choices

### DIFF
--- a/src/settings/controllers/ThemeController.js
+++ b/src/settings/controllers/ThemeController.js
@@ -20,6 +20,8 @@ import {DEFAULT_THEME, enumerateThemes} from "../../theme";
 
 export default class ThemeController extends SettingController {
     getValueOverride(level, roomId, calculatedValue, calculatedAtLevel) {
+        if (!calculatedValue) return null; // Don't override null themes
+
         const themes = enumerateThemes();
         // Override in case some no longer supported theme is stored here
         if (!themes[calculatedValue]) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -80,6 +80,8 @@ export class ThemeWatcher {
     }
 
     getEffectiveTheme() {
+        // Dev note: Much of this logic is replicated in the GeneralUserSettingsTab
+
         // If the user has specifically enabled the system matching option (excluding default),
         // then use that over anything else. We pick the lowest possible level for the setting
         // to ensure the ordering otherwise works.


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11518

This also fixes a bug where the the theme logic can incorrectly get stuck in the light theme - the ThemeController was overriding *all* values, not just supposed themes. Null values aren't overridden so that the various theme logic bits don't assume the user has chosen the light theme explicitly.

![image](https://user-images.githubusercontent.com/1190097/69831005-b2e83700-11e4-11ea-8525-86621144adba.png)
