### PR TITLE
Added the /html command

### DIFF
--- a/src/SlashCommands.js
+++ b/src/SlashCommands.js
@@ -128,6 +128,15 @@ export const CommandMap = {
         },
         category: CommandCategories.messages,
     }),
+    html: new Command({
+        name: 'html',
+        args: '<message>',
+        description: _td('Sends a message as html, without interpreting it as markdown'),
+        runFn: function(roomId, messages) {
+            return success(MatrixClientPeg.get().sendHtmlMessage(roomId, messages, messages));
+        },
+        category: CommandCategories.messages,
+    }),
     ddg: new Command({
         name: 'ddg',
         args: '<query>',

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -153,6 +153,7 @@
     "Usage": "Usage",
     "Prepends ¯\\_(ツ)_/¯ to a plain-text message": "Prepends ¯\\_(ツ)_/¯ to a plain-text message",
     "Sends a message as plain text, without interpreting it as markdown": "Sends a message as plain text, without interpreting it as markdown",
+    "Sends a message as html, without interpreting it as markdown": "Sends a message as html, without interpreting it as markdown",
     "Searches DuckDuckGo for results": "Searches DuckDuckGo for results",
     "/ddg is not a command": "/ddg is not a command",
     "To use it, just wait for autocomplete results to load and tab through them.": "To use it, just wait for autocomplete results to load and tab through them.",


### PR DESCRIPTION
This command lets you send html messages through riot. This is
incredibly useful for doing advanced formatting not supported by
markdown and lets riot support even more html tags.

I ended up implementing this for my fork of riot that supports extra html tags and it seemed useful to upstream, so here it is. I think there might be something missing here with respect to translations but I'm not sure how i18 works so I didn't put anything in.