### PR TITLE
Fix imports for help & support tab

### DIFF
--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.js
@@ -21,10 +21,10 @@ import {MatrixClientPeg} from "../../../../../MatrixClientPeg";
 import AccessibleButton from "../../../elements/AccessibleButton";
 import SdkConfig from "../../../../../SdkConfig";
 import createRoom from "../../../../../createRoom";
-const packageJson = require('../../../../../../package.json');
-const Modal = require("../../../../../Modal");
-const sdk = require("../../../../..");
-const PlatformPeg = require("../../../../../PlatformPeg");
+import packageJson from "../../../../../../package.json";
+import Modal from "../../../../../Modal";
+import * as sdk from "../../../../../";
+import PlatformPeg from "../../../../../PlatformPeg";
 
 // if this looks like a release, use the 'version' from package.json; else use
 // the git sha. Prepend version with v, to look like riot-web version


### PR DESCRIPTION
This was missed, somehow, in the sourcemaps stuff. The tab currently breaks the dialog on load.