### PR TITLE
Change user info verification checks to use cross-signing

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -75,7 +75,7 @@ export default class DeviceListener {
             if (device.deviceId == cli.deviceId) continue;
 
             const deviceTrust = await cli.checkDeviceTrust(cli.getUserId(), device.deviceId);
-            if (deviceTrust.isVerified() || this._dismissed.has(device.deviceId)) {
+            if (deviceTrust.isCrossSigningVerified() || this._dismissed.has(device.deviceId)) {
                 ToastStore.sharedInstance().dismissToast(toastKey(device));
             } else {
                 ToastStore.sharedInstance().addOrReplaceToast({


### PR DESCRIPTION
For users and your own devices, we want to use the stricter cross-signing check. For other people's devices, it's okay to continue with the looser check.

Fixes https://github.com/vector-im/riot-web/issues/11886