### PR TITLE
Get rid of the "View Community" button

### DIFF
--- a/src/components/views/context_menus/TagTileContextMenu.js
+++ b/src/components/views/context_menus/TagTileContextMenu.js
@@ -20,7 +20,6 @@ import PropTypes from 'prop-types';
 import { _t } from '../../../languageHandler';
 import dis from '../../../dispatcher';
 import TagOrderActions from '../../../actions/TagOrderActions';
-import * as sdk from '../../../index';
 import {MenuItem} from "../../structures/ContextMenu";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 
@@ -36,16 +35,7 @@ export default class TagTileContextMenu extends React.Component {
     constructor() {
         super();
 
-        this._onViewCommunityClick = this._onViewCommunityClick.bind(this);
         this._onRemoveClick = this._onRemoveClick.bind(this);
-    }
-
-    _onViewCommunityClick() {
-        dis.dispatch({
-            action: 'view_group',
-            group_id: this.props.tag,
-        });
-        this.props.onFinished();
     }
 
     _onRemoveClick() {
@@ -54,19 +44,7 @@ export default class TagTileContextMenu extends React.Component {
     }
 
     render() {
-        const TintableSvg = sdk.getComponent("elements.TintableSvg");
-
         return <div>
-            <MenuItem className="mx_TagTileContextMenu_item" onClick={this._onViewCommunityClick}>
-                <TintableSvg
-                    className="mx_TagTileContextMenu_item_icon"
-                    src={require("../../../../res/img/icons-groups.svg")}
-                    width="15"
-                    height="15"
-                />
-                { _t('View Community') }
-            </MenuItem>
-            <hr className="mx_TagTileContextMenu_separator" role="separator" />
             <MenuItem className="mx_TagTileContextMenu_item" onClick={this._onRemoveClick}>
                 <img className="mx_TagTileContextMenu_item_icon" src={require("../../../../res/img/icon_context_delete.svg")} width="15" height="15" alt="" />
                 { _t('Hide') }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1846,7 +1846,6 @@
     "Update status": "Update status",
     "Set status": "Set status",
     "Set a new status...": "Set a new status...",
-    "View Community": "View Community",
     "Hide": "Hide",
     "Home": "Home",
     "Sign in": "Sign in",

--- a/src/stores/TagOrderStore.js
+++ b/src/stores/TagOrderStore.js
@@ -146,9 +146,11 @@ class TagOrderStore extends Store {
                         if (this._state.selectedTags.length === 1 && this._state.selectedTags.includes(payload.tag)) {
                             // Existing (only) selected tag is being normally clicked again, clear tags
                             newTags = [];
+                            dis.dispatch({action: 'view_last_screen'});
                         } else {
                             // Select individual tag
                             newTags = [payload.tag];
+                            dis.dispatch({action: 'view_group', group_id: payload.tag});
                         }
                     }
                     // Only set the anchor tag if the tag was previously unselected, otherwise


### PR DESCRIPTION
The option to see all people and rooms in a community shouldn't be
hidden in a context menu. Just show the community page when the
community icon is clicked in the sidebar, and go back to whatever the
user was doing before when the community icon is clicked again.