### PR TITLE
Use `flex-start` instead of `start` for postcss

### DIFF
--- a/res/css/views/context_menus/_StatusMessageContextMenu.scss
+++ b/res/css/views/context_menus/_StatusMessageContextMenu.scss
@@ -61,5 +61,5 @@ input.mx_StatusMessageContextMenu_message {
 }
 
 .mx_StatusMessageContextMenu_actionContainer .mx_Spinner {
-    justify-content: start;
+    justify-content: flex-start;
 }

--- a/res/css/views/dialogs/_CreateRoomDialog.scss
+++ b/res/css/views/dialogs/_CreateRoomDialog.scss
@@ -30,7 +30,7 @@ limitations under the License.
 
     > div {
         display: flex;
-        align-items: start;
+        align-items: flex-start;
         margin: 5px 0;
 
         input[type=checkbox] {

--- a/res/css/views/dialogs/keybackup/_CreateKeyBackupDialog.scss
+++ b/res/css/views/dialogs/keybackup/_CreateKeyBackupDialog.scss
@@ -32,7 +32,7 @@ limitations under the License.
 
 .mx_CreateKeyBackupDialog_passPhraseContainer {
     display: flex;
-    align-items: start;
+    align-items: flex-start;
 }
 
 .mx_CreateKeyBackupDialog_passPhraseHelp {

--- a/res/css/views/dialogs/secretstorage/_CreateSecretStorageDialog.scss
+++ b/res/css/views/dialogs/secretstorage/_CreateSecretStorageDialog.scss
@@ -33,7 +33,7 @@ limitations under the License.
 
 .mx_CreateSecretStorageDialog_passPhraseContainer {
     display: flex;
-    align-items: start;
+    align-items: flex-start;
 }
 
 .mx_CreateSecretStorageDialog_passPhraseHelp {

--- a/res/css/views/rooms/_MemberDeviceInfo.scss
+++ b/res/css/views/rooms/_MemberDeviceInfo.scss
@@ -17,7 +17,7 @@ limitations under the License.
 .mx_MemberDeviceInfo {
     display: flex;
     padding-bottom: 10px;
-    align-items: start;
+    align-items: flex-start;
 }
 
 .mx_MemberDeviceInfo_icon {

--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -101,7 +101,7 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     min-height: 60px;
-    justify-content: start;
+    justify-content: flex-start;
     align-items: flex-start;
     font-size: 14px;
     margin-right: 6px;


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-react-sdk/pull/3744

This is just something the loaders complain about - apparently `start` is old and we should feel bad.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d