### PR TITLE
Use the proper aria-pressed attribute for the switch role.

### DIFF
--- a/src/components/views/elements/ToggleSwitch.js
+++ b/src/components/views/elements/ToggleSwitch.js
@@ -39,7 +39,7 @@ const ToggleSwitch = ({checked, disabled=false, onChange, ...props}) => {
             className={classes}
             onClick={_onClick}
             role="switch"
-            aria-checked={checked}
+            aria-pressed={checked}
             aria-disabled={disabled}
         >
             <div className="mx_ToggleSwitch_ball" />

--- a/src/components/views/elements/ToggleSwitch.js
+++ b/src/components/views/elements/ToggleSwitch.js
@@ -39,6 +39,7 @@ const ToggleSwitch = ({checked, disabled=false, onChange, ...props}) => {
             className={classes}
             onClick={_onClick}
             role="switch"
+            // aria-pressed despite the spec because of https://github.com/w3c/aria-practices/issues/1327.
             aria-pressed={checked}
             aria-disabled={disabled}
         >


### PR DESCRIPTION
The proper state to use is aria-pressed, not aria-checked. Otherwise, screen readers would read "not pressed checked" or similar nonsense.

Signed-off-by: Marco Zehe <marcozehe@mailbox.org>