### PR TITLE
apply unhomoglyph when filtering room list to fuzzify it

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -597,8 +597,7 @@ module.exports = createReactClass({
             if (filter[0] === "#" && room.getAliases().some((alias) => alias.toLowerCase().startsWith(lcFilter))) {
                 return true;
             }
-            const lcRoomName = room.name ? utils.removeHiddenChars(room.name).toLowerCase() : "";
-            return lcRoomName.includes(fuzzyFilter);
+            return room.name ? utils.removeHiddenChars(room.name).toLowerCase().includes(fuzzyFilter) : false;
         });
     },
 

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -22,6 +22,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
+import utils from "matrix-js-sdk/lib/utils";
 import { _t } from '../../../languageHandler';
 const MatrixClientPeg = require("../../../MatrixClientPeg");
 const CallHandler = require('../../../CallHandler');
@@ -588,11 +589,17 @@ module.exports = createReactClass({
 
     _applySearchFilter: function(list, filter) {
         if (filter === "") return list;
+        const fuzzyFilter = utils.removeHiddenChars(filter).toLowerCase();
         const lcFilter = filter.toLowerCase();
         // case insensitive if room name includes filter,
         // or if starts with `#` and one of room's aliases starts with filter
-        return list.filter((room) => (room.name && room.name.toLowerCase().includes(lcFilter)) ||
-            (filter[0] === '#' && room.getAliases().some((alias) => alias.toLowerCase().startsWith(lcFilter))));
+        return list.filter((room) => {
+            if (filter[0] === "#" && room.getAliases().some((alias) => alias.toLowerCase().startsWith(lcFilter))) {
+                return true;
+            }
+            const lcRoomName = room.name ? utils.removeHiddenChars(room.name).toLowerCase() : "";
+            return lcRoomName.includes(fuzzyFilter);
+        });
     },
 
     _handleCollapsedState: function(key, collapsed) {


### PR DESCRIPTION
Potentially fixes https://github.com/vector-im/riot-web/issues/3216 (depending on the final scope of that broad issue)

Makes it easier to find rooms which have strange unicode homoglyphy chars e.g:

![image](https://user-images.githubusercontent.com/2403652/71185752-f548e500-2273-11ea-93e9-e4264297bce8.png)
