### PR TITLE
Add separate component for post-auth security flows

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -36,6 +36,7 @@
 @import "./views/auth/_AuthHeader.scss";
 @import "./views/auth/_AuthHeaderLogo.scss";
 @import "./views/auth/_AuthPage.scss";
+@import "./views/auth/_CompleteSecurityBody.scss";
 @import "./views/auth/_CountryDropdown.scss";
 @import "./views/auth/_InteractiveAuthEntryComponents.scss";
 @import "./views/auth/_LanguageSelector.scss";
@@ -148,10 +149,10 @@
 @import "./views/rooms/_AuxPanel.scss";
 @import "./views/rooms/_BasicMessageComposer.scss";
 @import "./views/rooms/_E2EIcon.scss";
-@import "./views/rooms/_InviteOnlyIcon.scss";
 @import "./views/rooms/_EditMessageComposer.scss";
 @import "./views/rooms/_EntityTile.scss";
 @import "./views/rooms/_EventTile.scss";
+@import "./views/rooms/_InviteOnlyIcon.scss";
 @import "./views/rooms/_JumpToBottomButton.scss";
 @import "./views/rooms/_LinkPreviewWidget.scss";
 @import "./views/rooms/_MemberDeviceInfo.scss";

--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +16,9 @@ limitations under the License.
 */
 
 .mx_AuthBody {
+    width: 500px;
+    font-size: 12px;
+    color: $authpage-secondary-color;
     background-color: $authpage-body-bg-color;
     border-radius: 0 4px 4px 0;
     padding: 25px 60px;
@@ -90,16 +94,6 @@ limitations under the License.
             background-color: $authpage-focus-bg-color;
         }
     }
