### PR TITLE
Change the (edited) link to an AccessibleButton for a11y

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -401,13 +401,18 @@ module.exports = createReactClass({
                 label={_t("Edited at %(date)s. Click to view edits.", {date: dateString})}
             />;
         }
+
+        const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
         return (
-            <div
-                key="editedMarker" className="mx_EventTile_edited"
+            <AccessibleButton
+                key="editedMarker"
+                className="mx_EventTile_edited"
                 onClick={this._openHistoryDialog}
                 onMouseEnter={this._onMouseEnterEditedMarker}
                 onMouseLeave={this._onMouseLeaveEditedMarker}
-            >{editedTooltip}<span>{`(${_t("edited")})`}</span></div>
+            >
+                { editedTooltip }<span>{`(${_t("edited")})`}</span>
+            </AccessibleButton>
         );
     },
 


### PR DESCRIPTION
Fixes:
> oh, the text edited after the edited message should perhaps be also turned into an accessible button. Clicking it opens a dialog with all the edits of a message.

reported by @pvagner 

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>