### PR TITLE
Fix image thumbnail width when read receipts are hidden

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -111,6 +111,7 @@ limitations under the License.
 }
 
 .mx_EventTile_line, .mx_EventTile_reply {
+    clear: both;
     position: relative;
     padding-left: 65px; /* left gutter */
     padding-top: 4px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13072

RR on:
![image](https://user-images.githubusercontent.com/2403652/78895761-4bca7100-7a67-11ea-84ca-1cbd270525ae.png)
RR off:
![image](https://user-images.githubusercontent.com/2403652/78895788-55ec6f80-7a67-11ea-8d8e-321c6b6b6a52.png)
