### PR TITLE
Ensure verification QR codes use the right buffer size

### DIFF
--- a/src/components/views/elements/crypto/VerificationQRCode.js
+++ b/src/components/views/elements/crypto/VerificationQRCode.js
@@ -126,7 +126,7 @@ export default class VerificationQRCode extends React.PureComponent {
             buf = Buffer.concat([buf, tmpBuf]);
         };
         const appendInt = (i: number) => {
-            const tmpBuf = Buffer.alloc(4);
+            const tmpBuf = Buffer.alloc(2);
             tmpBuf.writeInt8(i, 0);
             buf = Buffer.concat([buf, tmpBuf]);
         };


### PR DESCRIPTION
The string length buffer only needs 2 bytes, not 4.