### PR TITLE
Don't remount main split children on rhs collapse

### DIFF
--- a/src/components/structures/MainSplit.js
+++ b/src/components/structures/MainSplit.js
@@ -93,14 +93,19 @@ export default class MainSplit extends React.Component {
         const bodyView = React.Children.only(this.props.children);
         const panelView = this.props.panel;
 
-        if (this.props.collapsedRhs || !panelView) {
-            return bodyView;
-        } else {
-            return <div className="mx_MainSplit" ref={this._setResizeContainerRef}>
-                { bodyView }
+        const hasResizer = !this.props.collapsedRhs && panelView;
+
+        let children;
+        if (hasResizer) {
+            children = <React.Fragment>
                 <ResizeHandle reverse={true} />
                 { panelView }
-            </div>;
+            </React.Fragment>;
         }
+
+        return <div className="mx_MainSplit" ref={hasResizer ? this._setResizeContainerRef : undefined}>
+            { bodyView }
+            { children }
+        </div>;
     }
 }


### PR DESCRIPTION
This was super painful to diagnose, because of the tree depth where we end up rendering the children changing, react thinks that they are unrelated and thus remounts from scratch, do not change depth when conditionally rendering children in a component.

Fixes https://github.com/vector-im/riot-web/issues/9822

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>