### PR TITLE
VoiceChannels: Alpha

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -29,6 +29,7 @@
 @import "./structures/_TopLeftMenuButton.scss";
 @import "./structures/_UploadBar.scss";
 @import "./structures/_ViewSource.scss";
+@import "./structures/_VoiceChannelControls.scss";
 @import "./structures/auth/_CompleteSecurity.scss";
 @import "./structures/auth/_Login.scss";
 @import "./views/auth/_AuthBody.scss";

--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -184,6 +184,7 @@
 @import "./views/rooms/_Stickers.scss";
 @import "./views/rooms/_TopUnreadMessagesBar.scss";
 @import "./views/rooms/_UserOnlineDot.scss";
+@import "./views/rooms/_VoiceUserTile.scss";
 @import "./views/rooms/_WhoIsTypingTile.scss";
 @import "./views/settings/_AvatarSetting.scss";
 @import "./views/settings/_CrossSigningPanel.scss";

--- a/res/css/structures/_TagPanel.scss
+++ b/res/css/structures/_TagPanel.scss
@@ -52,7 +52,7 @@ limitations under the License.
 .mx_TagPanel .mx_TagPanel_divider {
     height: 0px;
     width: 42px;
-    border-bottom: 1px solid $panel-divider-color;
+    border-bottom: 1px solid $header-divider-color;
     display: none;
 }
 
@@ -97,6 +97,30 @@ limitations under the License.
     &::before {
         background-color: $roomheader-addroom-fg-color;
         mask-image: url('$(res)/img/feather-customised/plus.svg');
+        mask-position: center;
+        mask-repeat: no-repeat;
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+    }
+}
+
+.mx_TagPanel .mx_TagTile_home {
+    margin-bottom: 12px;
+    height: 40px;
+    width: 40px;
+    border-radius: 20px;
+    background-color: $roomheader-addroom-bg-color;
+    position: relative;
+    /* overwrite mx_RoleButton inline-block */
+    display: block !important;
+
+    &::before {
+        background-color: $roomheader-addroom-fg-color;
+        mask-image: url('$(res)/img/feather-customised/home.svg');
         mask-position: center;
         mask-repeat: no-repeat;
         content: '';

--- a/res/css/structures/_VoiceChannelControls.scss
+++ b/res/css/structures/_VoiceChannelControls.scss
@@ -1,0 +1,74 @@
+.mx_VoiceChannelControls {
+    // min-height: 100px;
+    border-top: 1px solid $panel-divider-color;
+    background-color: $primary-bg-color;
+}
+
+
+
+.mx_VoiceChannelControls_labelContainer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    // flex: 0 0 50%;
+    overflow: hidden;
+    transition: flex-basis 0.2s;
+    box-sizing: border-box;
+
+    .mx_VoiceChannelControls_button {
+        flex: 0 0 auto;
+        font-size: 14px;
+        margin: 4px;
+        width: 21px;
+        height: 26px;
+        padding: 5px;
+        font-weight: 600;
+        color: $notice-secondary-color;
+        position: relative;
+        border-radius: 4px;
+        // display: inline-block;
+    
+        &:hover {
+            background-color: $dark-panel-bg-color;
+        }
+    
+        &::before {
+            cursor: pointer;
+            mask-repeat: no-repeat;
+            mask-position: center center;
+            content: "";
+            width: 21px;
+            height: 26px;
+            background-color: $notice-secondary-color;
+            position: absolute;
+        }
+    }
+
+    .mx_VoiceChannelControls_button object {
+        pointer-events: none;
+    }
+}
+
+.mx_VoiceChannelControls_label {
+    flex: 1 0 auto;
+    margin: 0 7px;
+    font-size: 18px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    font-weight: 600;
+    line-height: 48px;
+    color: $notice-secondary-color;
+}
+
+.mx_VoiceChannelControls_muted::before {
+    mask: url('$(res)/img/voice-mute.svg')
+}
+
+.mx_VoiceChannelControls_unmuted::before {
+    mask: url('$(res)/img/voice-unmute.svg')
+}
+
+.mx_VoiceChannelControls_leave::before {
+    mask: url('$(res)/img/feather-customised/x.svg')
+}

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -85,6 +85,11 @@ limitations under the License.
     vertical-align: middle;
 }
 
+//Overwrites the base avatar class in order to allow for transparency within avatar images (voice channels)
+.mx_BaseAvatar_image {
+    background-color: transparent;
+}
+
 .mx_RoomTile_hasSubtext .mx_RoomTile_avatar {
     padding-top: 0;
     vertical-align: super;
@@ -96,6 +101,10 @@ limitations under the License.
     bottom: 0;
     right: -5px;
     z-index: 2;
+}
+
+.mx_RoomTile_voiceChannelUsers {
+    padding-left: 30px;
 }
 
 // Note we match .mx_E2EIcon to make sure this matches more tightly than just

--- a/res/css/views/rooms/_VoiceUserTile.scss
+++ b/res/css/views/rooms/_VoiceUserTile.scss
@@ -1,0 +1,46 @@
+
+.mx_VoiceTile {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    cursor: pointer;
+    height: 34px;
+    margin: 0;
+    padding: 0 8px 0 10px;
+    position: relative;
+}
+
+.mx_VoiceTile_nameContainer {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    vertical-align: middle;
+    min-width: 0;
+}
+
+.mx_VoiceTile_labelContainer {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.mx_VoiceTile_name {
+    font-size: 14px;
+    padding: 0 4px;
+    color: $roomtile-name-color;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}
+
+.mx_VoiceTile_avatar_container {
+    position: relative;
+}
+
+.mx_VoiceTile_avatar {
+    flex: 0;
+    padding: 4px;
+    width: 24px;
+    vertical-align: middle;
+}

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -339,10 +339,11 @@ function _onAction(payload) {
                         description: _t('You cannot place a call with yourself.'),
                     });
                     return;
