### PR TITLE
null-guard MatrixClientPeg in RoomViewStore

### DIFF
--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -159,7 +159,7 @@ class RoomViewStore extends Store {
             }
             case 'sync_state':
                 this._setState({
-                    matrixClientIsReady: MatrixClientPeg.get().isInitialSyncComplete(),
+                    matrixClientIsReady: MatrixClientPeg.get() && MatrixClientPeg.get().isInitialSyncComplete(),
                 });
                 break;
         }


### PR DESCRIPTION
To fix test failure when MatrixChat unmounts within 1 tick of handling a Sync response.

The following would also fix this but might as well get rid of one possible race condition.
```diff
Index: test/app-tests/loading-test.js
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- test/app-tests/loading-test.js	(revision 3cbc9997b94a4ecaa3b85eb9762f1b3e3bd2c236)
+++ test/app-tests/loading-test.js	(date 1586968203189)
@@ -71,6 +71,7 @@
 
     afterEach(async function() {
         console.log(`${Date.now()}: loading: afterEach`);
+        await sleep(1);
         if (parentDiv) {
             ReactDOM.unmountComponentAtNode(parentDiv);
             parentDiv.remove();
```