### PR TITLE
Clear sessionStorage on sign out

### DIFF
--- a/src/Lifecycle.js
+++ b/src/Lifecycle.js
@@ -637,6 +637,10 @@ async function _clearStorage() {
         window.localStorage.clear();
     }
 
+    if (window.sessionStorage) {
+        window.sessionStorage.clear();
+    }
+
     // create a temporary client to clear out the persistent stores.
     const cli = createMatrixClient({
         // we'll never make any requests, so can pass a bogus HS URL


### PR DESCRIPTION
The browser's `sessionStorage` is only used for composer history today, but
still we should also clear this on sign out for those on shared computers, etc.

Fixes https://github.com/vector-im/riot-web/issues/13041