### PR TITLE
blank out UserInfo avatar when changing between members

### DIFF
--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -1388,6 +1388,7 @@ const UserInfoHeader = ({onClose, member, e2eStatus}) => {
             <div>
                 <div>
                     <MemberAvatar
+                        key={member.userId} // to instantly blank the avatar when UserInfo changes members
                         member={member}
                         width={2 * 0.3 * window.innerHeight} // 2x@30vh
                         height={2 * 0.3 * window.innerHeight} // 2x@30vh


### PR DESCRIPTION
MemberAvatar doesn't blank out on props changes to rip it out and render from scratch on a member change to cause a blank to show instead of the old avatar. 

Fixes https://github.com/vector-im/riot-web/issues/12899