### PR TITLE
Fix error about MessagePanel not being available for read markers

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -1136,7 +1136,9 @@ const TimelinePanel = createReactClass({
         const messagePanel = this._messagePanel.current;
         if (messagePanel === undefined) return null;
 
-        const wrapperRect = ReactDOM.findDOMNode(messagePanel).getBoundingClientRect();
+        const messagePanelNode = ReactDOM.findDOMNode(messagePanel);
+        if (!messagePanelNode) return null; // sometimes this happens for fresh rooms/post-sync
+        const wrapperRect = messagePanelNode.getBoundingClientRect();
         const myUserId = MatrixClientPeg.get().credentials.userId;
 
         const isNodeInView = (node) => {


### PR DESCRIPTION
Stacktrace:
```
TimelinePanel.js?b9ae:1139 Uncaught (in promise) TypeError: Cannot read property 'getBoundingClientRect' of null
    at Object._getLastDisplayedEventIndex (TimelinePanel.js?b9ae:1139)
    at Object.updateReadMarker (TimelinePanel.js?b9ae:751)
    at Object._callee$ (TimelinePanel.js?b9ae:613)
    at tryCatch (runtime.js?4422:45)
    at Generator.invoke [as _invoke] (runtime.js?4422:271)
    at Generator.prototype.<computed> [as next] (runtime.js?4422:97)
    at asyncGeneratorStep (asyncToGenerator.js?56ef:3)
    at _next (asyncToGenerator.js?56ef:25)
```