### PR TITLE
Don't leak if show_sas never comes (or already came)

### DIFF
--- a/src/components/views/right_panel/VerificationPanel.js
+++ b/src/components/views/right_panel/VerificationPanel.js
@@ -270,6 +270,8 @@ export default class VerificationPanel extends React.PureComponent {
     };
 
     _onVerifierShowSas = (sasEvent) => {
+        const {request} = this.props;
+        request.verifier.off('show_sas', this._onVerifierShowSas);
         this.setState({sasEvent});
     };
 
@@ -278,7 +280,7 @@ export default class VerificationPanel extends React.PureComponent {
         const hadVerifier = this._hasVerifier;
         this._hasVerifier = !!request.verifier;
         if (!hadVerifier && this._hasVerifier) {
-            request.verifier.once('show_sas', this._onVerifierShowSas);
+            request.verifier.on('show_sas', this._onVerifierShowSas);
             try {
                 // on the requester side, this is also awaited in _startSAS,
                 // but that's ok as verify should return the same promise.
@@ -299,6 +301,10 @@ export default class VerificationPanel extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        this.props.request.off("change", this._onRequestChange);
+        const {request} = this.props;
+        if (request.verifier) {
+            request.verifier.off('show_sas', this._onVerifierShowSas);
+        }
+        request.off("change", this._onRequestChange);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12481

This fixes the leak by not de-registering the `show_sas` event handler in `VerificationPanel` if the event never fires.

It only releases the everything after the verification request has been concluded (cancelled or finished) though, as we still await `verifier.verify()` even when unmounted. I tried to make those awaits race with a promise that gets rejected (with an `UnmountError`) when unmounting to get everything released on unmount no matter what the state of the request is, but somehow that didn't work, the `VerificationPanel` still seems retained for reasons aren't immediately clear to me:

![image](https://user-images.githubusercontent.com/274386/75170375-ebcf7380-5721-11ea-831b-e4454e34751f.png)
