### PR TITLE
Pass along key backup for bootstrap

### DIFF
--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -185,7 +185,7 @@ export async function promptForBackupPassphrase() {
 
     const RestoreKeyBackupDialog = sdk.getComponent('dialogs.keybackup.RestoreKeyBackupDialog');
     const { finished } = Modal.createTrackedDialog('Restore Backup', '', RestoreKeyBackupDialog, {
-            showSummary: false, keyCallback: k => key = k,
+        showSummary: false, keyCallback: k => key = k,
     }, null, /* priority = */ false, /* static = */ true);
 
     const success = await finished;


### PR DESCRIPTION
If we ask for the key backup key early in creating secret storage to ensure we
trust the backup, then we stash it to ensure it's available to bootstrap as well
without prompting again.

![backup-dialog-hellscape](https://user-images.githubusercontent.com/279572/78919388-c0160c00-7a89-11ea-8930-97440cd4648b.gif)

(Note: The above flow does prompt for a passphrase twice, but I'll address that separately.)

Fixes https://github.com/vector-im/riot-web/issues/12958