### PR TITLE
Fix: can't dismiss unverified session toast when encryption hasn't been upgraded

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -119,89 +119,85 @@ export default class DeviceListener {
 
         const crossSigningReady = await cli.isCrossSigningReady();
 
-        if (!crossSigningReady) {
-            if (this._dismissedThisDeviceToast) {
-                ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
-                return;
-            }
-
-            // cross signing isn't enabled - nag to enable it
-            // There are 3 different toasts for:
-            if (cli.getStoredCrossSigningForUser(cli.getUserId())) {
-                // Cross-signing on account but this device doesn't trust the master key (verify this session)
-                ToastStore.sharedInstance().addOrReplaceToast({
-                    key: THIS_DEVICE_TOAST_KEY,
-                    title: _t("Verify this session"),
-                    icon: "verification_warning",
-                    props: {kind: 'verify_this_session'},
-                    component: sdk.getComponent("toasts.SetupEncryptionToast"),
-                });
-            } else {
-                const backupInfo = await this._getKeyBackupInfo();
-                if (backupInfo) {
-                    // No cross-signing on account but key backup available (upgrade encryption)
+        if (this._dismissedThisDeviceToast) {
+            ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
+        } else {
+            if (!crossSigningReady) {
+                // cross signing isn't enabled - nag to enable it
+                // There are 3 different toasts for:
+                if (cli.getStoredCrossSigningForUser(cli.getUserId())) {
+                    // Cross-signing on account but this device doesn't trust the master key (verify this session)
                     ToastStore.sharedInstance().addOrReplaceToast({
                         key: THIS_DEVICE_TOAST_KEY,
-                        title: _t("Encryption upgrade available"),
+                        title: _t("Verify this session"),
                         icon: "verification_warning",
-                        props: {kind: 'upgrade_encryption'},
+                        props: {kind: 'verify_this_session'},
                         component: sdk.getComponent("toasts.SetupEncryptionToast"),
                     });
                 } else {
-                    // No cross-signing or key backup on account (set up encryption)
+                    const backupInfo = await this._getKeyBackupInfo();
+                    if (backupInfo) {
+                        // No cross-signing on account but key backup available (upgrade encryption)
+                        ToastStore.sharedInstance().addOrReplaceToast({
+                            key: THIS_DEVICE_TOAST_KEY,
+                            title: _t("Encryption upgrade available"),
+                            icon: "verification_warning",
+                            props: {kind: 'upgrade_encryption'},
+                            component: sdk.getComponent("toasts.SetupEncryptionToast"),
+                        });
+                    } else {
+                        // No cross-signing or key backup on account (set up encryption)
+                        ToastStore.sharedInstance().addOrReplaceToast({
+                            key: THIS_DEVICE_TOAST_KEY,
+                            title: _t("Set up encryption"),
+                            icon: "verification_warning",
+                            props: {kind: 'set_up_encryption'},
+                            component: sdk.getComponent("toasts.SetupEncryptionToast"),
+                        });
+                    }
+                }
+                return;
+            } else if (await cli.secretStorageKeyNeedsUpgrade()) {
+                ToastStore.sharedInstance().addOrReplaceToast({
+                    key: THIS_DEVICE_TOAST_KEY,
+                    title: _t("Encryption upgrade available"),
+                    icon: "verification_warning",
+                    props: {kind: 'upgrade_ssss'},
+                    component: sdk.getComponent("toasts.SetupEncryptionToast"),
+                });
+            }
+        }
+
+        // as long as cross-signing isn't ready,
+        // you can't see or dismiss any device toasts
+        if (crossSigningReady) {
+            const newActiveToasts = new Set();
+
+            const devices = await cli.getStoredDevicesForUser(cli.getUserId());
+            for (const device of devices) {
+                if (device.deviceId == cli.deviceId) continue;
+
+                const deviceTrust = await cli.checkDeviceTrust(cli.getUserId(), device.deviceId);
+                if (deviceTrust.isCrossSigningVerified() || this._dismissed.has(device.deviceId)) {
+                    ToastStore.sharedInstance().dismissToast(toastKey(device.deviceId));
+                } else {
+                    this._activeNagToasts.add(device.deviceId);
                     ToastStore.sharedInstance().addOrReplaceToast({
-                        key: THIS_DEVICE_TOAST_KEY,
-                        title: _t("Set up encryption"),
+                        key: toastKey(device.deviceId),
+                        title: _t("Unverified login. Was this you?"),
                         icon: "verification_warning",
-                        props: {kind: 'set_up_encryption'},
-                        component: sdk.getComponent("toasts.SetupEncryptionToast"),
+                        props: { device },
+                        component: sdk.getComponent("toasts.UnverifiedSessionToast"),
                     });
+                    newActiveToasts.add(device.deviceId);
                 }
             }
-            return;
-        } else if (await cli.secretStorageKeyNeedsUpgrade()) {
-            if (this._dismissedThisDeviceToast) {
-                ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
-                return;
+
+            // clear any other outstanding toasts (eg. logged out devices)
+            for (const deviceId of this._activeNagToasts) {
+                if (!newActiveToasts.has(deviceId)) ToastStore.sharedInstance().dismissToast(toastKey(deviceId));
             }
-
-            ToastStore.sharedInstance().addOrReplaceToast({
-                key: THIS_DEVICE_TOAST_KEY,
-                title: _t("Encryption upgrade available"),
-                icon: "verification_warning",
-                props: {kind: 'upgrade_ssss'},
-                component: sdk.getComponent("toasts.SetupEncryptionToast"),
-            });
-        } else {
-            ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
+            this._activeNagToasts = newActiveToasts;
         }
-
-        const newActiveToasts = new Set();
-
-        const devices = await cli.getStoredDevicesForUser(cli.getUserId());
-        for (const device of devices) {
-            if (device.deviceId == cli.deviceId) continue;
-
-            const deviceTrust = await cli.checkDeviceTrust(cli.getUserId(), device.deviceId);
-            if (deviceTrust.isCrossSigningVerified() || this._dismissed.has(device.deviceId)) {
-                ToastStore.sharedInstance().dismissToast(toastKey(device.deviceId));
-            } else {
-                this._activeNagToasts.add(device.deviceId);
-                ToastStore.sharedInstance().addOrReplaceToast({
-                    key: toastKey(device.deviceId),
-                    title: _t("Unverified login. Was this you?"),
-                    icon: "verification_warning",
-                    props: { device },
-                    component: sdk.getComponent("toasts.UnverifiedSessionToast"),
-                });
-                newActiveToasts.add(device.deviceId);
-            }
-        }
-
-        // clear any other outstanding toasts (eg. logged out devices)
-        for (const deviceId of this._activeNagToasts) {
-            if (!newActiveToasts.has(deviceId)) ToastStore.sharedInstance().dismissToast(toastKey(deviceId));
-        }
-        this._activeNagToasts = newActiveToasts;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12844

![dismiss-was-this-you](https://user-images.githubusercontent.com/274386/77775075-f55f3a80-7043-11ea-8b96-df87da25e39f.gif)
