### PR TITLE
Allow to disable per-user generated colors

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -522,6 +522,10 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
 
 // username colors
 // used by SenderProfile & RoomPreviewBar
+.mx_Username_defaultColor {
+    color: $username-variant3-color;
+}
+
 .mx_Username_color1 {
     color: $username-variant1-color;
 }

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -18,6 +18,7 @@ limitations under the License.
 import {MatrixClientPeg} from './MatrixClientPeg';
 import DMRoomMap from './utils/DMRoomMap';
 import {getHttpUriForMxc} from "matrix-js-sdk/src/content-repo";
+import SettingsStore from "./settings/SettingsStore";
 
 export function avatarUrlForMember(member, width, height, resizeMethod) {
     let url;
@@ -54,12 +55,22 @@ export function avatarUrlForUser(user, width, height, resizeMethod) {
 }
 
 export function defaultAvatarUrlForString(s) {
+    const attachColorToUsers = SettingsStore.getValue("attachColorToUsers");
     const images = ['03b381', '368bd6', 'ac3ba8'];
-    let total = 0;
-    for (let i = 0; i < s.length; ++i) {
-        total += s.charCodeAt(i);
+
+    // Used for every default avatar if no specific color is attached to users.
+    // Match mx_Username_defaultColor CSS class.
+    let selectedImage = ['03b381'];
+
+    if (attachColorToUsers) {
+        let total = 0;
+        for (let i = 0; i < s.length; ++i) {
+            total += s.charCodeAt(i);
+        }
+        selectedImage = images[total % images.length];
     }
-    return require('../res/img/' + images[total % images.length] + '.png');
+
+    return require('../res/img/' + selectedImage + '.png');
 }
 
 /**

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -25,6 +25,10 @@ import * as sdk from "../../../../..";
 import PlatformPeg from "../../../../../PlatformPeg";
 
 export default class PreferencesUserSettingsTab extends React.Component {
+    static THEME_SETTINGS = [
+        'attachColorToUsers',
+    ];
+
     static ROOM_LIST_SETTINGS = [
         'RoomList.orderAlphabetically',
         'RoomList.orderByImportance',
@@ -172,6 +176,11 @@ export default class PreferencesUserSettingsTab extends React.Component {
         return (
             <div className="mx_SettingsTab mx_PreferencesUserSettingsTab">
                 <div className="mx_SettingsTab_heading">{_t("Preferences")}</div>
+
+                <div className="mx_SettingsTab_section">
+                    <span className="mx_SettingsTab_subheading">{_t("Theme")}</span>
+                    {this._renderGroup(PreferencesUserSettingsTab.THEME_SETTINGS)}
+                </div>
 
                 <div className="mx_SettingsTab_section">
                     <span className="mx_SettingsTab_subheading">{_t("Room list")}</span>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -444,6 +444,7 @@
     "Keep secret storage passphrase in memory for this session": "Keep secret storage passphrase in memory for this session",
     "How fast should messages be downloaded.": "How fast should messages be downloaded.",
     "Manually verify all remote sessions": "Manually verify all remote sessions",
+    "Attach color to usernames and empty avatars": "Attach color to usernames and empty avatars",
     "Collecting app version information": "Collecting app version information",
     "Collecting logs": "Collecting logs",
     "Uploading report": "Uploading report",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -536,4 +536,9 @@ export const SETTINGS = {
             MatrixClient.prototype.setCryptoTrustCrossSignedDevices, true,
         ),
     },
+    "attachColorToUsers": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td("Attach color to usernames and empty avatars"),
+        default: true,
+    },
 };

--- a/src/utils/FormattingUtils.js
+++ b/src/utils/FormattingUtils.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import { _t } from '../languageHandler';
+import SettingsStore from "../settings/SettingsStore";
 
 /**
  * formats numbers to fit into ~3 characters, suitable for badge counts
@@ -88,8 +89,14 @@ export function hashCode(str) {
 }
 
 export function getUserNameColorClass(userId) {
-    const colorNumber = (hashCode(userId) % 8) + 1;
-    return `mx_Username_color${colorNumber}`;
+    const attachColorToUsers = SettingsStore.getValue("attachColorToUsers");
+
+    if (attachColorToUsers) {
+        const colorNumber = (hashCode(userId) % 8) + 1;
+        return `mx_Username_color${colorNumber}`;
+    } else {
+        return `mx_Username_defaultColor`;
+    }
 }
 
 /**


### PR DESCRIPTION
Some users are confused by the many colors used in Riot, and asked me to see what can be done. This patch add a new setting in the Preference tab allowing to disable per-username/avatar colors.

Fixes https://github.com/vector-im/riot-web/issues/13102 (which I believe to be closed by error).

![Screenshot from 2020-04-14 09-26-12](https://user-images.githubusercontent.com/1146924/79198093-353f6380-7e33-11ea-99bc-70968757d34c.png)
![Screenshot from 2020-04-14 09-27-17](https://user-images.githubusercontent.com/1146924/79198098-36709080-7e33-11ea-9d1c-f068fe0af59a.png)

CC @verysanghee