### PR TITLE
Migrate SSSS to symmetric

### DIFF
--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -96,6 +96,9 @@ async function getSecretStorageKey({ keys: keyInfos }, ssssItemName) {
         {
             keyInfo: info,
             checkPrivateKey: async (input) => {
+                if (!info.pubkey) {
+                    return true;
+                }
                 const key = await inputToKey(input);
                 return MatrixClientPeg.get().checkSecretStoragePrivateKey(key, info.pubkey);
             },

--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -143,6 +143,15 @@ export default class DeviceListener {
                 }
             }
             return;
+        } else if (await cli.secretStorageKeyNeedsUpgrade()) {
+            // FIXME: do we a different message?
+            ToastStore.sharedInstance().addOrReplaceToast({
+                key: THIS_DEVICE_TOAST_KEY,
+                title: _t("Encryption upgrade available"),
+                icon: "verification_warning",
+                props: {kind: 'upgrade_encryption'},
+                component: sdk.getComponent("toasts.SetupEncryptionToast"),
+            });
         } else {
             ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
         }


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1238

Scenarios:
- [x] user has existing asymmetric SSSS, user logs in to Riot
  - works, but user has to enter SSSS passphrase twice for some reason
- [x] user has existing asymmetric SSSS, user reloads already-logged-in Riot
  - works, but upgrade encryption toast doesn't seem to go away after completing the upgrade
- [ ] user has existing key backup but no SSSS, user logs in to Riot.
- [ ] user has existing key backup but no SSSS, user reloads already-logged-in Riot
- [ ] user has no backup/SSSS, user logs in to Riot
- [ ] user has no backup/SSSS, user reloads already-logged-in Riot
- [x] user has symmetric SSSS, user logs in to Riot
- [x] user has symmetric SSSS, user reloads already-logged-in Riot

For migrating existing key backup, no SSSS, react-sdk needs to pass the backup recovery key to js-sdk somehow.  This would be done in the the `_bootstrapSecretStorage` function of `CreateSecretStorageDialog.js`.  This would either be done by prompting the user and then passing the key to js-sdk's `bootstrapSecretStorage` (if `CreateSecretStorageDialog` knows when it needs to prompt for the recovery key), or by passing a callback to js-sdk's `bootstrapSecretStorage`, which will be called when `bootstrapSecretStorage` needs the key.  js-sdk currently hardcodes a random key at https://github.com/matrix-org/matrix-js-sdk/pull/1238/files#diff-fa4472db829c5a59596c29a2f43e8f9cR506 .