### PR TITLE
Limit UserInfo Displayname to 3 lines to get rid of scrollbars

### DIFF
--- a/res/css/views/right_panel/_UserInfo.scss
+++ b/res/css/views/right_panel/_UserInfo.scss
@@ -137,7 +137,6 @@ limitations under the License.
             font-size: 18px;
             line-height: 25px;
             flex: 1;
-            display: flex;
             justify-content: center;
             align-items: center;
 

--- a/res/css/views/right_panel/_UserInfo.scss
+++ b/res/css/views/right_panel/_UserInfo.scss
@@ -137,11 +137,19 @@ limitations under the License.
             font-size: 18px;
             line-height: 25px;
             flex: 1;
-            overflow-x: auto;
-            max-height: 50px;
             display: flex;
             justify-content: center;
             align-items: center;
+
+            // limit to 2 lines, show an ellipsis if it overflows
+            // this looks webkit specific but is supported by Firefox 68+
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+
+            overflow: hidden;
+            word-break: break-all;
+            text-overflow: ellipsis;
 
             .mx_E2EIcon {
                 margin: 5px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2403652/75350394-55748c80-589e-11ea-9b82-edbf93655d36.png)


After:
![image](https://user-images.githubusercontent.com/2403652/75350323-3675fa80-589e-11ea-868d-865cf9b01180.png)

Firefox supports this as of 68 https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp#Browser_compatibility


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>