### PR TITLE
RoomPreviewBar word-break the sender name too

### DIFF
--- a/res/css/views/rooms/_RoomPreviewBar.scss
+++ b/res/css/views/rooms/_RoomPreviewBar.scss
@@ -25,15 +25,19 @@ limitations under the License.
     h3 {
         font-size: 18px;
         font-weight: 600;
-        // break-word, with fallback to break-all, which is wider supported
-        word-break: break-all;
-        word-break: break-word;
 
         &.mx_RoomPreviewBar_spinnerTitle {
             display: flex;
             flex-direction: row;
             align-items: center;
         }
+    }
+
+    h3,
+    .mx_RoomPreviewBar_message p {
+        // break-word, with fallback to break-all, which is wider supported
+        word-break: break-all;
+        word-break: break-word;
     }
 
     .mx_Spinner {


### PR DESCRIPTION
Fixes this \\/
![image](https://user-images.githubusercontent.com/2403652/77083660-c3235c80-69f5-11ea-86b8-18d88a6286cd.png)
