### PR TITLE
Ensure the room list always triggers updates on itself

### DIFF
--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -372,6 +372,14 @@ class RoomListStore extends Store {
     _slotRoomIntoList(room, category, tag, existingEntries, newList, lastTimestampFn) {
         const targetCategoryIndex = CATEGORY_ORDER.indexOf(category);
 
+        let categoryComparator = (a, b) => lastTimestampFn(a.room) >= lastTimestampFn(b.room);
+        const sortAlgorithm = getListAlgorithm(tag, this._state.algorithm);
+        if (sortAlgorithm === ALGO_RECENT) {
+            categoryComparator = (a, b) => this._recentsComparator(a, b, lastTimestampFn);
+        } else if (sortAlgorithm === ALGO_ALPHABETIC) {
+            categoryComparator = (a, b) => this._lexicographicalComparator(a, b);
+        }
+
         // The slotting algorithm works by trying to position the room in the most relevant
         // category of the list (red > grey > etc). To accomplish this, we need to consider
         // a couple cases: the category existing in the list but having other rooms in it and
@@ -449,7 +457,7 @@ class RoomListStore extends Store {
                 // based on most recent timestamp.
                 const changedBoundary = entryCategoryIndex > targetCategoryIndex;
                 const currentCategory = entryCategoryIndex === targetCategoryIndex;
-                if (changedBoundary || (currentCategory && lastTimestampFn(room) >= lastTimestampFn(entry.room))) {
+                if (changedBoundary || (currentCategory && categoryComparator({room}, entry) <= 0)) {
                     if (changedBoundary) {
                         // If we changed a boundary, then we've gone too far - go to the top of the last
                         // section instead.

--- a/src/stores/RoomListStore.js
+++ b/src/stores/RoomListStore.js
@@ -479,12 +479,6 @@ class RoomListStore extends Store {
     _setRoomCategory(room, category) {
         if (!room) return; // This should only happen in tests
 
-        if (!this._state.orderImportantFirst) {
-            // XXX bail here early to avoid https://github.com/vector-im/riot-web/issues/9216
-            // this may mean that category updates are missed whilst not ordering by importance first
-            return;
-        }
-
         const listsClone = {};
 
         // Micro optimization: Support lazily loading the last timestamp in a room


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/4164 round two, without tripping all the bear traps that make this code awful to work with. Code is essentially stolen from @t3chguy to make the list stable, and actually update.

The index management stuff from https://github.com/matrix-org/matrix-react-sdk/pull/4164 appears to not be needed and is in fact one of the bear traps in this area.

Rewriting the whole room list store for https://github.com/vector-im/riot-web/issues/11743 is still a good idea, but in terms of actually fixing the bug this seems fine enough for now. It also means we can release without putting a block on rewriting the room list.

Fixes https://github.com/vector-im/riot-web/issues/12588

Edit: I've also broken out the commits to try and explain in future diffs what the problem was and what it fixes, hopefully.