### PR TITLE
Register Mac electron specific Cmd+, shortcut to User Settings

### DIFF
--- a/src/accessibility/KeyboardShortcuts.tsx
+++ b/src/accessibility/KeyboardShortcuts.tsx
@@ -313,3 +313,7 @@ export const toggleDialog = () => {
         },
     });
 };
+
+export const registerShortcut = (category: Categories, defn: IShortcut) => {
+    shortcuts[category].push(defn);
+};


### PR DESCRIPTION
Expose Keyboard Shortcuts to allow registrations from parent modules.