### PR TITLE
Show red shield for users that become unverified

### DIFF
--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -68,8 +68,10 @@ export const getE2EStatus = (cli, userId, devices) => {
         return hasUnverifiedDevice ? "warning" : "verified";
     }
     const isMe = userId === cli.getUserId();
-    const userVerified = cli.checkUserTrust(userId).isCrossSigningVerified();
-    if (!userVerified) return "normal";
+    const userTrust = cli.checkUserTrust(userId);
+    if (!userTrust.isCrossSigningVerified()) {
+        return userTrust.wasCrossSigningVerified() ? "warning" : "normal";
+    }
 
     const anyDeviceUnverified = devices.some(device => {
         const { deviceId } = device;

--- a/src/components/views/rooms/MemberTile.js
+++ b/src/components/views/rooms/MemberTile.js
@@ -121,10 +121,10 @@ export default createReactClass({
         const cli = MatrixClientPeg.get();
         const { userId } = this.props.member;
         const isMe = userId === cli.getUserId();
-        const userVerified = cli.checkUserTrust(userId).isCrossSigningVerified();
-        if (!userVerified) {
+        const userTrust = cli.checkUserTrust(userId);
+        if (!userTrust.isCrossSigningVerified()) {
             this.setState({
-                e2eStatus: "normal",
+                e2eStatus: userTrust.wasCrossSigningVerified() ? "warning" : "normal",
             });
             return;
         }

--- a/src/utils/ShieldUtils.ts
+++ b/src/utils/ShieldUtils.ts
@@ -5,6 +5,7 @@ interface Client {
     getUserId: () => string;
     checkUserTrust: (userId: string) => {
         isCrossSigningVerified: () => boolean
+        wasCrossSigningVerified: () => boolean
     };
     getStoredDevicesForUser: (userId: string) => Promise<[{ deviceId: string }]>;
     checkDeviceTrust: (userId: string, deviceId: string) => {
@@ -28,6 +29,13 @@ export async function shieldStatusForMembership(client: Client, room: Room): Pro
             (client.checkUserTrust(userId).isCrossSigningVerified() ?
             verified : unverified).push(userId);
         });
+
+    /* Alarm if any unverified users were verified before. */
+    for (const userId of unverified) {
+        if (client.checkUserTrust(userId).wasCrossSigningVerified()) {
+            return "warning";
+        }
+    }
 
     /* Check all verified user devices. */
     /* Don't alarm if no other users are verified  */

--- a/test/utils/ShieldUtils-test.js
+++ b/test/utils/ShieldUtils-test.js
@@ -6,7 +6,7 @@ function mkClient(selfTrust) {
         getUserId: () => "@self:localhost",
         checkUserTrust: (userId) => ({
             isCrossSigningVerified: () => userId[1] == "T",
-            wasCrossSigningVerified: () => userId[1] == "T",
+            wasCrossSigningVerified: () => userId[1] == "T" || userId[1] == "W",
         }),
         checkDeviceTrust: (userId, deviceId) => ({
             isVerified: () => userId === "@self:localhost" ? selfTrust : userId[2] == "T",
@@ -151,7 +151,7 @@ describe("shieldStatusForMembership other-trust behaviour", function() {
         const client = mkClient(true);
         const room = {
             roomId: dm ? "DM" : "other",
-            getEncryptionTargetMembers: () => ["@self:localhost", "@TF:h", "@TT: h"].map((userId) => ({userId})),
+            getEncryptionTargetMembers: () => ["@self:localhost", "@TF:h", "@TT:h"].map((userId) => ({userId})),
         };
         const status = await shieldStatusForRoom(client, room);
         expect(status).toEqual(result);
@@ -163,7 +163,19 @@ describe("shieldStatusForMembership other-trust behaviour", function() {
         const client = mkClient(true);
         const room = {
             roomId: dm ? "DM" : "other",
-            getEncryptionTargetMembers: () => ["@self:localhost", "@FF:h", "@FT: h"].map((userId) => ({userId})),
+            getEncryptionTargetMembers: () => ["@self:localhost", "@FF:h", "@FT:h"].map((userId) => ({userId})),
+        };
+        const status = await shieldStatusForRoom(client, room);
+        expect(status).toEqual(result);
+    });
+
+    it.each(
+        [["warning", true], ["warning", false]],
+    )("2 was verified: returns '%s', DM = %s", async (result, dm) => {
+        const client = mkClient(true);
+        const room = {
+            roomId: dm ? "DM" : "other",
+            getEncryptionTargetMembers: () => ["@self:localhost", "@WF:h", "@FT:h"].map((userId) => ({userId})),
         };
         const status = await shieldStatusForRoom(client, room);
         expect(status).toEqual(result);

--- a/test/utils/ShieldUtils-test.js
+++ b/test/utils/ShieldUtils-test.js
@@ -6,6 +6,7 @@ function mkClient(selfTrust) {
         getUserId: () => "@self:localhost",
         checkUserTrust: (userId) => ({
             isCrossSigningVerified: () => userId[1] == "T",
+            wasCrossSigningVerified: () => userId[1] == "T",
         }),
         checkDeviceTrust: (userId, deviceId) => ({
             isVerified: () => userId === "@self:localhost" ? selfTrust : userId[2] == "T",


### PR DESCRIPTION
For any users that we previously verified but that are not unverified, we will
now mark them and rooms they are in with a red shield.

Fixes https://github.com/vector-im/riot-web/issues/12808
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1292