### PR TITLE
Fix: dismiss setup encryption toast if cross-signing is ready

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -165,6 +165,9 @@ export default class DeviceListener {
                     props: {kind: 'upgrade_ssss'},
                     component: sdk.getComponent("toasts.SetupEncryptionToast"),
                 });
+            } else {
+                // cross-signing is ready, and we don't need to upgrade encryption
+                ToastStore.sharedInstance().dismissToast(THIS_DEVICE_TOAST_KEY);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12926

This probably regressed after refactoring the code in `DeviceListener:_recheck` in https://github.com/matrix-org/matrix-react-sdk/pull/4291 but we were basically not dismissing the `setupencryption` toast once cross-signing became ready.