### PR TITLE
Add temporary feature flag to control padlocks

### DIFF
--- a/src/components/views/rooms/InviteOnlyIcon.js
+++ b/src/components/views/rooms/InviteOnlyIcon.js
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import { _t } from '../../../languageHandler';
 import * as sdk from '../../../index';
+import SettingsStore from '../../../settings/SettingsStore';
 
 export default class InviteOnlyIcon extends React.Component {
     constructor() {
@@ -36,6 +37,10 @@ export default class InviteOnlyIcon extends React.Component {
     };
 
     render() {
+        if (!SettingsStore.isFeatureEnabled("feature_invite_only_padlocks")) {
+            return null;
+        }
+
         const Tooltip = sdk.getComponent("elements.Tooltip");
         let tooltip;
         if (this.state.hover) {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -374,6 +374,7 @@
     "Enable cross-signing to verify per-user instead of per-session (in development)": "Enable cross-signing to verify per-user instead of per-session (in development)",
     "Enable local event indexing and E2EE search (requires restart)": "Enable local event indexing and E2EE search (requires restart)",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
+    "Show padlocks on invite only rooms": "Show padlocks on invite only rooms",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",
     "Use compact timeline layout": "Use compact timeline layout",
     "Show a placeholder for removed messages": "Show a placeholder for removed messages",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -160,6 +160,12 @@ export const SETTINGS = {
         displayName: _td("Show info about bridges in room settings"),
         default: false,
     },
+    "feature_invite_only_padlocks": {
+        isFeature: true,
+        supportedLevels: LEVELS_FEATURE,
+        displayName: _td("Show padlocks on invite only rooms"),
+        default: true,
+    },
     "MessageComposerInput.suggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Enable Emoji suggestions while typing'),


### PR DESCRIPTION
This default on feature flag will help in case we want to trial padlocks on vs.
off this weekend.

(I have explicitly skipped the usual docs for flags... I imagine this will be very short lived.)

Fixes https://github.com/vector-im/riot-web/issues/12166