### PR TITLE
Fix: don't advertise ability to scan a QR code for verification

### DIFF
--- a/src/MatrixClientPeg.js
+++ b/src/MatrixClientPeg.js
@@ -32,7 +32,7 @@ import MatrixClientBackedSettingsHandler from "./settings/handlers/MatrixClientB
 import * as StorageManager from './utils/StorageManager';
 import IdentityAuthClient from './IdentityAuthClient';
 import { crossSigningCallbacks } from './CrossSigningManager';
-import {SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
+import {SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
 
 interface MatrixClientCreds {
     homeserverUrl: string,
@@ -221,7 +221,6 @@ class _MatrixClientPeg {
             verificationMethods: [
                 verificationMethods.SAS,
                 SHOW_QR_CODE_METHOD,
-                SCAN_QR_CODE_METHOD, // XXX: We don't actually support scanning yet!
                 verificationMethods.RECIPROCATE_QR_CODE,
             ],
             unstableClientRelationAggregation: true,

--- a/src/components/views/dialogs/DeviceVerifyDialog.js
+++ b/src/components/views/dialogs/DeviceVerifyDialog.js
@@ -27,7 +27,7 @@ import {verificationMethods} from 'matrix-js-sdk/src/crypto';
 import {ensureDMExists} from "../../../createRoom";
 import dis from "../../../dispatcher";
 import SettingsStore from '../../../settings/SettingsStore';
-import {SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
+import {SHOW_QR_CODE_METHOD} from "matrix-js-sdk/src/crypto/verification/QRCode";
 import VerificationQREmojiOptions from "../verification/VerificationQREmojiOptions";
 
 const MODE_LEGACY = 'legacy';
@@ -135,7 +135,6 @@ export default class DeviceVerifyDialog extends React.Component {
                 this._request = await client.requestVerification(this.props.userId, [
                     verificationMethods.SAS,
                     SHOW_QR_CODE_METHOD,
-                    SCAN_QR_CODE_METHOD,
                     verificationMethods.RECIPROCATE_QR_CODE,
                 ]);
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12321
This was introduced to be compatible with RiotX, but as of https://github.com/vector-im/riotX-android/issues/988 it is not needed anymore.