### PR TITLE
Revert "enable 4s when accepting a verification request"

### DIFF
--- a/src/components/views/toasts/VerificationRequestToast.js
+++ b/src/components/views/toasts/VerificationRequestToast.js
@@ -24,7 +24,6 @@ import {userLabelForEventRoom} from "../../../utils/KeyVerificationStateObserver
 import dis from "../../../dispatcher";
 import ToastStore from "../../../stores/ToastStore";
 import Modal from "../../../Modal";
-import {enable4SIfNeeded} from "../../../verification";
 
 export default class VerificationRequestToast extends React.PureComponent {
     constructor(props) {
@@ -74,9 +73,6 @@ export default class VerificationRequestToast extends React.PureComponent {
     }
 
     accept = async () => {
-        if (!await enable4SIfNeeded()) {
-            return;
-        }
         ToastStore.sharedInstance().dismissToast(this.props.toastKey);
         const {request} = this.props;
         // no room id for to_device requests

--- a/src/verification.js
+++ b/src/verification.js
@@ -24,7 +24,7 @@ import {findDMForUser} from './createRoom';
 import {accessSecretStorage} from './CrossSigningManager';
 import SettingsStore from './settings/SettingsStore';
 
-export async function enable4SIfNeeded() {
+async function enable4SIfNeeded() {
     const cli = MatrixClientPeg.get();
     if (!cli.isCryptoEnabled() || !SettingsStore.isFeatureEnabled("feature_cross_signing")) {
         return false;


### PR DESCRIPTION
This was not useful, as the other side already assumes the user doesn't have cross-signing keys and has consequently sent a legacy request. It doesn't change the behaviour if you **start** a request though, you'll still be asked to enable 4S then.

This was added in https://github.com/matrix-org/matrix-react-sdk/pull/4194/ just yesterday but realized this doesn't make much sense.