### PR TITLE
Remove debug line from Analytics

### DIFF
--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -260,7 +260,6 @@ class Analytics {
             });
         } catch (e) {
             console.error("Analytics error: ", e);
-            window.err = e;
         }
     }
 


### PR DESCRIPTION
When rewriting Analytics I left an ugly little debug helper in there, this removes it.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>