### PR TITLE
Remove exec so release script continues

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -35,7 +35,7 @@ do
     fi
 done
 
-exec ./node_modules/matrix-js-sdk/release.sh -z "$@"
+./node_modules/matrix-js-sdk/release.sh -z "$@"
 
 release="${1#v}"
 prerelease=0


### PR DESCRIPTION
We now want to do post-processing after the JS SDK release script, so we can't
use `exec` here.