### PR TITLE
Button size reviewed for word consuming languages & Settings showing devices are a bit too tight

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -62,7 +62,7 @@ limitations under the License.
     }
 
     .mx_InviteDialog_goButton {
-        width: 48px;
+        min-width: 48px;
         margin-left: 10px;
         height: 25px;
         line-height: 25px;
@@ -131,7 +131,7 @@ limitations under the License.
             height: 24px;
             grid-column: 1;
             grid-row: 1;
-            mask-image: url('$(res)/img/feather-customised/check.svg');
+            mask-image: url("$(res)/img/feather-customised/check.svg");
             mask-size: 100%;
             mask-repeat: no-repeat;
             position: absolute;

--- a/res/css/views/settings/_DevicesPanel.scss
+++ b/res/css/views/settings/_DevicesPanel.scss
@@ -18,7 +18,7 @@ limitations under the License.
     display: table;
     table-layout: fixed;
     width: 880px;
-    border-spacing: 2px;
+    border-spacing: 10px;
 }
 
 .mx_DevicesPanel_header {
@@ -32,7 +32,11 @@ limitations under the License.
 
 .mx_DevicesPanel_header > div {
     display: table-cell;
-    vertical-align: bottom;
+    vertical-align: middle;
+}
+
+.mx_DevicesPanel_header .mx_DevicesPanel_deviceName {
+    width: 50%;
 }
 
 .mx_DevicesPanel_header .mx_DevicesPanel_deviceLastSeen {


### PR DESCRIPTION
1. The width was not properly set to other languages than English, a min-width will keep the proper size of the button while leaving some room for more word expensive languages such as French.

![Screenshot_2020-02-02 Riot](https://user-images.githubusercontent.com/40339476/73611725-1cb9fe00-45e5-11ea-8236-cc9d1e068582.png)

2. Settings showing devices are pretty hard to read as it is. I have given it some breath.

Signed-off-by: Romain Testard <romain.rtestard@gmail.com>

Fixes https://github.com/vector-im/riot-web/issues/12204