### PR TITLE
Only apply padding to standard textual buttons (kind buttons)

### DIFF
--- a/res/css/views/right_panel/_UserInfo.scss
+++ b/res/css/views/right_panel/_UserInfo.scss
@@ -266,7 +266,7 @@ limitations under the License.
         }
     }
 
-    .mx_AccessibleButton {
+    .mx_AccessibleButton.mx_AccessibleButton_hasKind {
         padding: 8px 18px;
 
         &.mx_AccessibleButton_kind_primary {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12991