### PR TITLE
Remove .event property on verification request

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1453,7 +1453,6 @@ export default createReactClass({
 
         if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
             cli.on("crypto.verification.request", request => {
-                console.log(`MatrixChat got a .request ${request.channel.transactionId}`, request.event.getRoomId());
                 if (request.pending) {
                     ToastStore.sharedInstance().addOrReplaceToast({
                         key: 'verifreq_' + request.channel.transactionId,


### PR DESCRIPTION
This is likely the error Dave hit last week while trying to verify his own device (request.event being undefined, hence not being able to call getRoomId()), because there was
no .request event set yet for some other reasons that have
been fixed already (the event being put in the wrong map, theirs
instead of us) in the VerificationRequest object.

Matching js-sdk PR: https://github.com/matrix-org/matrix-js-sdk/pull/1166
Although https://github.com/vector-im/riot-web/issues/11980 is already fixed, this does some due diligence for it.