### PR TITLE
Pass new secret storage key to bootstrap path

### DIFF
--- a/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
@@ -69,6 +69,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
 
         this._keyInfo = null;
         this._encodedRecoveryKey = null;
+        this._recoveryKey = null;
         this._recoveryKeyNode = null;
         this._setZxcvbnResultTimeout = null;
 
@@ -234,14 +235,22 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
             if (force) {
                 await cli.bootstrapSecretStorage({
                     authUploadDeviceSigningKeys: this._doBootstrapUIAuth,
-                    createSecretStorageKey: async () => this._keyInfo,
+                    createSecretStorageKey: async () => [
+                        this._keyInfo,
+                        this._encodedRecoveryKey,
+                        this._recoveryKey,
+                    ],
                     setupNewKeyBackup: true,
                     setupNewSecretStorage: true,
                 });
             } else {
                 await cli.bootstrapSecretStorage({
                     authUploadDeviceSigningKeys: this._doBootstrapUIAuth,
-                    createSecretStorageKey: async () => this._keyInfo,
+                    createSecretStorageKey: async () => [
+                        this._keyInfo,
+                        this._encodedRecoveryKey,
+                        this._recoveryKey,
+                    ],
                     keyBackupInfo: this.state.backupInfo,
                     setupNewKeyBackup: !this.state.backupInfo && this.state.useKeyBackup,
                     getKeyBackupPassphrase: promptForBackupPassphrase,
@@ -299,10 +308,11 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
     }
 
     _onSkipPassPhraseClick = async () => {
-        const [keyInfo, encodedRecoveryKey] =
+        const [keyInfo, encodedRecoveryKey, recoveryKey] =
             await MatrixClientPeg.get().createRecoveryKeyFromPassphrase();
         this._keyInfo = keyInfo;
         this._encodedRecoveryKey = encodedRecoveryKey;
+        this._recoveryKey = recoveryKey;
         this.setState({
             copied: false,
             downloaded: false,
@@ -335,10 +345,11 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
 
         if (this.state.passPhrase !== this.state.passPhraseConfirm) return;
 
-        const [keyInfo, encodedRecoveryKey] =
+        const [keyInfo, encodedRecoveryKey, recoveryKey] =
             await MatrixClientPeg.get().createRecoveryKeyFromPassphrase(this.state.passPhrase);
         this._keyInfo = keyInfo;
         this._encodedRecoveryKey = encodedRecoveryKey;
+        this._recoveryKey = recoveryKey;
         this.setState({
             copied: false,
             downloaded: false,

--- a/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
@@ -67,8 +67,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this._keyInfo = null;
-        this._encodedRecoveryKey = null;
         this._recoveryKey = null;
         this._recoveryKeyNode = null;
         this._setZxcvbnResultTimeout = null;
@@ -181,7 +179,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
     }
 
     _onDownloadClick = () => {
-        const blob = new Blob([this._encodedRecoveryKey], {
+        const blob = new Blob([this._recoveryKey.encodedPrivateKey], {
             type: 'text/plain;charset=us-ascii',
         });
         FileSaver.saveAs(blob, 'recovery-key.txt');
@@ -235,22 +233,14 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
             if (force) {
                 await cli.bootstrapSecretStorage({
                     authUploadDeviceSigningKeys: this._doBootstrapUIAuth,
-                    createSecretStorageKey: async () => [
-                        this._keyInfo,
-                        this._encodedRecoveryKey,
-                        this._recoveryKey,
-                    ],
+                    createSecretStorageKey: async () => this._recoveryKey,
                     setupNewKeyBackup: true,
                     setupNewSecretStorage: true,
                 });
             } else {
                 await cli.bootstrapSecretStorage({
                     authUploadDeviceSigningKeys: this._doBootstrapUIAuth,
-                    createSecretStorageKey: async () => [
-                        this._keyInfo,
-                        this._encodedRecoveryKey,
-                        this._recoveryKey,
-                    ],
+                    createSecretStorageKey: async () => this._recoveryKey,
                     keyBackupInfo: this.state.backupInfo,
                     setupNewKeyBackup: !this.state.backupInfo && this.state.useKeyBackup,
                     getKeyBackupPassphrase: promptForBackupPassphrase,
@@ -308,11 +298,8 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
     }
 
     _onSkipPassPhraseClick = async () => {
-        const [keyInfo, encodedRecoveryKey, recoveryKey] =
+        this._recoveryKey =
             await MatrixClientPeg.get().createRecoveryKeyFromPassphrase();
-        this._keyInfo = keyInfo;
-        this._encodedRecoveryKey = encodedRecoveryKey;
-        this._recoveryKey = recoveryKey;
         this.setState({
             copied: false,
             downloaded: false,
@@ -345,11 +332,8 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
 
         if (this.state.passPhrase !== this.state.passPhraseConfirm) return;
 
-        const [keyInfo, encodedRecoveryKey, recoveryKey] =
+        this._recoveryKey =
             await MatrixClientPeg.get().createRecoveryKeyFromPassphrase(this.state.passPhrase);
-        this._keyInfo = keyInfo;
-        this._encodedRecoveryKey = encodedRecoveryKey;
-        this._recoveryKey = recoveryKey;
         this.setState({
             copied: false,
             downloaded: false,
@@ -624,7 +608,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
                 </div>
                 <div className="mx_CreateSecretStorageDialog_recoveryKeyContainer">
                     <div className="mx_CreateSecretStorageDialog_recoveryKey">
-                        <code ref={this._collectRecoveryKeyNode}>{this._encodedRecoveryKey}</code>
+                        <code ref={this._collectRecoveryKeyNode}>{this._recoveryKey.encodedPrivateKey}</code>
                     </div>
                     <div className="mx_CreateSecretStorageDialog_recoveryKeyButtons">
                         <AccessibleButton kind='primary' className="mx_Dialog_primary" onClick={this._onCopyClick}>


### PR DESCRIPTION
This passes the newly created secret storage key down to the bootstrap path for
temporary caching to avoid prompting the user for it again in the later stages
of bootstrapping.

Fixes https://github.com/vector-im/riot-web/issues/12867
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1293