### PR TITLE
Remove underscore from Jitsi conference names

### DIFF
--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -430,7 +430,7 @@ async function _startCallApp(roomId, type) {
         return;
     }
 
-    const confId = `JitsiConference_${generateHumanReadableId()}`;
+    const confId = `JitsiConference${generateHumanReadableId()}`;
     const jitsiDomain = SdkConfig.get()['jitsi']['preferredDomain'];
 
     let widgetUrl = WidgetUtils.getLocalJitsiWrapperUrl();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12929

Note: we don't need this to fix conferences in our hosted instance (riot.im or modular.im), but it is a common thing for self-hosters, including sometimes ourselves, to accidentally make mistakes on.