### PR TITLE
Pass widget data through from sticker picker

### DIFF
--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -246,6 +246,7 @@ export default class Stickerpicker extends React.Component {
                 url: stickerpickerWidget.content.url,
                 name: stickerpickerWidget.content.name,
                 type: stickerpickerWidget.content.type,
+                data: stickerpickerWidget.content.data,
             };
 
             stickersContent = (


### PR DESCRIPTION
This allows for sticker pickers to have custom template variables.

Fixes https://github.com/vector-im/riot-web/issues/6716

Horrible demo:
![image](https://user-images.githubusercontent.com/1190097/78938817-29892100-7a70-11ea-9a43-0fad49db37ca.png)

from widget:
![image](https://user-images.githubusercontent.com/1190097/78938847-360d7980-7a70-11ea-9445-da0916cbe30e.png)
