### PR TITLE
Fall back to non-standard persisted api for Safari

### DIFF
--- a/src/rageshake/submit-rageshake.js
+++ b/src/rageshake/submit-rageshake.js
@@ -118,9 +118,7 @@ export default async function sendBugReport(bugReportEndpoint, opts) {
         try {
             body.append("storageManager_persisted", await navigator.storage.persisted());
         } catch (e) {}
-    }
-    // Safari
-    if (document.hasStorageAccess) {
+    } else if (document.hasStorageAccess) { // Safari
         try {
             body.append("storageManager_persisted", await document.hasStorageAccess());
         } catch (e) {}

--- a/src/rageshake/submit-rageshake.js
+++ b/src/rageshake/submit-rageshake.js
@@ -119,6 +119,12 @@ export default async function sendBugReport(bugReportEndpoint, opts) {
             body.append("storageManager_persisted", await navigator.storage.persisted());
         } catch (e) {}
     }
+    // Safari
+    if (document.hasStorageAccess) {
+        try {
+            body.append("storageManager_persisted", await document.hasStorageAccess());
+        } catch (e) {}
+    }
     if (navigator.storage && navigator.storage.estimate) {
         try {
             const estimate = await navigator.storage.estimate();

--- a/src/utils/StorageManager.js
+++ b/src/utils/StorageManager.js
@@ -48,7 +48,7 @@ export function tryPersistStorage() {
         navigator.storage.persist().then(persistent => {
             console.log("StorageManager: Persistent?", persistent);
         });
-    } else if (document.requestStorageAccess) { //Safari
+    } else if (document.requestStorageAccess) { // Safari
         document.requestStorageAccess().then(
             () => console.log("StorageManager: Persistent?", true),
             () => console.log("StorageManager: Persistent?", false),

--- a/src/utils/StorageManager.js
+++ b/src/utils/StorageManager.js
@@ -48,6 +48,11 @@ export function tryPersistStorage() {
         navigator.storage.persist().then(persistent => {
             console.log("StorageManager: Persistent?", persistent);
         });
+    } else if (document.requestStorageAccess) { //Safari
+        document.requestStorageAccess().then(
+            () => console.log("StorageManager: Persistent?", true),
+            () => console.log("StorageManager: Persistent?", false),
+        );
     } else {
         console.log("StorageManager: Persistence unsupported");
     }


### PR DESCRIPTION
Fixes: https://github.com/vector-im/riot-web/issues/12866

Can somebody with a mac test this on safari and see if `StorageManager: Persistent?` appears in the logs? 