### PR TITLE
SearchBar: search by author

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -56,7 +56,6 @@ limitations under the License.
     width: 100%;
     margin: 0px auto;
 
-    overflow: auto;
     flex: 0 0 auto;
 }
 

--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -56,6 +56,7 @@ limitations under the License.
     width: 100%;
     margin: 0px auto;
 
+    overflow: auto;
     flex: 0 0 auto;
 }
 

--- a/res/css/views/rooms/_SearchBar.scss
+++ b/res/css/views/rooms/_SearchBar.scss
@@ -29,6 +29,7 @@ limitations under the License.
 
         .mx_Autocomplete {
             transform: translateY(100%);
+            box-shadow: 0px 16px 32px rgba(0, 0, 0, 0.04);
         }
 
         .mx_Pill {

--- a/res/css/views/rooms/_SearchBar.scss
+++ b/res/css/views/rooms/_SearchBar.scss
@@ -25,6 +25,11 @@ limitations under the License.
         // font-size: $font-15px;
         flex: 1 1 0;
         margin-left: 22px;
+        position: relative;
+
+        .mx_Autocomplete {
+            transform: translateY(100%);
+        }
     }
 
     .mx_SearchBar_searchButton {

--- a/res/css/views/rooms/_SearchBar.scss
+++ b/res/css/views/rooms/_SearchBar.scss
@@ -25,15 +25,20 @@ limitations under the License.
         // font-size: $font-15px;
         flex: 1 1 0;
         margin-left: 22px;
-        position: relative;
 
-        .mx_Autocomplete {
-            transform: translateY(100%);
-            box-shadow: 0px 16px 32px rgba(0, 0, 0, 0.04);
-        }
+        .mx_BasicMessageComposer {
+            flex: 1;
+            padding: 9px;
+            color: #2e2f32;
 
-        .mx_Pill {
-            margin-left: 9px;
+            .mx_BasicMessageComposer_AutoCompleteWrapper {
+                position: initial;
+
+                .mx_Autocomplete {
+                    transform: translateY(100%);
+                    box-shadow: 0px 16px 32px rgba(0, 0, 0, 0.04);
+                }
+            }
         }
     }
 

--- a/res/css/views/rooms/_SearchBar.scss
+++ b/res/css/views/rooms/_SearchBar.scss
@@ -30,6 +30,10 @@ limitations under the License.
         .mx_Autocomplete {
             transform: translateY(100%);
         }
+
+        .mx_Pill {
+            margin-left: 9px;
+        }
     }
 
     .mx_SearchBar_searchButton {

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -150,17 +150,9 @@ async function localSearch(searchTerm, roomId = undefined, senderId = undefined,
         after_limit: 1,
         limit: SEARCH_LIMIT,
         order_by_recency: true,
-        room_id: undefined,
-        sender_id: undefined,
+        room_id: roomId,
+        sender_id: senderId,
     };
-
-    if (roomId !== undefined) {
-        searchArgs.room_id = roomId;
-    }
-
-    if (senderId !== undefined) {
-        searchArgs.sender_id = senderId;
-    }
 
     const localResult = await eventIndex.search(searchArgs);
 

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -26,6 +26,8 @@ async function serverSideSearch(term, roomIds = undefined, senderIds = undefined
         search_categories: {
             room_events: {
                 filter: {
+                    rooms: roomIds,
+                    senders: senderIds,
                     limit: SEARCH_LIMIT,
                 },
                 order_by: "recent",
@@ -39,12 +41,6 @@ async function serverSideSearch(term, roomIds = undefined, senderIds = undefined
     };
 
     if (term !== "") body.search_categories.room_events.search_term = term;
-    if (roomIds !== undefined && roomIds.length > 0) {
-        body.search_categories.room_events.filter.rooms = roomIds;
-    }
-    if (senderIds !== undefined && senderIds.length > 0) {
-        body.search_categories.room_events.filter.senders = senderIds;
-    }
 
     const response = await client.search({body: body});
 

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -140,7 +140,7 @@ async function combinedSearch(searchTerm, senderId = undefined) {
     return result;
 }
 
-async function localSearch(searchTerm, roomId = undefined, processResult = true) {
+async function localSearch(searchTerm, roomId = undefined, senderId = undefined, processResult = true) {
     const eventIndex = EventIndexPeg.get();
 
     const searchArgs = {
@@ -150,10 +150,15 @@ async function localSearch(searchTerm, roomId = undefined, processResult = true)
         limit: SEARCH_LIMIT,
         order_by_recency: true,
         room_id: undefined,
+        sender_id: undefined,
     };
 
     if (roomId !== undefined) {
         searchArgs.room_id = roomId;
+    }
+
+    if (senderId !== undefined) {
+        searchArgs.sender_id = senderId;
     }
 
     const localResult = await eventIndex.search(searchArgs);
@@ -168,7 +173,7 @@ async function localSearch(searchTerm, roomId = undefined, processResult = true)
     return result;
 }
 
-async function localSearchProcess(searchTerm, roomId = undefined) {
+async function localSearchProcess(searchTerm, roomId = undefined, senderId = undefined) {
     const emptyResult = {
         results: [],
         highlights: [],
@@ -176,7 +181,7 @@ async function localSearchProcess(searchTerm, roomId = undefined) {
 
     if (searchTerm === "") return emptyResult;
 
-    const result = await localSearch(searchTerm, roomId);
+    const result = await localSearch(searchTerm, roomId, senderId);
 
     emptyResult.seshatQuery = result.query;
 
@@ -540,7 +545,7 @@ function eventIndexSearch(term, roomId = undefined, senderId = undefined) {
         if (MatrixClientPeg.get().isRoomEncrypted(roomId)) {
             // The search is for a single encrypted room, use our local
             // search method.
-            searchPromise = localSearchProcess(term, roomId);
+            searchPromise = localSearchProcess(term, roomId, senderId);
         } else {
             // The search is for a single non-encrypted room, use the
             // server-side search.

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -22,17 +22,12 @@ const SEARCH_LIMIT = 10;
 async function serverSideSearch(term, roomIds = undefined, senderIds = undefined) {
     const client = MatrixClientPeg.get();
 
-    const filter = {
-        limit: SEARCH_LIMIT,
-    };
-
-    if (roomIds !== undefined && roomIds.length > 0) filter.rooms = roomIds;
-    if (senderIds !== undefined && senderIds.length > 0) filter.senders = senderIds;
-
     const body = {
         search_categories: {
             room_events: {
-                filter: filter,
+                filter: {
+                    limit: SEARCH_LIMIT,
+                },
                 order_by: "recent",
                 event_context: {
                     before_limit: 1,
@@ -44,6 +39,12 @@ async function serverSideSearch(term, roomIds = undefined, senderIds = undefined
     };
 
     if (term !== "") body.search_categories.room_events.search_term = term;
+    if (roomIds !== undefined && roomIds.length > 0) {
+        body.search_categories.room_events.filter.rooms = roomIds;
+    }
+    if (senderIds !== undefined && senderIds.length > 0) {
+        body.search_categories.room_events.filter.senders = senderIds;
+    }
 
     const response = await client.search({body: body});
 

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -32,7 +32,6 @@ async function serverSideSearch(term, roomId = undefined, senderId = undefined) 
     const body = {
         search_categories: {
             room_events: {
-                search_term: term,
                 filter: filter,
                 order_by: "recent",
                 event_context: {
@@ -43,6 +42,8 @@ async function serverSideSearch(term, roomId = undefined, senderId = undefined) 
             },
         },
     };
+
+    if (term !== "") body.search_categories.room_events.search_term = term;
 
     const response = await client.search({body: body});
 
@@ -178,8 +179,6 @@ async function localSearchProcess(searchTerm, roomId = undefined, senderId = und
         results: [],
         highlights: [],
     };
-
-    if (searchTerm === "") return emptyResult;
 
     const result = await localSearch(searchTerm, roomId, senderId);
 

--- a/src/autocomplete/Autocompleter.ts
+++ b/src/autocomplete/Autocompleter.ts
@@ -66,13 +66,13 @@ export interface IProviderCompletions {
 }
 
 export default class Autocompleter {
-    room: Room;
+    rooms: Room[];
     providers: AutocompleteProvider[];
 
-    constructor(room: Room) {
-        this.room = room;
+    constructor(rooms: Room[]) {
+        this.rooms = rooms;
         this.providers = PROVIDERS.map((Prov) => {
-            return new Prov(room);
+            return new Prov(rooms);
         });
     }
 

--- a/src/autocomplete/NotifProvider.tsx
+++ b/src/autocomplete/NotifProvider.tsx
@@ -26,11 +26,11 @@ import {ICompletion, ISelectionRange} from "./Autocompleter";
 const AT_ROOM_REGEX = /@\S*/g;
 
 export default class NotifProvider extends AutocompleteProvider {
-    room: Room;
+    rooms: Room[];
 
-    constructor(room) {
+    constructor(rooms) {
         super(AT_ROOM_REGEX);
-        this.room = room;
+        this.rooms = rooms;
     }
 
     async getCompletions(query: string, selection: ISelectionRange, force= false): Promise<ICompletion[]> {
@@ -38,7 +38,10 @@ export default class NotifProvider extends AutocompleteProvider {
 
         const client = MatrixClientPeg.get();
 
-        if (!this.room.currentState.mayTriggerNotifOfType('room', client.credentials.userId)) return [];
+        if (
+            this.rooms.length > 0 &&
+            !this.rooms[0].currentState.mayTriggerNotifOfType('room', client.credentials.userId)
+        ) return [];
 
         const {command, range} = this.getCurrentCommand(query, selection, force);
         if (command && command[0] && '@room'.startsWith(command[0]) && command[0].length > 1) {
@@ -49,7 +52,7 @@ export default class NotifProvider extends AutocompleteProvider {
                 suffix: ' ',
                 component: (
                     <PillCompletion title="@room" description={_t("Notify the whole room")}>
-                        <RoomAvatar width={24} height={24} room={this.room} />
+                        <RoomAvatar width={24} height={24} room={this.rooms[0]} />
                     </PillCompletion>
                 ),
                 range,

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1941,7 +1941,7 @@ export default class RoomView extends React.Component<IProps, IState> {
             />;
         }
 
-        let messageComposer; let searchInfo;
+        let messageComposer; let searchCount;
         const canSpeak = (
             // joined and not showing search results
             myMembership === 'join' && !this.state.searchResults
@@ -1960,14 +1960,8 @@ export default class RoomView extends React.Component<IProps, IState> {
                 />;
         }
 
-        // TODO: Why aren't we storing the term/scope/count in this format
-        // in this.state if this is what RoomHeader desires?
         if (this.state.searchResults) {
-            searchInfo = {
-                searchTerm: this.state.searchTerm,
-                searchScope: this.state.searchScope,
-                searchCount: this.state.searchResults.count,
-            };
+            searchCount = this.state.searchResults.count;
         }
 
         if (inCall) {
@@ -2130,7 +2124,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                     <ErrorBoundary>
                         <RoomHeader
                             room={this.state.room}
-                            searchInfo={searchInfo}
+                            searchCount={searchCount}
                             oobData={this.props.oobData}
                             inRoom={myMembership === 'join'}
                             onSearchClick={this.onSearchClick}

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1242,7 +1242,7 @@ export default class RoomView extends React.Component<IProps, IState> {
     private onSearch = (term: string, roomIds, senderIds) => {
         this.setState({
             searchTerm: term,
-            searchMultiRoom: roomIds.length === 0 || roomIds.length > 1,
+            searchMultiRoom: roomIds === undefined || roomIds.length > 1,
             searchResults: {},
             searchHighlights: [],
         });

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1239,7 +1239,7 @@ export default class RoomView extends React.Component<IProps, IState> {
             });
     }
 
-    private onSearch = (term: string, scope) => {
+    private onSearch = (term: string, scope, senderId) => {
         this.setState({
             searchTerm: term,
             searchScope: scope,
@@ -1263,7 +1263,7 @@ export default class RoomView extends React.Component<IProps, IState> {
         if (scope === "Room") roomId = this.state.room.roomId;
 
         debuglog("sending search request");
-        const searchPromise = eventSearch(term, roomId);
+        const searchPromise = eventSearch(term, roomId, senderId);
         this.handleSearchResult(searchPromise);
     };
 
@@ -1863,6 +1863,7 @@ export default class RoomView extends React.Component<IProps, IState> {
         } else if (this.state.searching) {
             hideCancel = true; // has own cancel
             aux = <SearchBar
+                room={this.state.room}
                 searchInProgress={this.state.searchInProgress}
                 onCancelClick={this.onCancelSearchClick}
                 onSearch={this.onSearch}

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1239,7 +1239,7 @@ export default class RoomView extends React.Component<IProps, IState> {
             });
     }
 
-    private onSearch = (term: string, scope, senderId) => {
+    private onSearch = (term: string, scope, senderIds) => {
         this.setState({
             searchTerm: term,
             searchScope: scope,
@@ -1263,7 +1263,7 @@ export default class RoomView extends React.Component<IProps, IState> {
         if (scope === "Room") roomId = this.state.room.roomId;
 
         debuglog("sending search request");
-        const searchPromise = eventSearch(term, roomId, senderId);
+        const searchPromise = eventSearch(term, roomId, senderIds);
         this.handleSearchResult(searchPromise);
     };
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1290,7 +1290,7 @@ export default class RoomView extends React.Component<IProps, IState> {
             // whether it was used by the search engine or not.
 
             let highlights = results.highlights;
-            if (highlights.indexOf(this.state.searchTerm) < 0) {
+            if (this.state.searchTerm !== "" && highlights.indexOf(this.state.searchTerm) < 0) {
                 highlights = highlights.concat(this.state.searchTerm);
             }
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -134,8 +134,8 @@ export interface IState {
     numUnreadMessages: number;
     draggingFile: boolean;
     searching: boolean;
+    searchMultiRoom?: boolean;
     searchTerm?: string;
-    searchScope?: "All" | "Room";
     searchResults?: XOR<{}, {
         count: number;
         highlights: string[];
@@ -1239,10 +1239,10 @@ export default class RoomView extends React.Component<IProps, IState> {
             });
     }
 
-    private onSearch = (term: string, scope, senderIds) => {
+    private onSearch = (term: string, roomIds, senderIds) => {
         this.setState({
             searchTerm: term,
-            searchScope: scope,
+            searchMultiRoom: roomIds.length === 0 || roomIds.length > 1,
             searchResults: {},
             searchHighlights: [],
         });
@@ -1259,11 +1259,8 @@ export default class RoomView extends React.Component<IProps, IState> {
         // todo: should cancel any previous search requests.
         this.searchId = new Date().getTime();
 
-        let roomId;
-        if (scope === "Room") roomId = this.state.room.roomId;
-
         debuglog("sending search request");
-        const searchPromise = eventSearch(term, roomId, senderIds);
+        const searchPromise = eventSearch(term, roomIds, senderIds);
         this.handleSearchResult(searchPromise);
     };
 
@@ -1380,7 +1377,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                 continue;
             }
 
-            if (this.state.searchScope === 'All') {
+            if (this.state.searchMultiRoom) {
                 if (roomId !== lastRoomId) {
                     ret.push(<li key={mxEv.getId() + "-room"}>
                         <h2>{ _t("Room") }: { room.name }</h2>

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1860,15 +1860,6 @@ export default class RoomView extends React.Component<IProps, IState> {
         let forceHideRightPanel = false;
         if (this.state.forwardingEvent) {
             aux = <ForwardMessage onCancelClick={this.onCancelClick} />;
-        } else if (this.state.searching) {
-            hideCancel = true; // has own cancel
-            aux = <SearchBar
-                room={this.state.room}
-                searchInProgress={this.state.searchInProgress}
-                onCancelClick={this.onCancelSearchClick}
-                onSearch={this.onSearch}
-                isRoomEncrypted={this.context.isRoomEncrypted(this.state.room.roomId)}
-            />;
         } else if (showRoomUpgradeBar) {
             aux = <RoomUpgradeWarningBar room={this.state.room} recommendation={roomVersionRecommendation} />;
             hideCancel = true;
@@ -1938,6 +1929,17 @@ export default class RoomView extends React.Component<IProps, IState> {
                 { aux }
             </AuxPanel>
         );
+
+        let searchBar = null;
+        if (this.state.searching) {
+            searchBar = <SearchBar
+                room={this.state.room}
+                searchInProgress={this.state.searchInProgress}
+                onCancelClick={this.onCancelSearchClick}
+                onSearch={this.onSearch}
+                isRoomEncrypted={this.context.isRoomEncrypted(this.state.room.roomId)}
+            />;
+        }
 
         let messageComposer; let searchInfo;
         const canSpeak = (
@@ -2142,6 +2144,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                         <MainSplit panel={rightPanel} resizeNotifier={this.props.resizeNotifier}>
                             <div className={fadableSectionClasses}>
                                 {auxPanel}
+                                {searchBar}
                                 <div className={timelineClasses}>
                                     {topUnreadMessagesBar}
                                     {jumpToBottom}

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -66,6 +66,8 @@ class Pill extends React.Component {
         shouldShowPillAvatar: PropTypes.bool,
         // Whether to render this pill as if it were highlit by a selection
         isSelected: PropTypes.bool,
+        // Override onClick
+        onClick: PropTypes.func,
     };
 
     state = {
@@ -265,6 +267,10 @@ class Pill extends React.Component {
                 break;
         }
 
+        if (this.props.onClick) {
+            onClick = this.props.onClick;
+        }
+
         const classes = classNames("mx_Pill", pillClass, {
             "mx_UserPill_me": userId === MatrixClientPeg.get().getUserId(),
             "mx_UserPill_selected": this.props.isSelected,
@@ -272,7 +278,7 @@ class Pill extends React.Component {
 
         if (this.state.pillType) {
             return <MatrixClientContext.Provider value={this._matrixClient}>
-                { this.props.inMessage ?
+                { this.props.inMessage || this.props.onClick ?
                     <a className={classes} href={href} onClick={onClick} title={resource} data-offset-key={this.props.offsetKey}>
                         { avatar }
                         { linkText }

--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -267,10 +267,6 @@ class Pill extends React.Component {
                 break;
         }
 
-        if (this.props.onClick) {
-            onClick = this.props.onClick;
-        }
-
         const classes = classNames("mx_Pill", pillClass, {
             "mx_UserPill_me": userId === MatrixClientPeg.get().getUserId(),
             "mx_UserPill_selected": this.props.isSelected,
@@ -278,7 +274,7 @@ class Pill extends React.Component {
 
         if (this.state.pillType) {
             return <MatrixClientContext.Provider value={this._matrixClient}>
-                { this.props.inMessage || this.props.onClick ?
+                { this.props.inMessage ?
                     <a className={classes} href={href} onClick={onClick} title={resource} data-offset-key={this.props.offsetKey}>
                         { avatar }
                         { linkText }

--- a/src/components/views/rooms/Autocomplete.tsx
+++ b/src/components/views/rooms/Autocomplete.tsx
@@ -36,8 +36,8 @@ interface IProps {
     // method invoked when selected (if any) completion changes
     onSelectionChange?: (ICompletion, number) => void;
     selection: ISelectionRange;
-    // The room in which we're autocompleting
-    room: Room;
+    // The rooms in which we're autocompleting
+    rooms: Room[];
 }
 
 interface IState {
@@ -58,7 +58,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
     constructor(props) {
         super(props);
 
-        this.autocompleter = new Autocompleter(props.room);
+        this.autocompleter = new Autocompleter(props.rooms);
 
         this.state = {
             // list of completionResults, each containing completions
@@ -83,10 +83,24 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
         this.applyNewProps();
     }
 
-    private applyNewProps(oldQuery?: string, oldRoom?: Room) {
-        if (oldRoom && this.props.room.roomId !== oldRoom.roomId) {
-            this.autocompleter.destroy();
-            this.autocompleter = new Autocompleter(this.props.room);
+    private applyNewProps(oldQuery?: string, oldRooms?: Room[]) {
+        if (oldRooms) {
+            let changed = false;
+            if (this.props.rooms.length === oldRooms.length) {
+                for (let i = 0; i < oldRooms.length; i++) {
+                    if (!this.props.rooms.includes(oldRooms[0])) {
+                        changed = true;
+                        break;
+                    }
+                }
+            } else {
+                changed = true;
+            }
+
+            if (changed) {
+                this.autocompleter.destroy();
+                this.autocompleter = new Autocompleter(this.props.rooms);
+            }
         }
 
         // Query hasn't changed so don't try to complete it
@@ -251,7 +265,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
     }
 
     componentDidUpdate(prevProps: IProps) {
-        this.applyNewProps(prevProps.query, prevProps.room);
+        this.applyNewProps(prevProps.query, prevProps.rooms);
         // this is the selected completion, so scroll it into view if needed
         const selectedCompletion = this.refs[`completion${this.state.selectionOffset}`] as HTMLElement;
 

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -87,7 +87,7 @@ enum Formatting {
 
 interface IProps {
     model: EditorModel;
-    room: Room;
+    rooms: Room[];
     placeholder?: string;
     label?: string;
     initialCaret?: DocumentOffset;
@@ -212,7 +212,9 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                 isTyping = false;
             }
         }
-        TypingStore.sharedInstance().setSelfTyping(this.props.room.roomId, isTyping);
+        if (this.props.rooms.length > 0) {
+            TypingStore.sharedInstance().setSelfTyping(this.props.rooms[0].roomId, isTyping);
+        }
 
         if (this.props.onChange) {
             this.props.onChange();
@@ -659,7 +661,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                     onConfirm={this.onAutoCompleteConfirm}
                     onSelectionChange={this.onAutoCompleteSelectionChange}
                     selection={{beginning: true, end: queryLen, start: queryLen}}
-                    room={this.props.room}
+                    rooms={this.props.rooms}
                 />
             </div>);
         }

--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -273,7 +273,7 @@ export default class EditMessageComposer extends React.Component {
             <BasicMessageComposer
                 ref={this._setEditorRef}
                 model={this.model}
-                room={this._getRoom()}
+                rooms={[this._getRoom()]}
                 initialCaret={this.props.editState.getCaret()}
                 label={_t("Edit message")}
                 onChange={this._onChange}

--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -148,11 +148,10 @@ export default class RoomHeader extends React.Component {
 
         // don't display the search count until the search completes and
         // gives us a valid (possibly zero) searchCount.
-        if (this.props.searchInfo &&
-            this.props.searchInfo.searchCount !== undefined &&
-            this.props.searchInfo.searchCount !== null) {
+        if (this.props.searchCount !== undefined &&
+            this.props.searchCount !== null) {
             searchStatus = <div className="mx_RoomHeader_searchStatus">&nbsp;
-                { _t("(~%(count)s results)", { count: this.props.searchInfo.searchCount }) }
+                { _t("(~%(count)s results)", { count: this.props.searchCount }) }
             </div>;
         }
 

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -80,6 +80,10 @@ export default class SearchBar extends React.Component {
                                           this._search_term.current.value.substring(i + len);
     };
 
+    removeSender: function() {
+        this.setState({ senderId: undefined });
+    },
+
     render() {
         const searchButtonClasses = classNames("mx_SearchBar_searchButton", {
             mx_SearchBar_searching: this.props.searchInProgress,
@@ -113,6 +117,7 @@ export default class SearchBar extends React.Component {
                 room={this.props.room}
                 url={makeUserPermalink(this.state.senderId)}
                 shouldShowPillAvatar={true}
+                onClick={this.removeSender}
             />);
         }
 

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -34,6 +34,26 @@ export default class SearchBar extends React.Component {
         const partCreator = new PartCreator(this.props.room, this.context);
         const parts = [];
         this.model = new EditorModel(parts, partCreator);
+        this.state = {
+            roomIds: [],
+            rooms: [],
+        };
+    }
+
+    onChange = () => {
+        const roomIdMap = {};
+        const roomIds = [];
+        const rooms = [];
+        for (let i = 0; i < this.model._parts.length; i++) {
+            if (typeof this.model._parts[i].room !== 'undefined') {
+                roomIdMap[this.model._parts[i].room.roomId] = true;
+            }
+        }
+        for (const roomId in roomIdMap) {
+            roomIds.push(roomId);
+            rooms.push(this.context.getRoom(roomId));
+        }
+        this.setState({roomIds, rooms});
     }
 
     onSearchKeydown = (e) => {
@@ -50,15 +70,13 @@ export default class SearchBar extends React.Component {
 
     onSearch = () => {
             const searchTerm = [];
-            const senderIds = [];
-            const roomIds = [];
+            const senderIdMap = {};
             for (let i = 0; i < this.model._parts.length; i++) {
                 if (typeof this.model._parts[i].member !== 'undefined') {
-                    senderIds.push(this.model._parts[i].resourceId);
+                    senderIdMap[this.model._parts[i].resourceId] = true;
                     continue;
                 }
                 if (typeof this.model._parts[i].room !== 'undefined') {
-                    roomIds.push(this.model._parts[i].room.roomId);
                     continue;
                 }
                 const text = this.model._parts[i]._text.trim();
@@ -66,7 +84,7 @@ export default class SearchBar extends React.Component {
                     searchTerm.push(text);
                 }
             }
-            this.props.onSearch(searchTerm.join(' '), roomIds, senderIds);
+            this.props.onSearch(searchTerm.join(' '), this.state.roomIds, Object.keys(senderIdMap));
     };
 
     render() {
@@ -78,7 +96,7 @@ export default class SearchBar extends React.Component {
             <>
                 <div className="mx_SearchBar">
                     <div className="mx_SearchBar_input mx_textinput" onKeyDown={this.onSearchKeydown}>
-                        <BasicMessageComposer model={this.model} rooms={[this.props.room]} />
+                        <BasicMessageComposer model={this.model} rooms={this.state.rooms} onChange={this.onChange} />
                         <AccessibleButton className={ searchButtonClasses } onClick={this.onSearch} />
                     </div>
                     <AccessibleButton className="mx_SearchBar_cancel" onClick={this.props.onCancelClick} />

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -69,6 +69,10 @@ export default class SearchBar extends React.Component {
     };
 
     onSearch = () => {
+        if (this.model.autoComplete !== null) {
+            this.model.autoComplete.getAutocompleterComponent().hide();
+        }
+        if (this.model._parts.length > 0) {
             const searchTerm = [];
             const senderIdMap = {};
             for (let i = 0; i < this.model._parts.length; i++) {
@@ -85,6 +89,7 @@ export default class SearchBar extends React.Component {
                 }
             }
             this.props.onSearch(searchTerm.join(' '), this.state.roomIds, Object.keys(senderIdMap));
+        }
     };
 
     render() {

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -31,7 +31,7 @@ export default class SearchBar extends React.Component {
     constructor(props, context) {
         super(props, context);
 
-        const partCreator = new PartCreator(this.props.room, this.context);
+        const partCreator = new PartCreator(this.props.room, this.context, null, true);
         const parts = [];
         this.model = new EditorModel(parts, partCreator);
         this.state = {

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -78,7 +78,7 @@ export default class SearchBar extends React.Component {
             <>
                 <div className="mx_SearchBar">
                     <div className="mx_SearchBar_input mx_textinput" onKeyDown={this.onSearchKeydown}>
-                        <BasicMessageComposer model={this.model} room={this.props.room} />
+                        <BasicMessageComposer model={this.model} rooms={[this.props.room]} />
                         <AccessibleButton className={ searchButtonClasses } onClick={this.onSearch} />
                     </div>
                     <AccessibleButton className="mx_SearchBar_cancel" onClick={this.props.onCancelClick} />

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -113,7 +113,7 @@ export default class SearchBar extends React.Component {
                 room={this.props.room}
                 url={makeUserPermalink(this.state.senderId)}
                 shouldShowPillAvatar={true}
-            />)
+            />);
         }
 
         return (

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -75,6 +75,8 @@ export default class SearchBar extends React.Component {
         if (this.model._parts.length > 0) {
             const searchTerm = [];
             const senderIdMap = {};
+            let senderIds;
+            let roomIds;
             for (let i = 0; i < this.model._parts.length; i++) {
                 if (typeof this.model._parts[i].member !== 'undefined') {
                     senderIdMap[this.model._parts[i].resourceId] = true;
@@ -88,7 +90,10 @@ export default class SearchBar extends React.Component {
                     searchTerm.push(text);
                 }
             }
-            this.props.onSearch(searchTerm.join(' '), this.state.roomIds, Object.keys(senderIdMap));
+            const senderIdArray = Object.keys(senderIdMap);
+            if (this.state.roomIds.length > 0) roomIds = this.state.roomIds;
+            if (senderIdArray.length > 0) senderIds = senderIdArray;
+            this.props.onSearch(searchTerm.join(' '), roomIds, senderIds);
         }
     };
 

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -69,11 +69,11 @@ export default class SearchBar extends React.Component {
 
     onSearch = () => {
             const searchTerm = [];
-            const senders = [];
+            const senderIds = [];
             const rooms = [];
             for (let i = 0; i < this.model._parts.length; i++) {
                 if (typeof this.model._parts[i].member !== 'undefined') {
-                    senders.push(this.model._parts[i].resourceId);
+                    senderIds.push(this.model._parts[i].resourceId);
                     continue;
                 }
                 if (typeof this.model._parts[i].room !== 'undefined') {
@@ -85,12 +85,8 @@ export default class SearchBar extends React.Component {
                     searchTerm.push(text);
                 }
             }
-            let sender;
-            if (senders.length > 0) {
-                sender = senders[0];
-            }
-            this.props.onSearch(searchTerm.join(' '), this.state.scope, sender);
-        };
+            this.props.onSearch(searchTerm.join(' '), this.state.scope, senderIds);
+    };
 
     render() {
         const searchButtonClasses = classNames("mx_SearchBar_searchButton", {

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -22,7 +22,6 @@ import {PartCreator} from '../../../editor/parts';
 import BasicMessageComposer from "./BasicMessageComposer";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import classNames from "classnames";
-import { _t } from '../../../languageHandler';
 import {Key} from "../../../Keyboard";
 import DesktopBuildsNotice, {WarningKind} from "../elements/DesktopBuildsNotice";
 
@@ -32,22 +31,10 @@ export default class SearchBar extends React.Component {
     constructor(props, context) {
         super(props, context);
 
-        this.state = {
-            scope: 'Room',
-        };
-
         const partCreator = new PartCreator(this.props.room, this.context);
         const parts = [];
         this.model = new EditorModel(parts, partCreator);
     }
-
-    onThisRoomClick = () => {
-        this.setState({ scope: 'Room' }, () => this._searchIfQuery());
-    };
-
-    onAllRoomsClick = () => {
-        this.setState({ scope: 'All' }, () => this._searchIfQuery());
-    };
 
     onSearchKeydown = (e) => {
         switch (e.key) {
@@ -61,23 +48,17 @@ export default class SearchBar extends React.Component {
         }
     };
 
-    _searchIfQuery() {
-        if (this.model._parts.length > 0) {
-            this.onSearch();
-        }
-    }
-
     onSearch = () => {
             const searchTerm = [];
             const senderIds = [];
-            const rooms = [];
+            const roomIds = [];
             for (let i = 0; i < this.model._parts.length; i++) {
                 if (typeof this.model._parts[i].member !== 'undefined') {
                     senderIds.push(this.model._parts[i].resourceId);
                     continue;
                 }
                 if (typeof this.model._parts[i].room !== 'undefined') {
-                    rooms.push(this.model._parts[i].room.roomId);
+                    roomIds.push(this.model._parts[i].room.roomId);
                     continue;
                 }
                 const text = this.model._parts[i]._text.trim();
@@ -85,18 +66,12 @@ export default class SearchBar extends React.Component {
                     searchTerm.push(text);
                 }
             }
-            this.props.onSearch(searchTerm.join(' '), this.state.scope, senderIds);
+            this.props.onSearch(searchTerm.join(' '), roomIds, senderIds);
     };
 
     render() {
         const searchButtonClasses = classNames("mx_SearchBar_searchButton", {
             mx_SearchBar_searching: this.props.searchInProgress,
-        });
-        const thisRoomClasses = classNames("mx_SearchBar_button", {
-            mx_SearchBar_unselected: this.state.scope !== 'Room',
-        });
-        const allRoomsClasses = classNames("mx_SearchBar_button", {
-            mx_SearchBar_unselected: this.state.scope !== 'All',
         });
 
         return (

--- a/src/components/views/rooms/SearchBar.js
+++ b/src/components/views/rooms/SearchBar.js
@@ -18,6 +18,8 @@ limitations under the License.
 import React, {createRef} from 'react';
 import AccessibleButton from "../elements/AccessibleButton";
 import Autocomplete from './Autocomplete';
+import Pill from '../elements/Pill';
+import {makeUserPermalink} from '../../../utils/permalinks/Permalinks';
 import classNames from "classnames";
 import { _t } from '../../../languageHandler';
 import {Key} from "../../../Keyboard";
@@ -106,7 +108,12 @@ export default class SearchBar extends React.Component {
 
         let senderPart;
         if (this.state.senderId) {
-            senderPart = "sender: " + this.state.senderId;
+            senderPart = (<Pill
+                type={Pill.TYPE_USER_MENTION}
+                room={this.props.room}
+                url={makeUserPermalink(this.state.senderId)}
+                shouldShowPillAvatar={true}
+            />)
         }
 
         return (

--- a/src/components/views/rooms/SendMessageComposer.js
+++ b/src/components/views/rooms/SendMessageComposer.js
@@ -446,7 +446,7 @@ export default class SendMessageComposer extends React.Component {
                 <BasicMessageComposer
                     ref={this._setEditorRef}
                     model={this.model}
-                    room={this.props.room}
+                    rooms={[this.props.room]}
                     label={this.props.placeholder}
                     placeholder={this.props.placeholder}
                     onChange={this._saveStoredEditorState}

--- a/src/editor/autocomplete.ts
+++ b/src/editor/autocomplete.ts
@@ -128,7 +128,12 @@ export default class AutocompleteWrapperModel {
                 // not using suffix here, because we also need to calculate
                 // the suffix when clicking a display name to insert a mention,
                 // which happens in createMentionParts
-                return this.partCreator.createMentionParts(this.partIndex, text, completionId);
+                return this.partCreator.createMentionParts(
+                    this.partIndex,
+                    text,
+                    completionId,
+                    completion.component.props.children.props.member,
+                );
             case "command":
                 // command needs special handling for auto complete, but also renders as plain texts
                 return [(this.partCreator as CommandPartCreator).command(text)];

--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -46,7 +46,7 @@ function parseLink(a: HTMLAnchorElement, partCreator: PartCreator) {
     const prefix = resourceId ? resourceId[0] : undefined; // First character of ID
     switch (prefix) {
         case "@":
-            return partCreator.userPill(a.textContent, resourceId);
+            return partCreator.userPill(a.textContent, resourceId, null);
         case "#":
             return partCreator.roomPill(resourceId);
         default: {

--- a/src/editor/parts.ts
+++ b/src/editor/parts.ts
@@ -451,11 +451,18 @@ interface IAutocompleteCreator {
 
 export class PartCreator {
     protected readonly autoCompleteCreator: IAutocompleteCreator;
+    protected readonly disableSuffix: boolean;
 
-    constructor(private room: Room, private client: MatrixClient, autoCompleteCreator: AutoCompleteCreator = null) {
+    constructor(
+        private room: Room,
+        private client: MatrixClient,
+        autoCompleteCreator: AutoCompleteCreator = null,
+        disableSuffix: boolean,
+    ) {
         // pre-create the creator as an object even without callback so it can already be passed
         // to PillCandidatePart (e.g. while deserializing) and set later on
         this.autoCompleteCreator = {create: autoCompleteCreator && autoCompleteCreator(this)};
+        this.disableSuffix = disableSuffix;
     }
 
     setAutoCompleteCreator(autoCompleteCreator: AutoCompleteCreator) {
@@ -533,7 +540,7 @@ export class PartCreator {
 
     createMentionParts(partIndex: number, displayName: string, userId: string) {
         const pill = this.userPill(displayName, userId);
-        const postfix = this.plain(partIndex === 0 ? ": " : " ");
+        const postfix = this.plain(partIndex === 0 && !this.disableSuffix ? ": " : " ");
         return [pill, postfix];
     }
 }

--- a/src/editor/parts.ts
+++ b/src/editor/parts.ts
@@ -500,7 +500,7 @@ export class PartCreator {
             case Type.RoomPill:
                 return this.roomPill(part.text);
             case Type.UserPill:
-                return this.userPill(part.text, part.resourceId);
+                return this.userPill(part.text, part.resourceId, null);
         }
     }
 
@@ -533,13 +533,13 @@ export class PartCreator {
         return new AtRoomPillPart(text, this.room);
     }
 
-    userPill(displayName: string, userId: string) {
-        const member = this.room.getMember(userId);
+    userPill(displayName: string, userId: string, member: RoomMember) {
+        if (member === null) member = this.room.getMember(userId);
         return new UserPillPart(userId, displayName, member);
     }
 
-    createMentionParts(partIndex: number, displayName: string, userId: string) {
-        const pill = this.userPill(displayName, userId);
+    createMentionParts(partIndex: number, displayName: string, userId: string, member: RoomMember) {
+        const pill = this.userPill(displayName, userId, member);
         const postfix = this.plain(partIndex === 0 && !this.disableSuffix ? ": " : " ");
         return [pill, postfix];
     }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1204,7 +1204,6 @@
     "Only room administrators will see this warning": "Only room administrators will see this warning",
     "This Room": "This Room",
     "All Rooms": "All Rooms",
-    "Search…": "Search…",
     "Server error": "Server error",
     "Server unavailable, overloaded, or something else went wrong.": "Server unavailable, overloaded, or something else went wrong.",
     "Unknown Command": "Unknown Command",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1202,8 +1202,6 @@
     "This room has already been upgraded.": "This room has already been upgraded.",
     "This room is running room version <roomVersion />, which this homeserver has marked as <i>unstable</i>.": "This room is running room version <roomVersion />, which this homeserver has marked as <i>unstable</i>.",
     "Only room administrators will see this warning": "Only room administrators will see this warning",
-    "This Room": "This Room",
-    "All Rooms": "All Rooms",
     "Server error": "Server error",
     "Server unavailable, overloaded, or something else went wrong.": "Server unavailable, overloaded, or something else went wrong.",
     "Unknown Command": "Unknown Command",

--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -63,6 +63,7 @@ export interface SearchArgs {
     after_limit: number;
     order_by_recency: boolean;
     room_id?: string;
+    sender_id?: string;
 }
 
 export interface EventAndProfile {

--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -63,7 +63,7 @@ export interface SearchArgs {
     after_limit: number;
     order_by_recency: boolean;
     room_id?: string;
-    sender_id?: string;
+    sender_ids?: [string];
 }
 
 export interface EventAndProfile {

--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -62,7 +62,7 @@ export interface SearchArgs {
     before_limit: number;
     after_limit: number;
     order_by_recency: boolean;
-    room_id?: string;
+    room_ids?: [string];
     sender_ids?: [string];
 }
 


### PR DESCRIPTION
## Update 2020-09-16

**Preview:** https://element.fentker.eu

This PR replaces the SearchBar input field with a BasicMessageComposer, hooking up autocompleted user and room pills to search filters. Server-side search already implements these filters, seshat support may be found at matrix-org/seshat#71.

### UX consideration
The ability to filter is not obvious to the user, especially after removing the room filter buttons

Possible Solutions:
- Add new buttons ("in", "by") opening the autocompleter
- Autofill the pill of the current room on opening the SearchBar
- ... (Suggestions?)

### Screenshot
![image](https://user-images.githubusercontent.com/6042489/93364932-748e3800-f849-11ea-9c78-3ef439941763.png)


## Original

related to https://github.com/vector-im/riot-web/issues/4752

**Todo**
- [x] add styling
- [x] make filter removeable
- [x] local search support

**Status**

![image](https://user-images.githubusercontent.com/6042489/75634573-67905b00-5c0f-11ea-987d-293aa1d27e31.png)
