### PR TITLE
Don't peek until the matrix client is ready

### DIFF
--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -46,6 +46,7 @@ const INITIAL_STATE = {
     forwardingEvent: null,
 
     quotingEvent: null,
+    matrixClientIsReady: false,
 };
 
 /**
@@ -59,6 +60,9 @@ class RoomViewStore extends Store {
 
         // Initialise state
         this._state = INITIAL_STATE;
+        if (MatrixClientPeg.get()) {
+            this._state.matrixClientIsReady = MatrixClientPeg.get().isInitialSyncComplete();
+        }
     }
 
     _setState(newState) {
@@ -136,6 +140,11 @@ class RoomViewStore extends Store {
                 }, /*className=*/null, /*isPriority=*/false, /*isStatic=*/true);
                 break;
             }
+            case 'sync_state':
+                this._setState({
+                    matrixClientIsReady: MatrixClientPeg.get().isInitialSyncComplete(),
+                });
+                break;
         }
     }
 
@@ -350,7 +359,7 @@ class RoomViewStore extends Store {
     }
 
     shouldPeek() {
-        return this._state.shouldPeek;
+        return this._state.shouldPeek && this._state.matrixClientIsReady;
     }
 }
 


### PR DESCRIPTION
When the client loaded, we'd load the room view which would try to
get a room object from the client, fail because the client wasn't
ready, think it's because the user wasn't joined to the room and
start peeking instead.

Coupled with the bug fixed by https://github.com/matrix-org/matrix-js-sdk/pull/1188
this would have caused https://github.com/vector-im/riot-web/issues/11120