### PR TITLE
Verification: don't block UI update on verification finishing

### DIFF
--- a/src/components/views/messages/ViewSourceEvent.js
+++ b/src/components/views/messages/ViewSourceEvent.js
@@ -32,6 +32,13 @@ export default class ViewSourceEvent extends React.PureComponent {
         };
     }
 
+    componentDidMount() {
+        const {mxEvent} = this.props;
+        if (mxEvent.isBeingDecrypted()) {
+            mxEvent.once("Event.decrypted", () => this.forceUpdate());
+        }
+    }
+
     onToggle = (ev) => {
         ev.preventDefault();
         const { expanded } = this.state;

--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -217,7 +217,6 @@ export default class VerificationPanel extends React.PureComponent {
     };
 
     _onRequestChange = async () => {
-        this.forceUpdate();
         const {request} = this.props;
         const hadVerifier = this._hasVerifier;
         this._hasVerifier = !!request.verifier;

--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -217,9 +217,12 @@ export default class VerificationPanel extends React.PureComponent {
     };
 
     _onRequestChange = async () => {
+        this.forceUpdate();
         const {request} = this.props;
-        if (!this._hasVerifier && !!request.verifier) {
-            request.verifier.on('show_sas', this._onVerifierShowSas);
+        const hadVerifier = this._hasVerifier;
+        this._hasVerifier = !!request.verifier;
+        if (!hadVerifier && this._hasVerifier) {
+            request.verifier.once('show_sas', this._onVerifierShowSas);
             try {
                 // on the requester side, this is also awaited in _startSAS,
                 // but that's ok as verify should return the same promise.
@@ -227,10 +230,7 @@ export default class VerificationPanel extends React.PureComponent {
             } catch (err) {
                 console.error("error verify", err);
             }
-        } else if (this._hasVerifier && !request.verifier) {
-            request.verifier.removeListener('show_sas', this._onVerifierShowSas);
         }
-        this._hasVerifier = !!request.verifier;
     };
 
     componentDidMount() {

--- a/src/components/views/toasts/VerificationRequestToast.js
+++ b/src/components/views/toasts/VerificationRequestToast.js
@@ -56,7 +56,10 @@ export default class VerificationRequestToast extends React.PureComponent {
 
     _checkRequestIsPending = () => {
         const {request} = this.props;
-        if (request.ready || request.started || request.done || request.cancelled || request.observeOnly) {
+        const isPendingInRoomRequest = request.channel.roomId &&
+            !(request.ready || request.started || request.done || request.cancelled || request.observeOnly);
+        const isPendingDeviceRequest = request.channel.deviceId && request.started;
+        if (!isPendingInRoomRequest && !isPendingDeviceRequest) {
             ToastStore.sharedInstance().dismissToast(this.props.toastKey);
         }
     };


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11991
JS-SDK PR: https://github.com/matrix-org/matrix-js-sdk/pull/1187

Most of the fix is in the js-sdk PR, but we were only updating the `VerificationPanel` after verification finished. That doesn't work obviously.

Also to_device toasts were being dismissed when showing them.