### PR TITLE
Add user preference to toggle call-related messages

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -51,6 +51,8 @@ Settings are the different options a user may set or experience in the applicati
 }
 ```
 
+Note: The `invertedSettingName` key is only needed when migrating from legacy settings. Newer settings should not have it.
+
 Settings that support the config level can be set in the config file under the `settingDefaults` key (note that some settings, like the "theme" setting, are special cased in the config file):
 ```json
 {

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -50,6 +50,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
         'showJoinLeaves',
         'showAvatarChanges',
         'showDisplaynameChanges',
+        'showCallRelatedMessages',
         'showImages',
     ];
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -406,6 +406,7 @@
     "Show join/leave messages (invites/kicks/bans unaffected)": "Show join/leave messages (invites/kicks/bans unaffected)",
     "Show avatar changes": "Show avatar changes",
     "Show display name changes": "Show display name changes",
+    "Show messages about call information": "Show messages about call information",
     "Show read receipts sent by other users": "Show read receipts sent by other users",
     "Show timestamps in 12 hour format (e.g. 2:30pm)": "Show timestamps in 12 hour format (e.g. 2:30pm)",
     "Always show message timestamps": "Always show message timestamps",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -210,6 +210,12 @@ export const SETTINGS = {
         default: true,
         invertedSettingName: 'hideDisplaynameChanges',
     },
+    "showCallRelatedMessages": {
+        supportedLevels: LEVELS_ROOM_SETTINGS,
+        displayName: _td('Show messages about call information'),
+        default: true,
+        invertedSettingName: 'hideCallRelatedMessages',
+    },
     "showReadReceipts": {
         supportedLevels: LEVELS_ROOM_SETTINGS,
         displayName: _td('Show read receipts sent by other users'),

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -214,7 +214,6 @@ export const SETTINGS = {
         supportedLevels: LEVELS_ROOM_SETTINGS,
         displayName: _td('Show messages about call information'),
         default: true,
-        invertedSettingName: 'hideCallRelatedMessages',
     },
     "showReadReceipts": {
         supportedLevels: LEVELS_ROOM_SETTINGS,

--- a/src/shouldHideEvent.js
+++ b/src/shouldHideEvent.js
@@ -50,7 +50,7 @@ export default function shouldHideEvent(ev) {
     if (ev.isRelation("m.replace")) return true;
 
     // Hide call-related messages based on user preferences
-    if (ev.getType().startsWith("m.call") && !isEnabled('showCallRelatedMessages')) return true;
+    if (ev.getType().startsWith("m.call.") && !isEnabled('showCallRelatedMessages')) return true;
 
     const eventDiff = memberEventDiff(ev);
 

--- a/src/shouldHideEvent.js
+++ b/src/shouldHideEvent.js
@@ -49,6 +49,9 @@ export default function shouldHideEvent(ev) {
     // Hide replacement events since they update the original tile (if enabled)
     if (ev.isRelation("m.replace")) return true;
 
+    // Hide call-related messages based on user preferences
+    if (ev.getType().startsWith("m.call") && !isEnabled('showCallRelatedMessages')) return true;
+
     const eventDiff = memberEventDiff(ev);
 
     if (eventDiff.isMemberEvent) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/6841 

Also adds a note about `invertedSettingsName` to the documentation on settings. (See initial code review comments for context.)

Signed-off-by: Xinyue "Cheshire" Yang <hello@cheryllium.com>