### PR TITLE
Send verification request to a single device in a way compatible with non-cross-signing

### DIFF
--- a/src/verification.js
+++ b/src/verification.js
@@ -23,6 +23,7 @@ import {RIGHT_PANEL_PHASES} from "./stores/RightPanelStorePhases";
 import {findDMForUser} from './createRoom';
 import {accessSecretStorage} from './CrossSigningManager';
 import SettingsStore from './settings/SettingsStore';
+import {verificationMethods} from 'matrix-js-sdk/src/crypto';
 
 async function enable4SIfNeeded() {
     const cli = MatrixClientPeg.get();
@@ -57,9 +58,10 @@ export async function verifyDevice(user, device) {
                 return;
             }
             const cli = MatrixClientPeg.get();
-            const verificationRequestPromise = cli.requestVerification(
+            const verificationRequestPromise = cli.legacyDeviceVerification(
                 user.userId,
-                [device.deviceId],
+                device.deviceId,
+                verificationMethods.SAS,
             );
             dis.dispatch({
                 action: "set_right_panel_phase",
@@ -77,7 +79,7 @@ export async function legacyVerifyUser(user) {
         return;
     }
     const cli = MatrixClientPeg.get();
-    const verificationRequestPromise = cli.requestVerification(user.userId);
+    const verificationRequestPromise = cli.beginKeyVerification(user.userId);
     dis.dispatch({
         action: "set_right_panel_phase",
         phase: RIGHT_PANEL_PHASES.EncryptionPanel,


### PR DESCRIPTION
e.g. sending a .start even straight away with just SAS as a method

Requires https://github.com/matrix-org/matrix-js-sdk/pull/1257
Fixes https://github.com/vector-im/riot-web/issues/12636

Tested that this works between this branch and riot-web 1.4.0 released last september.