### PR TITLE
Remove all text when cutting in the composer

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -209,8 +209,9 @@ export default class BasicMessageEditor extends React.Component {
             const selectedParts = range.parts.map(p => p.serialize());
             event.clipboardData.setData("application/x-riot-composer", JSON.stringify(selectedParts));
             if (type === "cut") {
-                selection.deleteFromDocument();
-                range.replace([]);
+                // Remove the text from the composer
+                const {caret} = getCaretOffsetAndText(this._editorRef, selection);
+                this.props.model.update("", event.inputType, caret);
             }
             event.preventDefault();
         }

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -209,9 +209,8 @@ export default class BasicMessageEditor extends React.Component {
             const selectedParts = range.parts.map(p => p.serialize());
             event.clipboardData.setData("application/x-riot-composer", JSON.stringify(selectedParts));
             if (type === "cut") {
-                // Remove the text from the composer
-                const {caret} = getCaretOffsetAndText(this._editorRef, selection);
-                this.props.model.update("", event.inputType, caret);
+                // Remove the text, updating the model as appropriate
+                replaceRangeAndMoveCaret(range, []);
             }
             event.preventDefault();
         }

--- a/src/editor/position.js
+++ b/src/editor/position.js
@@ -117,7 +117,7 @@ export default class DocumentPosition {
         }
         offset += this.offset;
         const lastPart = model.parts[this.index];
-        const atEnd = offset >= lastPart.text.length;
+        const atEnd = !lastPart || offset >= lastPart.text.length; // if no last part, we're at the end
         return new DocumentOffset(offset, atEnd);
     }
 


### PR DESCRIPTION
The previous function did in fact remove the elements, but left the model thinking there was a zero-length string. This approach replaces the selection with empty text, making the model more accurate given the change in text goes through the model eventually.

Part of https://github.com/vector-im/riot-web/issues/11378
Fixes https://github.com/vector-im/riot-web/issues/11883