### PR TITLE
update phase when request prop changes

### DIFF
--- a/src/components/views/right_panel/EncryptionPanel.js
+++ b/src/components/views/right_panel/EncryptionPanel.js
@@ -32,11 +32,14 @@ const MISMATCHES = ["m.key_mismatch", "m.user_error", "m.mismatched_sas"];
 
 const EncryptionPanel = ({verificationRequest, member, onClose, layout}) => {
     const [request, setRequest] = useState(verificationRequest);
-    useEffect(() => {
-        setRequest(verificationRequest);
-    }, [verificationRequest]);
 
     const [phase, setPhase] = useState(request && request.phase);
+    useEffect(() => {
+        setRequest(verificationRequest);
+        if (verificationRequest) {
+            setPhase(verificationRequest.phase);
+        }
+    }, [verificationRequest]);
     const changeHandler = useCallback(() => {
         // handle transitions -> cancelled for mismatches which fire a modal instead of showing a card
         if (request && request.cancelled && MISMATCHES.includes(request.cancellationCode)) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12463

When the `verificationRequest` prop of the EncryptionPanel gets set to a just-accepted request while looking at the EncryptionInfo, the phase wasn't being updated and you would see a spinner in the EncryptionInfo that would spin until the request emitted `change` again (likely when the other side clicked "verify by emoji"). This updates the phase when the request prop changes.