### PR TITLE
Fix formatBar not hidden after highlight and backspacing some text

### DIFF
--- a/src/Keyboard.ts
+++ b/src/Keyboard.ts
@@ -22,6 +22,7 @@ export const Key = {
     PAGE_UP: "PageUp",
     PAGE_DOWN: "PageDown",
     BACKSPACE: "Backspace",
+    DELETE: "Delete",
     ARROW_UP: "ArrowUp",
     ARROW_DOWN: "ArrowDown",
     ARROW_LEFT: "ArrowLeft",

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -447,6 +447,8 @@ export default class BasicMessageEditor extends React.Component {
             } else if (event.key === Key.TAB) {
                 this._tabCompleteName();
                 handled = true;
+            } else if (event.key === Key.BACKSPACE) {
+                this._formatBarRef.hide();
             }
         }
         if (handled) {

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -447,7 +447,7 @@ export default class BasicMessageEditor extends React.Component {
             } else if (event.key === Key.TAB) {
                 this._tabCompleteName();
                 handled = true;
-            } else if (event.key === Key.BACKSPACE) {
+            } else if (event.key === Key.BACKSPACE || Key.DELETE) {
                 this._formatBarRef.hide();
             }
         }

--- a/src/components/views/rooms/BasicMessageComposer.js
+++ b/src/components/views/rooms/BasicMessageComposer.js
@@ -447,7 +447,7 @@ export default class BasicMessageEditor extends React.Component {
             } else if (event.key === Key.TAB) {
                 this._tabCompleteName();
                 handled = true;
-            } else if (event.key === Key.BACKSPACE || Key.DELETE) {
+            } else if (event.key === Key.BACKSPACE || event.key === Key.DELETE) {
                 this._formatBarRef.hide();
             }
         }


### PR DESCRIPTION
This fixes https://github.com/vector-im/riot-web/issues/12671

Hopeful for a review soon. Seems to be that `_onSelectionChange` does not trigger on backspace so catching this event/key manually was quiet useful.

Signed-off-by: thobyv-kismat <vivee18@gmail.com>