### PR TITLE
Fix verifying individual devices

### DIFF
--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -51,7 +51,7 @@ export default class VerificationPanel extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {};
-        this._hasVerifier = !!props.request.verifier;
+        this._hasVerifier = false;
     }
 
     renderQRPhase(pending) {
@@ -234,6 +234,7 @@ export default class VerificationPanel extends React.PureComponent {
 
     componentDidMount() {
         this.props.request.on("change", this._onRequestChange);
+        this._onRequestChange();
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
evaluate on mount whether we need to call .verify()
as the request might be in phase started already.