### PR TITLE
Move room header shields over the avatar for the room

### DIFF
--- a/res/css/views/rooms/_RoomHeader.scss
+++ b/res/css/views/rooms/_RoomHeader.scss
@@ -19,7 +19,10 @@ limitations under the License.
     border-bottom: 1px solid $primary-hairline-color;
 
     .mx_E2EIcon {
-        margin: 0 5px;
+        margin: 0;
+        position: absolute;
+        bottom: 0;
+        right: -5px;
     }
 }
 
@@ -171,6 +174,7 @@ limitations under the License.
     width: 28px;
     height: 28px;
     margin: 0 7px;
+    position: relative;
 }
 
 .mx_RoomHeader_avatar .mx_BaseAvatar_image {

--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -310,8 +310,7 @@ export default createReactClass({
         return (
             <div className="mx_RoomHeader light-panel">
                 <div className="mx_RoomHeader_wrapper">
-                    <div className="mx_RoomHeader_avatar">{ roomAvatar }</div>
-                    { e2eIcon }
+                    <div className="mx_RoomHeader_avatar">{ roomAvatar }{ e2eIcon }</div>
                     { privateIcon }
                     { name }
                     { topicElement }


### PR DESCRIPTION
Currently this is calibrated like the lil' DM icon is.

Fixes https://github.com/vector-im/riot-web/issues/11833

<img width="185" alt="Screenshot 2020-01-21 at 13 34 06" src="https://user-images.githubusercontent.com/3935731/72809067-ca76f580-3c52-11ea-9538-28a8fb6edb24.png">
