### PR TITLE
Fix view community link icon contrast

### DIFF
--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -137,7 +137,7 @@ limitations under the License.
     top: -8px;
     border-radius: 8px;
     background-color: $neutral-badge-color;
-    color: #ffffff;
+    color: #000;
     font-weight: 600;
     font-size: 10px;
     text-align: center;


### PR DESCRIPTION
This Fixes https://github.com/vector-im/riot-web/issues/12797

Here's how it looks now. My sincere apologies for the poor image resolution.

![rsz_1screenshot_from_2020-03-21_09-54-34](https://user-images.githubusercontent.com/26300284/77223575-13b5c980-6b5e-11ea-9377-d94b9327e4f3.png)


Signed-off-by: thobyv-kismat <vivee18@gmail.com>