### PR TITLE
fix SAS dialog width

### DIFF
--- a/src/components/views/dialogs/IncomingSasDialog.js
+++ b/src/components/views/dialogs/IncomingSasDialog.js
@@ -227,6 +227,7 @@ export default class IncomingSasDialog extends React.Component {
             <BaseDialog
                 title={_t("Incoming Verification Request")}
                 onFinished={this._onFinished}
+                fixedWidth={false}
             >
                 {body}
             </BaseDialog>


### PR DESCRIPTION
Fixes: https://github.com/vector-im/riot-web/issues/12106

<img width="696" alt="Screenshot 2020-01-30 at 12 20 49" src="https://user-images.githubusercontent.com/3935731/73449448-13b5fc00-435b-11ea-825e-479496031cef.png">
