### PR TITLE
Reintroduce working resizer code for right panel

### DIFF
--- a/src/components/structures/MainSplit.js
+++ b/src/components/structures/MainSplit.js
@@ -74,6 +74,21 @@ export default class MainSplit extends React.Component {
         }
     }
 
+    componentDidUpdate(prevProps) {
+        const wasPanelSet = this.props.panel && !prevProps.panel;
+        const wasPanelCleared = !this.props.panel && prevProps.panel;
+
+        if (this.resizeContainer && wasPanelSet) {
+            // The resizer can only be created when **both** expanded and the panel is
+            // set. Once both are true, the container ref will mount, which is required
+            // for the resizer to work.
+            this._createResizer();
+        } else if (this.resizer && wasPanelCleared) {
+            this.resizer.detach();
+            this.resizer = null;
+        }
+    }
+
     render() {
         const bodyView = React.Children.only(this.props.children);
         const panelView = this.props.panel;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11674

This re-introduces and adapted version of what was there before, but fixed for the new collapsed logic: https://github.com/matrix-org/matrix-react-sdk/pull/3703/files#diff-633a0248e235d7446a8868a9145efce2L77-L93

We no longer have a collapsedRhs variable and only set the panel when it is opened, so we can accurately track expanded/collapsed state through presence of a panel.