### PR TITLE
Check for a matrixclient before trying to use it

### DIFF
--- a/src/integrations/IntegrationManagers.js
+++ b/src/integrations/IntegrationManagers.js
@@ -83,6 +83,7 @@ export class IntegrationManagers {
     }
 
     async _setupHomeserverManagers() {
+        if (!MatrixClientPeg.get()) return;
         try {
             console.log("Updating homeserver-configured integration managers...");
             const homeserverDomain = MatrixClientPeg.getHomeserverName();


### PR DESCRIPTION
Was being caught by the try block but still logging an error to the
console unnecessarily: we should not expect there to necessarily
be a matrix client since we run this from the constructor and
there's a shared instance which could be constructed at any point.