### PR TITLE
word-break in pills and wrap the background correctly

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -13,6 +13,11 @@
     padding-left: 5px;
 }
 
+a.mx_Pill {
+    word-break: break-all;
+    display: inline;
+}
+
 /* More specific to override `.markdown-body a` text-decoration */
 .mx_EventTile_content .markdown-body a.mx_Pill {
     text-decoration: none;


### PR DESCRIPTION
Do we want to truncate it at any point?

![image](https://user-images.githubusercontent.com/2403652/75598828-bb2b6900-5a96-11ea-8bcf-961a7771abd9.png)

Fixes https://github.com/vector-im/riot-web/issues/12363