### PR TITLE
Fix user trust text to match what was checked

### DIFF
--- a/src/components/views/rooms/E2EIcon.js
+++ b/src/components/views/rooms/E2EIcon.js
@@ -33,7 +33,7 @@ export const E2E_STATE = {
 
 const crossSigningUserTitles = {
     [E2E_STATE.WARNING]: _td("This user has not verified all of their sessions."),
-    [E2E_STATE.NORMAL]: _td("You have not verified this user. This user has verified all of their sessions."),
+    [E2E_STATE.NORMAL]: _td("You have not verified this user."),
     [E2E_STATE.VERIFIED]: _td("You have verified this user. This user has verified all of their sessions."),
 };
 const crossSigningRoomTitles = {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -900,7 +900,7 @@
     "Join as <voiceText>voice</voiceText> or <videoText>video</videoText>.": "Join as <voiceText>voice</voiceText> or <videoText>video</videoText>.",
     "Ongoing conference call%(supportedText)s.": "Ongoing conference call%(supportedText)s.",
     "This user has not verified all of their sessions.": "This user has not verified all of their sessions.",
-    "You have not verified this user. This user has verified all of their sessions.": "You have not verified this user. This user has verified all of their sessions.",
+    "You have not verified this user.": "You have not verified this user.",
     "You have verified this user. This user has verified all of their sessions.": "You have verified this user. This user has verified all of their sessions.",
     "Someone is using an unknown session": "Someone is using an unknown session",
     "This room is end-to-end encrypted": "This room is end-to-end encrypted",


### PR DESCRIPTION
This fixes the unverified users status text to omit devices since they haven't
been checked.

Fixes https://github.com/vector-im/riot-web/issues/12176