### PR TITLE
Tweak styling of the unread indicator circle.

### DIFF
--- a/res/css/views/rooms/_TopUnreadMessagesBar.scss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.scss
@@ -25,19 +25,16 @@ limitations under the License.
 }
 
 .mx_TopUnreadMessagesBar::after {
-    content: "·";
+    content: "";
     position: absolute;
     top: -8px;
     left: 11px;
-    width: 16px;
-    height: 16px;
+    width: 4px;
+    height: 4px;
     border-radius: 16px;
-    font-weight: 600;
-    font-size: 30px;
-    line-height: 14px;
-    text-align: center;
-    color: $secondary-accent-color;
-    background-color: $accent-color;
+    overflow: hidden;
+    background-color: $secondary-accent-color;
+    border: 6px solid $accent-color;
 }
 
 .mx_TopUnreadMessagesBar_scrollUp {


### PR DESCRIPTION
Before:
<img width="77" alt="Screen Shot 2020-01-28 at 2 44 49 PM" src="https://user-images.githubusercontent.com/961291/73271322-aaaa7900-41e0-11ea-9e13-ff23fa4b9d85.png">
After: 
<img width="61" alt="Screen Shot 2020-01-28 at 2 52 02 PM" src="https://user-images.githubusercontent.com/961291/73271337-ae3e0000-41e0-11ea-83ea-80abf938349b.png">

The arrow button in channels with unread messages has a small circle thingy at the top. This circle thingy had two problems:
 1. It reduced the hit target of the arrow button by a lot more than you'd expect. (Set `outline:1px dotted blue;` on the `::after` element in Firefox to see just how much.)
 2. It looked unbalanced because the white dot wasn't always centered.

This commit fixes both - it makes the hit target the size you'd expect, and uses a rounded border rather than a background + text glyph.

---

@jryans: Fixes https://github.com/vector-im/riot-web/issues/8019