### PR TITLE
Fix toast icon to prevent clipping

### DIFF
--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -51,8 +51,8 @@ limitations under the License.
         &.mx_Toast_hasIcon {
             &::after {
                 content: "";
-                width: 21px;
-                height: 20px;
+                width: 22px;
+                height: 22px;
                 grid-column: 1;
                 grid-row: 1;
                 mask-size: 100%;


### PR DESCRIPTION
This fixes the bottom and right edges of the toast icon, which were getting
clipped away.

<img width="163" alt="2020-01-21 at 15 28" src="https://user-images.githubusercontent.com/279572/72818251-10d45080-3c63-11ea-8d20-89b99866aad7.png">

Fixes https://github.com/vector-im/riot-web/issues/11915