### PR TITLE
remove methods arg to requestVerification(DM)

### DIFF
--- a/src/components/views/dialogs/DeviceVerifyDialog.js
+++ b/src/components/views/dialogs/DeviceVerifyDialog.js
@@ -123,7 +123,7 @@ export default class DeviceVerifyDialog extends React.Component {
                 const roomId = await ensureDMExistsAndOpen(this.props.userId);
                 // throws upon cancellation before having started
                 const request = await client.requestVerificationDM(
-                    this.props.userId, roomId, [verificationMethods.SAS],
+                    this.props.userId, roomId,
                 );
                 await request.waitFor(r => r.ready || r.started);
                 if (request.ready) {

--- a/src/components/views/dialogs/NewSessionReviewDialog.js
+++ b/src/components/views/dialogs/NewSessionReviewDialog.js
@@ -22,9 +22,7 @@ import { replaceableComponent } from '../../../utils/replaceableComponent';
 import VerificationRequestDialog from './VerificationRequestDialog';
 import BaseDialog from './BaseDialog';
 import DialogButtons from '../elements/DialogButtons';
-import {verificationMethods} from 'matrix-js-sdk/src/crypto';
 import {MatrixClientPeg} from "../../../MatrixClientPeg";
-import {SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
 
 @replaceableComponent("views.dialogs.NewSessionReviewDialog")
 export default class NewSessionReviewDialog extends React.PureComponent {

--- a/src/components/views/dialogs/NewSessionReviewDialog.js
+++ b/src/components/views/dialogs/NewSessionReviewDialog.js
@@ -43,12 +43,6 @@ export default class NewSessionReviewDialog extends React.PureComponent {
         const cli = MatrixClientPeg.get();
         const request = await cli.requestVerification(
             userId,
-            [
-                verificationMethods.SAS,
-                SHOW_QR_CODE_METHOD,
-                SCAN_QR_CODE_METHOD,
-                verificationMethods.RECIPROCATE_QR_CODE,
-            ],
             [device.deviceId],
         );
 

--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -157,12 +157,6 @@ async function verifyDevice(userId, device) {
             const cli = MatrixClientPeg.get();
             const verificationRequest = await cli.requestVerification(
                 userId,
-                [
-                    verificationMethods.SAS,
-                    SHOW_QR_CODE_METHOD,
-                    SCAN_QR_CODE_METHOD,
-                    verificationMethods.RECIPROCATE_QR_CODE,
-                ],
                 [device.deviceId],
             );
             dis.dispatch({

--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -42,8 +42,6 @@ import {textualPowerLevel} from '../../../Roles';
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import {RIGHT_PANEL_PHASES} from "../../../stores/RightPanelStorePhases";
 import EncryptionPanel from "./EncryptionPanel";
-import {verificationMethods} from 'matrix-js-sdk/src/crypto';
-import {SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
 
 const _disambiguateDevices = (devices) => {
     const names = Object.create(null);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12319
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1206

It's easy for all the calls in react-sdk to `requestVerification(DM)` to have a different set of methods they pass along. There is also little value to it, as clients built on top of js-sdk can already select the subset of methods they can provide an UI for through the `verificationMethods` option when creating the client.