### PR TITLE
Don't try to collapse zero events with a group

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -873,6 +873,11 @@ class CreationGrouper {
     }
 
     getTiles() {
+        // If we don't have any events to group, don't even try to group them. The logic
+        // below assumes that we have a group of events to deal with, but we might not if
+        // the events we were supposed to group were redacted.
+        if (!this.events || !this.events.length) return [];
+
         const DateSeparator = sdk.getComponent('messages.DateSeparator');
         const EventListSummary = sdk.getComponent('views.elements.EventListSummary');
 
@@ -959,6 +964,11 @@ class MemberGrouper {
     }
 
     getTiles() {
+        // If we don't have any events to group, don't even try to group them. The logic
+        // below assumes that we have a group of events to deal with, but we might not if
+        // the events we were supposed to group were redacted.
+        if (!this.events || !this.events.length) return [];
+
         const DateSeparator = sdk.getComponent('messages.DateSeparator');
         const MemberEventListSummary = sdk.getComponent('views.elements.MemberEventListSummary');
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12423

When events are redacted they fail to make it into the Grouper because the `shouldAddEvent` check blocks them from entering. However, the grouper expects that when `getTiles()` is called that there's events to group and dutifully grabs some context from the array. Because JavaScript is the least helpful language, `myArray[-1]` returns `undefined` or `null` and thus you get `cannot read 'sender' of undefined`.

Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/4059