### PR TITLE
Disable verification buttons after clicking to avoid double submission

### DIFF
--- a/src/components/views/messages/MKeyVerificationRequest.js
+++ b/src/components/views/messages/MKeyVerificationRequest.js
@@ -27,6 +27,7 @@ import {RIGHT_PANEL_PHASES} from "../../../stores/RightPanelStorePhases";
 export default class MKeyVerificationRequest extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {};
     }
 
     componentDidMount() {
@@ -58,6 +59,7 @@ export default class MKeyVerificationRequest extends React.Component {
     };
 
     _onAcceptClicked = async () => {
+        this.setState({acceptOrCancelClicked: true});
         const request = this.props.mxEvent.verificationRequest;
         if (request) {
             try {
@@ -70,6 +72,7 @@ export default class MKeyVerificationRequest extends React.Component {
     };
 
     _onRejectClicked = async () => {
+        this.setState({acceptOrCancelClicked: true});
         const request = this.props.mxEvent.verificationRequest;
         if (request) {
             try {
@@ -135,9 +138,10 @@ export default class MKeyVerificationRequest extends React.Component {
             subtitle = (<div className="mx_cryptoEvent_subtitle">{
                 userLabelForEventRoom(request.requestingUserId, mxEvent.getRoomId())}</div>);
             if (request.requested && !request.observeOnly) {
+                const disabled = this.state.acceptOrCancelClicked;
                 stateNode = (<div className="mx_cryptoEvent_buttons">
-                    <FormButton kind="danger" onClick={this._onRejectClicked} label={_t("Decline")} />
-                    <FormButton onClick={this._onAcceptClicked} label={_t("Accept")} />
+                    <FormButton disabled={disabled} kind="danger" onClick={this._onRejectClicked} label={_t("Decline")} />
+                    <FormButton disabled={disabled} onClick={this._onAcceptClicked} label={_t("Accept")} />
                 </div>);
             }
         } else { // request sent by us

--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -62,8 +62,9 @@ export default class VerificationPanel extends React.PureComponent {
         if (pending) {
             button = <Spinner />;
         } else {
+            const disabled = this.state.emojiButtonClicked;
             button = (
-                <AccessibleButton kind="primary" className="mx_UserInfo_wideButton" onClick={this._startSAS}>
+                <AccessibleButton disabled={disabled} kind="primary" className="mx_UserInfo_wideButton" onClick={this._startSAS}>
                     {_t("Verify by emoji")}
                 </AccessibleButton>
             );
@@ -196,6 +197,7 @@ export default class VerificationPanel extends React.PureComponent {
     }
 
     _startSAS = async () => {
+        this.setState({emojiButtonClicked: true});
         const verifier = this.props.request.beginKeyVerification(verificationMethods.SAS);
         try {
             await verifier.verify();


### PR DESCRIPTION
Disable verification buttons after clicking them to avoid double submission. Note that this doesn't solve all of our local echo woes as they toast still wouldn't disappear until the remote echo arrives when you click accept in the timeline for example.