### PR TITLE
Simple autocomplete without trapping tab

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -366,9 +366,15 @@ export default class BasicMessageEditor extends React.Component {
                             handled = true;
                         }
                         break;
+                    case Key.ENTER:
+                        if (!metaOrAltPressed) {
+                            autoComplete.onEnter();
+                            handled = true;
+                        }
+                        break;
                     case Key.TAB:
                         if (!metaOrAltPressed) {
-                            autoComplete.onTab(event);
+                            autoComplete.onTab();
                             handled = true;
                         }
                         break;

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -49,7 +49,7 @@ export default class AutocompleteWrapperModel {
         this._updateCallback({close: true});
     }
 
-    async onTab(e) {
+    async onTab() {
         const acComponent = this._getAutocompleterComponent();
 
         if (acComponent.countCompletions() === 0) {
@@ -58,7 +58,7 @@ export default class AutocompleteWrapperModel {
             // Select the first item by moving "down"
             await acComponent.moveSelection(+1);
         } else {
-            await acComponent.moveSelection(e.shiftKey ? -1 : +1);
+            this._updateCallback({close: true});
         }
     }
 


### PR DESCRIPTION
Simplest changeset to relieve tab-trapping of Composer Autocomplete
this is without the massive change that the whole a11y_poc was which changed from aria-autocomplete="both" to aria-autocomplete="list"

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>