### PR TITLE
Apply the Olympic effect to SAS Emoji Verification

### DIFF
--- a/res/css/views/right_panel/_UserInfo.scss
+++ b/res/css/views/right_panel/_UserInfo.scss
@@ -211,7 +211,7 @@ limitations under the License.
         padding-bottom: 16px;
     }
 
-    .mx_UserInfo_scrollContainer:not(.mx_UserInfo_separator) {
+    .mx_UserInfo_container:not(.mx_UserInfo_separator) {
         padding-top: 16px;
         padding-bottom: 0;
 

--- a/res/css/views/verification/_VerificationShowSas.scss
+++ b/res/css/views/verification/_VerificationShowSas.scss
@@ -28,21 +28,42 @@ limitations under the License.
 
 .mx_VerificationShowSas_emojiSas {
     text-align: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 25px 0;
 }
 
 .mx_VerificationShowSas_emojiSas_block {
     display: inline-block;
-    margin-left: 15px;
-    margin-right: 15px;
     text-align: center;
-    margin-bottom: 20px;
+    margin-bottom: 30px;
+    position: relative;
+    // allow the blocks to grow to space themselves evenly up to a limit of 100px
+    flex-grow: 1;
+    max-width: 100px;
 }
 
 .mx_VerificationShowSas_emojiSas_emoji {
     font-size: 48px;
 }
 
+.mx_UserInfo .mx_VerificationShowSas_emojiSas_emoji {
+    font-size: 32px; // in UserInfo use a smaller font-size to fit in a smaller space
+    width: 43px;
+    margin: 0 auto;
+}
+
 .mx_VerificationShowSas_emojiSas_label {
     text-align: center;
     font-weight: bold;
+    // allow the text to overflow the parent by 15px on each side
+    // this is to keep the width of the parent consistent for spacing centrally via flexbox
+    position: absolute;
+    left: -15px;
+    right: -15px;
+}
+
+.mx_VerificationShowSas_emojiSas_break {
+    flex-basis: 100%;
 }

--- a/res/css/views/verification/_VerificationShowSas.scss
+++ b/res/css/views/verification/_VerificationShowSas.scss
@@ -36,7 +36,6 @@ limitations under the License.
 
 .mx_VerificationShowSas_emojiSas_block {
     display: inline-block;
-    text-align: center;
     margin-bottom: 30px;
     position: relative;
     // allow the blocks to grow to space themselves evenly up to a limit of 100px
@@ -50,12 +49,9 @@ limitations under the License.
 
 .mx_UserInfo .mx_VerificationShowSas_emojiSas_emoji {
     font-size: 32px; // in UserInfo use a smaller font-size to fit in a smaller space
-    width: 43px;
-    margin: 0 auto;
 }
 
 .mx_VerificationShowSas_emojiSas_label {
-    text-align: center;
     font-weight: bold;
     // allow the text to overflow the parent by 15px on each side
     // this is to keep the width of the parent consistent for spacing centrally via flexbox

--- a/src/components/views/verification/VerificationShowSas.js
+++ b/src/components/views/verification/VerificationShowSas.js
@@ -62,7 +62,9 @@ export default class VerificationShowSas extends React.Component {
                 </div>,
             );
             sasDisplay = <div className="mx_VerificationShowSas_emojiSas">
-                {emojiBlocks}
+                {emojiBlocks.slice(0, 4)}
+                <div className="mx_VerificationShowSas_emojiSas_break" />
+                {emojiBlocks.slice(4)}
             </div>;
             sasCaption = _t(
                 "Verify this user by confirming the following emoji appear on their screen.",
@@ -105,8 +107,8 @@ export default class VerificationShowSas extends React.Component {
 
         return <div className="mx_VerificationShowSas">
             <p>{sasCaption}</p>
-            <p>{_t("To be secure, do this in person or use a trusted way to communicate.")}</p>
             {sasDisplay}
+            <p>{_t("To be secure, do this in person or use a trusted way to communicate.")}</p>
             {confirm}
         </div>;
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12133

![image](https://user-images.githubusercontent.com/2403652/73405033-dc0f6b80-42ea-11ea-9a21-997e73faa54d.png)
![image](https://user-images.githubusercontent.com/2403652/73405042-e0d41f80-42ea-11ea-9fc3-8070e6660e9e.png)
![image](https://user-images.githubusercontent.com/2403652/73404321-360f3180-42e9-11ea-8e05-851be59cf47f.png)

This was a *HUGE* pain, if someone spots a simplification I might cry

re-arranges order of the card to match the Figma also (puts the Emoji between the two paragraphs of text)
Fixes broken left margins of UserInfo
