### PR TITLE
Fix escaped markdown passing backslashes through

### DIFF
--- a/src/editor/serialize.js
+++ b/src/editor/serialize.js
@@ -44,7 +44,11 @@ export function htmlSerializeIfNeeded(model, {forceHTML = false} = {}) {
     // Format "plain" text to ensure removal of backslash escapes
     // https://github.com/vector-im/riot-web/issues/11230
     // https://github.com/vector-im/riot-web/issues/2870
-    return parser.toPlaintext();
+    const postParsePlaintext = parser.toPlaintext();
+    if (postParsePlaintext !== md) {
+        // only return "formatted" text if it differs from the source text
+        return postParsePlaintext;
+    }
 }
 
 export function textSerialize(model) {

--- a/src/editor/serialize.js
+++ b/src/editor/serialize.js
@@ -41,6 +41,10 @@ export function htmlSerializeIfNeeded(model, {forceHTML = false} = {}) {
     if (!parser.isPlainText() || forceHTML) {
         return parser.toHTML();
     }
+    // Format "plain" text to ensure removal of backslash escapes
+    // https://github.com/vector-im/riot-web/issues/11230
+    // https://github.com/vector-im/riot-web/issues/2870
+    return parser.toPlaintext();
 }
 
 export function textSerialize(model) {

--- a/test/editor/serialize-test.js
+++ b/test/editor/serialize-test.js
@@ -43,4 +43,10 @@ describe('editor/serialize', function() {
         const html = htmlSerializeIfNeeded(model, {});
         expect(html).toBe("<em>hello</em> world");
     });
+    it('escaped markdown should not retain backslashes', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain('\\*hello\\* world')]);
+        const html = htmlSerializeIfNeeded(model, {});
+        expect(html).toBe('*hello* world');
+    })
 });

--- a/test/editor/serialize-test.js
+++ b/test/editor/serialize-test.js
@@ -48,5 +48,5 @@ describe('editor/serialize', function() {
         const model = new EditorModel([pc.plain('\\*hello\\* world')]);
         const html = htmlSerializeIfNeeded(model, {});
         expect(html).toBe('*hello* world');
-    })
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11230

This implements the simpler approach I suggested in the linked issue, namely always returning the CommonMark parsed result even if we think it's plaintext. This is because the current plaintext check only checks after any backslash escapes were processed by CommonMark, but if we then send the pre-parse message that results in the backslashes becoming visible in the message.

This currently causes test failures in tests (currently 3) that do not expect any HTML content, since it causes HTML content to be *always* generated and sent unless `/plain` is explicitly requested.

If this absolutely cannot happen (and we can't change those tests accordingly), then an alternative is to only send the post-parse 'plaintext' if it differs from the source markdown, e.g.:

```js
    const postParsePlaintext = parser.toPlaintext();
    if (postParsePlaintext !== md) {
        return postParsePlaintext;
    }
```

Not sure which approach (change tests vs only send when different) is better.