### PR TITLE
Add Copy Message Contents option in Context Menu

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -253,6 +253,16 @@ module.exports = createReactClass({
         this.closeMenu();
     },
 
+    onCopyClick: function(e: Event) {
+        const textField = document.createElement('textarea');
+        textField.innerText = this.props.mxEvent.event.content.body;
+        document.body.appendChild(textField);
+        textField.select();
+        document.execCommand('copy');
+        textField.remove();
+        this.closeMenu();
+    },
+
     onPermalinkClick: function(e: Event) {
         e.preventDefault();
         const ShareDialog = sdk.getComponent("dialogs.ShareDialog");
@@ -314,6 +324,7 @@ module.exports = createReactClass({
         let unhidePreviewButton;
         let externalURLButton;
         let quoteButton;
+        let copyButton;
         let collapseReplyThread;
 
         // status is SENT before remote-echo, null after
@@ -430,6 +441,14 @@ module.exports = createReactClass({
             );
         }
 
+        if (this.props.eventTileOps && this.props.eventTileOps.getInnerText) {
+            copyButton = (
+                <MenuItem className="mx_MessageContextMenu_field" onClick={this.onCopyClick}>
+                    { _t('Copy Message Contents') }
+                </MenuItem>
+            );
+        }
+
         // Bridges can provide a 'external_url' to link back to the source.
         if (
             typeof(mxEvent.event.content.external_url) === "string" &&
@@ -491,6 +510,7 @@ module.exports = createReactClass({
                 { unhidePreviewButton }
                 { permalinkButton }
                 { quoteButton }
+                { copyButton }
                 { externalURLButton }
                 { collapseReplyThread }
                 { e2eInfo }

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -746,5 +746,6 @@
     "Failed to start chat": "Failed to start chat",
     "Messages": "Messages",
     "Actions": "Actions",
-    "Other": "Other"
+    "Other": "Other",
+    "Copy Message Contents": "Copy Message Contents"
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10649 and a few hackernews comments I saw earlier today with the second option from the issue (as I think it is the more common pattern I have seen for regular messages)

First time contributing to a react project, so I did it as simply as I could - very much so open to feedback if there is a more "react" or "matrix" way of doing this.

Copies the content from a message to clipboard - tested in firefox, chrome, safari and with the electron app