### PR TITLE
BuildKite: Retry end-to-end tests automatically once if they fail

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -77,6 +77,10 @@ steps:
           image: "matrixdotorg/riotweb-ci-e2etests-env:latest"
           propagate-environment: true
           workdir: "/workdir/matrix-react-sdk"
+    retry:
+      automatic:
+        - exit_status: 1 # retry end-to-end tests once as Puppeteer sometimes fails
+        - limit: 1
 
   - label: "🔧 Riot Tests"
     agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -80,7 +80,7 @@ steps:
     retry:
       automatic:
         - exit_status: 1 # retry end-to-end tests once as Puppeteer sometimes fails
-        - limit: 1
+          limit: 1
 
   - label: "🔧 Riot Tests"
     agents:


### PR DESCRIPTION
They fairly frequently flake, transparently rerolling the end to end test is one way around it