### PR TITLE
Remove end-to-end message info option when cross-signing is used

### DIFF
--- a/src/components/views/messages/MessageActionBar.js
+++ b/src/components/views/messages/MessageActionBar.js
@@ -26,6 +26,7 @@ import Modal from '../../../Modal';
 import {aboveLeftOf, ContextMenu, ContextMenuButton, useContextMenu} from '../../structures/ContextMenu';
 import { isContentActionable, canEditContent } from '../../../utils/EventUtils';
 import RoomContext from "../../../contexts/RoomContext";
+import SettingsStore from '../../../settings/SettingsStore';
 
 const OptionsButton = ({mxEvent, getTile, getReplyThread, permalinkCreator, onFocusChange}) => {
     const [menuDisplayed, button, openMenu, closeMenu] = useContextMenu();
@@ -48,7 +49,7 @@ const OptionsButton = ({mxEvent, getTile, getReplyThread, permalinkCreator, onFo
         };
 
         let e2eInfoCallback = null;
-        if (mxEvent.isEncrypted()) {
+        if (mxEvent.isEncrypted() && !SettingsStore.isFeatureEnabled("feature_cross_signing")) {
             e2eInfoCallback = onCryptoClick;
         }
 


### PR DESCRIPTION
This end-to-end info dialog repeats info available elsewhere and has not been
updated to make sense for cross-signing, triggers old verification methods, etc.
For now, this hides the option to present a more consistent UI.

Relates to https://github.com/vector-im/riot-web/issues/11752