### PR TITLE
Use alt_aliases for pills and autocomplete

### DIFF
--- a/src/Rooms.js
+++ b/src/Rooms.js
@@ -23,7 +23,7 @@ import {MatrixClientPeg} from './MatrixClientPeg';
  * of aliases. Otherwise return null;
  */
 export function getDisplayAliasForRoom(room) {
-    return room.getCanonicalAlias() || room.getAliases()[0];
+    return room.getCanonicalAlias() || room.getAltAliases()[0];
 }
 
 /**

--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -23,7 +23,6 @@ import AutocompleteProvider from './AutocompleteProvider';
 import {MatrixClientPeg} from '../MatrixClientPeg';
 import QueryMatcher from './QueryMatcher';
 import {PillCompletion} from './Components';
-import {getDisplayAliasForRoom} from '../Rooms';
 import * as sdk from '../index';
 import _sortBy from 'lodash/sortBy';
 import {makeRoomPermalink} from "../utils/permalinks/Permalinks";
@@ -92,6 +91,7 @@ export default class RoomProvider extends AutocompleteProvider {
             completions = _sortBy(completions, [
                 (c) => score(matchedString, c.displayedAlias),
                 (c) => c.displayedAlias.length,
+            ]);
             completions = completions.map((room) => {
                 return {
                     completion: room.displayedAlias,

--- a/src/autocomplete/RoomProvider.js
+++ b/src/autocomplete/RoomProvider.js
@@ -40,11 +40,19 @@ function score(query, space) {
     }
 }
 
+function matcherObject(room, displayedAlias, matchName = "") {
+    return {
+        room,
+        matchName,
+        displayedAlias,
+    };
+}
+
 export default class RoomProvider extends AutocompleteProvider {
     constructor() {
         super(ROOM_REGEX);
         this.matcher = new QueryMatcher([], {
-            keys: ['displayedAlias', 'name'],
+            keys: ['displayedAlias', 'matchName'],
         });
     }
 
@@ -56,16 +64,16 @@ export default class RoomProvider extends AutocompleteProvider {
         const {command, range} = this.getCurrentCommand(query, selection, force);
         if (command) {
             // the only reason we need to do this is because Fuse only matches on properties
-            let matcherObjects = client.getVisibleRooms().filter(
-                (room) => !!room && !!getDisplayAliasForRoom(room),
-            ).map((room) => {
-                return {
-                    room: room,
-                    name: room.name,
-                    displayedAlias: getDisplayAliasForRoom(room),
-                };
-            });
-
+            let matcherObjects = client.getVisibleRooms().reduce((aliases, room) => {
+                if (room.getCanonicalAlias()) {
+                    aliases = aliases.concat(matcherObject(room, room.getCanonicalAlias(), room.name));
+                }
+                if (room.getAltAliases().length) {
+                    const altAliases = room.getAltAliases().map(alias => matcherObject(room, alias));
+                    aliases = aliases.concat(altAliases);
+                }
+                return aliases;
+            }, []);
             // Filter out any matches where the user will have also autocompleted new rooms
             matcherObjects = matcherObjects.filter((r) => {
                 const tombstone = r.room.currentState.getStateEvents("m.room.tombstone", "");
@@ -84,16 +92,15 @@ export default class RoomProvider extends AutocompleteProvider {
             completions = _sortBy(completions, [
                 (c) => score(matchedString, c.displayedAlias),
                 (c) => c.displayedAlias.length,
-            ]).map((room) => {
-                const displayAlias = getDisplayAliasForRoom(room.room) || room.roomId;
+            completions = completions.map((room) => {
                 return {
-                    completion: displayAlias,
-                    completionId: displayAlias,
+                    completion: room.displayedAlias,
+                    completionId: room.room.roomId,
                     type: "room",
                     suffix: ' ',
-                    href: makeRoomPermalink(displayAlias),
+                    href: makeRoomPermalink(room.displayedAlias),
                     component: (
-                        <PillCompletion initialComponent={<RoomAvatar width={24} height={24} room={room.room} />} title={room.name} description={displayAlias} />
+                        <PillCompletion initialComponent={<RoomAvatar width={24} height={24} room={room.room} />} title={room.room.name} description={room.displayedAlias} />
                     ),
                     range,
                 };

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -129,7 +129,7 @@ const Pill = createReactClass({
                 const localRoom = resourceId[0] === '#' ?
                     MatrixClientPeg.get().getRooms().find((r) => {
                         return r.getCanonicalAlias() === resourceId ||
-                               r.getAliases().includes(resourceId);
+                               r.getAltAliases().includes(resourceId);
                     }) : MatrixClientPeg.get().getRoom(resourceId);
                 room = localRoom;
                 if (!localRoom) {

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -237,15 +237,7 @@ const Pill = createReactClass({
             case Pill.TYPE_ROOM_MENTION: {
                 const room = this.state.room;
                 if (room) {
-                    const isModeratedAlias = room.getCanonicalAlias() === resource ||
-                        room.getAltAliases().includes(resource);
-                    if (!isModeratedAlias) {
-                        linkText = getDisplayAliasForRoom(room);
-                    }
-                    // if there are no moderated aliases, stick to resource
-                    if (!linkText) {
-                        linkText = resource;
-                    }
+                    linkText = resource;
                     if (this.props.shouldShowPillAvatar) {
                         avatar = <RoomAvatar room={room} width={16} height={16} aria-hidden="true" />;
                     }

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -23,7 +23,6 @@ import classNames from 'classnames';
 import { Room, RoomMember } from 'matrix-js-sdk';
 import PropTypes from 'prop-types';
 import {MatrixClientPeg} from '../../../MatrixClientPeg';
-import { getDisplayAliasForRoom } from '../../../Rooms';
 import FlairStore from "../../../stores/FlairStore";
 import {getPrimaryPermalinkEntity} from "../../../utils/permalinks/Permalinks";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -241,8 +241,8 @@ const Pill = createReactClass({
                     if (this.props.shouldShowPillAvatar) {
                         avatar = <RoomAvatar room={room} width={16} height={16} aria-hidden="true" />;
                     }
-                    pillClass = 'mx_RoomPill';
                 }
+                pillClass = 'mx_RoomPill';
             }
                 break;
             case Pill.TYPE_GROUP_MENTION: {

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -237,7 +237,15 @@ const Pill = createReactClass({
             case Pill.TYPE_ROOM_MENTION: {
                 const room = this.state.room;
                 if (room) {
-                    linkText = (room ? getDisplayAliasForRoom(room) : null) || resource;
+                    const isModeratedAlias = room.getCanonicalAlias() === resource ||
+                        room.getAltAliases().includes(resource);
+                    if (!isModeratedAlias) {
+                        linkText = getDisplayAliasForRoom(room);
+                    }
+                    // if there are no moderated aliases, stick to resource
+                    if (!linkText) {
+                        linkText = resource;
+                    }
                     if (this.props.shouldShowPillAvatar) {
                         avatar = <RoomAvatar room={room} width={16} height={16} aria-hidden="true" />;
                     }

--- a/src/editor/autocomplete.js
+++ b/src/editor/autocomplete.js
@@ -102,7 +102,7 @@ export default class AutocompleteWrapperModel {
         const text = completion.completion;
         switch (completion.type) {
             case "room":
-                return [this._partCreator.roomPill(completionId), this._partCreator.plain(completion.suffix)];
+                return [this._partCreator.roomPill(text, completionId), this._partCreator.plain(completion.suffix)];
             case "at-room":
                 return [this._partCreator.atRoomPill(completionId), this._partCreator.plain(completion.suffix)];
             case "user":

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -428,7 +428,8 @@ export class PartCreator {
             room = this._client.getRoom(roomId || alias);
         } else {
             room = this._client.getRooms().find((r) => {
-                return r.getCanonicalAlias() === alias || r.getAliases().includes(alias);
+                return r.getCanonicalAlias() === alias ||
+                       r.getAltAliases().includes(alias);
             });
         }
         return new RoomPillPart(alias, room);

--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -422,14 +422,14 @@ export class PartCreator {
         return new PillCandidatePart(text, this._autoCompleteCreator);
     }
 
-    roomPill(alias) {
+    roomPill(alias, roomId) {
         let room;
-        if (alias[0] === '#') {
+        if (roomId || alias[0] !== "#") {
+            room = this._client.getRoom(roomId || alias);
+        } else {
             room = this._client.getRooms().find((r) => {
                 return r.getCanonicalAlias() === alias || r.getAliases().includes(alias);
             });
-        } else {
-            room = this._client.getRoom(alias);
         }
         return new RoomPillPart(alias, room);
     }


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1225
Fixes https://github.com/vector-im/riot-web/issues/12364

As explained in [MSC2432](https://github.com/matrix-org/matrix-doc/pull/2432), `m.room.aliases` are being retired. Moderators can set `alt_aliases` on the canonical alias event to support more than 1 moderated alias (note that there is no UI for this yet). Clients can query the local aliases of a HS through a new /aliases endpoint but should really not show these by default as they are an abuse vector.

So, this PR:
 - adds `alt_aliases` in addition to the canonical alias to autocomplete
 - leaves the label of a pill as is
 - always renders room pills inside a grey pill (so no more blue link when the room is not found), albeit without an avatar for local non-moderated aliases (we'd have to query /directory otherwise).

Ideally, we'd also add exact matches for local aliases to the autocomplete, so you would be able to send pills for non-moderated aliases from riot, but that proved a bit harder, so let's defer that until it's obvious we need it.