### PR TITLE
Compute download file icon immediately

### DIFF
--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -1,14 +1,15 @@
 const en = require("../src/i18n/strings/en_EN");
 
 module.exports = jest.fn((opts, cb) => {
-    if (opts.url.endsWith("languages.json")) {
+    const url = opts.url || opts.uri;
+    if (url && url.endsWith("languages.json")) {
         cb(undefined, {status: 200}, JSON.stringify({
             "en": {
                 "fileName": "en_EN.json",
                 "label": "English",
             },
         }));
-    } else if (opts.url.endsWith("en_EN.json")) {
+    } else if (url && url.endsWith("en_EN.json")) {
         cb(undefined, {status: 200}, JSON.stringify(en));
     } else {
         cb(undefined, {status: 404}, "");

--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -12,6 +12,6 @@ module.exports = jest.fn((opts, cb) => {
     } else if (url && url.endsWith("en_EN.json")) {
         cb(undefined, {status: 200}, JSON.stringify(en));
     } else {
-        cb(undefined, {status: 404}, "");
+        cb(true, {status: 404}, "");
     }
 });

--- a/src/Tinter.js
+++ b/src/Tinter.js
@@ -143,10 +143,14 @@ class Tinter {
      * over time then the best bet is to register a single callback for the
      * entire set.
      *
+     * To ensure the tintable work happens at least once, it is also called as
+     * part of registration.
+     *
      * @param {Function} tintable Function to call when the tint changes.
      */
     registerTintable(tintable) {
         this.tintables.push(tintable);
+        tintable();
     }
 
     getKeyRgb() {


### PR DESCRIPTION
Build process changes may have changed the load order, so this tintable is now
registered too late (after the theme is set).

<img width="91" alt="2020-01-16 at 11 52" src="https://user-images.githubusercontent.com/279572/72523372-8b623200-3857-11ea-9c02-239a8c3353d9.png">

Fixes https://github.com/vector-im/riot-web/issues/11881