### PR TITLE
Fix spurious extra devices on registration

### DIFF
--- a/src/components/structures/auth/Registration.js
+++ b/src/components/structures/auth/Registration.js
@@ -463,7 +463,7 @@ export default createReactClass({
             initial_device_display_name: this.props.defaultDeviceDisplayName,
         };
         if (auth) registerParams.auth = auth;
-        if (inhibitLogin !== undefined && inhibitLogin !== null) registerParams.inhibitLogin = inhibitLogin;
+        if (inhibitLogin !== undefined && inhibitLogin !== null) registerParams.inhibit_login = inhibitLogin;
         return this.state.matrixClient.registerRequest(registerParams);
     },
 


### PR DESCRIPTION
We send a parameter to prevent being immediately logged in after
registration, but we regressed it from snake case to camelcase
during the course of cross-signing dev.

Fixes https://github.com/vector-im/riot-web/issues/12865