### PR TITLE
Fixes for printing event indexing stats.

### DIFF
--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -50,11 +50,11 @@ export default class ManageEventIndexDialog extends React.Component {
         const eventIndex = EventIndexPeg.get();
         let stats;
 
-        // This call may fail if sporadically, not a huge issue as we will try
-        // later again and probably succeed.
         try {
             stats = await eventIndex.getStats();
         } catch {
+            // This call may fail if sporadically, not a huge issue as we will
+            // try later again and probably succeed.
             return;
         }
 
@@ -99,6 +99,9 @@ export default class ManageEventIndexDialog extends React.Component {
                 eventIndexSize = stats.size;
                 eventCount = stats.eventCount;
             } catch {
+                // This call may fail if sporadically, not a huge issue as we
+                // will try later again in the updateCurrentRoom call and
+                // probably succeed.
             }
 
             const roomStats = eventIndex.crawlingRooms();

--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -46,7 +46,7 @@ export default class ManageEventIndexDialog extends React.Component {
         };
     }
 
-    updateCurrentRoom = async(room) => {
+    updateCurrentRoom = async (room) => {
         const eventIndex = EventIndexPeg.get();
         let stats;
 

--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -48,7 +48,16 @@ export default class ManageEventIndexDialog extends React.Component {
 
     updateCurrentRoom = async(room) => {
         const eventIndex = EventIndexPeg.get();
-        const stats = await eventIndex.getStats();
+        let stats;
+
+        // This call may fail if sporadically, not a huge issue as we will try
+        // later again and probably succeed.
+        try {
+            stats = await eventIndex.getStats();
+        } catch {
+            return;
+        }
+
         let currentRoom = null;
 
         if (room) currentRoom = room.name;
@@ -85,12 +94,16 @@ export default class ManageEventIndexDialog extends React.Component {
         if (eventIndex !== null) {
             eventIndex.on("changedCheckpoint", this.updateCurrentRoom);
 
-            const stats = await eventIndex.getStats();
+            try {
+                const stats = await eventIndex.getStats();
+                eventIndexSize = stats.size;
+                eventCount = stats.eventCount;
+            } catch {
+            }
+
             const roomStats = eventIndex.crawlingRooms();
-            eventIndexSize = stats.size;
             crawlingRoomsCount = roomStats.crawlingRooms.size;
             roomCount = roomStats.totalRooms.size;
-            eventCount = stats.eventCount;
 
             const room = eventIndex.currentRoom();
             if (room) currentRoom = room.name;

--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.js
@@ -46,7 +46,7 @@ export default class ManageEventIndexDialog extends React.Component {
         };
     }
 
-    updateCurrentRoom = async (room) => {
+    updateCurrentRoom = async(room) => {
         const eventIndex = EventIndexPeg.get();
         const stats = await eventIndex.getStats();
         let currentRoom = null;

--- a/src/components/views/settings/EventIndexPanel.js
+++ b/src/components/views/settings/EventIndexPanel.js
@@ -41,11 +41,11 @@ export default class EventIndexPanel extends React.Component {
         const eventIndex = EventIndexPeg.get();
         let stats;
 
-        // This call may fail if sporadically, not a huge issue as we will try
-        // later again and probably succeed.
         try {
             stats = await eventIndex.getStats();
         } catch {
+            // This call may fail if sporadically, not a huge issue as we will
+            // try later again and probably succeed.
             return;
         }
 
@@ -83,6 +83,9 @@ export default class EventIndexPanel extends React.Component {
                 eventIndexSize = stats.size;
                 roomCount = stats.roomCount;
             } catch {
+                // This call may fail if sporadically, not a huge issue as we
+                // will try later again in the updateCurrentRoom call and
+                // probably succeed.
             }
         }
 

--- a/src/components/views/settings/EventIndexPanel.js
+++ b/src/components/views/settings/EventIndexPanel.js
@@ -39,7 +39,15 @@ export default class EventIndexPanel extends React.Component {
 
     updateCurrentRoom = async (room) => {
         const eventIndex = EventIndexPeg.get();
-        const stats = await eventIndex.getStats();
+        let stats;
+
+        // This call may fail if sporadically, not a huge issue as we will try
+        // later again and probably succeed.
+        try {
+            stats = await eventIndex.getStats();
+        } catch {
+            return;
+        }
 
         this.setState({
             eventIndexSize: stats.size,
@@ -70,9 +78,12 @@ export default class EventIndexPanel extends React.Component {
         if (eventIndex !== null) {
             eventIndex.on("changedCheckpoint", this.updateCurrentRoom);
 
-            const stats = await eventIndex.getStats();
-            eventIndexSize = stats.size;
-            roomCount = stats.roomCount;
+            try {
+                const stats = await eventIndex.getStats();
+                eventIndexSize = stats.size;
+                roomCount = stats.roomCount;
+            } catch {
+            }
         }
 
         this.setState({


### PR DESCRIPTION
The first patch fixes an issue where the event listener wouldn't get removed correctly. 

The second patch just catches errors of the `getStats()` method since those can occasionally happen. Related Seshat issue for the second patch can be found here https://github.com/matrix-org/seshat/issues/42.

This closes https://github.com/vector-im/riot-web/issues/12387.