### PR TITLE
Fix formatbar not hidden on highlighted message sent

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -152,6 +152,7 @@ export default class BasicMessageEditor extends React.Component {
         if (this.props.placeholder) {
             const {isEmpty} = this.props.model;
             if (isEmpty) {
+                this._formatBarRef.hide();
                 this._showPlaceholder();
             } else {
                 this._hidePlaceholder();

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -149,14 +149,16 @@ export default class BasicMessageEditor extends React.Component {
             const position = selection.end || selection;
             this._setLastCaretFromPosition(position);
         }
+        const {isEmpty} = this.props.model;
         if (this.props.placeholder) {
-            const {isEmpty} = this.props.model;
             if (isEmpty) {
-                this._formatBarRef.hide();
                 this._showPlaceholder();
             } else {
                 this._hidePlaceholder();
             }
+        }
+        if(isEmpty) {
+            this._formatBarRef.hide();
         }
         this.setState({autoComplete: this.props.model.autoComplete});
         this.historyManager.tryPush(this.props.model, selection, inputType, diff);

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -157,7 +157,7 @@ export default class BasicMessageEditor extends React.Component {
                 this._hidePlaceholder();
             }
         }
-        if(isEmpty) {
+        if (isEmpty) {
             this._formatBarRef.hide();
         }
         this.setState({autoComplete: this.props.model.autoComplete});


### PR DESCRIPTION
This fixes https://github.com/vector-im/riot-web/issues/12817

Tracking the component `model` state/length seems to work. Hopeful for a review soon.

Signed-off-by: thobyv-kismat <vivee18@gmail.com>