### PR TITLE
Fix: ensure local state for aliases doesn't get garbled up

### DIFF
--- a/src/components/views/room_settings/AliasSettings.js
+++ b/src/components/views/room_settings/AliasSettings.js
@@ -233,11 +233,11 @@ export default class AliasSettings extends React.Component {
 
     onLocalAliasDeleted = (index) => {
         const alias = this.state.localAliases[index];
+        console.log("removing local alias", index, alias);
         // TODO: In future, we should probably be making sure that the alias actually belongs
         // to this room. See https://github.com/vector-im/riot-web/issues/7353
         MatrixClientPeg.get().deleteAlias(alias).then(() => {
-            const localAliases = this.state.localAliases.slice();
-            localAliases.splice(index, 1);
+            const localAliases = this.state.localAliases.filter(a => a !== alias);
             this.setState({localAliases});
 
             if (this.state.canonicalAlias === alias) {

--- a/src/components/views/room_settings/AliasSettings.js
+++ b/src/components/views/room_settings/AliasSettings.js
@@ -233,7 +233,6 @@ export default class AliasSettings extends React.Component {
 
     onLocalAliasDeleted = (index) => {
         const alias = this.state.localAliases[index];
-        console.log("removing local alias", index, alias);
         // TODO: In future, we should probably be making sure that the alias actually belongs
         // to this room. See https://github.com/vector-im/riot-web/issues/7353
         MatrixClientPeg.get().deleteAlias(alias).then(() => {


### PR DESCRIPTION
when removing another alias before the response of the first comes back

Fixes https://github.com/vector-im/riot-web/issues/12765