### PR TITLE
ManageEventIndexDialog: Show how many rooms are being currently crawled.

### DIFF
--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -144,7 +144,8 @@ export default class ManageEventIndexDialog extends React.Component {
                 <div className='mx_SettingsTab_subsectionText'>
                     {_t("Space used:")} {formatBytes(this.state.eventIndexSize, 0)}<br />
                     {_t("Indexed messages:")} {formatCountLong(this.state.eventCount)}<br />
-                    {_t("Number of rooms:")} {formatCountLong(this.state.crawlingRoomsCount)} {_t("of")} {formatCountLong(this.state.roomCount)}<br />
+                    {_t("Number of rooms:")} {formatCountLong(this.state.crawlingRoomsCount)} {_t("of ")}
+                    {formatCountLong(this.state.roomCount)}<br />
                     {crawlerState}<br />
                     <Field
                         id={"crawlerSleepTimeMs"}

--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -38,6 +38,7 @@ export default class ManageEventIndexDialog extends React.Component {
         this.state = {
             eventIndexSize: 0,
             eventCount: 0,
+            crawlingRoomsCount: 0,
             roomCount: 0,
             currentRoom: null,
             crawlerSleepTime:
@@ -51,11 +52,15 @@ export default class ManageEventIndexDialog extends React.Component {
         let currentRoom = null;
 
         if (room) currentRoom = room.name;
+        const roomStats = eventIndex.crawlingRooms();
+        const crawlingRoomsCount = roomStats.crawlingRooms.size;
+        const roomCount = roomStats.totalRooms.size;
 
         this.setState({
             eventIndexSize: stats.size,
-            roomCount: stats.roomCount,
             eventCount: stats.eventCount,
+            crawlingRoomsCount: crawlingRoomsCount,
+            roomCount: roomCount,
             currentRoom: currentRoom,
         });
     }
@@ -70,6 +75,7 @@ export default class ManageEventIndexDialog extends React.Component {
 
     async componentWillMount(): void {
         let eventIndexSize = 0;
+        let crawlingRoomsCount = 0;
         let roomCount = 0;
         let eventCount = 0;
         let currentRoom = null;
@@ -80,8 +86,10 @@ export default class ManageEventIndexDialog extends React.Component {
             eventIndex.on("changedCheckpoint", this.updateCurrentRoom.bind(this));
 
             const stats = await eventIndex.getStats();
+            const roomStats = eventIndex.crawlingRooms();
             eventIndexSize = stats.size;
-            roomCount = stats.roomCount;
+            crawlingRoomsCount = roomStats.crawlingRooms.size;
+            roomCount = roomStats.totalRooms.size;
             eventCount = stats.eventCount;
 
             const room = eventIndex.currentRoom();
@@ -91,6 +99,7 @@ export default class ManageEventIndexDialog extends React.Component {
         this.setState({
             eventIndexSize,
             eventCount,
+            crawlingRoomsCount,
             roomCount,
             currentRoom,
         });
@@ -135,7 +144,7 @@ export default class ManageEventIndexDialog extends React.Component {
                 <div className='mx_SettingsTab_subsectionText'>
                     {_t("Space used:")} {formatBytes(this.state.eventIndexSize, 0)}<br />
                     {_t("Indexed messages:")} {formatCountLong(this.state.eventCount)}<br />
-                    {_t("Number of rooms:")} {formatCountLong(this.state.roomCount)}<br />
+                    {_t("Number of rooms:")} {formatCountLong(this.state.crawlingRoomsCount)} {_t("of")} {formatCountLong(this.state.roomCount)}<br />
                     {crawlerState}<br />
                     <Field
                         id={"crawlerSleepTimeMs"}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2095,7 +2095,7 @@
     "Space used:": "Space used:",
     "Indexed messages:": "Indexed messages:",
     "Number of rooms:": "Number of rooms:",
-    "of": "of",
+    "of ": "of ",
     "Message downloading sleep time(ms)": "Message downloading sleep time(ms)",
     "Failed to set direct chat tag": "Failed to set direct chat tag",
     "Failed to remove tag %(tagName)s from room": "Failed to remove tag %(tagName)s from room",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2095,6 +2095,7 @@
     "Space used:": "Space used:",
     "Indexed messages:": "Indexed messages:",
     "Number of rooms:": "Number of rooms:",
+    "of": "of",
     "Message downloading sleep time(ms)": "Message downloading sleep time(ms)",
     "Failed to set direct chat tag": "Failed to set direct chat tag",
     "Failed to remove tag %(tagName)s from room": "Failed to remove tag %(tagName)s from room",

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -748,4 +748,31 @@ export default class EventIndex extends EventEmitter {
             return client.getRoom(this.crawlerCheckpoints[0].roomId);
         }
     }
+
+    crawlingRooms() {
+        const totalRooms = new Set();
+        const crawlingRooms = new Set();
+
+        this.crawlerCheckpoints.forEach((checkpoint, index) => {
+            crawlingRooms.add(checkpoint.roomId);
+        });
+
+        if (this._currentCheckpoint !== null) {
+            crawlingRooms.add(this._currentCheckpoint.roomId);
+        }
+
+        const client = MatrixClientPeg.get();
+        const rooms = client.getRooms();
+
+        const isRoomEncrypted = (room) => {
+            return client.isRoomEncrypted(room.roomId);
+        };
+
+        const encryptedRooms = rooms.filter(isRoomEncrypted);
+        encryptedRooms.forEach((room, index) => {
+            totalRooms.add(room.roomId);
+        });
+
+        return {crawlingRooms, totalRooms};
+    }
 }


### PR DESCRIPTION
PR adds the number of currently crawled rooms to the ManageEventIndexDialog. Before this it only showed the total room that will be indexed.

![image](https://user-images.githubusercontent.com/552026/73591105-c36da400-44ea-11ea-8458-3faa5b84c24b.png)
