### PR TITLE
Do not trap Key ContextMenu into composer for keyboard a11y

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -78,6 +78,7 @@ export const Key = {
     CONTROL: "Control",
     META: "Meta",
     SHIFT: "Shift",
+    CONTEXT_MENU: "ContextMenu",
 
     LESS_THAN: "<",
     GREATER_THAN: ">",

--- a/src/components/structures/LoggedInView.js
+++ b/src/components/structures/LoggedInView.js
@@ -401,6 +401,11 @@ const LoggedInView = createReactClass({
             const isClickShortcut = ev.target !== document.body &&
                 (ev.key === Key.SPACE || ev.key === Key.ENTER);
 
+            // Do not capture the context menu key to improve keyboard accessibility
+            if (ev.key === Key.CONTEXT_MENU) {
+                return;
+            }
+
             // XXX: Remove after CIDER replaces Slate completely: https://github.com/vector-im/riot-web/issues/11036
             // If using Slate, consume the Backspace without first focusing as it causes an implosion
             if (ev.key === Key.BACKSPACE && !SettingsStore.getValue("useCiderComposer")) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11573

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>