### PR TITLE
Fix event handler leak in MemberStatusMessageAvatar

### DIFF
--- a/src/components/views/avatars/MemberStatusMessageAvatar.js
+++ b/src/components/views/avatars/MemberStatusMessageAvatar.js
@@ -63,7 +63,7 @@ export default class MemberStatusMessageAvatar extends React.Component {
         user.on("User._unstable_statusMessage", this._onStatusMessageCommitted);
     }
 
-    componentWillUmount() {
+    componentWillUnmount() {
         const { user } = this.props.member;
         if (!user) {
             return;


### PR DESCRIPTION
A typo led to an event handler leak with the custom status labs feature. A new
handler would leak each time you change rooms, which can add up over the course
of a long-lived session.