### PR TITLE
Enable encryption in DMs with device keys

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -961,9 +961,9 @@ export default createReactClass({
         const CreateRoomDialog = sdk.getComponent('dialogs.CreateRoomDialog');
         const modal = Modal.createTrackedDialog('Create Room', '', CreateRoomDialog);
 
-        const [shouldCreate, createOpts] = await modal.finished;
+        const [shouldCreate, opts] = await modal.finished;
         if (shouldCreate) {
-            createRoom({createOpts});
+            createRoom(opts);
         }
     },
 

--- a/src/components/views/dialogs/CreateRoomDialog.js
+++ b/src/components/views/dialogs/CreateRoomDialog.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Michael Telatynski <7t3chguy@gmail.com>
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -44,13 +45,13 @@ export default createReactClass({
     },
 
     _roomCreateOptions() {
-        const createOpts = {};
+        const opts = {};
+        const createOpts = opts.createOpts = {};
         createOpts.name = this.state.name;
         if (this.state.isPublic) {
             createOpts.visibility = "public";
             createOpts.preset = "public_chat";
-            // to prevent createRoom from enabling guest access
-            createOpts['initial_state'] = [];
+            opts.guestAccess = false;
             const {alias} = this.state;
             const localPart = alias.substr(1, alias.indexOf(":") - 1);
             createOpts['room_alias_name'] = localPart;
@@ -61,7 +62,7 @@ export default createReactClass({
         if (this.state.noFederate) {
             createOpts.creation_content = {'m.federate': false};
         }
-        return createOpts;
+        return opts;
     },
 
     componentDidMount() {

--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -1,6 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import {getAddressType} from "./UserAddress";
  * @param {object=} opts.createOpts set of options to pass to createRoom call.
  * @param {bool=} opts.spinner True to show a modal spinner while the room is created.
  *     Default: True
+ * @param {bool=} opts.guestAccess Whether to enable guest access.
+ *     Default: True
  *
  * @returns {Promise} which resolves to the room id, or null if the
  * action was aborted or failed.
@@ -39,6 +41,7 @@ import {getAddressType} from "./UserAddress";
 export default function createRoom(opts) {
     opts = opts || {};
     if (opts.spinner === undefined) opts.spinner = true;
+    if (opts.guestAccess === undefined) opts.guestAccess = true;
 
     const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
     const Loader = sdk.getComponent("elements.Spinner");
@@ -80,15 +83,16 @@ export default function createRoom(opts) {
     // Allow guests by default since the room is private and they'd
     // need an invite. This means clicking on a 3pid invite email can
     // actually drop you right in to a chat.
-    createOpts.initial_state = createOpts.initial_state || [
-        {
+    createOpts.initial_state = createOpts.initial_state || [];
+    if (opts.guestAccess) {
+        createOpts.initial_state.push({
             content: {
                 guest_access: 'can_join',
             },
             type: 'm.room.guest_access',
             state_key: '',
-        },
-    ];
+        });
+    }
 
     let modal;
     if (opts.spinner) modal = Modal.createDialog(Loader, null, 'mx_Dialog_spinner');

--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -34,6 +34,8 @@ import {getAddressType} from "./UserAddress";
  *     Default: True
  * @param {bool=} opts.guestAccess Whether to enable guest access.
  *     Default: True
+ * @param {bool=} opts.encryption Whether to enable encryption.
+ *     Default: False
  *
  * @returns {Promise} which resolves to the room id, or null if the
  * action was aborted or failed.
@@ -42,6 +44,7 @@ export default function createRoom(opts) {
     opts = opts || {};
     if (opts.spinner === undefined) opts.spinner = true;
     if (opts.guestAccess === undefined) opts.guestAccess = true;
+    if (opts.encryption === undefined) opts.encryption = false;
 
     const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
     const Loader = sdk.getComponent("elements.Spinner");
@@ -80,17 +83,28 @@ export default function createRoom(opts) {
         opts.andView = true;
     }
 
+    createOpts.initial_state = createOpts.initial_state || [];
+
     // Allow guests by default since the room is private and they'd
     // need an invite. This means clicking on a 3pid invite email can
     // actually drop you right in to a chat.
-    createOpts.initial_state = createOpts.initial_state || [];
     if (opts.guestAccess) {
         createOpts.initial_state.push({
+            type: 'm.room.guest_access',
+            state_key: '',
             content: {
                 guest_access: 'can_join',
             },
-            type: 'm.room.guest_access',
+        });
+    }
+
+    if (opts.encryption) {
+        createOpts.initial_state.push({
+            type: 'm.room.encryption',
             state_key: '',
+            content: {
+                algorithm: 'm.megolm.v1.aes-sha2',
+            },
         });
     }
 


### PR DESCRIPTION
When the cross-signing lab is enabled, this changes DMs to use encryption as
long as all invited users have uploaded device keys (which we're using as a
proxy for "has some client that understands E2E").

Fixes https://github.com/vector-im/riot-web/issues/12005
