### PR TITLE
fix compound emoji

### DIFF
--- a/src/emoji.js
+++ b/src/emoji.js
@@ -79,13 +79,13 @@ EMOJIBASE.forEach(emoji => {
 });
 
 /**
- * Strips variation selectors from a string
- * NB. Skin tone modifers are not variation selectors:
+ * Strips variation selectors from the end of given string
+ * NB. Skin tone modifiers are not variation selectors:
  * this function does not touch them. (Should it?)
  *
  * @param {string} str string to strip
  * @returns {string} stripped string
  */
 function stripVariation(str) {
-    return str.replace(/[\uFE00-\uFE0F]/, "");
+    return str.replace(/[\uFE00-\uFE0F]$/, "");
 }


### PR DESCRIPTION
It was stripping the glue from compound emoji which made them compound emoji, changes the regex to only strip from the end and not ever from between emojis.

Fixes https://github.com/vector-im/riot-web/issues/11550
Fixes https://github.com/vector-im/riot-web/issues/11446