### PR TITLE
Wrap the await call for unknown device lookups

### DIFF
--- a/src/cryptodevices.js
+++ b/src/cryptodevices.js
@@ -44,7 +44,7 @@ export function markAllDevicesKnown(matrixClient, devices) {
  * module:crypto~DeviceInfo|DeviceInfo}.
  */
 export async function getUnknownDevicesForRoom(matrixClient, room) {
-    const roomMembers = await room.getEncryptionTargetMembers().map((m) => {
+    const roomMembers = (await room.getEncryptionTargetMembers()).map((m) => {
         return m.userId;
     });
     const devices = await matrixClient.downloadKeys(roomMembers, false);


### PR DESCRIPTION
Otherwise we're awaiting the result of `map()`, which isn't accurate.