### PR TITLE
Let pointer events fall through to scroll button

### DIFF
--- a/res/css/views/rooms/_TopUnreadMessagesBar.scss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.scss
@@ -32,9 +32,9 @@ limitations under the License.
     width: 4px;
     height: 4px;
     border-radius: 16px;
-    overflow: hidden;
     background-color: $secondary-accent-color;
     border: 6px solid $accent-color;
+    pointer-events: none;
 }
 
 .mx_TopUnreadMessagesBar_scrollUp {


### PR DESCRIPTION
This makes it easier to click the entire visible area of the scroll button,
including the green circle at the top.