### PR TITLE
Fix wrong scope binding on openHelp for TopLeftMenu

### DIFF
--- a/src/components/views/context_menus/TopLeftMenu.js
+++ b/src/components/views/context_menus/TopLeftMenu.js
@@ -128,11 +128,11 @@ export class TopLeftMenu extends React.Component {
         </div>;
     }
 
-    openHelp() {
+    openHelp = () => {
         this.closeMenu();
         const RedesignFeedbackDialog = sdk.getComponent("views.dialogs.RedesignFeedbackDialog");
         Modal.createTrackedDialog('Report bugs & give feedback', '', RedesignFeedbackDialog);
-    }
+    };
 
     viewHomePage() {
         dis.dispatch({action: 'view_home_page'});


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11708