### PR TITLE
Truncate SAS emoji labels to fit

### DIFF
--- a/res/css/structures/_RightPanel.scss
+++ b/res/css/structures/_RightPanel.scss
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +19,7 @@ limitations under the License.
     overflow-x: hidden;
     flex: 0 0 auto;
     position: relative;
-    min-width: 250px;
+    min-width: 264px;
     display: flex;
     flex-direction: column;
 }

--- a/res/css/views/verification/_VerificationShowSas.scss
+++ b/res/css/views/verification/_VerificationShowSas.scss
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 New Vector Ltd.
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,11 +37,9 @@ limitations under the License.
 
 .mx_VerificationShowSas_emojiSas_block {
     display: inline-block;
-    margin-bottom: 30px;
+    margin-bottom: 16px;
     position: relative;
-    // allow the blocks to grow to space themselves evenly up to a limit of 100px
-    flex-grow: 1;
-    max-width: 100px;
+    width: 52px;
 }
 
 .mx_VerificationShowSas_emojiSas_emoji {
@@ -52,12 +51,9 @@ limitations under the License.
 }
 
 .mx_VerificationShowSas_emojiSas_label {
-    font-weight: bold;
-    // allow the text to overflow the parent by 15px on each side
-    // this is to keep the width of the parent consistent for spacing centrally via flexbox
-    position: absolute;
-    left: -15px;
-    right: -15px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .mx_VerificationShowSas_emojiSas_break {


### PR DESCRIPTION
![Screenshot 2020-01-31 at 15 28 34](https://user-images.githubusercontent.com/986903/73551881-27d32980-443f-11ea-9613-30c81b0c90ed.png)

![Screenshot 2020-01-31 at 15 26 28](https://user-images.githubusercontent.com/986903/73551886-299ced00-443f-11ea-9917-9c62d0db1b41.png)

This keeps the layout of the emoji fixed as much as possible.

Other changes:
 * Fix width of each emoji container to static 52px
 * Bump minimum width of right panel from 250px to 264px to match the
   width in the figma
 * Use normal font-weight for labels as per design
 * Smaller vertical gap between emojis, again to match design

Related: https://github.com/matrix-org/matrix-react-sdk/pull/3997