### PR TITLE
Fix click-to-ping not inserting colon if composer non-empty

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.js
+++ b/src/components/views/rooms/SendMessageComposer.js
@@ -326,7 +326,8 @@ export default class SendMessageComposer extends React.Component {
             member.rawDisplayName : userId;
         const caret = this._editorRef.getCaret();
         const position = model.positionForOffset(caret.offset, caret.atNodeEnd);
-        const insertIndex = position.index + 1;
+        // index is -1 if there are no parts but we only care for if this would be the part in position 0
+        const insertIndex = position.index > 0 ? position.index : 0;
         const parts = partCreator.createMentionParts(insertIndex, displayName, userId);
         model.transform(() => {
             const addedLen = model.insert(parts, position);


### PR DESCRIPTION
index is -1 when there are no parts
otherwise 0 for the first part
both should cause a colon to be inserted, to match keyboard autocomplete behaviour where it is not possible for the -1 case.

Fixes https://github.com/vector-im/riot-web/issues/11563