### PR TITLE
Emoji verification: avoid emoji text overlapping

### DIFF
--- a/res/css/views/verification/_VerificationShowSas.scss
+++ b/res/css/views/verification/_VerificationShowSas.scss
@@ -27,20 +27,12 @@ limitations under the License.
 }
 
 .mx_VerificationShowSas_emojiSas {
-    text-align: center;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
     margin: 25px 0;
 }
 
 .mx_VerificationShowSas_emojiSas_block {
     display: inline-block;
-    margin-bottom: 30px;
-    position: relative;
-    // allow the blocks to grow to space themselves evenly up to a limit of 100px
-    flex-grow: 1;
-    max-width: 100px;
+    padding: 5px 2px;
 }
 
 .mx_VerificationShowSas_emojiSas_emoji {
@@ -53,13 +45,17 @@ limitations under the License.
 
 .mx_VerificationShowSas_emojiSas_label {
     font-weight: bold;
-    // allow the text to overflow the parent by 15px on each side
-    // this is to keep the width of the parent consistent for spacing centrally via flexbox
-    position: absolute;
-    left: -15px;
-    right: -15px;
 }
 
-.mx_VerificationShowSas_emojiSas_break {
-    flex-basis: 100%;
+.mx_VerificationShowSas_emojiSas_row {
+    text-align: center;
+    display: flex;
+    justify-content: space-evenly;
+    margin: 0 auto;
+}
+
+.mx_VerificationShowSas_emojiSas_row:nth-child(2) {
+    // make the bottom row with 3 instead of 4 icons 3/4 of the width
+    // so the space-evenly doesn't distort the olympic ring formation
+    width: 75%;
 }

--- a/src/components/views/verification/VerificationShowSas.js
+++ b/src/components/views/verification/VerificationShowSas.js
@@ -66,7 +66,7 @@ export default class VerificationShowSas extends React.Component {
                     {emojiBlocks.slice(0, 4)}
                 </div>
                 <div className="mx_VerificationShowSas_emojiSas_row">
-                {emojiBlocks.slice(4)}
+                    {emojiBlocks.slice(4)}
                 </div>
             </div>;
             sasCaption = _t(

--- a/src/components/views/verification/VerificationShowSas.js
+++ b/src/components/views/verification/VerificationShowSas.js
@@ -62,9 +62,12 @@ export default class VerificationShowSas extends React.Component {
                 </div>,
             );
             sasDisplay = <div className="mx_VerificationShowSas_emojiSas">
-                {emojiBlocks.slice(0, 4)}
-                <div className="mx_VerificationShowSas_emojiSas_break" />
+                <div className="mx_VerificationShowSas_emojiSas_row">
+                    {emojiBlocks.slice(0, 4)}
+                </div>
+                <div className="mx_VerificationShowSas_emojiSas_row">
                 {emojiBlocks.slice(4)}
+                </div>
             </div>;
             sasCaption = _t(
                 "Verify this user by confirming the following emoji appear on their screen.",


### PR DESCRIPTION
while maintaining some sort of olypmic rings formation.

This makes the emoji columns not a fixed width anymore so the text can fit, at the cost of not maintaining a perfect symmetrical olympic ring formation.

![olympic](https://user-images.githubusercontent.com/274386/73462818-46b8b980-4374-11ea-9f72-b40f7a9dff1d.gif)
This is what the dialog looks like
![image](https://user-images.githubusercontent.com/274386/73463214-cb0b3c80-4374-11ea-982a-d178811493ed.png)


Related to https://github.com/vector-im/riot-web/issues/12133