### PR TITLE
Add a class for styling room directory permissions

### DIFF
--- a/res/css/structures/_RoomDirectory.scss
+++ b/res/css/structures/_RoomDirectory.scss
@@ -119,6 +119,16 @@ limitations under the License.
     display: inline-block;
 }
 
+.mx_RoomDirectory_perm {
+    border-radius: 10px;
+    display: inline-block;
+    height: 20px;
+    line-height: 20px;
+    padding: 0 5px;
+    color: $accent-fg-color;
+    background-color: $rte-room-pill-color;
+}
+
 .mx_RoomDirectory_topic {
     cursor: initial;
     color: $light-fg-color;


### PR DESCRIPTION
|Before|After|
|---|---|
|![Screenshot from 2020-01-31 00-13-41](https://user-images.githubusercontent.com/30577011/73498815-a50a8a00-43be-11ea-8c2a-a854949d281d.png)|![Screenshot from 2020-01-31 00-13-01](https://user-images.githubusercontent.com/30577011/73498814-a50a8a00-43be-11ea-8ba6-b594b099db8a.png)|

Fixes vector-im/riot-web#11174