### PR TITLE
Remove temporary key backup button

### DIFF
--- a/src/components/views/settings/KeyBackupPanel.js
+++ b/src/components/views/settings/KeyBackupPanel.js
@@ -127,19 +127,7 @@ export default class KeyBackupPanel extends React.PureComponent {
         Modal.createTrackedDialogAsync('Key Backup', 'Key Backup',
             import('../../../async-components/views/dialogs/keybackup/CreateKeyBackupDialog'),
             {
-                secureSecretStorage: false,
-                onFinished: () => {
-                    this._loadBackupStatus();
-                },
-            }, null, /* priority = */ false, /* static = */ true,
-        );
-    }
-
-    _startNewBackupWithSecureSecretStorage = async () => {
-        Modal.createTrackedDialogAsync('Key Backup', 'Key Backup',
-            import('../../../async-components/views/dialogs/keybackup/CreateKeyBackupDialog'),
-            {
-                secureSecretStorage: true,
+                secureSecretStorage: SettingsStore.isFeatureEnabled("feature_cross_signing"),
                 onFinished: () => {
                     this._loadBackupStatus();
                 },
@@ -361,22 +349,6 @@ export default class KeyBackupPanel extends React.PureComponent {
                 {buttonRow}
             </div>;
         } else {
-            // This is a temporary button for testing the new path which stores
-            // the key backup key in SSSS. Initialising SSSS depends on
-            // cross-signing and is part of the same project, so we only show
-            // this mode when the cross-signing feature is enabled.
-            // TODO: Clean this up when removing the feature flag.
-            let secureSecretStorageKeyBackup;
-            if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
-                secureSecretStorageKeyBackup = (
-                    <div className="mx_KeyBackupPanel_buttonRow">
-                        <AccessibleButton kind="primary" onClick={this._startNewBackupWithSecureSecretStorage}>
-                            {_t("Start using Key Backup with Secure Secret Storage")}
-                        </AccessibleButton>
-                    </div>
-                );
-            }
-
             return <div>
                 <div>
                     <p>{_t(
@@ -391,7 +363,6 @@ export default class KeyBackupPanel extends React.PureComponent {
                         {_t("Start using Key Backup")}
                     </AccessibleButton>
                 </div>
-                {secureSecretStorageKeyBackup}
             </div>;
         }
     }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -588,7 +588,6 @@
     "Backup version: ": "Backup version: ",
     "Algorithm: ": "Algorithm: ",
     "Backup key stored: ": "Backup key stored: ",
-    "Start using Key Backup with Secure Secret Storage": "Start using Key Backup with Secure Secret Storage",
     "Your keys are <b>not being backed up from this device</b>.": "Your keys are <b>not being backed up from this device</b>.",
     "Back up your keys before signing out to avoid losing them.": "Back up your keys before signing out to avoid losing them.",
     "Start using Key Backup": "Start using Key Backup",


### PR DESCRIPTION
This removes the temporary extra key backup setup button in Settings used for
testing with and without cross-signing. With this change, there's only one
button and the path you take is determined by the labs flag.

Fixes https://github.com/vector-im/riot-web/issues/11890