### PR TITLE
Only show devices and verify actions in E2EE rooms

### DIFF
--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -1308,15 +1308,18 @@ const UserInfo = ({user, groupId, roomId, onClose}) => {
         userTrust.isVerified();
     const isMe = user.userId === cli.getUserId();
     let verifyButton;
-    if (!userVerified && !isMe) {
+    if (isRoomEncrypted && !userVerified && !isMe) {
         verifyButton = <AccessibleButton className="mx_UserInfo_verify" onClick={() => verifyUser(user)}>
             {_t("Verify")}
         </AccessibleButton>;
     }
 
-    const devicesSection = <DevicesSection
-        loading={devices === undefined}
-        devices={devices} userId={user.userId} />;
+    let devicesSection;
+    if (isRoomEncrypted) {
+        devicesSection = <DevicesSection
+            loading={devices === undefined}
+            devices={devices} userId={user.userId} />;
+    }
 
     const securitySection = (
         <div className="mx_UserInfo_container">


### PR DESCRIPTION
This changes logic to only show the devices list and verify button in E2EE
rooms, matching the design.

**Reviewer:** This change is not guarded by a labs flag, as it doesn't seem cross-signing specific to me.

Fixes https://github.com/vector-im/riot-web/issues/11839