### PR TITLE
Fix recaptcha blocked by CSP for non-SSL origins

### DIFF
--- a/src/components/views/auth/CaptchaForm.js
+++ b/src/components/views/auth/CaptchaForm.js
@@ -61,13 +61,9 @@ export default createReactClass({
         } else {
             console.log("Loading recaptcha script...");
             window.mx_on_recaptcha_loaded = () => {this._onCaptchaLoaded();};
-            let protocol = global.location.protocol;
-            if (protocol !== "http:") {
-                protocol = "https:";
-            }
             const scriptTag = document.createElement('script');
             scriptTag.setAttribute(
-                'src', `${protocol}//www.recaptcha.net/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit`,
+                'src', `https://www.recaptcha.net/recaptcha/api.js?onload=mx_on_recaptcha_loaded&render=explicit`,
             );
             this._recaptchaContainer.current.appendChild(scriptTag);
         }


### PR DESCRIPTION
Fixes captcha loading on non-SSL origins due to strict CSP meta tag.
Previously we were going for non-SSL but their docs say

> The script must be loaded using the HTTPS protocol and can be included from any point on the page without restriction.

It works for localhost as expected.

Src: https://developers.google.com/recaptcha/docs/display