### PR TITLE
Use crypto.verification.request even when xsign is disabled

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1503,7 +1503,12 @@ export default createReactClass({
                 return;
             }
 
-            if (request.pending) {
+            if (request.started) {
+                const VerificationRequestDialog = sdk.getComponent("views.dialogs.VerificationRequestDialog");
+                Modal.createTrackedDialog('Incoming Verification', '', VerificationRequestDialog, {
+                    verificationRequest: request,
+                }, null, /* priority = */ false, /* static = */ true);
+            } else if (request.pending) {
                 ToastStore.sharedInstance().addOrReplaceToast({
                     key: 'verifreq_' + request.channel.transactionId,
                     title: _t("Verification Request"),
@@ -1511,11 +1516,6 @@ export default createReactClass({
                     props: {request},
                     component: sdk.getComponent("toasts.VerificationRequestToast"),
                 });
-            } else if (request.started) {
-                const VerificationRequestDialog = sdk.getComponent("views.dialogs.VerificationRequestDialog");
-                Modal.createTrackedDialog('Incoming Verification', '', VerificationRequestDialog, {
-                    verificationRequest: request,
-                }, null, /* priority = */ false, /* static = */ true);
             }
         });
         // Fire the tinter right on startup to ensure the default theme is applied

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1503,10 +1503,10 @@ export default createReactClass({
                 return;
             }
 
-            if (request.started) {
-                const VerificationRequestDialog = sdk.getComponent("views.dialogs.VerificationRequestDialog");
-                Modal.createTrackedDialog('Incoming Verification', '', VerificationRequestDialog, {
-                    verificationRequest: request,
+            if (request.verifier) {
+                const IncomingSasDialog = sdk.getComponent("views.dialogs.IncomingSasDialog");
+                Modal.createTrackedDialog('Incoming Verification', '', IncomingSasDialog, {
+                    verifier: request.verifier,
                 }, null, /* priority = */ false, /* static = */ true);
             } else if (request.pending) {
                 ToastStore.sharedInstance().addOrReplaceToast({


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12586

With cross-signing off, we're still starting to-device verifications with a .request event now, and the `crypto.verification.start` event was never firing because nobody was accepting those requests so they would enter in the `started` phase.

This always listens for `crypto.verification.request`, even with cross-signing off, and cancels the request if it is a cross-signing request instead of just letting it spin.