### PR TITLE
Support Jitsi conferences sent/received on Riot Mobile and older Riot Webs

### DIFF
--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -433,7 +433,13 @@ async function _startCallApp(roomId, type) {
     const confId = `JitsiConference_${generateHumanReadableId()}`;
     const jitsiDomain = SdkConfig.get()['jitsi']['preferredDomain'];
 
-    const widgetUrl = WidgetUtils.getLocalJitsiWrapperUrl();
+    let widgetUrl = WidgetUtils.getLocalJitsiWrapperUrl();
+
+    // TODO: Remove URL hacks when the mobile clients eventually support v2 widgets
+    const parsedUrl = new URL(widgetUrl);
+    parsedUrl.search = ''; // set to empty string to make the URL class use searchParams instead
+    parsedUrl.searchParams.set('confId', confId);
+    widgetUrl = parsedUrl.toString();
 
     const widgetData = {
         conferenceId: confId,

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -422,17 +422,28 @@ export default class WidgetUtils {
         app.eventId = eventId;
         app.name = app.name || app.type;
 
+        if (app.type === 'jitsi') {
+            console.log("Replacing Jitsi widget URL with local wrapper");
+            if (!app.data || !app.data.conferenceId) {
+                // Assumed to be a v1 widget: add a data object for visibility on the wrapper
+                // TODO: Remove this once mobile supports v2 widgets
+                console.log("Replacing v1 Jitsi widget with v2 equivalent");
+                const parsed = new URL(app.url);
+                app.data = {
+                    conferenceId: parsed.searchParams.get("confId"),
+                    domain: "jitsi.riot.im", // v1 widgets have this hardcoded
+                };
+            }
+
+            app.url = WidgetUtils.getLocalJitsiWrapperUrl({forLocalRender: true});
+        }
+
         if (app.data) {
             Object.keys(app.data).forEach((key) => {
                 params['$' + key] = app.data[key];
             });
 
             app.waitForIframeLoad = (app.data.waitForIframeLoad === 'false' ? false : true);
-        }
-
-        if (app.type === 'jitsi') {
-            console.log("Replacing Jitsi widget URL with local wrapper");
-            app.url = WidgetUtils.getLocalJitsiWrapperUrl({forLocalRender: true});
         }
 
         app.url = encodeUri(app.url, params);


### PR DESCRIPTION
The mobile apps have no way of knowing the conference domain, so this won't work anyways for those cases. The best we can do is support duality of the widgets and hope for the best.

Fixes https://github.com/vector-im/riot-web/issues/12816
Fixes https://github.com/vector-im/riot-web/issues/12814