### PR TITLE
Include a mark as read X under the scroll to unread button

### DIFF
--- a/res/css/views/rooms/_TopUnreadMessagesBar.scss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.scss
@@ -56,3 +56,17 @@ limitations under the License.
     mask-position: 9px 13px;
     background: $roomtile-name-color;
 }
+
+.mx_TopUnreadMessagesBar_markAsRead {
+    display: block;
+    width: 18px;
+    height: 18px;
+    background-image: url('$(res)/img/cancel.svg');
+    background-position: center;
+    background-size: 10px;
+    background-repeat: no-repeat;
+    background-color: $primary-bg-color;
+    border: 1.3px solid $roomtile-name-color;
+    border-radius: 99px;
+    margin: 5px auto;
+}

--- a/src/components/views/rooms/TopUnreadMessagesBar.js
+++ b/src/components/views/rooms/TopUnreadMessagesBar.js
@@ -27,6 +27,7 @@ export default createReactClass({
 
     propTypes: {
         onScrollUpClick: PropTypes.func,
+        onCloseClick: PropTypes.func,
     },
 
     render: function() {
@@ -35,6 +36,10 @@ export default createReactClass({
                 <AccessibleButton className="mx_TopUnreadMessagesBar_scrollUp"
                     title={_t('Jump to first unread message.')}
                     onClick={this.props.onScrollUpClick}>
+                </AccessibleButton>
+                <AccessibleButton className="mx_TopUnreadMessagesBar_markAsRead"
+                    title={_t('Mark all as read')}
+                    onClick={this.props.onCloseClick}>
                 </AccessibleButton>
             </div>
         );

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1139,6 +1139,7 @@
     "Revoke invite": "Revoke invite",
     "Invited by %(sender)s": "Invited by %(sender)s",
     "Jump to first unread message.": "Jump to first unread message.",
+    "Mark all as read": "Mark all as read",
     "Error updating main address": "Error updating main address",
     "There was an error updating the room's main address. It may not be allowed by the server or a temporary failure occurred.": "There was an error updating the room's main address. It may not be allowed by the server or a temporary failure occurred.",
     "Error creating alias": "Error creating alias",


### PR DESCRIPTION
This adds a simple X button under the scroll to top button that will mark all as read.

Probably needs some tests or something, but I didn't want to invest too much into this if it wasn't the desired solution.

Looks like the functionality was nearly there but I might be missing something. Open to suggestions but mostly wanted to get something started here.

![A screenshot](https://user-images.githubusercontent.com/211578/75713294-30618e80-5c8f-11ea-9cb3-b73dbc0e6c9c.png)
![In use](https://user-images.githubusercontent.com/211578/75713327-3fe0d780-5c8f-11ea-9585-a1f3bb443ab0.gif)

Fixes vector-im/riot-web#8666.