### PR TITLE
Investigation into replacing LinkifyJS

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -98,7 +98,7 @@ export function processHtmlForSending(html: string): string {
     }
 
     let contentHTML = "";
-    for (let i=0; i < contentDiv.children.length; i++) {
+    for (let i = 0; i < contentDiv.children.length; i++) {
         const element = contentDiv.children[i];
         if (element.tagName.toLowerCase() === 'p') {
             contentHTML += element.innerHTML;
@@ -386,7 +386,7 @@ interface IOpts {
  * opts.forComposerQuote: optional param to lessen the url rewriting done by sanitization, for quoting into composer
  * opts.ref: React ref to attach to any React components returned (not compatible with opts.returnString)
  */
-export function bodyToHtml(content: {[key: string]: any}, highlights: string[], opts: IOpts={}) {
+export function bodyToHtml(content: {[key: string]: any}, highlights: string[], opts: IOpts = {}) {
     const isHtmlMessage = content.format === "org.matrix.custom.html" && content.formatted_body;
     let bodyHasEmoji = false;
 
@@ -454,7 +454,7 @@ export function bodyToHtml(content: {[key: string]: any}, highlights: string[], 
                     // their username. Permalinks (links in pills) can be any URL
                     // now, so we just check for an HTTP-looking thing.
                     (
-                        content.formatted_body == undefined ||
+                        content.formatted_body === undefined ||
                         (!content.formatted_body.includes("http:") &&
                         !content.formatted_body.includes("https:"))
                     );

--- a/src/linkify-matrix.ts
+++ b/src/linkify-matrix.ts
@@ -1,6 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/linkify-matrix.ts
+++ b/src/linkify-matrix.ts
@@ -193,7 +193,7 @@ matrixLinkify.VECTOR_URL_PATTERN = "^(?:https?://)?(?:"
 matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?://)?(?:www\\.)?matrix\\.to/#/(([#@!+]).*)";
 matrixLinkify.MATRIXTO_MD_LINK_PATTERN =
     '\\[([^\\]]*)\\]\\((?:https?://)?(?:www\\.)?matrix\\.to/#/([#@!+][^\\)]*)\\)';
-matrixLinkify.MATRIXTO_BASE_URL= baseUrl;
+matrixLinkify.MATRIXTO_BASE_URL = baseUrl;
 
 matrixLinkify.options = {
     events: function(href, type) {


### PR DESCRIPTION
To be able to linkify things like `mxc://` (https://github.com/Soapbox/linkifyjs/issues/194) and IP addresses.

- [x] Convert surrounding code to typescript
- [ ] Write unit tests including tests of desired acceptance cases
- [ ] Replace things until it all works