### PR TITLE
Use https for recaptcha for all non-http protocols

### DIFF
--- a/src/components/views/auth/CaptchaForm.js
+++ b/src/components/views/auth/CaptchaForm.js
@@ -62,7 +62,7 @@ export default createReactClass({
             console.log("Loading recaptcha script...");
             window.mx_on_recaptcha_loaded = () => {this._onCaptchaLoaded();};
             let protocol = global.location.protocol;
-            if (protocol === "vector:") {
+            if (protocol !== "http:") {
                 protocol = "https:";
             }
             const scriptTag = document.createElement('script');


### PR DESCRIPTION
This prevents recaptcha from failing in WebExtensions contexts. Needed to make [riot-webext](https://github.com/stoically/riot-webext) work.