### PR TITLE
Disable 'start' button after clicking in VerificationPanel

### DIFF
--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -88,7 +88,7 @@ export default class VerificationPanel extends React.PureComponent {
                         <div className='mx_VerificationPanel_QRPhase_startOption'>
                             <p>{_t("Compare unique emoji")}</p>
                             <span className='mx_VerificationPanel_QRPhase_helpText'>{_t("Compare a unique set of emoji if you don't have a camera on either device")}</span>
-                            <AccessibleButton onClick={this._startSAS} kind='primary'>
+                            <AccessibleButton disabled={this.state.emojiButtonClicked} onClick={this._startSAS} kind='primary'>
                                 {_t("Start")}
                             </AccessibleButton>
                         </div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12335, kind of?

I suspect the issue for me was transient, but this adds user feedback, even if that feedback is just that the button becomes disabled and then nothing else happens