### PR TITLE
Fix not being able to open profiles from the timeline

### DIFF
--- a/src/components/views/avatars/MemberAvatar.js
+++ b/src/components/views/avatars/MemberAvatar.js
@@ -83,7 +83,7 @@ export default createReactClass({
 
         if (viewUserOnClick) {
             onClick = () => {
-                dispatcher.dispatch({
+                dis.dispatch({
                     action: 'view_user',
                     member: this.props.member,
                 });


### PR DESCRIPTION
MemberAvatar was referencing the wrong dispatcher (it was imported as `dis`, like everywhere else, not `dispatcher`).

Fixes https://github.com/vector-im/riot-web/issues/11887