### PR TITLE
Add feature flag around the presence indicator in room list

### DIFF
--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -381,7 +381,10 @@ module.exports = createReactClass({
 
             const { room } = this.props;
             const member = room.getMember(dmUserId);
-            if (member && member.membership === "join" && room.getJoinedMemberCount() === 2) {
+            if (
+                member && member.membership === "join" && room.getJoinedMemberCount() === 2 &&
+                SettingsStore.isFeatureEnabled("feature_presence_in_room_list")
+            ) {
                 const UserOnlineDot = sdk.getComponent('rooms.UserOnlineDot');
                 dmOnline = <UserOnlineDot userId={dmUserId} />;
             }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -359,6 +359,7 @@
     "Multiple integration managers": "Multiple integration managers",
     "Try out new ways to ignore people (experimental)": "Try out new ways to ignore people (experimental)",
     "New DM invite dialog (under development)": "New DM invite dialog (under development)",
+    "Show a presence dot next to DMs in the room list": "Show a presence dot next to DMs in the room list",
     "Enable cross-signing to verify per-user instead of per-device (in development)": "Enable cross-signing to verify per-user instead of per-device (in development)",
     "Enable local event indexing and E2EE search (requires restart)": "Enable local event indexing and E2EE search (requires restart)",
     "Show info about bridges in room settings": "Show info about bridges in room settings",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -134,6 +134,12 @@ export const SETTINGS = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
+    "feature_presence_in_room_list": {
+        isFeature: true,
+        displayName: _td("Show a presence dot next to DMs in the room list"),
+        supportedLevels: LEVELS_FEATURE,
+        default: false,
+    },
     "mjolnirRooms": {
         supportedLevels: ['account'],
         default: [],


### PR DESCRIPTION
This adds a feature flag (disabled by default for now) around the room list
presence indicator, as it still needs some tweaking before it's ready for
production use.

Part of https://github.com/vector-im/riot-web/issues/11799
See also https://github.com/vector-im/riot-web/pull/11829