### PR TITLE
Fix: prevent spurious notifications from indexer

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -383,7 +383,7 @@ export default class EventIndex extends EventEmitter {
 
             // We have a checkpoint, let us fetch some messages, again, very
             // conservatively to not bother our homeserver too much.
-            const eventMapper = client.getEventMapper();
+            const eventMapper = client.getEventMapper({preventReEmit: true});
             // TODO we need to ensure to use member lazy loading with this
             // request so we get the correct profiles.
             let res;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12659

The problem was that `EventIndex` using an event mapper from the js-sdk to decrypt and create `MatrixEvent` object, it was also causing `Event.decrypted` to be emitted on the client, triggering https://github.com/matrix-org/matrix-js-sdk/blob/1b8f6d173953ac49c3178456ecb587ccefeb0cd3/src/client.js#L353 to add push actions for e2ee events. The highlight count there should only be set if the event hasn't been read before, but `Room.hasUserReadEvent` assumes that the whole timeline between the m.read marker and the given event id is known, which is not the case for older events or even rooms of a previous room version, as the bug indicates. In this case `hasUserReadEvent` returns false and the hightlight count is set, causing the badge.

Ideally, we'd fill any gaps created by a limited sync and store them, and only from this create e2ee notifications. But right now we don't have a good way to do that. So the solution taken here is to further disconnect the `EventIndex` from everything else that listens to the js-sdk, and the disable remitting from the event to the client from events created in the indexer.