### PR TITLE
Always speak the full text of the typing indicator when it updates.

### DIFF
--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -213,7 +213,7 @@ export default createReactClass({
         }
 
         return (
-            <li className="mx_WhoIsTypingTile">
+            <li className="mx_WhoIsTypingTile" aria-atomic="true">
                 <div className="mx_WhoIsTypingTile_avatars">
                     { this._renderTypingIndicatorAvatars(usersTyping, this.props.whoIsTypingLimit) }
                 </div>


### PR DESCRIPTION
By default, aria-live regions only speak partial updates. However in the case of the typing indicator, if it goes from one person typing to several, and back, the updated text would only be spoken in fragments by screen readers. Adding the aria-atomic attribute with a value of true makes screen readers always speak the full update for this tile, making the experience much nicer.

Signed-off-by: Marco Zehe <marcozehe@mailbox.org>