### PR TITLE
fuzzy-sort MemberList

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -32,6 +32,9 @@ const INITIAL_LOAD_NUM_MEMBERS = 30;
 const INITIAL_LOAD_NUM_INVITED = 5;
 const SHOW_MORE_INCREMENT = 100;
 
+// Regex applied to member names before applying sort, to fuzzy it a little
+const SORT_REGEX = /[.?!,;:\-()[\]{}'"&@]+/g;
+
 module.exports = createReactClass({
     displayName: 'MemberList',
 
@@ -336,10 +339,13 @@ module.exports = createReactClass({
         }
 
         // Fourth by name (alphabetical)
-        const nameA = memberA.name[0] === '@' ? memberA.name.substr(1) : memberA.name;
-        const nameB = memberB.name[0] === '@' ? memberB.name.substr(1) : memberB.name;
+        const nameA = (memberA.name[0] === '@' ? memberA.name.substr(1) : memberA.name).replace(SORT_REGEX, "");
+        const nameB = (memberB.name[0] === '@' ? memberB.name.substr(1) : memberB.name).replace(SORT_REGEX, "");
         // console.log(`Comparing userA_name=${nameA} against userB_name=${nameB} - returning`);
-        return nameA.localeCompare(nameB);
+        return nameA.localeCompare(nameB, {
+            ignorePunctuation: true,
+            sensitivity: "base",
+        });
     },
 
     onSearchQueryChanged: function(searchQuery) {

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -32,8 +32,9 @@ const INITIAL_LOAD_NUM_MEMBERS = 30;
 const INITIAL_LOAD_NUM_INVITED = 5;
 const SHOW_MORE_INCREMENT = 100;
 
-// Regex applied to member names before applying sort, to fuzzy it a little
-const SORT_REGEX = /[.?!,;:\-()[\]{}'"&@#\\/+_=]+/g;
+// Regex applied to filter our punctuation in member names before applying sort, to fuzzy it a little
+// matches all ASCII punctuation: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+const SORT_REGEX = /[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]+/g;
 
 module.exports = createReactClass({
     displayName: 'MemberList',

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -33,7 +33,7 @@ const INITIAL_LOAD_NUM_INVITED = 5;
 const SHOW_MORE_INCREMENT = 100;
 
 // Regex applied to member names before applying sort, to fuzzy it a little
-const SORT_REGEX = /[.?!,;:\-()[\]{}'"&@]+/g;
+const SORT_REGEX = /[.?!,;:\-()[\]{}'"&@#\\/+_=]+/g;
 
 module.exports = createReactClass({
     displayName: 'MemberList',


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11707

Strips out punctuation and ignores accents when sorting, we could go the extra mile and use unhomoglyph