### PR TITLE
Update link to css location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Code should be committed as follows:
    * In practice, `matrix-react-sdk` is still evolving so fast that the maintenance
      burden of customising and overriding these components for Riot can seriously
      impede development.  So right now, there should be very few (if any) customisations for Riot.
- * CSS: https://github.com/vector-im/riot-web/tree/master/src/skins/vector/css/matrix-react-sdk
+ * CSS: https://github.com/matrix-org/matrix-react-sdk/tree/master/res/css
  * Theme specific CSS & resources: https://github.com/matrix-org/matrix-react-sdk/tree/master/res/themes
 
 React components in matrix-react-sdk are come in two different flavours:


### PR DESCRIPTION
Just a quick doc fix updating the css location which seems to have moved from riot-web to the matrix-react-sdk