### PR TITLE
Define getLanguageFromBrowser() for LanguageDropdown

### DIFF
--- a/src/languageHandler.js
+++ b/src/languageHandler.js
@@ -336,6 +336,10 @@ export function getLanguagesFromBrowser() {
     return [navigator.userLanguage || "en"];
 }
 
+export function getLanguageFromBrowser() {
+    return getLanguagesFromBrowser()[0];
+}
+
 /**
  * Turns a language string, normalises it,
  * (see normalizeLanguageKey) into an array of language strings


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-react-sdk/pull/3744

Without it we can't compile, so we should define it. It looks like it's never been defined, and LanguageDropdown seems to use it as a last resort - it should be safe to land.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d