### PR TITLE
Wrap large room names when previewing them

### DIFF
--- a/res/css/views/rooms/_RoomPreviewBar.scss
+++ b/res/css/views/rooms/_RoomPreviewBar.scss
@@ -25,6 +25,9 @@ limitations under the License.
     h3 {
         font-size: 18px;
         font-weight: 600;
+        // break-word, with fallback to break-all, which is wider supported
+        word-break: break-all;
+        word-break: break-word;
 
         &.mx_RoomPreviewBar_spinnerTitle {
             display: flex;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/274386/76622974-7689de00-652a-11ea-8399-10747cf364e8.png)

After:
![image](https://user-images.githubusercontent.com/274386/76622958-6f62d000-652a-11ea-913e-e8127c2a6c7c.png)
