### PR TITLE
Populate the file panel using the event index if available.

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -588,8 +588,8 @@ async function startMatrixClient(startSyncing=true) {
     Mjolnir.sharedInstance().start();
 
     if (startSyncing) {
-        await MatrixClientPeg.start();
         await EventIndexPeg.init();
+        await MatrixClientPeg.start();
     } else {
         console.warn("Caller requested only auxiliary services be started");
         await MatrixClientPeg.assign();

--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -588,6 +588,9 @@ async function startMatrixClient(startSyncing=true) {
     Mjolnir.sharedInstance().start();
 
     if (startSyncing) {
+        // The client might want to populate some views with events from the
+        // index (e.g. the FilePanel), therefore initialize the event index
+        // before the client.
         await EventIndexPeg.init();
         await MatrixClientPeg.start();
     } else {

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -42,7 +42,7 @@ const FilePanel = createReactClass({
         };
     },
 
-    onRoomTimeline (ev, room, toStartOfTimeline, removed, data) {
+    onRoomTimeline(ev, room, toStartOfTimeline, removed, data) {
         if (room.roomId !== this.props.roomId) return;
         if (toStartOfTimeline || !data || !data.liveEvent || ev.isRedacted()) return;
 
@@ -53,7 +53,7 @@ const FilePanel = createReactClass({
         }
     },
 
-    onEventDecrypted (ev, err) {
+    onEventDecrypted(ev, err) {
         if (ev.getRoomId() !== this.props.roomId) return;
         const eventId = ev.getId();
 

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -98,7 +98,7 @@ const FilePanel = createReactClass({
 
                 if (client.isRoomEncrypted(roomId) && eventIndex !== null) {
                     const timeline = timelineSet.getLiveTimeline();
-                    await eventIndex.populateFileTimeline(timelineSet, timeline, room, 1);
+                    await eventIndex.populateFileTimeline(timelineSet, timeline, room, 10);
                 }
 
                 this.setState({ timelineSet: timelineSet });

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -19,7 +19,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-import Matrix from 'matrix-js-sdk';
+import {Filter} from 'matrix-js-sdk';
 import * as sdk from '../../index';
 import {MatrixClientPeg} from '../../MatrixClientPeg';
 import EventIndexPeg from "../../indexing/EventIndexPeg";
@@ -105,7 +105,7 @@ const FilePanel = createReactClass({
     async fetchFileEventsServer(room) {
         const client = MatrixClientPeg.get();
 
-        const filter = new Matrix.Filter(client.credentials.userId);
+        const filter = new Filter(client.credentials.userId);
         filter.setDefinition(
             {
                 "room": {

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -62,8 +62,6 @@ const FilePanel = createReactClass({
             },
         );
 
-        // FIXME: we shouldn't be doing this every time we change room - see comment above.
-        // TODO: Remove this stale comment? Which comment above?
         const filterId = await client.getOrCreateFilter("FILTER_FILES_" + client.credentials.userId,
                                                         filter);
         filter.filterId = filterId;

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -62,8 +62,7 @@ const FilePanel = createReactClass({
             },
         );
 
-        const filterId = await client.getOrCreateFilter("FILTER_FILES_" + client.credentials.userId,
-                                                        filter);
+        const filterId = await client.getOrCreateFilter("FILTER_FILES_" + client.credentials.userId, filter);
         filter.filterId = filterId;
         const timelineSet = room.getOrCreateFilteredTimelineSet(filter);
 

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -64,7 +64,8 @@ const FilePanel = createReactClass({
 
         // FIXME: we shouldn't be doing this every time we change room - see comment above.
         // TODO: Remove this stale comment? Which comment above?
-        const filterId = await client.getOrCreateFilter("FILTER_FILES_" + client.credentials.userId, filter)
+        const filterId = await client.getOrCreateFilter("FILTER_FILES_" + client.credentials.userId,
+                                                        filter);
         filter.filterId = filterId;
         const timelineSet = room.getOrCreateFilteredTimelineSet(filter);
 
@@ -96,7 +97,7 @@ const FilePanel = createReactClass({
             let timelineSet;
 
             try {
-                timelineSet = await this.fetchFileEventsServer(room)
+                timelineSet = await this.fetchFileEventsServer(room);
 
                 if (client.isRoomEncrypted(roomId) && eventIndex !== null) {
                     const timeline = timelineSet.getLiveTimeline();
@@ -104,7 +105,6 @@ const FilePanel = createReactClass({
                 }
 
                 this.setState({ timelineSet: timelineSet });
-
             } catch (error) {
                 console.error("Failed to get or create file panel filter", error);
             }

--- a/src/components/structures/FilePanel.js
+++ b/src/components/structures/FilePanel.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 import Matrix from 'matrix-js-sdk';
 import * as sdk from '../../index';
 import {MatrixClientPeg} from '../../MatrixClientPeg';
-import {EventIndexPeg} from "../../indexing/EventIndexPeg";
+import EventIndexPeg from "../../indexing/EventIndexPeg";
 import { _t } from '../../languageHandler';
 
 /*

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -94,6 +94,10 @@ const TimelinePanel = createReactClass({
         // callback which is called when the read-up-to mark is updated.
         onReadMarkerUpdated: PropTypes.func,
 
+        // callback which is called when we wish to paginate the timeline
+        // window.
+        onPaginationRequest: PropTypes.func,
+
         // maximum number of events to show in a timeline
         timelineCap: PropTypes.number,
 
@@ -338,6 +342,14 @@ const TimelinePanel = createReactClass({
         }
     },
 
+    onPaginationRequest(timelineWindow, direction, size) {
+        if (this.props.onPaginationRequest) {
+            return this.props.onPaginationRequest(timelineWindow, direction, size);
+        } else {
+            return timelineWindow.paginate(direction, size);
+        }
+    },
+
     // set off a pagination request.
     onMessageListFillRequest: function(backwards) {
         if (!this._shouldPaginate()) return Promise.resolve(false);
@@ -360,7 +372,7 @@ const TimelinePanel = createReactClass({
         debuglog("TimelinePanel: Initiating paginate; backwards:"+backwards);
         this.setState({[paginatingKey]: true});
 
-        return this._timelineWindow.paginate(dir, PAGINATE_SIZE).then((r) => {
+        return this.onPaginationRequest(this._timelineWindow, dir, PAGINATE_SIZE).then((r) => {
             if (this.unmounted) { return; }
 
             debuglog("TimelinePanel: paginate complete backwards:"+backwards+"; success:"+r);

--- a/src/indexing/BaseEventIndexManager.js
+++ b/src/indexing/BaseEventIndexManager.js
@@ -62,9 +62,16 @@ export interface SearchArgs {
     room_id: ?string;
 }
 
-export interface HistoricEvent {
+export interface EventAndProfile {
     event: MatrixEvent;
     profile: MatrixProfile;
+}
+
+export interface LoadArgs {
+    roomId: string;
+    limit: number;
+    fromEvent: string;
+    direction: string;
 }
 
 /**
@@ -145,7 +152,7 @@ export default class BaseEventIndexManager {
      *
      * This is used to add a batch of events to the index.
      *
-     * @param {[HistoricEvent]} events The list of events and profiles that
+     * @param {[EventAndProfile]} events The list of events and profiles that
      * should be added to the event index.
      * @param {[CrawlerCheckpoint]} checkpoint A new crawler checkpoint that
      * should be stored in the index which should be used to continue crawling
@@ -158,7 +165,7 @@ export default class BaseEventIndexManager {
      * were already added to the index, false otherwise.
      */
     async addHistoricEvents(
-        events: [HistoricEvent],
+        events: [EventAndProfile],
         checkpoint: CrawlerCheckpoint | null,
         oldCheckpoint: CrawlerCheckpoint | null,
     ): Promise<bool> {
@@ -198,6 +205,23 @@ export default class BaseEventIndexManager {
      * array of crawler checkpoints once they have been loaded from the index.
      */
     async loadCheckpoints(): Promise<[CrawlerCheckpoint]> {
+        throw new Error("Unimplemented");
+    }
+
+    /** Load events that contain an mxc URL to a file from the index.
+     *
+     * @param  {object} args Arguments object for the method.
+     * @param  {string} args.roomId The ID of the room for which the events
+     * should be loaded.
+     * @param  {number} args.limit The maximum number of events to return.
+     * @param  {string} args.fromEvent An event id of a previous event returned
+     * by this method. If set events that are older than the event with the
+     * given event ID will be returned.
+     *
+     * @return {Promise<[EventAndProfile]>} A promise that will resolve to an array
+     * of Matrix events that contain mxc URLs.
+     */
+    async loadFileEvents(args: LoadArgs): Promise<[EventAndProfile]> {
         throw new Error("Unimplemented");
     }
 

--- a/src/indexing/BaseEventIndexManager.js
+++ b/src/indexing/BaseEventIndexManager.js
@@ -215,11 +215,14 @@ export default class BaseEventIndexManager {
      * should be loaded.
      * @param  {number} args.limit The maximum number of events to return.
      * @param  {string} args.fromEvent An event id of a previous event returned
-     * by this method. If set events that are older than the event with the
-     * given event ID will be returned.
+     * by this method. Passing this means that we are going to continue loading
+     * events from this point in the history.
+     * @param  {string} args.direction The direction to which we should continue
+     * loading events from. This is used only if fromEvent is used as well.
      *
-     * @return {Promise<[EventAndProfile]>} A promise that will resolve to an array
-     * of Matrix events that contain mxc URLs.
+     * @return {Promise<[EventAndProfile]>} A promise that will resolve to an
+     * array of Matrix events that contain mxc URLs accompanied with the
+     * historic profile of the sender.
      */
     async loadFileEvents(args: LoadArgs): Promise<[EventAndProfile]> {
         throw new Error("Unimplemented");

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -476,6 +476,16 @@ export default class EventIndex {
                                fromEvent = null, direction = EventTimeline.BACKWARDS) {
         const matrixEvents = await this.loadFileEvents(room, limit, fromEvent, direction);
 
+        // If this is a normal fill request, not a pagination request, we need
+        // to get our events in the BACKWARDS direction but populate them in the
+        // forwards direction.
+        // This needs to happen because a fill request might come with an
+        // exisitng timeline e.g. if you close and re-open the FilePanel.
+        if (fromEvent === null) {
+            matrixEvents.reverse();
+            direction = direction == EventTimeline.BACKWARDS ? EventTimeline.FORWARDS: EventTimeline.BACKWARDS;
+        }
+
         // Add the events to the live timeline of the file panel.
         matrixEvents.forEach(e => {
             if (!timelineSet.eventIdToTimeline(e.getId())) {

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -172,7 +172,7 @@ export default class EventIndex {
         }
 
         const jsonEvent = ev.toJSON();
-        const e = ev.isEncrypted() ? jsonEvent.decrypted: jsonEvent;
+        const e = ev.isEncrypted() ? jsonEvent.decrypted : jsonEvent;
 
         const profile = {
             displayname: ev.sender.rawDisplayName,
@@ -308,7 +308,7 @@ export default class EventIndex {
             // consume.
             const events = filteredEvents.map((ev) => {
                 const jsonEvent = ev.toJSON();
-                const e = ev.isEncrypted() ? jsonEvent.decrypted: jsonEvent;
+                const e = ev.isEncrypted() ? jsonEvent.decrypted : jsonEvent;
 
                 let profile = {};
                 if (e.sender in profiles) profile = profiles[e.sender];

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -170,7 +170,12 @@ export default class EventIndex {
             return;
         }
 
-        const e = ev.toJSON().decrypted;
+        const jsonEvent = ev.toJSON();
+
+        let e;
+        if (ev.isEncrypted()) e = jsonEvent.decrypted;
+        else e = jsonEvent;
+
         const profile = {
             displayname: ev.sender.rawDisplayName,
             avatar_url: ev.sender.getMxcAvatarUrl(),

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -17,11 +17,9 @@ limitations under the License.
 import PlatformPeg from "../PlatformPeg";
 import {MatrixClientPeg} from "../MatrixClientPeg";
 
-import Matrix from 'matrix-js-sdk';
-import EventTimelineSet from 'matrix-js-sdk/lib/models/event-timeline-set';
-import EventTimeline from 'matrix-js-sdk/lib/models/event-timeline';
-import MatrixEvent from 'matrix-js-sdk/lib/models/event';
-import RoomMember from 'matrix-js-sdk/lib/models/room-member';
+import * as Matrix from 'matrix-js-sdk';
+import {EventTimelineSet} from 'matrix-js-sdk';
+import {EventTimeline} from 'matrix-js-sdk';
 
 /*
  * Event indexing class that wraps the platform specific event indexing.
@@ -448,7 +446,7 @@ export default class EventIndex {
         const matrixEvents = events.map(e => {
             const matrixEvent = eventMapper(e.event);
 
-            const member = new RoomMember(room.roomId, matrixEvent.getSender());
+            const member = new Matrix.RoomMember(room.roomId, matrixEvent.getSender());
 
             // We can't really reconstruct the whole room state from our
             // EventIndex to calculate the correct display name. Use the

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -479,15 +479,13 @@ export default class EventIndex {
         // Add the events to the live timeline of the file panel.
         matrixEvents.forEach(e => {
             if (!timelineSet.eventIdToTimeline(e.getId())) {
-                timelineSet.addEventToTimeline(e, timeline,
-                                               direction == EventTimeline.BACKWARDS);
+                timelineSet.addEventToTimeline(e, timeline, direction == EventTimeline.BACKWARDS);
             }
         });
 
         // Set the pagination token to the oldest event that we retrieved.
         if (matrixEvents.length > 0) {
-            timeline.setPaginationToken(matrixEvents[matrixEvents.length - 1].getId(),
-                                        EventTimeline.BACKWARDS);
+            timeline.setPaginationToken(matrixEvents[matrixEvents.length - 1].getId(), EventTimeline.BACKWARDS);
             return true;
         } else {
             timeline.setPaginationToken("", EventTimeline.BACKWARDS);
@@ -501,7 +499,7 @@ export default class EventIndex {
         // TODO this is from the js-sdk, this should probably be exposed to
         // us through the js-sdk.
         const moveWindowCap = (titmelineWindow, timeline, direction, limit) => {
-            const count = (direction == EventTimeline.BACKWARDS) ?
+            const count = (direction === EventTimeline.BACKWARDS) ?
             timeline.retreat(limit) : timeline.advance(limit);
 
             if (count) {
@@ -509,7 +507,7 @@ export default class EventIndex {
                 const excess = timelineWindow._eventCount - timelineWindow._windowLimit;
 
                 if (excess > 0) {
-                    timelineWindow.unpaginate(3, direction != EventTimeline.BACKWARDS);
+                    timelineWindow.unpaginate(3, direction !== EventTimeline.BACKWARDS);
                 }
                 return true;
             }
@@ -532,8 +530,7 @@ export default class EventIndex {
             const timelineSet = timelineWindow._timelineSet;
             const token = timeline.timeline.getPaginationToken(direction);
 
-            const ret = await this.populateFileTimeline(timelineSet, timeline.timeline,
-                                                        room, limit, token, direction);
+            const ret = await this.populateFileTimeline(timelineSet, timeline.timeline, room, limit, token, direction);
 
             moveWindowCap(timelineWindow, timeline, direction, limit);
             timeline.pendingPaginate = null;
@@ -541,8 +538,7 @@ export default class EventIndex {
             return ret;
         };
 
-        const paginationPromise = paginationMethod(timelineWindow, tl, room,
-                                                   direction, limit);
+        const paginationPromise = paginationMethod(timelineWindow, tl, room, direction, limit);
         tl.pendingPaginate = paginationPromise;
 
         return paginationPromise;

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -172,10 +172,7 @@ export default class EventIndex {
         }
 
         const jsonEvent = ev.toJSON();
-
-        let e;
-        if (ev.isEncrypted()) e = jsonEvent.decrypted;
-        else e = jsonEvent;
+        const e = ev.isEncrypted() ? jsonEvent.decrypted: jsonEvent;
 
         const profile = {
             displayname: ev.sender.rawDisplayName,
@@ -311,10 +308,7 @@ export default class EventIndex {
             // consume.
             const events = filteredEvents.map((ev) => {
                 const jsonEvent = ev.toJSON();
-
-                let e;
-                if (ev.isEncrypted()) e = jsonEvent.decrypted;
-                else e = jsonEvent;
+                const e = ev.isEncrypted() ? jsonEvent.decrypted: jsonEvent;
 
                 let profile = {};
                 if (e.sender in profiles) profile = profiles[e.sender];

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -16,9 +16,7 @@ limitations under the License.
 
 import PlatformPeg from "../PlatformPeg";
 import {MatrixClientPeg} from "../MatrixClientPeg";
-
-import * as Matrix from 'matrix-js-sdk';
-import {EventTimeline} from 'matrix-js-sdk';
+import {EventTimeline, RoomMember} from 'matrix-js-sdk';
 
 /*
  * Event indexing class that wraps the platform specific event indexing.
@@ -445,7 +443,7 @@ export default class EventIndex {
         const matrixEvents = events.map(e => {
             const matrixEvent = eventMapper(e.event);
 
-            const member = new Matrix.RoomMember(room.roomId, matrixEvent.getSender());
+            const member = new RoomMember(room.roomId, matrixEvent.getSender());
 
             // We can't really reconstruct the whole room state from our
             // EventIndex to calculate the correct display name. Use the

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -18,7 +18,6 @@ import PlatformPeg from "../PlatformPeg";
 import {MatrixClientPeg} from "../MatrixClientPeg";
 
 import * as Matrix from 'matrix-js-sdk';
-import {EventTimelineSet} from 'matrix-js-sdk';
 import {EventTimeline} from 'matrix-js-sdk';
 
 /*
@@ -420,27 +419,27 @@ export default class EventIndex {
         const client = MatrixClientPeg.get();
         const indexManager = PlatformPeg.get().getEventIndexingManager();
 
-        let loadArgs = {
+        const loadArgs = {
             roomId: room.roomId,
-            limit: limit
-        }
+            limit: limit,
+        };
 
         if (fromEvent) {
             loadArgs.fromEvent = fromEvent;
             loadArgs.direction = direction;
         }
 
-        let events
+        let events;
 
         // Get our events from the event index.
         try {
             events = await indexManager.loadFileEvents(loadArgs);
         } catch (e) {
             console.log("EventIndex: Error getting file events", e);
-            return []
+            return [];
         }
 
-        let eventMapper = client.getEventMapper();
+        const eventMapper = client.getEventMapper();
 
         // Turn the events into MatrixEvent objects.
         const matrixEvents = events.map(e => {
@@ -466,8 +465,8 @@ export default class EventIndex {
                     room_id: matrixEvent.getRoomId(),
                     sender: matrixEvent.getSender(),
                     origin_server_ts: matrixEvent.getTs(),
-                    state_key: matrixEvent.getSender()
-                }
+                    state_key: matrixEvent.getSender(),
+                },
             );
 
             // We set this manually to avoid emitting RoomMember.membership and
@@ -483,13 +482,13 @@ export default class EventIndex {
 
     async populateFileTimeline(timelineSet, timeline, room, limit = 10,
                                fromEvent = null, direction = EventTimeline.BACKWARDS) {
-        let matrixEvents = await this.loadFileEvents(room, limit, fromEvent, direction);
+        const matrixEvents = await this.loadFileEvents(room, limit, fromEvent, direction);
 
         // Add the events to the live timeline of the file panel.
         matrixEvents.forEach(e => {
             if (!timelineSet.eventIdToTimeline(e.getId())) {
                 timelineSet.addEventToTimeline(e, timeline,
-                                               direction == EventTimeline.BACKWARDS)
+                                               direction == EventTimeline.BACKWARDS);
             }
         });
 
@@ -510,12 +509,12 @@ export default class EventIndex {
         // TODO this is from the js-sdk, this should probably be exposed to
         // us through the js-sdk.
         const moveWindowCap = (titmelineWindow, timeline, direction, limit) => {
-            var count = (direction == EventTimeline.BACKWARDS) ?
+            const count = (direction == EventTimeline.BACKWARDS) ?
             timeline.retreat(limit) : timeline.advance(limit);
 
             if (count) {
                 timelineWindow._eventCount += count;
-                var excess = timelineWindow._eventCount - timelineWindow._windowLimit;
+                const excess = timelineWindow._eventCount - timelineWindow._windowLimit;
 
                 if (excess > 0) {
                     timelineWindow.unpaginate(3, direction != EventTimeline.BACKWARDS);
@@ -544,7 +543,7 @@ export default class EventIndex {
             const ret = await this.populateFileTimeline(timelineSet, timeline.timeline,
                                                         room, limit, token, direction);
 
-            moveWindowCap(timelineWindow, timeline, direction, limit)
+            moveWindowCap(timelineWindow, timeline, direction, limit);
             timeline.pendingPaginate = null;
 
             return ret;


### PR DESCRIPTION
As the title says, this pull request implements pulling events containing files out of the event index and populating the file panel with them.

This intends to fix https://github.com/vector-im/riot-web/issues/4959.

A demonstration of this can be found [here](https://streamable.com/tbvqh).

The remaining issue for now is that live events aren't added to the file panel while the panel is open. If the panel is reopened the newly arrived events are added to the top instead of the bottom.

I suspect we want to fix both of those at the same time while we add the ability for riot-web, which doesn't have event indexing, to show at least events in the live timeline in the file panel.

The main issue with that seems to be that [this](https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/components/structures/FilePanel.js#L57) filter isn't smart enough to understand decrypted events that contain URLs.