### PR TITLE
Adjust secret storage to work before sync

### DIFF
--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -107,7 +107,7 @@ export async function accessSecretStorage(func = async () => { }) {
     cachingAllowed = true;
 
     try {
-        if (!cli.hasSecretStorageKey()) {
+        if (!await cli.hasSecretStorageKey()) {
             // This dialog calls bootstrap itself after guiding the user through
             // passphrase creation.
             const { finished } = Modal.createTrackedDialogAsync('Create Secret Storage dialog', '',

--- a/src/components/views/settings/CrossSigningPanel.js
+++ b/src/components/views/settings/CrossSigningPanel.js
@@ -60,14 +60,14 @@ export default class CrossSigningPanel extends React.PureComponent {
         this.setState(this._getUpdatedStatus());
     };
 
-    _getUpdatedStatus() {
+    async _getUpdatedStatus() {
         // XXX: Add public accessors if we keep this around in production
         const cli = MatrixClientPeg.get();
         const crossSigning = cli._crypto._crossSigningInfo;
         const secretStorage = cli._crypto._secretStorage;
         const crossSigningPublicKeysOnDevice = crossSigning.getId();
-        const crossSigningPrivateKeysInStorage = crossSigning.isStoredInSecretStorage(secretStorage);
-        const secretStorageKeyInAccount = secretStorage.hasKey();
+        const crossSigningPrivateKeysInStorage = await crossSigning.isStoredInSecretStorage(secretStorage);
+        const secretStorageKeyInAccount = await secretStorage.hasKey();
 
         return {
             crossSigningPublicKeysOnDevice,


### PR DESCRIPTION
This adjusts to changed JS SDK APIs that allow secret storage to optionally ask
the server for any account data needed at login.

Fixes https://github.com/vector-im/riot-web/issues/11901
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1154