### PR TITLE
Disable key request dialogs with cross-signing

### DIFF
--- a/src/KeyRequestHandler.js
+++ b/src/KeyRequestHandler.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +18,8 @@ limitations under the License.
 import * as sdk from './index';
 import Modal from './Modal';
 
+// TODO: We can remove this once cross-signing is the only way.
+// https://github.com/vector-im/riot-web/issues/11908
 export default class KeyRequestHandler {
     constructor(matrixClient) {
         this._matrixClient = matrixClient;
@@ -30,6 +33,11 @@ export default class KeyRequestHandler {
     }
 
     handleKeyRequest(keyRequest) {
+        // Ignore own device key requests if cross-signing lab enabled
+        if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
+            return;
+        }
+
         const userId = keyRequest.userId;
         const deviceId = keyRequest.deviceId;
         const requestId = keyRequest.requestId;
@@ -60,6 +68,11 @@ export default class KeyRequestHandler {
     }
 
     handleKeyRequestCancellation(cancellation) {
+        // Ignore own device key requests if cross-signing lab enabled
+        if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
+            return;
+        }
+
         // see if we can find the request in the queue
         const userId = cancellation.userId;
         const deviceId = cancellation.deviceId;

--- a/src/KeyRequestHandler.js
+++ b/src/KeyRequestHandler.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import * as sdk from './index';
 import Modal from './Modal';
+import SettingsStore from './settings/SettingsStore';
 
 // TODO: We can remove this once cross-signing is the only way.
 // https://github.com/vector-im/riot-web/issues/11908

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1383,6 +1383,8 @@ export default createReactClass({
         cli.on("Session.logged_out", () => dft.stop());
         cli.on("Event.decrypted", (e, err) => dft.eventDecrypted(e, err));
 
+        // TODO: We can remove this once cross-signing is the only way.
+        // https://github.com/vector-im/riot-web/issues/11908
         const krh = new KeyRequestHandler(cli);
         cli.on("crypto.roomKeyRequest", (req) => {
             krh.handleKeyRequest(req);

--- a/src/components/views/dialogs/KeyShareDialog.js
+++ b/src/components/views/dialogs/KeyShareDialog.js
@@ -22,6 +22,9 @@ import * as sdk from '../../../index';
 
 import { _t, _td } from '../../../languageHandler';
 
+// TODO: We can remove this once cross-signing is the only way.
+// https://github.com/vector-im/riot-web/issues/11908
+
 /**
  * Dialog which asks the user whether they want to share their keys with
  * an unverified device.


### PR DESCRIPTION
Cross-signing verification is meant to replace the old key share between devices
flow. This disables it when the cross-signing lab is enabled.

Fixes https://github.com/vector-im/riot-web/issues/11904