### PR TITLE
Add prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "typings": "./lib/index.d.ts",
   "matrix_src_main": "./src/index.js",
   "scripts": {
+    "prepublish": "yarn build",
     "i18n": "matrix-gen-i18n",
     "prunei18n": "matrix-prune-i18n",
     "diff-i18n": "cp src/i18n/strings/en_EN.json src/i18n/strings/en_EN_orig.json && ./scripts/gen-i18n.js && node scripts/compare-file.js src/i18n/strings/en_EN_orig.json src/i18n/strings/en_EN.json",


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/3723 removed
the prepare script which was how the SDK got built before being
published. Add it back as a more modern prepublish script.