### PR TITLE
Check more account data in toast listener

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -90,8 +90,15 @@ export default class DeviceListener {
     }
 
     _onAccountData = (ev) => {
-        // User may have migrated SSSS to symmetric, in which case we can dismiss that toast
-        if (ev.getType().startsWith('m.secret_storage.key.')) {
+        // User may have:
+        // * migrated SSSS to symmetric
+        // * uploaded keys to secret storage
+        // * completed secret storage creation
+        // which result in account data changes affecting checks below.
+        if (
+            ev.getType().startsWith('m.secret_storage.') ||
+            ev.getType().startsWith('m.cross_signing.')
+        ) {
             this._recheck();
         }
     }


### PR DESCRIPTION
Since any change to cross-signing or secret storage account data may affect the
outcome of checks in the toast listener, we need to broaden the account data
listener there to re-run for changes to all such bits of account data.

Fixes https://github.com/vector-im/riot-web/issues/13048