### PR TITLE
Fix: legacy verify user throwing error

### DIFF
--- a/src/verification.js
+++ b/src/verification.js
@@ -99,7 +99,7 @@ export async function legacyVerifyUser(user) {
         return;
     }
     const cli = MatrixClientPeg.get();
-    const verificationRequestPromise = cli.beginKeyVerification(user.userId);
+    const verificationRequestPromise = cli.requestVerification(user.userId);
     dis.dispatch({
         action: "set_right_panel_phase",
         phase: RIGHT_PANEL_PHASES.EncryptionPanel,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12951

Note that this won't work with older riots, as they don't support verification requests not being started with a `.start` event. I'm assuming that the legacy user verification feature is mainly aimed at users with a recent riot but that haven't set up cross-signing yet. For older riots, you still have the option of verifying an individual device, which does work.