### PR TITLE
Ensure errors when creating a DM are raised to the user

### DIFF
--- a/src/components/views/dialogs/AskInviteAnywayDialog.js
+++ b/src/components/views/dialogs/AskInviteAnywayDialog.js
@@ -72,7 +72,7 @@ export default createReactClass({
                     <button onClick={this._onInviteNeverWarnClicked}>
                         { _t('Invite anyway and never warn me again') }
                     </button>
-                    <button onClick={this._onInviteClicked} autoFocus="true">
+                    <button onClick={this._onInviteClicked} autoFocus={true}>
                         { _t('Invite anyway') }
                     </button>
                 </div>

--- a/src/components/views/dialogs/InviteDialog.js
+++ b/src/components/views/dialogs/InviteDialog.js
@@ -564,7 +564,7 @@ export default class InviteDialog extends React.PureComponent {
             return;
         }
 
-        const createRoomOptions = {};
+        const createRoomOptions = {inlineErrors: true};
 
         if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
             // Check whether all users have uploaded device keys before.

--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -37,6 +37,8 @@ import SettingsStore from "./settings/SettingsStore";
  *     Default: True
  * @param {bool=} opts.encryption Whether to enable encryption.
  *     Default: False
+ * @param {bool=} opts.inlineErrors True to raise errors off the promise instead of resolving to null.
+ *     Default: False
  *
  * @returns {Promise} which resolves to the room id, or null if the
  * action was aborted or failed.
@@ -140,6 +142,9 @@ export default function createRoom(opts) {
         }
         return roomId;
     }, function(err) {
+        // Raise the error if the caller requested that we do so.
+        if (opts.inlineErrors) throw err;
+
         // We also failed to join the room (this sets joining to false in RoomViewStore)
         dis.dispatch({
             action: 'join_room_error',


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12186

Note: this will still result in an empty room being created, but that's a Synapse issue and not something we can solve.