### PR TITLE
Do not show alarming red shields on large encrypted rooms for your own device

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -811,7 +811,9 @@ export default createReactClass({
         debuglog("e2e verified", verified, "unverified", unverified);
 
         /* Check all verified user devices. */
-        for (const userId of [...verified, cli.getUserId()]) {
+        /* Don't alarm if no other users are verified  */
+        const targets = (verified.length > 0) ? [...verified, cli.getUserId()] : verified;
+        for (const userId of targets) {
             const devices = await cli.getStoredDevicesForUser(userId);
             const anyDeviceNotVerified = devices.some(({deviceId}) => {
                 return !cli.checkDeviceTrust(userId, deviceId).isVerified();

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -166,7 +166,9 @@ export default createReactClass({
             });
 
         /* Check all verified user devices. */
-        for (const userId of [...verified, cli.getUserId()]) {
+        /* Don't alarm if no other users are verified  */
+        const targets = (verified.length > 0) ? [...verified, cli.getUserId()] : verified;
+        for (const userId of targets) {
             const devices = await cli.getStoredDevicesForUser(userId);
             const allDevicesVerified = devices.every(({deviceId}) => {
                 return cli.checkDeviceTrust(userId, deviceId).isVerified();


### PR DESCRIPTION

Fixes: https://github.com/vector-im/riot-web/issues/12214