-}
-
-.mx_AuthBody_noHeader {
-    border-radius: 4px;
-}
-
-.mx_AuthBody_loginRegister {
-    width: 500px;
-    font-size: 12px;
-    color: $authpage-secondary-color;
 }
 
 .mx_AuthBody_editServerDetails {

--- a/res/css/views/auth/_CompleteSecurityBody.scss
+++ b/res/css/views/auth/_CompleteSecurityBody.scss
@@ -1,4 +1,5 @@
 /*
+Copyright 2019 New Vector Ltd
 Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,38 +15,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_CompleteSecurity_header {
-    display: flex;
-    align-items: center;
-}
+.mx_CompleteSecurityBody {
+    width: 600px;
+    color: $authpage-primary-color;
+    background-color: $authpage-body-bg-color;
+    border-radius: 4px;
+    padding: 20px;
+    box-sizing: border-box;
 
-.mx_CompleteSecurity_headerIcon {
-    width: 24px;
-    height: 24px;
-    margin-right: 4px;
-    position: relative;
-}
+    h2 {
+        font-size: 24px;
+        font-weight: 600;
+        margin-top: 0;
+    }
 
-.mx_CompleteSecurity_heroIcon {
-    width: 128px;
-    height: 128px;
-    position: relative;
-    margin: 0 auto;
-}
+    h3 {
+        font-size: 14px;
+        font-weight: 600;
+    }
 
-.mx_CompleteSecurity_body {
-    font-size: 15px;
-}
-
-.mx_CompleteSecurity_actionRow {
-    display: flex;
-    justify-content: flex-end;
-
-    .mx_AccessibleButton {
-        margin-inline-start: 18px;
-
-        &.warning {
-            color: $warning-color;
-        }
+    a:link,
+    a:hover,
+    a:visited {
+        @mixin mx_Dialog_link;
     }
 }

--- a/src/components/structures/auth/CompleteSecurity.js
+++ b/src/components/structures/auth/CompleteSecurity.js
@@ -112,7 +112,7 @@ export default class CompleteSecurity extends React.Component {
 
     render() {
         const AuthPage = sdk.getComponent("auth.AuthPage");
-        const AuthBody = sdk.getComponent("auth.AuthBody");
+        const CompleteSecurityBody = sdk.getComponent("auth.CompleteSecurityBody");
         const AccessibleButton = sdk.getComponent("elements.AccessibleButton");
 
         const {
@@ -204,7 +204,7 @@ export default class CompleteSecurity extends React.Component {
 
         return (
             <AuthPage>
-                <AuthBody header={false}>
+                <CompleteSecurityBody>
                     <h2 className="mx_CompleteSecurity_header">
                         {icon}
                         {title}
@@ -212,7 +212,7 @@ export default class CompleteSecurity extends React.Component {
                     <div className="mx_CompleteSecurity_body">
                         {body}
                     </div>
-                </AuthBody>
+                </CompleteSecurityBody>
             </AuthPage>
         );
     }

--- a/src/components/structures/auth/E2eSetup.js
+++ b/src/components/structures/auth/E2eSetup.js
@@ -34,16 +34,16 @@ export default class E2eSetup extends React.Component {
 
     render() {
         const AuthPage = sdk.getComponent("auth.AuthPage");
-        const AuthBody = sdk.getComponent("auth.AuthBody");
+        const CompleteSecurityBody = sdk.getComponent("auth.CompleteSecurityBody");
         return (
             <AuthPage>
-                <AuthBody header={false}>
+                <CompleteSecurityBody>
                     <AsyncWrapper prom={this._createStorageDialogPromise}
                         hasCancel={false}
                         onFinished={this.props.onFinished}
                         accountPassword={this.props.accountPassword}
                     />
-                </AuthBody>
+                </CompleteSecurityBody>
             </AuthPage>
         );
     }

--- a/src/components/views/auth/AuthBody.js
+++ b/src/components/views/auth/AuthBody.js
@@ -17,29 +17,10 @@ limitations under the License.
 'use strict';
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 export default class AuthBody extends React.PureComponent {
-    static PropTypes = {
-        header: PropTypes.bool,
-    };
-
-    static defaultProps = {
-        header: true,
-    };
-
     render() {
-        const classes = {
-            'mx_AuthBody': true,
-            'mx_AuthBody_noHeader': !this.props.header,
-            // XXX The login pages all use a smaller fonts size but we don't want this
-            // for subsequent auth screens like the e2e setup. Doing this a terrible way
-            // for now.
-            'mx_AuthBody_loginRegister': this.props.header,
-        };
-
-        return <div className={classnames(classes)}>
+        return <div className="mx_AuthBody">
             { this.props.children }
         </div>;
     }

--- a/src/components/views/auth/CompleteSecurityBody.js
+++ b/src/components/views/auth/CompleteSecurityBody.js
@@ -14,38 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_CompleteSecurity_header {
-    display: flex;
-    align-items: center;
-}
+'use strict';
 
-.mx_CompleteSecurity_headerIcon {
-    width: 24px;
-    height: 24px;
-    margin-right: 4px;
-    position: relative;
-}
+import React from 'react';
 
-.mx_CompleteSecurity_heroIcon {
-    width: 128px;
-    height: 128px;
-    position: relative;
-    margin: 0 auto;
-}
-
-.mx_CompleteSecurity_body {
-    font-size: 15px;
-}
-
-.mx_CompleteSecurity_actionRow {
-    display: flex;
-    justify-content: flex-end;
-
-    .mx_AccessibleButton {
-        margin-inline-start: 18px;
-
-        &.warning {
-            color: $warning-color;
-        }
+export default class CompleteSecurityBody extends React.PureComponent {
+    render() {
+        return <div className="mx_CompleteSecurityBody">
+            { this.props.children }
+        </div>;
     }
 }


### PR DESCRIPTION
Instead of twisting `AuthBody`, this adds a new component for the different
styling of post-auth security flows. This also makes them fixed width and
adjusts padding to match designs.

<img width="643" alt="2020-01-27 at 22 27" src="https://user-images.githubusercontent.com/279572/73219654-8bfea080-4154-11ea-8fc1-a214476caf63.png">

<img width="632" alt="2020-01-27 at 22 30" src="https://user-images.githubusercontent.com/279572/73219672-97ea6280-4154-11ea-8f32-f0612cacaa92.png">