### PR TITLE
Add an override for the theme

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -507,7 +507,7 @@ export default createReactClass({
                     view: VIEWS.LOGIN,
                 });
                 this.notifyNewScreen('login');
-                ThemeController.setIsLogin(true);
+                ThemeController.isLogin = true;
                 this._themeWatcher.recheck();
                 break;
             case 'start_post_registration':
@@ -763,7 +763,7 @@ export default createReactClass({
         }
 
         this.setStateForNewView(newState);
-        ThemeController.setIsLogin(true);
+        ThemeController.isLogin = true;
         this._themeWatcher.recheck();
         this.notifyNewScreen('register');
     },
@@ -915,7 +915,7 @@ export default createReactClass({
             view: VIEWS.WELCOME,
         });
         this.notifyNewScreen('welcome');
-        ThemeController.setIsLogin(true);
+        ThemeController.isLogin = true;
         this._themeWatcher.recheck();
     },
 
@@ -926,7 +926,7 @@ export default createReactClass({
         });
         this._setPage(PageTypes.HomePage);
         this.notifyNewScreen('home');
-        ThemeController.setIsLogin(false);
+        ThemeController.isLogin = false;
         this._themeWatcher.recheck();
     },
 
@@ -1240,7 +1240,7 @@ export default createReactClass({
         });
         this.subTitleStatus = '';
         this._setPageSubtitle();
-        ThemeController.setIsLogin(true);
+        ThemeController.isLogin = true;
         this._themeWatcher.recheck();
     },
 

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -53,6 +53,7 @@ import createRoom from "../../createRoom";
 import KeyRequestHandler from '../../KeyRequestHandler';
 import { _t, getCurrentLanguage } from '../../languageHandler';
 import SettingsStore, {SettingLevel} from "../../settings/SettingsStore";
+import ThemeController from "../../settings/controllers/ThemeController";
 import { startAnyRegistrationFlow } from "../../Registration.js";
 import { messageForSyncError } from '../../utils/ErrorUtils';
 import ResizeNotifier from "../../utils/ResizeNotifier";
@@ -506,6 +507,8 @@ export default createReactClass({
                     view: VIEWS.LOGIN,
                 });
                 this.notifyNewScreen('login');
+                ThemeController.setIsLogin(true);
+                this._themeWatcher.recheck();
                 break;
             case 'start_post_registration':
                 this.setState({
@@ -760,6 +763,8 @@ export default createReactClass({
         }
 
         this.setStateForNewView(newState);
+        ThemeController.setIsLogin(true);
+        this._themeWatcher.recheck();
         this.notifyNewScreen('register');
     },
 
@@ -910,6 +915,8 @@ export default createReactClass({
             view: VIEWS.WELCOME,
         });
         this.notifyNewScreen('welcome');
+        ThemeController.setIsLogin(true);
+        this._themeWatcher.recheck();
     },
 
     _viewHome: function() {
@@ -919,6 +926,8 @@ export default createReactClass({
         });
         this._setPage(PageTypes.HomePage);
         this.notifyNewScreen('home');
+        ThemeController.setIsLogin(false);
+        this._themeWatcher.recheck();
     },
 
     _viewUser: function(userId, subAction) {
@@ -1231,6 +1240,8 @@ export default createReactClass({
         });
         this.subTitleStatus = '';
         this._setPageSubtitle();
+        ThemeController.setIsLogin(true);
+        this._themeWatcher.recheck();
     },
 
     /**

--- a/src/settings/controllers/ThemeController.js
+++ b/src/settings/controllers/ThemeController.js
@@ -21,10 +21,6 @@ import {DEFAULT_THEME, enumerateThemes} from "../../theme";
 export default class ThemeController extends SettingController {
     static isLogin = false;
 
-    static setIsLogin(val) {
-        ThemeController.isLogin = val;
-    }
-
     getValueOverride(level, roomId, calculatedValue, calculatedAtLevel) {
         if (!calculatedValue) return null; // Don't override null themes
 

--- a/src/settings/controllers/ThemeController.js
+++ b/src/settings/controllers/ThemeController.js
@@ -19,8 +19,16 @@ import SettingController from "./SettingController";
 import {DEFAULT_THEME, enumerateThemes} from "../../theme";
 
 export default class ThemeController extends SettingController {
+    static isLogin = false;
+
+    static setIsLogin(val) {
+        ThemeController.isLogin = val;
+    }
+
     getValueOverride(level, roomId, calculatedValue, calculatedAtLevel) {
         if (!calculatedValue) return null; // Don't override null themes
+
+        if (ThemeController.isLogin) return 'light';
 
         const themes = enumerateThemes();
         // Override in case some no longer supported theme is stored here


### PR DESCRIPTION
So we can force the light theme on unthemeable pages like the login
& complete security page.

Fixes https://github.com/vector-im/riot-web/issues/12149
Fixes https://github.com/vector-im/riot-web/issues/12157