### PR TITLE
Revert "Fix escaped markdown passing backslashes through"

### DIFF
--- a/src/editor/serialize.js
+++ b/src/editor/serialize.js
@@ -41,14 +41,6 @@ export function htmlSerializeIfNeeded(model, {forceHTML = false} = {}) {
     if (!parser.isPlainText() || forceHTML) {
         return parser.toHTML();
     }
-    // Format "plain" text to ensure removal of backslash escapes
-    // https://github.com/vector-im/riot-web/issues/11230
-    // https://github.com/vector-im/riot-web/issues/2870
-    const postParsePlaintext = parser.toPlaintext();
-    if (postParsePlaintext !== md) {
-        // only return "formatted" text if it differs from the source text
-        return postParsePlaintext;
-    }
 }
 
 export function textSerialize(model) {

--- a/test/editor/serialize-test.js
+++ b/test/editor/serialize-test.js
@@ -43,10 +43,4 @@ describe('editor/serialize', function() {
         const html = htmlSerializeIfNeeded(model, {});
         expect(html).toBe("<em>hello</em> world");
     });
-    it('escaped markdown should not retain backslashes', function() {
-        const pc = createPartCreator();
-        const model = new EditorModel([pc.plain('\\*hello\\* world')]);
-        const html = htmlSerializeIfNeeded(model, {});
-        expect(html).toBe('*hello* world');
-    });
 });


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#4008

Reverting because this also removes quotes where they are intended, as in the message:

> looks like we're not escaping '<' ☹️

(only when the ☹️ is auto completed by the composer though)