### PR TITLE
only automatically download in usercontent if user requested it

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -271,6 +271,8 @@ export default createReactClass({
                     // We can't provide a Content-Disposition header like we would for HTTP.
                     download: fileName,
                     textContent: _t("Download %(text)s", { text: text }),
+                    // only auto-download if a user triggered this iframe explicitly
+                    auto: !this.props.decryptedBlob,
                 }, "*");
             };
 

--- a/src/usercontent/index.js
+++ b/src/usercontent/index.js
@@ -27,7 +27,10 @@ function remoteRender(event) {
     // Don't display scrollbars if the link takes more than one line to display.
     body.style = "margin: 0px; overflow: hidden";
     body.appendChild(a);
-    a.click(); // try to trigger download automatically
+
+    if (event.data.auto) {
+        a.click(); // try to trigger download automatically
+    }
 }
 
 function remoteSetTint(event) {


### PR DESCRIPTION
Video and Audio were decrypted in advance to show the inline player, so the download got triggered wrongly.