### PR TITLE
Fix uncentered letter inside avatar for currently typing users

### DIFF
--- a/res/css/views/rooms/_WhoIsTypingTile.scss
+++ b/res/css/views/rooms/_WhoIsTypingTile.scss
@@ -31,10 +31,6 @@ limitations under the License.
     margin-left: -12px;
 }
 
-.mx_WhoIsTypingTile_avatars .mx_BaseAvatar_image {
-    border: 1px solid $primary-bg-color;
-}
-
 .mx_WhoIsTypingTile_avatars .mx_BaseAvatar_initial {
     padding-top: 1px;
 }

--- a/res/css/views/rooms/_WhoIsTypingTile.scss
+++ b/res/css/views/rooms/_WhoIsTypingTile.scss
@@ -35,6 +35,11 @@ limitations under the License.
     padding-top: 1px;
 }
 
+.mx_WhoIsTypingTile_avatars .mx_BaseAvatar {
+    border: 1px solid $primary-bg-color;
+    border-radius: 40px;
+}
+
 .mx_WhoIsTypingTile_remainingAvatarPlaceholder {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
I have removed styling on the currently typing avatar. It was giving place to an uncentered letter within the avatar as explained in this issue: The letter in the default avatar in typing section is not well centered.
Fixes vector-im/riot-web#12298

Previously : 
![image](https://user-images.githubusercontent.com/40339476/74188076-0ac40500-4c4e-11ea-956c-68c591d3703b.png)
Currently: 
![image](https://user-images.githubusercontent.com/40339476/74188139-25967980-4c4e-11ea-8969-def8ad0d3627.png)

Cheers,

Signed-off-by: Romain Testard <romain.rtestard@gmail.com>