### PR TITLE
Use the right function for creating binary verification QR codes

### DIFF
--- a/src/components/views/elements/crypto/VerificationQRCode.js
+++ b/src/components/views/elements/crypto/VerificationQRCode.js
@@ -127,7 +127,7 @@ export default class VerificationQRCode extends React.PureComponent {
         };
         const appendInt = (i: number) => {
             const tmpBuf = Buffer.alloc(2);
-            tmpBuf.writeInt8(i, 0);
+            tmpBuf.writeInt16BE(i, 0);
             buf = Buffer.concat([buf, tmpBuf]);
         };
         const appendStr = (s: string, enc: string, withLengthPrefix = true) => {


### PR DESCRIPTION
`writeInt8` happened to work because the strings we're writing happen to fit within a single byte so the LSB doesn't matter. We actually want a 16 bit (2 byte) number in big-endian format.