### PR TITLE
Hide algorithm from the message about turning on encryption

### DIFF
--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -420,9 +420,7 @@ function textForHistoryVisibilityEvent(event) {
 
 function textForEncryptionEvent(event) {
     const senderName = event.sender ? event.sender.name : event.getSender();
-    return _t('%(senderName)s turned on end-to-end encryption.', {
-        senderName
-    });
+    return _t('%(senderName)s turned on end-to-end encryption.', {senderName});
 }
 
 // Currently will only display a change if a user's power level is changed

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -420,9 +420,8 @@ function textForHistoryVisibilityEvent(event) {
 
 function textForEncryptionEvent(event) {
     const senderName = event.sender ? event.sender.name : event.getSender();
-    return _t('%(senderName)s turned on end-to-end encryption (algorithm %(algorithm)s).', {
-        senderName,
-        algorithm: event.getContent().algorithm,
+    return _t('%(senderName)s turned on end-to-end encryption.', {
+        senderName
     });
 }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -260,7 +260,7 @@
     "%(senderName)s made future room history visible to all room members.": "%(senderName)s made future room history visible to all room members.",
     "%(senderName)s made future room history visible to anyone.": "%(senderName)s made future room history visible to anyone.",
     "%(senderName)s made future room history visible to unknown (%(visibility)s).": "%(senderName)s made future room history visible to unknown (%(visibility)s).",
-    "%(senderName)s turned on end-to-end encryption (algorithm %(algorithm)s).": "%(senderName)s turned on end-to-end encryption (algorithm %(algorithm)s).",
+    "%(senderName)s turned on end-to-end encryption.": "%(senderName)s turned on end-to-end encryption.",
     "%(userId)s from %(fromPowerLevel)s to %(toPowerLevel)s": "%(userId)s from %(fromPowerLevel)s to %(toPowerLevel)s",
     "%(senderName)s changed the power level of %(powerLevelDiffText)s.": "%(senderName)s changed the power level of %(powerLevelDiffText)s.",
     "%(senderName)s changed the pinned messages for the room.": "%(senderName)s changed the pinned messages for the room.",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8829

Before:
<img width="525" alt="Screen Shot 2020-01-07 at 11 34 40 AM" src="https://user-images.githubusercontent.com/5855073/71915632-c969a280-3141-11ea-8e45-2245d71daba1.png">

After:
<img width="326" alt="Screen Shot 2020-01-07 at 11 34 54 AM" src="https://user-images.githubusercontent.com/5855073/71915610-bc4cb380-3141-11ea-8a6a-03a73417ea28.png">
