### PR TITLE
Mark AccessSecretStorageDialog to not be closed by clicking background

### DIFF
--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -70,11 +70,28 @@ async function getSecretStorageKey({ keys: keyInfos }) {
         sdk.getComponent("dialogs.secretstorage.AccessSecretStorageDialog");
     const { finished } = Modal.createTrackedDialog("Access Secret Storage dialog", "",
         AccessSecretStorageDialog,
+        /* props= */
         {
             keyInfo: info,
             checkPrivateKey: async (input) => {
                 const key = await inputToKey(input);
                 return MatrixClientPeg.get().checkSecretStoragePrivateKey(key, info.pubkey);
+            },
+        },
+        /* className= */ null,
+        /* isPriorityModal= */ false,
+        /* isStaticModal= */ false,
+        /* options= */ {
+            onBeforeClose: async (reason) => {
+                if (reason !== "backgroundClick") {
+                    return true;
+                }
+                const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
+                const [sure] = await Modal.createDialog(QuestionDialog, {
+                    title: _t("Cancel entering passphrase?"),
+                    description: _t("If you cancel now, you won't complete your SSSS operation!"),
+                }).finished;
+                return sure;
             },
         },
     );

--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -89,7 +89,7 @@ async function getSecretStorageKey({ keys: keyInfos }) {
                 const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
                 const [sure] = await Modal.createDialog(QuestionDialog, {
                     title: _t("Cancel entering passphrase?"),
-                    description: _t("If you cancel now, you won't complete your SSSS operation!"),
+                    description: _t("If you cancel now, you won't complete your secret storage operation!"),
                 }).finished;
                 return sure;
             },

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -171,6 +171,12 @@ class ModalManager {
     }
 
     /**
+     * @callback onBeforeClose
+     * @param {string?} reason either "backgroundClick" or null
+     * @return {Promise<bool>} whether the dialog should close
+     */
+
+    /**
      * Open a modal view.
      *
      * This can be used to display a react component which is loaded as an asynchronous
@@ -197,6 +203,8 @@ class ModalManager {
      *                                 also be removed from the stack. This is not compatible
      *                                 with being a priority modal. Only one modal can be
      *                                 static at a time.
+     * @param {Object} options? extra options for the dialog
+     * @param {onBeforeClose} options.onBeforeClose a callback to decide whether to close the dialog
      * @returns {object} Object with 'close' parameter being a function that will close the dialog
      */
     createDialogAsync(prom, props, className, isPriorityModal, isStaticModal, options = {}) {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -201,7 +201,6 @@ class ModalManager {
      */
     createDialogAsync(prom, props, className, isPriorityModal, isStaticModal, options = {}) {
         const {modal, closeDialog, onFinishedProm} = this._buildModal(prom, props, className, options);
-        modal.close = closeDialog;
         if (isPriorityModal) {
             // XXX: This is destructive
             this._priorityModal = modal;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -217,9 +217,13 @@ class ModalManager {
     }
 
     closeAll() {
-        const modalsToClose = [...this._modals, this._priorityModal];
+        const modalsToClose = this._modals.slice();
         this._modals = [];
-        this._priorityModal = null;
+
+        if (this._priorityModal) {
+            modalsToClose.push(this._priorityModal);
+            this._priorityModal = null;
+        }
 
         if (this._staticModal && modalsToClose.length === 0) {
             modalsToClose.push(this._staticModal);

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -47,7 +47,7 @@ class ModalManager {
                } */
         ];
 
-        this.closeAll = this.closeAll.bind(this);
+        this.onBackgroundClick = this.onBackgroundClick.bind(this);
     }
 
     hasDialogs() {
@@ -124,6 +124,7 @@ class ModalManager {
         );
         modal.onFinished = props ? props.onFinished : null;
         modal.className = className;
+        modal.close = closeDialog;
 
         return {modal, closeDialog, onFinishedProm};
     }
@@ -216,28 +217,16 @@ class ModalManager {
         };
     }
 
-    closeAll() {
-        const modalsToClose = this._modals.slice();
-        this._modals = [];
-
-        if (this._priorityModal) {
-            modalsToClose.push(this._priorityModal);
-            this._priorityModal = null;
+    onBackgroundClick() {
+        const modal = this._getCurrentModal();
+        if (!modal) {
+            return;
         }
+        modal.close();
+    }
 
-        if (this._staticModal && modalsToClose.length === 0) {
-            modalsToClose.push(this._staticModal);
-            this._staticModal = null;
-        }
-
-        for (let i = 0; i < modalsToClose.length; i++) {
-            const m = modalsToClose[i];
-            if (m && m.onFinished) {
-                m.onFinished(false);
-            }
-        }
-
-        this._reRender();
+    _getCurrentModal() {
+        return this._priorityModal ? this._priorityModal : (this._modals[0] || this._staticModal);
     }
 
     _reRender() {
@@ -268,7 +257,7 @@ class ModalManager {
                     <div className="mx_Dialog">
                         { this._staticModal.elem }
                     </div>
-                    <div className="mx_Dialog_background mx_Dialog_staticBackground" onClick={this.closeAll}></div>
+                    <div className="mx_Dialog_background mx_Dialog_staticBackground" onClick={this.onBackgroundClick}></div>
                 </div>
             );
 
@@ -278,8 +267,8 @@ class ModalManager {
             ReactDOM.unmountComponentAtNode(this.getOrCreateStaticContainer());
         }
 
-        const modal = this._priorityModal ? this._priorityModal : this._modals[0];
-        if (modal) {
+        const modal = this._getCurrentModal();
+        if (modal !== this._staticModal) {
             const classes = "mx_Dialog_wrapper "
                 + (this._staticModal ? "mx_Dialog_wrapperWithStaticUnder " : '')
                 + (modal.className ? modal.className : '');
@@ -289,7 +278,7 @@ class ModalManager {
                     <div className="mx_Dialog">
                         {modal.elem}
                     </div>
-                    <div className="mx_Dialog_background" onClick={this.closeAll}></div>
+                    <div className="mx_Dialog_background" onClick={this.onBackgroundClick}></div>
                 </div>
             );
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -60,6 +60,8 @@
     "Server may be unavailable, overloaded, or you hit a bug.": "Server may be unavailable, overloaded, or you hit a bug.",
     "The server does not support the room version specified.": "The server does not support the room version specified.",
     "Failure to create room": "Failure to create room",
+    "Cancel entering passphrase?": "Cancel entering passphrase?",
+    "If you cancel now, you won't complete your secret storage operation!": "If you cancel now, you won't complete your secret storage operation!",
     "Setting up keys": "Setting up keys",
     "Send anyway": "Send anyway",
     "Send": "Send",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12199

It uses a prop to disable the background click handler, for lack of a nicer way to pass the flag. Suggestions welcome.

The PR also fixes not being able to close a static dialog (like the Settings) by clicking the background.