### PR TITLE
Fix size of invite only icon

### DIFF
--- a/res/css/views/rooms/_InviteOnlyIcon.scss
+++ b/res/css/views/rooms/_InviteOnlyIcon.scss
@@ -34,5 +34,7 @@ limitations under the License.
         bottom: 0;
         left: 0;
         right: 0;
+        width: 12px;
+        height: 12px;
     }
 }


### PR DESCRIPTION
So it doesn't become tiny with long room names

Fixes https://github.com/vector-im/riot-web/issues/12168