### PR TITLE
Don't prefix QR codes with the length of the static marker string

### DIFF
--- a/src/components/views/elements/crypto/VerificationQRCode.js
+++ b/src/components/views/elements/crypto/VerificationQRCode.js
@@ -130,9 +130,9 @@ export default class VerificationQRCode extends React.PureComponent {
             tmpBuf.writeInt8(i, 0);
             buf = Buffer.concat([buf, tmpBuf]);
         };
-        const appendStr = (s: string, enc: string) => {
+        const appendStr = (s: string, enc: string, withLengthPrefix = true) => {
             const tmpBuf = Buffer.from(s, enc);
-            appendInt(tmpBuf.byteLength);
+            if (withLengthPrefix) appendInt(tmpBuf.byteLength);
             buf = Buffer.concat([buf, tmpBuf]);
         };
         const appendEncBase64 = (b64: string) => {
@@ -142,7 +142,7 @@ export default class VerificationQRCode extends React.PureComponent {
         };
 
         // Actually build the buffer for the QR code
-        appendStr(this.props.prefix, "ascii");
+        appendStr(this.props.prefix, "ascii", false);
         appendByte(this.props.version);
         appendByte(this.props.mode);
         appendStr(this.props.transactionId, "utf-8");


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12489