### PR TITLE
Tidy Jest test stuff and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,7 @@
     "isomorphic-fetch": "^2.2.1",
     "linkifyjs": "^2.1.6",
     "lodash": "^4.17.14",
-    "lolex": "4.2",
     "matrix-js-sdk": "3.0.0",
-    "optimist": "^0.6.1",
     "pako": "^1.0.5",
     "png-chunks-extract": "^1.0.0",
     "prop-types": "^15.5.8",
@@ -138,6 +136,7 @@
     "file-loader": "^3.0.1",
     "flow-parser": "^0.57.3",
     "jest": "^24.9.0",
+    "lolex": "^5.1.2",
     "matrix-mock-request": "^1.2.3",
     "matrix-react-test-utils": "^0.2.2",
     "react-test-renderer": "^16.9.0",
@@ -157,7 +156,9 @@
     "testMatch": [
       "<rootDir>/test/**/*-test.js"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setupTests.js"
+    ],
     "moduleNameMapper": {
       "\\.(gif|png|svg|ttf|woff2)$": "<rootDir>/__mocks__/imageMock.js",
       "\\$webapp/i18n/languages.json": "<rootDir>/__mocks__/languages.json"

--- a/test/UserActivity-test.js
+++ b/test/UserActivity-test.js
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import lolex from 'lolex';
-import jest from 'jest-mock';
 import EventEmitter from 'events';
 import UserActivity from '../src/UserActivity';
 
@@ -36,8 +35,8 @@ describe('UserActivity', function() {
     let clock;
 
     beforeEach(function() {
-        fakeWindow = new FakeDomEventEmitter(),
-        fakeDocument = new FakeDomEventEmitter(),
+        fakeWindow = new FakeDomEventEmitter();
+        fakeDocument = new FakeDomEventEmitter();
         userActivity = new UserActivity(fakeWindow, fakeDocument);
         userActivity.start();
         clock = lolex.install();

--- a/test/components/views/messages/TextualBody-test.js
+++ b/test/components/views/messages/TextualBody-test.js
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React from "react";
-import expect from 'expect';
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 

--- a/test/components/views/rooms/MemberList-test.js
+++ b/test/components/views/rooms/MemberList-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
-import lolex from 'lolex';
 
 import * as TestUtils from '../../../test-utils';
 
@@ -27,7 +26,6 @@ describe('MemberList', () => {
     let parentDiv = null;
     let client = null;
     let root = null;
-    let clock = null;
     let memberListRoom;
     let memberList = null;
 
@@ -39,8 +37,6 @@ describe('MemberList', () => {
         TestUtils.stubClient();
         client = MatrixClientPeg.get();
         client.hasLazyLoadMembersEnabled = () => false;
-
-        clock = lolex.install();
 
         parentDiv = document.createElement('div');
         document.body.appendChild(parentDiv);
@@ -113,8 +109,6 @@ describe('MemberList', () => {
             parentDiv.remove();
             parentDiv = null;
         }
-
-        clock.uninstall();
 
         done();
     });

--- a/test/components/views/rooms/RoomSettings-test.js
+++ b/test/components/views/rooms/RoomSettings-test.js
@@ -1,7 +1,6 @@
 // TODO: Rewrite room settings tests for dialog support
 import React from 'react';
 import ReactDOM from 'react-dom';
-import jest from 'jest-mock';
 import * as testUtils from '../../../test-utils';
 import sdk from '../../../skinned-sdk';
 import {MatrixClientPeg} from '../../../../src/MatrixClientPeg';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,6 +1137,13 @@
     tslib "^1.10.0"
     webcrypto-core "^1.0.17"
 
+"@sinonjs/commons@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
+  integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==
+  dependencies:
+    type-detect "4.0.8"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -5610,10 +5617,12 @@ loglevel@^1.6.4:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz#0ee6300cc058db6b3551fa1c4bf73b83bb771312"
   integrity sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==
 
-lolex@4.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
-  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
+lolex@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 longest-streak@^2.0.1:
   version "2.0.3"
@@ -8579,6 +8588,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
stop using expect and jest-mock which must be transitive deps.
Get rid of useless usages of lolex, put the dep in the right place. Remove unused optimist dep.