### PR TITLE
Don't error on unverified/unknown devices.

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1505,16 +1505,17 @@ export default createReactClass({
                 "blacklistUnverifiedDevices",
             );
             cli.setGlobalBlacklistUnverifiedDevices(blacklistEnabled);
+
+            // With cross-signing enabled, we send to unknown devices
+            // without prompting. Any bad-device status the user should
+            // be aware of will be signalled through the room shield
+            // changing colour. More advanced behaviour will come once
+            // we implement more settings.
+            cli.setGlobalErrorOnUnknownDevices(
+                !SettingsStore.isFeatureEnabled("feature_cross_signing"),
+            );
         }
 
-        // With cross-signing enabled, we send to unknown devices
-        // without prompting. Any bad-device status the user should
-        // be aware of will be signalled through the room shield
-        // changing colour. More advanced behaviour will come once
-        // we implement more settings.
-        cli.setGlobalErrorOnUnknownDevices(
-            !SettingsStore.isFeatureEnabled("feature_cross_signing"),
-        );
     },
 
     showScreen: function(screen, params) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1513,7 +1513,7 @@ export default createReactClass({
         // changing colour. More advanced behaviour will come once
         // we implement more settings.
         cli.setGlobalErrorOnUnknownDevices(
-            !SettingsStore.isFeatureEnabled("feature_cross_signing")
+            !SettingsStore.isFeatureEnabled("feature_cross_signing"),
         );
     },
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1515,7 +1515,6 @@ export default createReactClass({
                 !SettingsStore.isFeatureEnabled("feature_cross_signing"),
             );
         }
-
     },
 
     showScreen: function(screen, params) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1506,6 +1506,15 @@ export default createReactClass({
             );
             cli.setGlobalBlacklistUnverifiedDevices(blacklistEnabled);
         }
+
+        // With cross-signing enabled, we send to unknown devices
+        // without prompting. Any bad-device status the user should
+        // be aware of will be signalled through the room shield
+        // changing colour. More advanced behaviour will come once
+        // we implement more settings.
+        cli.setGlobalErrorOnUnknownDevices(
+            !SettingsStore.isFeatureEnabled("feature_cross_signing")
+        );
     },
 
     showScreen: function(screen, params) {


### PR DESCRIPTION
When cross-signing is enabled, we no longer want to fail and
prompt the user to ack every device in the room. All the info should
be conveyed in the shield colour (although isn't fully just yet).

Fixes https://github.com/vector-im/riot-web/issues/11750
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1150