### PR TITLE
Fix copy button on code blocks when there is no code tag just pre

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -278,7 +278,7 @@ export default createReactClass({
             const button = document.createElement("span");
             button.className = "mx_EventTile_copyButton";
             button.onclick = (e) => {
-                const copyCode = button.parentNode.getElementsByTagName("code")[0];
+                const copyCode = button.parentNode.getElementsByTagName("pre")[0];
                 const successful = this.copyToClipboard(copyCode.textContent);
 
                 const buttonRect = e.target.getBoundingClientRect();


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

The selector matches, pre's so we never check for code.
`.mx_EventTile_body pre`