### PR TITLE
Fix peeking keeping two timeline update mechanisms in play

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -236,6 +236,11 @@ export default createReactClass({
             showReadReceipts: SettingsStore.getValue("showReadReceipts", roomId),
         };
 
+        if (!initial && this.state.shouldPeek && !newState.shouldPeek) {
+            // Stop peeking because we have joined this room now
+            this.context.stopPeeking();
+        }
+
         // Temporary logging to diagnose https://github.com/vector-im/riot-web/issues/4307
         console.log(
             'RVS update:',

--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -472,6 +472,10 @@ export default createReactClass({
             RoomScrollStateStore.setScrollState(this.state.roomId, this._getScrollState());
         }
 
+        if (this.state.shouldPeek) {
+            this.context.stopPeeking();
+        }
+
         // stop tracking room changes to format permalinks
         this._stopAllPermalinkCreators();
 

--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -123,6 +123,9 @@ class RoomViewStore extends Store {
             case 'join_room_error':
                 this._joinRoomError(payload);
                 break;
+            case 'join_room_ready':
+                this._setState({ shouldPeek: false });
+                break;
             case 'on_client_not_viable':
             case 'on_logged_out':
                 this.reset();
@@ -259,11 +262,10 @@ class RoomViewStore extends Store {
         MatrixClientPeg.get().joinRoom(
             this._state.roomAlias || this._state.roomId, payload.opts,
         ).then(() => {
-            // We don't actually need to do anything here: we do *not*
-            // clear the 'joining' flag because the Room object and/or
-            // our 'joined' member event may not have come down the sync
-            // stream yet, and that's the point at which we'd consider
-            // the user joined to the room.
+            // We do *not* clear the 'joining' flag because the Room object and/or our 'joined' member event may not
+            // have come down the sync stream yet, and that's the point at which we'd consider the user joined to the
+            // room.
+            dis.dispatch({ action: 'join_room_ready' });
         }, (err) => {
             dis.dispatch({
                 action: 'join_room_error',


### PR DESCRIPTION
shouldPeek was only being cleared on viewRoom which was not in the path of joinRoom (as joinRoom was often called from viewRoom) so re-dispatch to emit a clear of shouldPeek and handle that properly in RoomView, not just when initial=true.

Fixes https://github.com/vector-im/riot-web/issues/12760