### PR TITLE
Remove extraneous tab stop from room tree view.

### DIFF
--- a/src/components/views/rooms/RoomList.js
+++ b/src/components/views/rooms/RoomList.js
@@ -778,6 +778,9 @@ export default createReactClass({
                     className="mx_RoomList"
                     role="tree"
                     aria-label={_t("Rooms")}
+                    // Firefox sometimes makes this element focusable due to
+                    // overflow:scroll;, so force it out of tab order.
+                    tabindex="-1"
                     onMouseMove={this.onMouseMove}
                     onMouseLeave={this.onMouseLeave}
                 >


### PR DESCRIPTION
This was introduced some time ago when the room list became scrollable. Divs with overflow:scroll; become focusable for the keyboard in Firefox, but since we have keyboard handling for the whole compound widget, we don't need that tab stop on the tree view container div. Putting tabindex="-1" on it fixes it.

Signed-off-by: Marco Zehe <marcozehe@mailbox.org>