### PR TITLE
Add a bit of debugging to incorrect components in the Skinner

### DIFF
--- a/src/Skinner.js
+++ b/src/Skinner.js
@@ -58,7 +58,7 @@ class Skinner {
         // components have to be functions.
         const validType = typeof comp === 'function';
         if (!validType) {
-            throw new Error(`Not a valid component: ${name}.`);
+            throw new Error(`Not a valid component: ${name} (type = ${typeof(comp)}).`);
         }
         return comp;
     }


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-react-sdk/pull/3744

This is primarily useful for development and serves no functional benefit.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d