### PR TITLE
Fix a fixed-width render issue in the sign-in verification flow

### DIFF
--- a/res/css/views/auth/_CompleteSecurityBody.scss
+++ b/res/css/views/auth/_CompleteSecurityBody.scss
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 .mx_CompleteSecurityBody {
-    width: 600px;
     color: $authpage-primary-color;
     background-color: $authpage-body-bg-color;
     border-radius: 4px;


### PR DESCRIPTION
Fixes: https://github.com/vector-im/riot-web/issues/12106

Specifically the issue was that the outer container `CompleteSecurityBody` was set to a fixed width of 600px, but also contained an instance of `BaseDialog`, which also uses this class:

```
.mx_Dialog_fixedWidth {
    width: 60vw;
    max-width: 704px;
}
```