### PR TITLE
Don't group blank membership changes

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -962,6 +962,17 @@ class MemberGrouper {
     }
 
     add(ev) {
+        if (ev.getType() === 'm.room.member') {
+            // We'll just double check that it's worth our time to do so...
+            if (ev.getPrevContent()) {
+                const membershipChange = ev.getPrevContent()['membership'] !== ev.getContent()['membership'];
+                const displayNameChange = ev.getPrevContent()['displayname'] !== ev.getContent()['displayname'];
+                const avatarChange = ev.getPrevContent()['avatar_url'] !== ev.getContent()['avatar_url'];
+                if (!membershipChange && !displayNameChange && !avatarChange) {
+                    return; // Not a substantial change - quietly ignore
+                }
+            }
+        }
         this.readMarker = this.readMarker || this.panel._readMarkerForEvent(ev.getId());
         this.events.push(ev);
     }

--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -28,6 +28,7 @@ import {MatrixClientPeg} from '../../MatrixClientPeg';
 import SettingsStore from '../../settings/SettingsStore';
 import {_t} from "../../languageHandler";
 import {haveTileForEvent} from "../views/rooms/EventTile";
+import {textForEvent} from "../../TextForEvent";
 
 const CONTINUATION_MAX_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const continuedTypes = ['m.sticker', 'm.room.message'];
@@ -963,15 +964,11 @@ class MemberGrouper {
 
     add(ev) {
         if (ev.getType() === 'm.room.member') {
-            // We'll just double check that it's worth our time to do so...
-            if (ev.getPrevContent()) {
-                const membershipChange = ev.getPrevContent()['membership'] !== ev.getContent()['membership'];
-                const displayNameChange = ev.getPrevContent()['displayname'] !== ev.getContent()['displayname'];
-                const avatarChange = ev.getPrevContent()['avatar_url'] !== ev.getContent()['avatar_url'];
-                if (!membershipChange && !displayNameChange && !avatarChange) {
-                    return; // Not a substantial change - quietly ignore
-                }
-            }
+            // We'll just double check that it's worth our time to do so, through an
+            // ugly hack. If textForEvent returns something, we should group it for
+            // rendering but if it doesn't then we'll exclude it.
+            const renderText = textForEvent(ev);
+            if (!renderText || renderText.trim().length === 0) return; // quietly ignore
         }
         this.readMarker = this.readMarker || this.panel._readMarkerForEvent(ev.getId());
         this.events.push(ev);


### PR DESCRIPTION
We already drop noop membership changes when they don't make it into a MELS, so we just need to make the MELS aware enough to drop messages early that are noops.

Fixes https://github.com/vector-im/riot-web/issues/12575