### PR TITLE
EventIndex: Mark the initial checkpoints for a full crawl.

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -109,6 +109,7 @@ export default class EventIndex extends EventEmitter {
                 roomId: room.roomId,
                 token: token,
                 direction: "b",
+                fullCrawl: true,
             };
 
             const forwardCheckpoint = {


### PR DESCRIPTION
The logic determining if a batch of events is already in the database
has been reported to be faulty. Since we know that when we add initial
checkpoints they need to go to the start of the timeline we can mark
them to do a full crawl which will skip the test if the events are
already in the database.

This is a quick fix for this and checkpoints that are added after a gap
in the timeline might incorrectly conclude the same resulting in missing
events if there was a gap and the issue is triggered.