### PR TITLE
Switch back to legacy decorators

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
         "@babel/preset-react"
     ],
     "plugins": [
-        ["@babel/plugin-proposal-decorators", {decoratorsBeforeExport: true}],
+        ["@babel/plugin-proposal-decorators", {legacy: true}],
         "@babel/plugin-proposal-export-default-from",
         "@babel/plugin-proposal-numeric-separator",
         "@babel/plugin-proposal-class-properties",

--- a/src/utils/replaceableComponent.ts
+++ b/src/utils/replaceableComponent.ts
@@ -32,13 +32,9 @@ import * as sdk from '../index';
  * with a skinned version. If no skinned version is available, this component
  * will be used.
  */
-export function replaceableComponent<T extends{new(...args: any[])}>(name: string) {
+export function replaceableComponent(name: string, origComponent: React.Component) {
     // Decorators return a function to override the class (origComponent). This
     // ultimately assumes that `getComponent()` won't throw an error and instead
     // return a falsey value like `null` when the skin doesn't have a component.
-    return (origComponent) => {
-        const c = sdk.getComponent(name) || origComponent;
-        c.kind = "class"; // appeases babel
-        return c;
-    };
+    return () => sdk.getComponent(name) || origComponent;
 }


### PR DESCRIPTION
Empirically the build is fine with these, but it is unfortunate that we have to reply on deprecated semantics. TypeScript should help fix this.

**Review with https://github.com/vector-im/riot-web/pull/12110**