### PR TITLE
Fix room list filtering weird case sensitivity

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -589,15 +589,17 @@ module.exports = createReactClass({
 
     _applySearchFilter: function(list, filter) {
         if (filter === "") return list;
-        const fuzzyFilter = utils.removeHiddenChars(filter).toLowerCase();
         const lcFilter = filter.toLowerCase();
+        // apply toLowerCase before and after removeHiddenChars because different rules get applied
+        // e.g M -> M but m -> n, yet some unicode homoglyphs come out as uppsercase, e.g 𝚮 -> H
+        const fuzzyFilter = utils.removeHiddenChars(lcFilter).toLowerCase();
         // case insensitive if room name includes filter,
         // or if starts with `#` and one of room's aliases starts with filter
         return list.filter((room) => {
             if (filter[0] === "#" && room.getAliases().some((alias) => alias.toLowerCase().startsWith(lcFilter))) {
                 return true;
             }
-            return room.name ? utils.removeHiddenChars(room.name).toLowerCase().includes(fuzzyFilter) : false;
+            return room.name && utils.removeHiddenChars(room.name.toLowerCase()).toLowerCase().includes(fuzzyFilter);
         });
     },
 

--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -591,7 +591,7 @@ module.exports = createReactClass({
         if (filter === "") return list;
         const lcFilter = filter.toLowerCase();
         // apply toLowerCase before and after removeHiddenChars because different rules get applied
-        // e.g M -> M but m -> n, yet some unicode homoglyphs come out as uppsercase, e.g 𝚮 -> H
+        // e.g M -> M but m -> n, yet some unicode homoglyphs come out as uppercase, e.g 𝚮 -> H
         const fuzzyFilter = utils.removeHiddenChars(lcFilter).toLowerCase();
         // case insensitive if room name includes filter,
         // or if starts with `#` and one of room's aliases starts with filter


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11701

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

unhomoglyph converts funky unicode characters to their non-confusable counterparts as per http://www.unicode.org/Public/security/latest/confusables.txt

the issue was we converted the output of it to lower case but its input was mixed case, which causes fun cases like
e.g `m` -> `rn`, (r, n) but `M` -> `M` which means we should lowerCase its input, but we must also lowerCase its output because of mappings like `𝐊` -> `K` (which would not match `k` otherwise)