### PR TITLE
Fix the last char of people's names being cut off in the invite dialog

### DIFF
--- a/src/components/views/dialogs/InviteDialog.js
+++ b/src/components/views/dialogs/InviteDialog.js
@@ -219,7 +219,7 @@ class DMRoomTile extends React.PureComponent {
         }
 
         // Push any text we missed (end of text)
-        if (i < (str.length - 1)) {
+        if (i < str.length) {
             result.push(<span key={i + 'end'}>{str.substring(i)}</span>);
         }
 


### PR DESCRIPTION
If someone named "TravisR" was being searched for with just "Travis", the last R in their name would be cut off because of the highlighting. Entering "TravisR" would restore it. Likewise, searching for "vis" would have done the same thing.