### PR TITLE
Fix inverted diff line highlighting in dark theme

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -244,7 +244,7 @@ $breadcrumb-placeholder-bg-color: #272c35;
     }
 }
 
-// Fixes diff color inversion by swapping add / del colors
+// diff highlight colors
 .hljs-addition {
     background: #fdd;
 }

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -243,3 +243,12 @@ $breadcrumb-placeholder-bg-color: #272c35;
         }
     }
 }
+
+// Fixes diff color inversion by swapping add / del colors
+.hljs-addition {
+    background: #fdd;
+}
+
+.hljs-deletion {
+    background: #dfd;
+}

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -245,6 +245,7 @@ $breadcrumb-placeholder-bg-color: #272c35;
 }
 
 // diff highlight colors
+// intentionally swapped to avoid inversion
 .hljs-addition {
     background: #fdd;
 }

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -338,3 +338,12 @@ $breadcrumb-placeholder-bg-color: #e8eef5;
     color: $accent-color;
     text-decoration: none;
 }
+
+// diff highlight colors
+.hljs-addition {
+    background: #dfd;
+}
+
+.hljs-deletion {
+    background: #fdd;
+}


### PR DESCRIPTION
Fixes vector-im/riot-web#7921.

Before:
![2019-12-28-23:55:38](https://user-images.githubusercontent.com/14955039/71553054-e2e64e00-29cd-11ea-9d87-9d5c1e541aee.png)

After:
![2019-12-28-23:58:42](https://user-images.githubusercontent.com/14955039/71553059-fbeeff00-29cd-11ea-99d6-867ed6a7029f.png)