### PR TITLE
Fix: pick last active DM for verification request

### DIFF
--- a/src/createRoom.js
+++ b/src/createRoom.js
@@ -174,6 +174,9 @@ export function findDMForUser(client, userId) {
             return member && (member.membership === "invite" || member.membership === "join");
         }
         return false;
+    }).sort((r1, r2) => {
+        return r2.getLastActiveTimestamp() -
+            r1.getLastActiveTimestamp();
     });
     if (suitableDMRooms.length) {
         return suitableDMRooms[0];


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12850

Tested it with 2 DMs, and it did pick the one I was last active in.