### PR TITLE
Ignore cursor jumping shortcuts with shift

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -393,14 +393,14 @@ export default class BasicMessageEditor extends React.Component {
             this._insertText("\n");
             handled = true;
         // move selection to start of composer
-        } else if (modKey && event.key === Key.HOME) {
+        } else if (modKey && event.key === Key.HOME && !event.shiftKey) {
             setSelection(this._editorRef, model, {
                 index: 0,
                 offset: 0,
             });
             handled = true;
         // move selection to end of composer
-        } else if (modKey && event.key === Key.END) {
+        } else if (modKey && event.key === Key.END && !event.shiftKey) {
             setSelection(this._editorRef, model, {
                 index: model.parts.length - 1,
                 offset: model.parts[model.parts.length - 1].text.length,


### PR DESCRIPTION
This tweaks the new cursor jumping shortcuts in the composer so that they only
activate without shift. When shift _is_ pressed, you want to extend the
selection instead of just moving.

Fixes https://github.com/vector-im/riot-web/issues/12549