### PR TITLE
Revert "Fix: load Twemoji before login so complete security gets the right emojis during SAS"

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -25,6 +25,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import {Key, isOnlyCtrlOrCmdKeyEvent, isOnlyCtrlOrCmdIgnoreShiftKeyEvent} from '../../Keyboard';
 import PageTypes from '../../PageTypes';
 import CallMediaHandler from '../../CallMediaHandler';
+import { fixupColorFonts } from '../../utils/FontManager';
 import * as sdk from '../../index';
 import dis from '../../dispatcher';
 import sessionStore from '../../stores/SessionStore';
@@ -164,6 +165,8 @@ class LoggedInView extends React.PureComponent<IProps, IState> {
         this._matrixClient.on("accountData", this.onAccountData);
         this._matrixClient.on("sync", this.onSync);
         this._matrixClient.on("RoomState.events", this.onRoomStateEvents);
+
+        fixupColorFonts();
 
         this._roomView = React.createRef();
         this._resizeContainer = React.createRef();

--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -66,7 +66,6 @@ import { storeRoomAliasInCache } from '../../RoomAliasCache';
 import { defer } from "../../utils/promise";
 import ToastStore from "../../stores/ToastStore";
 import * as StorageManager from "../../utils/StorageManager";
-import { fixupColorFonts } from '../../utils/FontManager';
 
 /** constants for MatrixChat.state.view */
 export const VIEWS = {
@@ -245,8 +244,6 @@ export default createReactClass({
 
         this._pageChanging = false;
 
-        // load emoji font
-        fixupColorFonts();
         // check we have the right tint applied for this theme.
         // N.B. we don't call the whole of setTheme() here as we may be
         // racing with the theme CSS download finishing from index.js


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#4419