### PR TITLE
Add some media queries to improve UI on mobile

### DIFF
--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 .mx_AuthBody {
-    width: 500px;
+    max-width: 500px;
     font-size: 12px;
     color: $authpage-secondary-color;
     background-color: $authpage-body-bg-color;
@@ -151,4 +151,10 @@ limitations under the License.
     &::-webkit-progress-value {
         background-color: $accent-color;
     }
+}
+
+@media only screen and (max-width : 480px) {
+  .mx_AuthBody {
+      padding: 10px;
+  }
 }

--- a/res/css/views/auth/_AuthHeader.scss
+++ b/res/css/views/auth/_AuthHeader.scss
@@ -21,3 +21,9 @@ limitations under the License.
     padding: 25px 40px;
     box-sizing: border-box;
 }
+
+@media only screen and (max-width : 480px) {
+  .mx_AuthHeader {
+    display: none;
+  }
+}

--- a/res/css/views/auth/_AuthHeaderLogo.scss
+++ b/res/css/views/auth/_AuthHeaderLogo.scss
@@ -23,3 +23,9 @@ limitations under the License.
 .mx_AuthHeaderLogo img {
     width: 100%;
 }
+
+@media only screen and (max-width : 480px) {
+  .mx_AuthHeaderLogo {
+    display: none;
+  }
+}

--- a/res/css/views/auth/_AuthPage.scss
+++ b/res/css/views/auth/_AuthPage.scss
@@ -29,3 +29,9 @@ limitations under the License.
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.33);
     background-color: $authpage-modal-bg-color;
 }
+
+@media only screen and (max-width : 480px) {
+  .mx_AuthPage_modal {
+    margin-top: 0;
+  }
+}

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -653,3 +653,14 @@ div.mx_EventTile_notSent.mx_EventTile_redacted .mx_UnknownBody {
         }
     }
 }
+
+@media only screen and (max-width : 480px) {
+  .mx_EventTile_line, .mx_EventTile_reply {
+    padding-left: 0;
+    margin-right: 0;
+  }
+  .mx_EventTile_content {
+    margin-top: 10px;
+    margin-right: 0;
+  }
+}

--- a/res/css/views/rooms/_RoomHeader.scss
+++ b/res/css/views/rooms/_RoomHeader.scss
@@ -269,3 +269,12 @@ limitations under the License.
 .mx_RoomHeader_pinsIndicatorUnread {
     background-color: $pinned-unread-color;
 }
+
+@media only screen and (max-width : 480px) {
+  .mx_RoomHeader_wrapper {
+    padding: 0;
+  }
+  .mx_RoomHeader {
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
So there is a lot of work to do here, I wanted to put up the minimal patch that gets the UI usable on mobile and touches the least amount of things as possible so we can discuss the overall approach without too big a patch.

It looks like: 

https://i.imgur.com/Z8TU0VE.png
https://i.imgur.com/gvVVlJu.png
https://i.imgur.com/jSMuqAN.png

I feel like we probably dont want to be repeating this media query so often so not sure if we want to put this all in a dedicated mobile-overrides.scss ? 
