### PR TITLE
Test for cross-signing homeserver support during login, toasts

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -99,8 +99,12 @@ export default class DeviceListener {
     }
 
     async _recheck() {
-        if (!SettingsStore.isFeatureEnabled("feature_cross_signing")) return;
         const cli = MatrixClientPeg.get();
+
+        if (
+            !SettingsStore.isFeatureEnabled("feature_cross_signing") ||
+            !await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")
+        ) return;
 
         if (!cli.isCryptoEnabled()) return;
         if (!cli.getCrossSigningId()) {

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1911,7 +1911,10 @@ export default createReactClass({
             // secret storage.
             SettingsStore.setFeatureEnabled("feature_cross_signing", true);
             this.setStateForNewView({ view: VIEWS.COMPLETE_SECURITY });
-        } else if (SettingsStore.isFeatureEnabled("feature_cross_signing")) {
+        } else if (
+            SettingsStore.isFeatureEnabled("feature_cross_signing") &&
+            await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")
+        ) {
             // This will only work if the feature is set to 'enable' in the config,
             // since it's too early in the lifecycle for users to have turned the
             // labs flag on.

--- a/src/components/structures/auth/CompleteSecurity.js
+++ b/src/components/structures/auth/CompleteSecurity.js
@@ -59,9 +59,10 @@ export default class CompleteSecurity extends React.Component {
             phase: PHASE_BUSY,
         });
         const cli = MatrixClientPeg.get();
-        const backupInfo = await cli.getKeyBackupVersion();
-        this.setState({backupInfo});
         try {
+            const backupInfo = await cli.getKeyBackupVersion();
+            this.setState({backupInfo});
+
             await accessSecretStorage(async () => {
                 await cli.checkOwnCrossSigningTrust();
                 if (backupInfo) await cli.restoreKeyBackupWithSecretStorage(backupInfo);


### PR DESCRIPTION
This adds more checking of homeserver support for cross-signing at login and in
toasts.

Fixes https://github.com/vector-im/riot-web/issues/12228