### PR TITLE
WIP: Small room directory fixes

### DIFF
--- a/res/css/views/directory/_NetworkDropdown.scss
+++ b/res/css/views/directory/_NetworkDropdown.scss
@@ -49,6 +49,10 @@ limitations under the License.
     text-overflow: ellipsis;
 }
 
+.mx_NetworkDropdown_networkoption::placeholder {
+    opacity: 0.6;
+}
+
 .mx_NetworkDropdown_networkoption img {
     margin: 5px;
     width: 25px;

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -44,7 +44,7 @@ export default class NetworkDropdown extends React.Component {
             expanded: false,
             selectedServer: server,
             selectedInstanceId: null,
-            includeAllNetworks: false,
+            includeAllNetworks: true,
         };
     }
 
@@ -111,7 +111,7 @@ export default class NetworkDropdown extends React.Component {
                 expanded: false,
                 selectedServer: e.target.value,
                 selectedNetwork: null,
-                includeAllNetworks: false,
+                includeAllNetworks: true,
             });
             this.props.onOptionChange(e.target.value, null);
         }
@@ -151,8 +151,9 @@ export default class NetworkDropdown extends React.Component {
         for (const server of servers) {
             options.push(this._makeMenuOption(server, null, true));
             if (server === MatrixClientPeg.getHomeserverName()) {
-                options.push(this._makeMenuOption(server, null, false));
-                if (this.props.protocols) {
+                if (Object.keys(this.props.protocols).length > 0) {
+                    options.push(this._makeMenuOption(server, null, false));
+
                     for (const proto of Object.keys(this.props.protocols)) {
                         if (!this.props.protocols[proto].instances) continue;
 
@@ -223,7 +224,7 @@ export default class NetworkDropdown extends React.Component {
             </div>;
             currentValue = <input type="text" className="mx_NetworkDropdown_networkoption"
                 ref={this.collectInputTextBox} onKeyUp={this.onInputKeyUp}
-                placeholder="matrix.org" // 'matrix.org' as an example of an HS name
+                placeholder="example.com" // an example of an HS name
             />;
         } else {
             const instance = instanceForInstanceId(this.props.protocols, this.state.selectedInstanceId);


### PR DESCRIPTION
Temporary fixes for the room directory until a real design is finalized. Tries to improve https://github.com/vector-im/riot-web/issues/5194 https://github.com/vector-im/riot-web/issues/3769

Fixes https://github.com/vector-im/riot-web/issues/12497

This PR tries to encourage people to type into the dropdown by:
1. Changing the placeholder text to example.com rather than matrix.org
1. Fades out the placeholder text so it is more clear that it is a text field

This PR also removes the "[M] Matrix" option when there are no other bridged networks. 

## Before:
On a server with no bridged networks:
<img width="229" alt="Screen Shot 2020-03-08 at 8 39 14 PM" src="https://user-images.githubusercontent.com/5855073/76175965-e855d680-617c-11ea-9804-8dd8d85728d6.png">

On a server with bridged networks:
<img width="223" alt="Screen Shot 2020-03-08 at 8 39 50 PM" src="https://user-images.githubusercontent.com/5855073/76175981-fefc2d80-617c-11ea-9882-feb9b1dd4b89.png">

## After:
On a server with no bridged networks:
<img width="228" alt="Screen Shot 2020-03-08 at 8 37 24 PM" src="https://user-images.githubusercontent.com/5855073/76175999-0cb1b300-617d-11ea-807d-5a78901b6c02.png">

On a server with bridged networks:
<img width="256" alt="Screen Shot 2020-03-08 at 8 35 15 PM" src="https://user-images.githubusercontent.com/5855073/76175823-577efb00-617c-11ea-990c-82fb642ec691.png">
