### PR TITLE
Sort emoji by shortcodes for autocomplete primarily for :-1 and :+1 

### DIFF
--- a/src/autocomplete/EmojiProvider.js
+++ b/src/autocomplete/EmojiProvider.js
@@ -101,9 +101,7 @@ export default class EmojiProvider extends AutocompleteProvider {
             // then sort by score (Infinity if matchedString not in shortname)
             sorters.push((c) => score(matchedString, c.shortname));
             // then sort by max score of all shortcodes, trim off the `:`
-            sorters.push((c) => {
-                return Math.min.apply(null, c.emoji.shortcodes.map(s => score(matchedString.substring(1), s)));
-            });
+            sorters.push((c) => Math.min(...c.emoji.shortcodes.map(s => score(matchedString.substring(1), s))));
             // If the matchedString is not empty, sort by length of shortname. Example:
             //  matchedString = ":bookmark"
             //  completions = [":bookmark:", ":bookmark_tabs:", ...]

--- a/src/autocomplete/EmojiProvider.js
+++ b/src/autocomplete/EmojiProvider.js
@@ -100,6 +100,10 @@ export default class EmojiProvider extends AutocompleteProvider {
 
             // then sort by score (Infinity if matchedString not in shortname)
             sorters.push((c) => score(matchedString, c.shortname));
+            // then sort by max score of all shortcodes, trim off the `:`
+            sorters.push((c) => {
+                return Math.min.apply(null, c.emoji.shortcodes.map(s => score(matchedString.substring(1), s)));
+            });
             // If the matchedString is not empty, sort by length of shortname. Example:
             //  matchedString = ":bookmark"
             //  completions = [":bookmark:", ":bookmark_tabs:", ...]


### PR DESCRIPTION
https://github.com/vector-im/riot-web/issues/5291
![image](https://user-images.githubusercontent.com/2403652/79050120-c938e180-7c1f-11ea-995a-08c749be61d8.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>