-                } else if (members.length === 2) {
-                    console.info("Place %s call in %s", payload.type, payload.room_id);
-                    const call = Matrix.createNewMatrixCall(MatrixClientPeg.get(), payload.room_id);
-                    placeCall(call);
+                //TODO: Reenable after testing
+                // } else if (members.length === 2) {
+                    // console.info("Place %s call in %s", payload.type, payload.room_id);
+                    // const call = Matrix.createNewMatrixCall(MatrixClientPeg.get(), payload.room_id);
+                    // placeCall(call);
                 } else { // > 2
                     dis.dispatch({
                         action: "place_conference_call",

--- a/src/VoiceChannelUtils.js
+++ b/src/VoiceChannelUtils.js
@@ -1,10 +1,11 @@
 import {MatrixClientPeg} from './MatrixClientPeg'
 import WidgetUtils from './utils/WidgetUtils';
+import dis from './dispatcher'
 
 export const VoiceChannelStateKey = 'im.riot.voicechannel'
 export const VoiceChannelState = {
     enabled: 'enabled', //boolean
-    users: 'users' //string[] of userids
+    users: 'users' //{(jitsi)participantId: userId}
 }
 
 class VoiceChannelUtils {
@@ -15,6 +16,15 @@ class VoiceChannelUtils {
         return MatrixClientPeg.get().getRoom(roomId)
     }
 
+    _getCurrentConfig = (roomId) => {
+        const room = this._getRoom(roomId)
+        if (!room) return null
+        const stateEvent = room.currentState.getStateEvents(VoiceChannelStateKey, '')
+        if (!stateEvent) return null
+        return stateEvent.getContent()
+    }
+
+    //Returns MatrixEvent of first jitsi widget it can find
     _getConferenceWidgetContent = (roomId) => {
         const room = this._getRoom(roomId)
         if (!room) return null;
@@ -28,22 +38,81 @@ class VoiceChannelUtils {
         return currentJitsiVoiceWidgets[0].getContent();
     }
 
+    //Has valid jitsi widget means it can be configured to act as a voice channel
     canBeVoiceChannel = (roomId) => {
         return Boolean(this._getConferenceWidgetContent(roomId))
     }
 
+    //Current config makes this a voice channel
     isVoiceChannel = (roomId) => {
         if (this.canBeVoiceChannel(roomId)) {
-            const room = this._getRoom(roomId)
-            const event = room.currentState.getStateEvents(VoiceChannelStateKey, '')
-            if (!event) return false
-            else return Boolean(event.getContent() ? event.getContent()[VoiceChannelState.enabled] : false)
+            const config = this._getCurrentConfig(roomId)
+            if (!config) return false
+            else return Boolean(config[VoiceChannelState.enabled])
         }
          return false
     }
 
     getConferenceData = (roomId) => {
         return this._getConferenceWidgetContent(roomId)
+    }
+
+    // getVoiceChannelContent = (roomId) => {
+    //     const event = this._getCurrentConfig(roomId)
+    //     if (!event) return null
+    //     return event
+    // }
+
+    //Actions
+
+    joinAsVoiceChannel = (roomId) => {
+        const data = this._getConferenceWidgetContent(roomId).data
+        if (!data) return false
+        dis.dispatch({
+            action: 'join_channel',
+            roomId: roomId,
+            confId: data.conferenceId,
+            jitsiDomain: data.domain
+        })
+        return true
+    }
+
+    //Active functions
+
+    updateState = async (roomId, toUpdate) => {
+        const config = this._getCurrentConfig(roomId)
+        //No config means that the room probably isnt a voice channel eg. The user 'joined as voice channel'
+        if (!config) return null
+        Object.assign(config, toUpdate)
+        //Empty object wont have overwritten keys. Obviously want to clear voicechannel config
+        if (Object.keys(toUpdate).length === 0) config = {}
+        console.log('VCU state update', config)
+        await MatrixClientPeg.get().sendStateEvent(roomId, VoiceChannelStateKey, config, '')
+    }
+
+    //Gets current room state event data listing the users in the voice channel
+    //returns object{jitsiPartcipantId: matrixUserId} mapping or null
+    // Note: object can be empty. eg no key value pairs
+    getUsers = (roomId) => {
+        const config = this._getCurrentConfig(roomId)
+        if (!config) return null
+        return (config[VoiceChannelState.users] ? config[VoiceChannelState.users] : null)
+    }
+
+    setUsers = (roomId, userMap = {}) => {
+        const updatedConfig = {[VoiceChannelState.users]: userMap}
+        this.updateState(roomId, updatedConfig)
+    }
+
+    addUser = (roomId, userData) => {
+        const users = this.getUsers(roomId)
+        this.setUsers(roomId, Object.assign(users, userData))
+    }
+
+    removeUser = (roomId, participantId) => {
+        const users = this.getUsers(roomId)
+        delete users[participantId]
+        this.setUsers(roomId, users)
     }
 }
 

--- a/src/VoiceChannelUtils.js
+++ b/src/VoiceChannelUtils.js
@@ -1,0 +1,50 @@
+import {MatrixClientPeg} from './MatrixClientPeg'
+import WidgetUtils from './utils/WidgetUtils';
+
+export const VoiceChannelStateKey = 'im.riot.voicechannel'
+export const VoiceChannelState = {
+    enabled: 'enabled', //boolean
+    users: 'users' //string[] of userids
+}
+
+class VoiceChannelUtils {
+
+    constructor() {}
+
+    _getRoom = (roomId) => {
+        return MatrixClientPeg.get().getRoom(roomId)
+    }
+
+    _getConferenceWidgetContent = (roomId) => {
+        const room = this._getRoom(roomId)
+        if (!room) return null;
+
+        const widgets = WidgetUtils.getRoomWidgets(room);
+        const currentJitsiVoiceWidgets = widgets.filter((ev) => {
+            const content = ev.getContent()
+            return ((content.type === 'jitsi' || content.type === "m.jitsi") && content.data.isAudioOnly);
+        });
+        if (!currentJitsiVoiceWidgets || currentJitsiVoiceWidgets.length <= 0) return false;
+        return currentJitsiVoiceWidgets[0].getContent();
+    }
+
+    canBeVoiceChannel = (roomId) => {
+        return Boolean(this._getConferenceWidgetContent(roomId))
+    }
+
+    isVoiceChannel = (roomId) => {
+        if (this.canBeVoiceChannel(roomId)) {
+            const room = this._getRoom(roomId)
+            const event = room.currentState.getStateEvents(VoiceChannelStateKey, '')
+            if (!event) return false
+            else return Boolean(event.getContent() ? event.getContent()[VoiceChannelState.enabled] : false)
+        }
+         return false
+    }
+
+    getConferenceData = (roomId) => {
+        return this._getConferenceWidgetContent(roomId)
+    }
+}
+
+export default VoiceChannelUtils = new VoiceChannelUtils();

--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -225,6 +225,7 @@ const LeftPanel = createReactClass({
         const SearchBox = sdk.getComponent('structures.SearchBox');
         const CallPreview = sdk.getComponent('voip.CallPreview');
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
+        const VoiceChannelControls = sdk.getComponent('structures.VoiceChannelControls')
 
         const tagPanelEnabled = SettingsStore.getValue("TagPanel.enableTagPanel");
         let tagPanelContainer;
@@ -293,6 +294,7 @@ const LeftPanel = createReactClass({
                         collapsed={this.props.collapsed}
                         searchFilter={this.state.searchFilter}
                         ConferenceHandler={VectorConferenceHandler} />
+                    <VoiceChannelControls />
                 </aside>
             </div>
         );

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -32,6 +32,7 @@ import RoomTile from "../views/rooms/RoomTile";
 import LazyRenderList from "../views/elements/LazyRenderList";
 import {_t} from "../../languageHandler";
 import {RovingTabIndexWrapper} from "../../accessibility/RovingTabIndex";
+import VoiceChannelUtils from '../../VoiceChannelUtils'
 
 // turn this on for drop & drag console debugging galore
 const debug = false;
@@ -41,6 +42,7 @@ export default class RoomSubList extends React.PureComponent {
     static debug = debug;
 
     static propTypes = {
+        //List of Room objects
         list: PropTypes.arrayOf(PropTypes.object).isRequired,
         label: PropTypes.string.isRequired,
         tagName: PropTypes.string,

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -193,6 +193,7 @@ export default class RoomSubList extends React.PureComponent {
     };
 
     onRoomTileClick = (roomId, ev) => {
+        if (VoiceChannelUtils.joinAsVoiceChannel(roomId)) return null
         dis.dispatch({
             action: 'view_room',
             show_room_tile: true, // to make sure the room gets scrolled into view
@@ -385,7 +386,10 @@ export default class RoomSubList extends React.PureComponent {
 
     setHeight = (height) => {
         if (this._subList.current) {
-            this._subList.current.style.height = `${height}px`;
+        //Make sub list work with users in voice channels
+        const numItems = this.props.list.map(r => (VoiceChannelUtils.isVoiceChannel(r.roomId) ? Object.keys(VoiceChannelUtils.getUsers(r.roomId)).length : 0))
+        const additionalHeightHack = numItems.length ? numItems.reduce((a,b) => a+b)*34 : 0
+            this._subList.current.style.height = `${height+additionalHeightHack}px`;
         }
         this._updateLazyRenderHeight(height);
     };

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -106,6 +106,7 @@ const TagPanel = createReactClass({
         const DNDTagTile = sdk.getComponent('elements.DNDTagTile');
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
         const ActionButton = sdk.getComponent('elements.ActionButton');
+        const TagTile = sdk.getComponent('elements.TagTile');
         const TintableSvg = sdk.getComponent('elements.TintableSvg');
 
         const tags = this.state.orderedTags.map((tag, index) => {
@@ -133,11 +134,23 @@ const TagPanel = createReactClass({
             mx_TagPanel_items_selected: itemsSelected,
         });
 
+        const dividerStyle = {
+            display: 'block'
+        }
+
+        const homeTag = {
+            tag: "Home"
+        }
+
         return <div className={classes}>
             <div className="mx_TagPanel_clearButton_container">
                 { clearButton }
             </div>
             <div className="mx_TagPanel_divider" />
+            <div>
+                <TagTile {...homeTag} selected={!this.state.selectedTags.length}/>
+            </div>
+            <div className="mx_TagPanel_divider" style={dividerStyle} />
             <AutoHideScrollbar
                 className="mx_TagPanel_scroller"
                 // XXX: Use onMouseDown as a workaround for https://github.com/atlassian/react-beautiful-dnd/issues/273

--- a/src/components/structures/TagPanel.js
+++ b/src/components/structures/TagPanel.js
@@ -102,6 +102,40 @@ const TagPanel = createReactClass({
         dis.dispatch({action: 'deselect_tags'});
     },
 
+    _makeHomeTag() {
+        const AccessibleTooltipButton = sdk.getComponent("elements.AccessibleTooltipButton")
+        const BaseAvatar = sdk.getComponent('avatars.BaseAvatar')
+        const avatarHeight = 40
+        const name = 'Home'
+
+        const httpUrl = require('../../../../riot-web/res/vector-icons/favicon.ico')
+
+        const className = classNames({
+            mx_TagTile: true,
+            mx_TagTile_selected: !this.state.selectedTags.length,
+        })
+        const homeClick = (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            dis.dispatch({
+                action: 'deselect_tags'
+            })
+        }
+        return <React.Fragment>
+            <AccessibleTooltipButton className={className} onClick={homeClick} title={name}>
+                <div className="mx_TagTile_avatar">
+                    <BaseAvatar
+                        name={name}
+                        idName={name}
+                        url={httpUrl}
+                        width={avatarHeight}
+                        height={avatarHeight}
+                    />
+                </div>
+            </AccessibleTooltipButton>
+        </React.Fragment>
+    },
+
     render() {
         const DNDTagTile = sdk.getComponent('elements.DNDTagTile');
         const AccessibleButton = sdk.getComponent('elements.AccessibleButton');
@@ -138,8 +172,9 @@ const TagPanel = createReactClass({
             display: 'block'
         }
 
-        const homeTag = {
-            tag: "Home"
+        const homeTile = this._makeHomeTag()
+        const homeTileStyle = {
+            padding: '2px 0 9px 0'
         }
 
         return <div className={classes}>
@@ -147,8 +182,8 @@ const TagPanel = createReactClass({
                 { clearButton }
             </div>
             <div className="mx_TagPanel_divider" />
-            <div>
-                <TagTile {...homeTag} selected={!this.state.selectedTags.length}/>
+            <div style={homeTileStyle}>
+                { homeTile }
             </div>
             <div className="mx_TagPanel_divider" style={dividerStyle} />
             <AutoHideScrollbar

--- a/src/components/structures/VoiceChannelControls.js
+++ b/src/components/structures/VoiceChannelControls.js
@@ -1,0 +1,213 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import RoomAvatar from '../views/avatars/RoomAvatar';
+import AccessibleButton from '../views/elements/AccessibleButton';
+import { _t } from '../../languageHandler';
+import * as sdk from '../../index';
+import classNames from 'classnames';
+import SdkConfig from '../../SdkConfig'
+import dis from '../../dispatcher';
+//Need to import a singleton something what is it?
+
+// var JitsiMeetExternalAPI;
+var activeChannel;
+let script;
+let loaded;
+
+export default class VoiceChannelControls extends React.Component {
+    dispatcherRef;
+
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            isMicrophoneMuted: false,
+            joined: false,
+            joinError: false,
+            // js-sdk Room object
+            room: PropTypes.object,
+        };
+        
+    };
+
+    componentDidMount() {
+        this.dispatcherRef = dis.register(this._onAction);
+        script = document.createElement('script');
+        script.src = SdkConfig.get()['jitsi']['externalApiUrl'];
+        script.async = true;
+        //  script.onload = () => this.scriptLoaded();
+        document.body.appendChild(script); //Need to remove on destroy?
+    }
+
+    componentWillUnmount() {
+        dis.unregister(this.dispatcherRef)
+        console.log('Voice channel component unregistered from dispatcher')
+        if (activeChannel){
+            //last one out sets room vc state
+            activeChannel.dispose();
+        } 
+        document.body.removeChild(script)
+    }
+
+    _onAction = (payload) => {
+        switch (payload.action) {
+            case 'join_channel':
+            console.log('VoiceChannel recieved joinchannel event', payload)
+            this._joinChannel(payload.jitsiDomain, payload.confId)
+            break;
+        }
+    }
+
+    _joinChannel(jitsiDomain, roomName) {
+        console.log('Voice channel joining with', jitsiDomain, roomName)
+        loaded = false;
+        this.state.joinError = false
+        if (!jitsiDomain) jitsiDomain = SdkConfig.get()['jitsi']['preferredDomain'] //TODO: Or fail to join if no domain?
+        activeChannel = new JitsiMeetExternalAPI(jitsiDomain, {
+            width: 0,
+            height: 0,
+            parentNode: document.querySelector('#jitsiVoiceChannelWrapper'),
+            roomName: roomName,
+            interfaceConfigOverwrite: {
+            SHOW_JITSI_WATERMARK: false,
+            SHOW_WATERMARK_FOR_GUESTS: false,
+            MAIN_TOOLBAR_BUTTONS: [],
+            VIDEO_LAYOUT_FIT: "height",
+        },
+            onload: this._onLoad
+        })
+        this.setState(this.state)
+    }
+
+    _toggleMicMute = (changeTo) => {
+        if (!activeChannel) return;
+        activeChannel.isAudioMuted().then(muted => {
+            if (muted !== changeTo) {
+                this._channel('toggleAudio')
+            }
+        })
+    }
+
+    _leaveChannel = () => {
+        console.log('Attempting to leave channel')
+        //Try to leave jitsi gracefully
+        this._channel('hangup')
+        //Cleanup on this side
+        this._close()
+    }
+
+    _onMicClick = () => {
+        console.log('Microphone muted:', this.state.isMicrophoneMuted);
+        this.state.isMicrophoneMuted = !this.state.isMicrophoneMuted;
+        this._toggleMicMute(this.state.isMicrophoneMuted)
+        this.setState(this.state)
+    };
+
+    ///******************************************///
+    ///*   Safe Jitsi API accessors / helpers   *///
+    ///******************************************///
+
+    _register = (eventName, callback) => {
+        if (!activeChannel || !eventName || !callback) return;
+        activeChannel.addListener(eventName, callback)
+    }
+
+    _channel = (command) => {
+        if (!activeChannel) {
+             console.log(`Could not execute voice channel command: ${command}. There is no active channel`)
+             return;
+        }
+        activeChannel.executeCommand(command)
+    }
+
+
+    ///*******************************************///
+    ///*         Jitsi callback handlers         *///
+    ///*******************************************///
+
+    _onLoad = () => {
+        if (loaded) { //Has already loaded/jitsi failed to connect
+        //TODO: Implement retry system
+            this.state.joinError = true;
+            this.setState(this.state);
+            this._close();
+            return
+        }
+        loaded = true;
+        console.log('Channel loaded', activeChannel)
+        this.toggleMicMute(this.state.isMicrophoneMuted)
+        this._register('readyToClose', this._close)
+        this._register('videoConferenceJoined', this._onJoin)
+        //TODO: register more flow control callbacks
+        //state or props didnt change. need to update manually for connection data to update
+        this.forceUpdate()
+    }
+
+    _onJoin = () => {
+        this.state.joined = true
+        this.setState(this.state)
+        console.log('Joined channel successfully')
+    }
+
+    _close = () => {
+        console.log("Closing Voice Channel")
+        if (activeChannel) {
+            activeChannel.dispose()
+            activeChannel = null
+        } else {
+            this.state.joinError = false
+            this.setState(this.state)
+        }
+        this.forceUpdate()
+    }
+
+    ///*******************************************///
+
+    render () {
+
+        let channelState;
+        let leaveButton;
+        if (this.state.joinError) {
+            channelState = "Connection Error"
+        } else if (activeChannel) {
+            if (this.state.joined) {
+                channelState = "Connected"
+            } else {
+                channelState = "Connecting"
+            }
+            
+            leaveButton = (
+                <AccessibleButton className={'mx_VoiceChannelControls_button mx_VoiceChannelControls_leave'}
+                   onClick={this._leaveChannel}
+                    title={_t("Click to leave voice channel")}
+                />
+            )
+        } else {
+            channelState = "Not Connected"
+        }
+
+        const className = classNames({
+            'mx_VoiceChannelControls_button': true,
+            'mx_VoiceChannelControls_unmuted': this.state.isMicrophoneMuted,
+            'mx_VoiceChannelControls_muted': !this.state.isMicrophoneMuted
+        });
+
+        return (
+            <div className='mx_VoiceChannelControls'>
+                <div id="jitsiVoiceChannelWrapper"></div>
+                <div className='mx_VoiceChannelControls_labelContainer' >
+                    <div className='mx_VoiceChannelControls_label'>
+                        { channelState }
+                    </div>
+
+                    <AccessibleButton className={className}
+                                    onClick={this._onMicClick}
+                                    title={this.state.isMicrophoneMuted ? _t("Click to unmute audio") : _t("Click to mute audio")}
+                    />
+                    { leaveButton }
+                </div>
+            </div>
+        );
+    };
+}

--- a/src/components/structures/VoiceChannelControls.js
+++ b/src/components/structures/VoiceChannelControls.js
@@ -99,7 +99,7 @@ export default class VoiceChannelControls extends React.Component {
         this._channel('hangup')
         //Cleanup on this side
         //Call a settimeout to give time for a graceful exit?
-        this._close()
+        //this._close()
     }
 
     //Click event for microphone button. Helps to keep microphone state consistent when changing voice channels

--- a/src/components/views/avatars/RoomAvatar.js
+++ b/src/components/views/avatars/RoomAvatar.js
@@ -21,6 +21,7 @@ import Modal from '../../../Modal';
 import * as sdk from "../../../index";
 import * as Avatar from '../../../Avatar';
 import {getHttpUriForMxc} from "matrix-js-sdk/src/content-repo";
+import VoiceChannelUtils from "../../../VoiceChannelUtils";
 
 export default createReactClass({
     displayName: 'RoomAvatar',
@@ -98,6 +99,10 @@ export default createReactClass({
 
     getRoomAvatarUrl: function(props) {
         if (!props.room) return null;
+
+        if (VoiceChannelUtils.isVoiceChannel(props.room.roomId)) {
+            return require('../../../../res/img/sound-indicator.svg')
+        }
 
         return Avatar.avatarUrlForRoom(
             props.room,

--- a/src/components/views/context_menus/RoomTileContextMenu.js
+++ b/src/components/views/context_menus/RoomTileContextMenu.js
@@ -191,16 +191,17 @@ export default createReactClass({
     },
 
     _onClickJoinAsChannel: function() {
-        const data = VoiceChannelUtils.getConferenceData(this.props.room.roomId)
-        if (!data) return
-        dis.dispatch({
-            action: 'join_channel',
-            room_Id: this.props.room.roomId,
-            confId: data.conferenceId,
-            jitsiDomain: data.domain
-        })
+        VoiceChannelUtils.joinAsVoiceChannel(this.props.room.roomId)
+        
         //Close context menu
         this.props.onFinished ? this.props.onFinished() : null
+    },
+
+    _onClickViewChannel: function() {
+        dis.dispatch({
+            action: 'view_room',
+            room_id: this.props.room.roomId
+        });
     },
 
     _onClickForget: function() {
@@ -363,6 +364,14 @@ export default createReactClass({
     },
 
     _renderRoomTagMenu: function() {
+        const viewRoom = VoiceChannelUtils.isVoiceChannel(this.props.room.roomId) ? 
+                                <RoomTagOption
+                                    active={true}
+                                    label={_t('View Room messages')}
+                                    onClick={this._onClickViewChannel}
+                                />
+                            : null
+
         return (
             <div>
                 <RoomTagOption
@@ -387,13 +396,14 @@ export default createReactClass({
                     srcSet={require("../../../../res/img/icon_context_person_on.svg")}
                 />
                 <RoomTagOption
-                    //active={this.state.hasActiveJitsiWidget}
+                    active={this.state.hasActiveJitsiWidget}
                     disabled={!this.state.hasActiveJitsiWidget}
                     label={_t('Join as Voice Channel')}
                     onClick={this._onClickJoinAsChannel}
                     src={require("../../../../res/img/sound-indicator.svg")}
                     srcSet={require("../../../../res/img/sound-indicator.svg")}
                 />
+                { viewRoom }
             </div>
         );
     },

--- a/src/components/views/context_menus/RoomTileContextMenu.js
+++ b/src/components/views/context_menus/RoomTileContextMenu.js
@@ -33,6 +33,7 @@ import RoomListActions from '../../../actions/RoomListActions';
 import RoomViewStore from '../../../stores/RoomViewStore';
 import {sleep} from "../../../utils/promise";
 import {MenuItem, MenuItemCheckbox, MenuItemRadio} from "../../structures/ContextMenu";
+import VoiceChannelUtils from '../../../VoiceChannelUtils'
 
 const RoomTagOption = ({active, onClick, src, srcSet, label}) => {
     const classes = classNames('mx_RoomTileContextMenu_tag_field', {
@@ -79,6 +80,7 @@ export default createReactClass({
             isFavourite: this.props.room.tags.hasOwnProperty("m.favourite"),
             isLowPriority: this.props.room.tags.hasOwnProperty("m.lowpriority"),
             isDirectMessage: Boolean(dmRoomMap.getUserIdForRoomId(this.props.room.roomId)),
+            hasActiveJitsiWidget: VoiceChannelUtils.canBeVoiceChannel(this.props.room.roomId),
         };
     },
 
@@ -186,6 +188,19 @@ export default createReactClass({
         if (this.props.onFinished) {
             this.props.onFinished();
         }
+    },
+
+    _onClickJoinAsChannel: function() {
+        const data = VoiceChannelUtils.getConferenceData(this.props.room.roomId)
+        if (!data) return
+        dis.dispatch({
+            action: 'join_channel',
+            room_Id: this.props.room.roomId,
+            confId: data.conferenceId,
+            jitsiDomain: data.domain
+        })
+        //Close context menu
+        this.props.onFinished ? this.props.onFinished() : null
     },
 
     _onClickForget: function() {
@@ -370,6 +385,14 @@ export default createReactClass({
                     onClick={this._onClickDM}
                     src={require("../../../../res/img/icon_context_person.svg")}
                     srcSet={require("../../../../res/img/icon_context_person_on.svg")}
+                />
+                <RoomTagOption
+                    //active={this.state.hasActiveJitsiWidget}
+                    disabled={!this.state.hasActiveJitsiWidget}
+                    label={_t('Join as Voice Channel')}
+                    onClick={this._onClickJoinAsChannel}
+                    src={require("../../../../res/img/sound-indicator.svg")}
+                    srcSet={require("../../../../res/img/sound-indicator.svg")}
                 />
             </div>
         );

--- a/src/components/views/dialogs/InviteDialog.js
+++ b/src/components/views/dialogs/InviteDialog.js
@@ -1074,9 +1074,9 @@ export default class InviteDialog extends React.PureComponent {
             helpText = _t(
                 "Start a conversation with someone using their name, username (like <userId/>) or email address.",
                 {},
-                {userId: () => {
-                    return <a href={makeUserPermalink(userId)} rel="noreferrer noopener" target="_blank">{userId}</a>;
-                }},
+                {userId: () => 
+                    <a href={makeUserPermalink(userId)} rel="noreferrer noopener" target="_blank">{userId}</a>
+                },
             );
             buttonText = _t("Go");
             goButtonFn = this._startDm;
@@ -1084,10 +1084,10 @@ export default class InviteDialog extends React.PureComponent {
             title = _t("Invite to this room");
             helpText = _t(
                 "If you can't find someone, ask them for their username (e.g. @user:server.com) or " +
-                "<a>share this room</a>.", {},
-                {
-                    a: (sub) =>
-                        <a href={makeRoomPermalink(this.props.roomId)} rel="noreferrer noopener" target="_blank">{sub}</a>,
+                "<a>share this room</a>.", 
+                {},
+                {a: (sub) =>
+                    <a href={makeRoomPermalink(this.props.roomId)} rel="noreferrer noopener" target="_blank">{sub}</a>
                 },
             );
             buttonText = _t("Invite");

--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -42,7 +42,7 @@ export default createReactClass({
     propTypes: {
         // A string tag such as "m.favourite" or a group ID such as "+groupid:domain.bla"
         // For now, only group IDs are handled.
-        tag: PropTypes.string,
+        tag: PropTypes.string.isRequired,
     },
 
     statics: {

--- a/src/components/views/room_settings/RoomProfileSettings.js
+++ b/src/components/views/room_settings/RoomProfileSettings.js
@@ -46,8 +46,7 @@ export default class RoomProfileSettings extends React.Component {
         const nameEvent = room.currentState.getStateEvents('m.room.name', '');
         const name = nameEvent && nameEvent.getContent() ? nameEvent.getContent()['name'] : '';
 
-        const voiceChannelEvent = room.currentState.getStateEvents(VoiceChannelStateKey, '');
-        const isVoiceChannel = VoiceChannelUtils.canBeVoiceChannel(props.roomId)
+        const isVoiceChannel = VoiceChannelUtils.isVoiceChannel(props.roomId)
         const canBeVoiceChannel = VoiceChannelUtils.canBeVoiceChannel(props.roomId)
 
         this.state = {
@@ -118,7 +117,7 @@ export default class RoomProfileSettings extends React.Component {
 
         //TODO: change to empty state content for disabled?
         if (this.state.originalIsVoiceChannel !== this.state.isVoiceChannel) {
-            await client.sendStateEvent(this.props.roomId, VoiceChannelStateKey, {[VoiceChannelState.enabled]: this.state.isVoiceChannel}, '')
+            VoiceChannelUtils.updateState(this.props.roomId, {[VoiceChannelState.enabled]: this.state.isVoiceChannel})
             newState.originalIsVoiceChannel = this.state.isVoiceChannel
         }
 

--- a/src/components/views/rooms/RoomTile.js
+++ b/src/components/views/rooms/RoomTile.js
@@ -35,6 +35,7 @@ import {_t} from "../../../languageHandler";
 import {RovingTabIndexWrapper} from "../../../accessibility/RovingTabIndex";
 import E2EIcon from './E2EIcon';
 import InviteOnlyIcon from './InviteOnlyIcon';
+import VoiceChannelUtils from '../../../VoiceChannelUtils'
 // eslint-disable-next-line camelcase
 import rate_limited_func from '../../../ratelimitedfunc';
 import { shieldStatusForRoom } from '../../../utils/ShieldUtils';
@@ -424,6 +425,7 @@ export default createReactClass({
 
         const avatarClasses = classNames({
             'mx_RoomTile_avatar': true,
+            'mx_BaseAvatar_image': VoiceChannelUtils.isVoiceChannel(this.props.room.roomId)
         });
 
         const badgeClasses = classNames({
@@ -543,9 +545,23 @@ export default createReactClass({
             e2eIcon = <E2EIcon status={this.state.e2eStatus} className="mx_RoomTile_e2eIcon" />;
         }
 
+        const VoiceUserTile = sdk.getComponent('rooms.VoiceUserTile')
+        const cli = MatrixClientPeg.get()
+        
+        const voiceChannelUsers = VoiceChannelUtils.isVoiceChannel(this.props.room.roomId) ? VoiceChannelUtils.getUsers(this.props.room.roomId) : null
+        let voiceChannelUserTiles = []
+        if (voiceChannelUsers) {
+            for (var participantId in voiceChannelUsers) {
+                const user = cli.getUser(voiceChannelUsers[participantId])
+                if (user) voiceChannelUserTiles.push(<VoiceUserTile key={participantId} user={user}/>)
+            }
+        }
+        // console.log('VC users tiles', room, voiceChannelUsers2)
+
         return <React.Fragment>
             <RovingTabIndexWrapper inputRef={this._roomTile}>
                 {({onFocus, isActive, ref}) =>
+                    <React.Fragment>
                     <AccessibleButton
                         onFocus={onFocus}
                         tabIndex={isActive ? 0 : -1}
@@ -578,7 +594,12 @@ export default createReactClass({
                         </div>
                         { /* { incomingCallBox } */ }
                         { tooltip }
+                        
                     </AccessibleButton>
+                    <div className='mx_RoomTile_voiceChannelUsers'>
+                            { voiceChannelUserTiles }
+                    </div>
+                    </React.Fragment>
                 }
             </RovingTabIndexWrapper>
 

--- a/src/components/views/rooms/VoiceUserTile.js
+++ b/src/components/views/rooms/VoiceUserTile.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import * as sdk from '../../../index'
+import PropTypes from 'prop-types'
+import classNames from 'classnames';
+
+export default class VoiceUserTile extends React.Component {
+
+    constructor (props) {
+        super(props)
+
+        this.state = {}
+    }
+
+
+    render = () => {
+        const BaseAvatar = sdk.getComponent('avatars.BaseAvatar')
+        const AccessibleButton = sdk.getComponent('elements.AccessibleButton')
+
+        
+        const buttonClasses = classNames({
+            'mx_VoiceTile': true,
+        })
+        const labelClasses = classNames({
+            'mx_VoiceTile_name': true
+        })
+        const avatarClasses = classNames({
+            'mx_VoiceTile_avatar': true
+        })
+
+        const {user, ...otherProps} = this.props
+
+        return <div>
+                <AccessibleButton
+                    className={buttonClasses}
+                    onClick={() => {}}
+                >
+                    <div className={avatarClasses}>
+                        <div className='mx_VoiceTile_avatar_container'>
+                            <BaseAvatar 
+                                {...otherProps}
+                                name={user.displayName}
+                                idName={user.userId}
+                                url={user.avatarUrl}
+                            />
+                        </div>
+                    </div>
+                    <div className='mx_VoiceTile_nameContainer'>
+                        <div className='mx_VoiceTile_labelContainer'>
+                            <div title={user.displayName} className={labelClasses} tabIndex={-1} dir='auto'>{ user.displayName }</div>
+                        </div>
+                    </div>
+                </AccessibleButton>
+            </div>
+    }
+
+}
+
+VoiceUserTile.propTypes = {
+    user: PropTypes.object.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    resizeMethod: PropTypes.string
+}
+
+VoiceUserTile.defaultProps = {
+    width: 24,
+    height: 24,
+    resizeMethod: 'crop'
+}

--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.js
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.js
@@ -21,6 +21,7 @@ import {MatrixClientPeg} from "../../../../../MatrixClientPeg";
 import * as sdk from "../../../../..";
 import AccessibleButton from "../../../elements/AccessibleButton";
 import Modal from "../../../../../Modal";
+import { VoiceChannelStateKey } from '../../../../../VoiceChannelUtils'
 
 const plEventsToLabels = {
     // These will be translated for us later.
@@ -34,6 +35,7 @@ const plEventsToLabels = {
     "m.room.encryption": _td("Enable room encryption"),
 
     "im.vector.modular.widgets": _td("Modify widgets"),
+    [VoiceChannelStateKey]: _td('Manipulate VoiceChannel State')
 };
 
 const plEventsToShow = {
@@ -48,6 +50,7 @@ const plEventsToShow = {
     "m.room.encryption": {isState: true},
 
     "im.vector.modular.widgets": {isState: true},
+    [VoiceChannelStateKey]: {isState: true}
 };
 
 // parse a string as an integer; if the input is undefined, or cannot be parsed

--- a/src/components/views/voip/CallPreview.js
+++ b/src/components/views/voip/CallPreview.js
@@ -82,7 +82,9 @@ export default createReactClass({
     },
 
     render: function() {
+        //Get call for currently viewed room
         const callForRoom = CallHandler.getCallForRoom(this.state.roomId);
+        //Call is active and are not viewing that room
         const showCall = (this.state.activeCall && this.state.activeCall.call_state === 'connected' && !callForRoom);
 
         if (showCall) {

--- a/src/components/views/voip/CallView.js
+++ b/src/components/views/voip/CallView.js
@@ -86,6 +86,7 @@ export default createReactClass({
         if (this.props.room) {
             const roomId = this.props.room.roomId;
             call = CallHandler.getCallForRoom(roomId) ||
+                //Deprectated?
                 (this.props.ConferenceHandler ?
                  this.props.ConferenceHandler.getConferenceCallForRoom(roomId) :
                  null


### PR DESCRIPTION
### Introduction
Adds the functionality to turn a room with a Jitsi conference into a 'Voice Channel'
This pull request is mostly just to showcase a proof of concept that looks to satisfy vector-im/riot-web#3546.
![image](https://user-images.githubusercontent.com/16231111/79195726-df92a780-7e82-11ea-82c6-dc9c6d41144b.png)


Also related to vector-im/riot-web#7487

**I suspect things will break when trying to compile/run. I made these changes in a full dev environment and with a couple hacks that reference the riot-web project from this project**

### How it works
- Have a room with a Jitsi widget (or create one)
- Mark room as voice channel (under general in room settings)
- Click on the now voice channel and hopefully you will connect.

The microphone mute button does work. However, currently you need to dismiss the 'rate the meeting' jitsi dialog before you are disconnected properly (show jitsi debug to dismiss this)

### Under the hood
A new component that is responsible for managing voice channels. (Plus other utils)
It loads the jitsi api as specified by the riot config. (I had CSP issues. Will need to edit riot index.html to allow)
When trying to connect to a voice channel will create a hidden jitsi widget (can be shown for debug).

New room state 'im.riot.voicechannel'. This stores the fact that a room is a voice channel and a list of the current users in the voice channel. This data format is subject to change no doubt.
Currently each user is responsible for updating this state when they join/leave.
Config option has been added to allow all room users to update this state (still defaults to moderator)

### Forseeable Issues
- Jitsi API currently doesn't have commands to perform moderation. Won't be able to moderate via riot since the widget isnt shown.
- In the same vein, Jitisi grants moderator privileges to the first user to the conference.
- Conference name leaking and no longer being a private room. Especially for rooms that have been around for a long time. (Simple fix currently is to delete and recreate the widget, or room admins could even manually change the event data)
- Other Jitsi API limitations. Cant mute received audio? etc

### Conclusion
There's still plenty to do, as this is still really just a proof of concept.
I'm open to any feedback/suggestions people may have.
There is already plenty of community support for a feature like this. So I'm happy to keep developing this provided that the Riot/Matrix staff believe that this is within the scope and direction of Riot/Matrix.

