### PR TITLE
Temporarily remove decorator

### DIFF
--- a/src/components/views/elements/crypto/VerificationQRCode.js
+++ b/src/components/views/elements/crypto/VerificationQRCode.js
@@ -20,7 +20,7 @@ import {replaceableComponent} from "../../../../utils/replaceableComponent";
 import * as qs from "qs";
 import QRCode from "qrcode-react";
 
-@replaceableComponent("views.elements.crypto.VerificationQRCode")
+//@replaceableComponent("views.elements.crypto.VerificationQRCode")
 export default class VerificationQRCode extends React.PureComponent {
     static propTypes = {
         // Common for all kinds of QR codes

--- a/src/components/views/elements/crypto/VerificationQRCode.js
+++ b/src/components/views/elements/crypto/VerificationQRCode.js
@@ -16,7 +16,6 @@ limitations under the License.
 
 import React from "react";
 import PropTypes from "prop-types";
-import {replaceableComponent} from "../../../../utils/replaceableComponent";
 import * as qs from "qs";
 import QRCode from "qrcode-react";
 


### PR DESCRIPTION
As, for reasons not yet fully understood, it causes riot to crash
on load if babel's targets are set to exclude IE11.