### PR TITLE
Switch ReactionsRowButton to an AccessibleButton for space/enter handling

### DIFF
--- a/src/components/views/messages/ReactionsRowButton.js
+++ b/src/components/views/messages/ReactionsRowButton.js
@@ -126,10 +126,9 @@ export default class ReactionsRowButton extends React.PureComponent {
             );
         }
 
-        return <span className={classes}
-            role="button"
+        const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
+        return <AccessibleButton className={classes}
             aria-label={label}
-            tabindex="0"
             onClick={this.onClick}
             onMouseOver={this.onMouseOver}
             onMouseOut={this.onMouseOut}
@@ -141,6 +140,6 @@ export default class ReactionsRowButton extends React.PureComponent {
                 {count}
             </span>
             {tooltip}
-        </span>;
+        </AccessibleButton>;
     }
 }


### PR DESCRIPTION
Builds on top of https://github.com/matrix-org/matrix-react-sdk/pull/3704
to allow toggling using space/enter as buttons should be in the aria spec

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>