### PR TITLE
If cached keys are present in the key backup dialog, use them

### DIFF
--- a/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
+++ b/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
@@ -200,6 +200,24 @@ export default class RestoreKeyBackupDialog extends React.PureComponent {
         }
     }
 
+    async _restoreWithCachedKey(backupInfo) {
+        if (!backupInfo) return false;
+        try {
+            const recoverInfo = await MatrixClientPeg.get().restoreKeyBackupWithCache(
+                undefined, /* targetRoomId */
+                undefined, /* targetSessionId */
+                backupInfo
+            );
+            this.setState({
+                recoverInfo
+            });
+            return true;
+        } catch (e) {
+            console.log("restoreWithCachedKey failed:", e);
+            return false;
+        }
+    }
+
     async _loadBackupStatus() {
         this.setState({
             loading: true,
@@ -212,6 +230,15 @@ export default class RestoreKeyBackupDialog extends React.PureComponent {
                 backupInfo,
                 backupKeyStored,
             });
+
+            const gotCache = await this._restoreWithCachedKey(backupInfo);
+            if (gotCache) {
+                console.log("RestoreKeyBackupDialog: found cached backup key");
+                this.setState({
+                    loading: false,
+                });
+                return;
+            }
 
             // If the backup key is stored, we can proceed directly to restore.
             if (backupKeyStored) {

--- a/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
+++ b/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
@@ -206,10 +206,10 @@ export default class RestoreKeyBackupDialog extends React.PureComponent {
             const recoverInfo = await MatrixClientPeg.get().restoreKeyBackupWithCache(
                 undefined, /* targetRoomId */
                 undefined, /* targetSessionId */
-                backupInfo
+                backupInfo,
             );
             this.setState({
-                recoverInfo
+                recoverInfo,
             });
             return true;
         } catch (e) {


### PR DESCRIPTION
Relates to https://github.com/vector-im/riot-web/issues/12704

If the key is cached, use it.

I've tested corrupting the cache, and the recovery function catches that and throws an error.  The user i then prompted for their SSSS key, which then updates the cache with the correct key.