### PR TITLE
Lock login and registration buttons after submit

### DIFF
--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -186,6 +186,12 @@ export default createReactClass({
                 stageErrorText: null,
             });
         }
+        // The JS SDK eagerly reports itself as "not busy" right after any
+        // immediate work has completed, but that's not really what we want at
+        // the UI layer, so we ignore this signal and show a spinner until
+        // there's a new screen to show the user. This is implemented by setting
+        // `busy: false` in `_authStateUpdated`.
+        // See also https://github.com/vector-im/riot-web/issues/12546
     },
 
     _setFocus: function() {

--- a/src/components/structures/InteractiveAuth.js
+++ b/src/components/structures/InteractiveAuth.js
@@ -161,6 +161,7 @@ export default createReactClass({
     _authStateUpdated: function(stageType, stageState) {
         const oldStage = this.state.authStage;
         this.setState({
+            busy: false,
             authStage: stageType,
             stageState: stageState,
             errorText: stageState.error,
@@ -183,10 +184,6 @@ export default createReactClass({
                 busy: true,
                 errorText: null,
                 stageErrorText: null,
-            });
-        } else {
-            this.setState({
-                busy: false,
             });
         }
     },

--- a/src/components/structures/auth/Login.js
+++ b/src/components/structures/auth/Login.js
@@ -245,19 +245,13 @@ export default createReactClass({
             }
 
             this.setState({
+                busy: false,
                 errorText: errorText,
                 // 401 would be the sensible status code for 'incorrect password'
                 // but the login API gives a 403 https://matrix.org/jira/browse/SYN-744
                 // mentions this (although the bug is for UI auth which is not this)
                 // We treat both as an incorrect password
                 loginIncorrect: error.httpStatus === 401 || error.httpStatus === 403,
-            });
-        }).finally(() => {
-            if (this._unmounted) {
-                return;
-            }
-            this.setState({
-                busy: false,
             });
         });
     },


### PR DESCRIPTION
This tweaks both password login and interactive auth so that they are held busy on success to avoid the chance of double submission.

Fixes https://github.com/vector-im/riot-web/issues/12546