### PR TITLE
Fix false boolean values in SettingsStore being handled incorrectly

### DIFF
--- a/src/settings/handlers/ConfigSettingsHandler.js
+++ b/src/settings/handlers/ConfigSettingsHandler.js
@@ -32,7 +32,7 @@ export default class ConfigSettingsHandler extends SettingsHandler {
         }
 
         const settingsConfig = config["settingDefaults"];
-        if (!settingsConfig || !settingsConfig[settingName]) return null;
+        if (!settingsConfig || settingsConfig[settingName] == null) return null;
         return settingsConfig[settingName];
     }
 


### PR DESCRIPTION
I think there is a bug in how default settings are handled. I may have misunderstood your work but let's say I'd like to change the default value of a setting by changing config.json : 
`    
"settingDefaults": {
        "RoomList.orderByImportance": false
}, 
`
In that case the false value will be converted to null instead of being kept to false. The following process while ignore the value (because it's null) and fallback to the DefaultSettingsHandler.
@turt2live you were the last one committing on this file. Could you help me understand if it's a bug or an expected behaviour ? I can make settingDefaults in config.json work ... :(