### PR TITLE
Fix custom tags causing left panel to over-expand

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -36,6 +36,7 @@ limitations under the License.
 .mx_LeftPanel_tagPanelContainer {
     flex: 0 0 70px;
     height: 100%;
+    display: -webkit-box;
 }
 
 .mx_LeftPanel_hideButton {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12785

This got regressed by removing Gemini