### PR TITLE
Fix having to decrypt & download in two steps

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -247,6 +247,8 @@ export default createReactClass({
                     });
                 };
 
+                // This button should actually Download because usercontent/ will try to click itself
+                // but it is not guaranteed between various browsers' settings.
                 return (
                     <span className="mx_MFileBody">
                         <div className="mx_MFileBody_download">
@@ -290,7 +292,7 @@ export default createReactClass({
                             src={`${url}?origin=${encodeURIComponent(window.location.origin)}`}
                             onLoad={onIframeLoad}
                             ref={this._iframe}
-                            sandbox="allow-scripts allow-downloads" />
+                            sandbox="allow-scripts allow-downloads allow-downloads-without-user-activation" />
                     </div>
                 </span>
             );

--- a/src/usercontent/index.js
+++ b/src/usercontent/index.js
@@ -27,6 +27,7 @@ function remoteRender(event) {
     // Don't display scrollbars if the link takes more than one line to display.
     body.style = "margin: 0px; overflow: hidden";
     body.appendChild(a);
+    a.click(); // try to trigger download automatically
 }
 
 function remoteSetTint(event) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9035

This may not work in all browser configurations until `allow-downloads-without-user-activation` is everywhere which is why the button remains "Decrypt". Nad OK'd this. https://github.com/vector-im/riot-web/issues/7431 tracks further UX improvements.

Tested in:

- [x] Chrome
- [x] Firefox
- [x] Safari