### PR TITLE
Always display verification request toasts on top

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1524,6 +1524,7 @@ export default createReactClass({
                     icon: "verification",
                     props: {request},
                     component: sdk.getComponent("toasts.VerificationRequestToast"),
+                    priority: ToastStore.PRIORITY_REALTIME,
                 });
             }
         });

--- a/src/stores/ToastStore.js
+++ b/src/stores/ToastStore.js
@@ -20,6 +20,9 @@ import EventEmitter from 'events';
  * Holds the active toasts
  */
 export default class ToastStore extends EventEmitter {
+    static PRIORITY_REALTIME = 1;
+    static PRIORITY_DEFAULT = 0;
+
     static sharedInstance() {
         if (!global.mx_ToastStore) global.mx_ToastStore = new ToastStore();
         return global.mx_ToastStore;
@@ -36,9 +39,16 @@ export default class ToastStore extends EventEmitter {
     }
 
     addOrReplaceToast(newToast) {
+        if (newToast.priority === undefined) newToast.priority = ToastStore.PRIORITY_DEFAULT;
+
         const oldIndex = this._toasts.findIndex(t => t.key === newToast.key);
         if (oldIndex === -1) {
-            this._toasts.push(newToast);
+            // we only have two priorities so just push realtime ones onto the front
+            if (newToast.priority) {
+                this._toasts.unshift(newToast);
+            } else {
+                this._toasts.push(newToast);
+            }
         } else {
             this._toasts[oldIndex] = newToast;
         }


### PR DESCRIPTION
As they're interactive and time-sensitive.

Fixes https://github.com/vector-im/riot-web/issues/12141