### PR TITLE
EventIndex: Properly await the index closing.

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -549,7 +549,8 @@ export default class EventIndex extends EventEmitter {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
         this.removeListeners();
         this.stopCrawler();
-        return indexManager.closeEventIndex();
+        await indexManager.closeEventIndex();
+        return;
     }
 
     /**

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -135,7 +135,7 @@ class EventIndexPeg {
      */
     async unset() {
         if (this.index === null) return;
-        this.index.close();
+        await this.index.close();
         this.index = null;
     }
 
@@ -151,7 +151,7 @@ class EventIndexPeg {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
 
         if (indexManager !== null) {
-            this.unset();
+            await this.unset();
             console.log("EventIndex: Deleting event index.");
             await indexManager.deleteEventIndex();
         }


### PR DESCRIPTION
React-sdk side of fixes for: https://github.com/vector-im/riot-web/issues/12721

Note that this depends on the delete-events branch, which in turn depends on a Seshat release.