### PR TITLE
Add border radius to uploaded images

### DIFF
--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -25,6 +25,7 @@ limitations under the License.
     height: 100%;
     left: 0;
     top: 0;
+    border-radius: 0.5rem;
 }
 
 .mx_MImageBody_thumbnail_container {


### PR DESCRIPTION
This adds a nice little border radius to uploaded images in discussions.

[![screenshot-rounder-corners.png](https://i.postimg.cc/d3NwkP4g/screenshot-rounder-corners.png)](https://postimg.cc/bSnKWMXR)

Signed-off-by: Touhami MAHDI <touhami@touha.me>