### PR TITLE
we don't do mx_fadable anymore so get rid of broken RightPanel disabling

### DIFF
--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -555,10 +555,6 @@ export default createReactClass({
                         GROUP_JOINPOLICY_INVITE,
             },
         });
-        dis.dispatch({
-            action: 'panel_disable',
-            sideDisabled: true,
-        });
     },
 
     _onShareClick: function() {

--- a/src/components/views/rooms/ForwardMessage.js
+++ b/src/components/views/rooms/ForwardMessage.js
@@ -33,7 +33,6 @@ export default createReactClass({
     componentWillMount: function() {
         dis.dispatch({
             action: 'panel_disable',
-            rightDisabled: true,
             middleDisabled: true,
         });
     },
@@ -45,7 +44,6 @@ export default createReactClass({
     componentWillUnmount: function() {
         dis.dispatch({
             action: 'panel_disable',
-            sideDisabled: false,
             middleDisabled: false,
         });
         document.removeEventListener('keydown', this._onKeyDown);

--- a/src/stores/RightPanelStore.js
+++ b/src/stores/RightPanelStore.js
@@ -42,8 +42,6 @@ const GROUP_PHASES = Object.keys(RIGHT_PANEL_PHASES).filter(k => k.startsWith("G
 export default class RightPanelStore extends Store {
     static _instance;
 
-    _inhibitUpdates = false;
-
     constructor() {
         super(dis);
 
@@ -116,11 +114,6 @@ export default class RightPanelStore extends Store {
     }
 
     __onDispatch(payload) {
-        if (payload.action === 'panel_disable') {
-            this._inhibitUpdates = payload.rightDisabled || payload.sideDisabled || false;
-            return;
-        }
-
         if (payload.action === 'view_room' || payload.action === 'view_group') {
             // Reset to the member list if we're viewing member info
             const memberInfoPhases = [
@@ -138,7 +131,7 @@ export default class RightPanelStore extends Store {
             }
         }
 
-        if (payload.action !== 'set_right_panel_phase' || this._inhibitUpdates) return;
+        if (payload.action !== 'set_right_panel_phase') return;
 
         const targetPhase = payload.phase;
         if (!RIGHT_PANEL_PHASES[targetPhase]) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12788

Group editing locked and never unlocked the RLS, Forwarding locked it whilst it was open. Locking the RLS has regressed, it was meant to get covered by an `mx_fadable` to make it clear you cannot interact with it. Removing as the redesign changed this but left stale code.