### PR TITLE
DialogButtons: Don't use tabs for indentation.

### DIFF
--- a/src/components/views/elements/DialogButtons.js
+++ b/src/components/views/elements/DialogButtons.js
@@ -83,7 +83,7 @@ export default createReactClass({
                 // primary in the DOM so will get form submissions unless we make it not a submit.
                 type="button"
                 onClick={this._onCancelClick}
-		className={this.props.cancelButtonClass}
+                className={this.props.cancelButtonClass}
                 disabled={this.props.disabled}
             >
                 { this.props.cancelButton || _t("Cancel") }


### PR DESCRIPTION
A small mishap while merging the EventIndex UI. The mergetool editor used tabs for indentation instead of spaces. 