### PR TITLE
Fix right panel for multiple member info viewings

### DIFF
--- a/src/stores/RightPanelStore.js
+++ b/src/stores/RightPanelStore.js
@@ -154,7 +154,7 @@ export default class RightPanelStore extends Store {
                 });
             }
         } else {
-            if (targetPhase === this._state.lastRoomPhase) {
+            if (targetPhase === this._state.lastRoomPhase && !payload.refireParams) {
                 this._setState({
                     showRoomPanel: !this._state.showRoomPanel,
                 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11663

Member info is special because it has parameters associated with it. What was happening was the RightPanelStore was seeing that it was already on member info and deciding to hide the pane instead. What we do now is consider any phase change with parameters (such as the user to pass to member info) as a proper phase change.