### PR TITLE
Implement widget API for signaling widgets to gracefully terminate

### DIFF
--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -88,6 +88,19 @@ export default class WidgetMessaging {
     }
 
     /**
+     * Tells the widget that it should terminate now.
+     * It is not necessarily called in all instances before the widget is removed,
+     * and the client may force termination with a timeout.
+     * @returns {Promise<*>} Resolves when widget has acknowledged the message.
+     */
+    terminate() {
+        return this.messageToWidget({
+            api: OUTBOUND_API_NAME,
+            action: KnownWidgetActions.Terminate,
+        });
+    }
+
+    /**
      * Request a screenshot from a widget
      * @return {Promise} To be resolved with screenshot data when it has been generated
      */

--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -89,8 +89,6 @@ export default class WidgetMessaging {
 
     /**
      * Tells the widget that it should terminate now.
-     * It is not necessarily called in all instances before the widget is removed,
-     * and the client may force termination with a timeout.
      * @returns {Promise<*>} Resolves when widget has acknowledged the message.
      */
     terminate() {

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -344,10 +344,18 @@ export default class AppTile extends React.Component {
      * @returns {Promise<*>} Resolves when the widget is terminated, or timeout passed.
      */
     _endWidgetActions() {
-        const timeout = 2000;
-        const messaging = ActiveWidgetStore.getWidgetMessaging(this.props.app.id);
+        let promise;
 
-        return Promise.race([messaging.terminate(), sleep(timeout)]).finally(() => {
+        if (this._hasCapability('m.receive_terminate')) {
+            // Wait for widget to terminate within a timeout
+            const timeout = 2000;
+            const messaging = ActiveWidgetStore.getWidgetMessaging(this.props.app.id);
+            promise = Promise.race([messaging.terminate(), sleep(timeout)]);
+        } else {
+            promise = Promise.resolve();
+        }
+
+        return promise.finally(() => {
             // HACK: This is a really dirty way to ensure that Jitsi cleans up
             // its hold on the webcam. Without this, the widget holds a media
             // stream open, even after death. See https://github.com/vector-im/riot-web/issues/7351

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -346,7 +346,7 @@ export default class AppTile extends React.Component {
     _endWidgetActions() {
         let promise;
 
-        if (this._hasCapability('m.receive_terminate')) {
+        if (this._hasCapability('im.vector.receive_terminate')) {
             // Wait for widget to terminate within a timeout
             const timeout = 2000;
             const messaging = ActiveWidgetStore.getWidgetMessaging(this.props.app.id);
@@ -396,20 +396,20 @@ export default class AppTile extends React.Component {
                     this.setState({deleting: true});
 
                     this._endWidgetActions().then(() => {
-                        WidgetUtils.setRoomWidget(
+                        return WidgetUtils.setRoomWidget(
                             this.props.room.roomId,
                             this.props.app.id,
-                        ).catch((e) => {
-                            console.error('Failed to delete widget', e);
-                            const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
+                        );
+                    }).catch((e) => {
+                        console.error('Failed to delete widget', e);
+                        const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
 
-                            Modal.createTrackedDialog('Failed to remove widget', '', ErrorDialog, {
-                                title: _t('Failed to remove widget'),
-                                description: _t('An error ocurred whilst trying to remove the widget from the room'),
-                            });
-                        }).finally(() => {
-                            this.setState({deleting: false});
+                        Modal.createTrackedDialog('Failed to remove widget', '', ErrorDialog, {
+                            title: _t('Failed to remove widget'),
+                            description: _t('An error ocurred whilst trying to remove the widget from the room'),
                         });
+                    }).finally(() => {
+                        this.setState({deleting: false});
                     });
                 },
             });

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -420,6 +420,7 @@ export default class WidgetUtils {
         if (WidgetType.JITSI.matches(appType)) {
             capWhitelist.push(Capability.AlwaysOnScreen);
         }
+        capWhitelist.push(Capability.ReceiveTerminate);
 
         return capWhitelist;
     }

--- a/src/widgets/WidgetApi.ts
+++ b/src/widgets/WidgetApi.ts
@@ -18,12 +18,13 @@ limitations under the License.
 // https://github.com/turt2live/matrix-dimension/blob/4f92d560266635e5a3c824606215b84e8c0b19f5/web/app/shared/services/scalar/scalar-widget.api.ts
 
 import { randomString } from "matrix-js-sdk/src/randomstring";
+import { EventEmitter } from "events";
 
 export enum Capability {
     Screenshot = "m.capability.screenshot",
     Sticker = "m.sticker",
     AlwaysOnScreen = "m.always_on_screen",
-    ReceiveTerminate = "m.receive_terminate",
+    ReceiveTerminate = "im.vector.receive_terminate",
 }
 
 export enum KnownWidgetActions {
@@ -64,14 +65,17 @@ export interface FromWidgetRequest extends WidgetRequest {
 
 /**
  * Handles Riot <--> Widget interactions for embedded/standalone widgets.
+ *
+ * Emitted events:
+ * - terminate(wait): client requested the widget to terminate.
+ *   Call the argument 'wait(promise)' to postpone the finalization until
+ *   the given promise resolves.
  */
-export class WidgetApi {
+export class WidgetApi extends EventEmitter {
     private origin: string;
     private inFlightRequests: { [requestId: string]: (reply: FromWidgetRequest) => void } = {};
     private readyPromise: Promise<any>;
     private readyPromiseResolve: () => void;
-    private terminatePromise: Promise<any>;
-    private terminatePromiseResolve: () => void;
 
     /**
      * Set this to true if your widget is expecting a ready message from the client. False otherwise (default).
@@ -79,10 +83,11 @@ export class WidgetApi {
     public expectingExplicitReady = false;
 
     constructor(currentUrl: string, private widgetId: string, private requestedCapabilities: string[]) {
+        super();
+
         this.origin = new URL(currentUrl).origin;
 
         this.readyPromise = new Promise<any>(resolve => this.readyPromiseResolve = resolve);
-        this.terminatePromise = new Promise<any>(resolve => this.terminatePromiseResolve = resolve);
 
         window.addEventListener("message", event => {
             if (event.origin !== this.origin) return; // ignore: invalid origin
@@ -104,11 +109,15 @@ export class WidgetApi {
                     // Automatically acknowledge so we can move on
                     this.replyToRequest(<ToWidgetRequest>payload, {});
                 } else if (payload.action === KnownWidgetActions.Terminate) {
-                    // Reply after resolving
-                    this.terminatePromise.then(() => {
+                    // Finalization needs to be async, so postpone with a promise
+                    let finalizePromise = Promise.resolve();
+                    const wait = promise => {
+                        finalizePromise = finalizePromise.then(value => promise);
+                    }
+                    this.emit('terminate', wait);
+                    Promise.resolve(finalizePromise).then(() => {
                         this.replyToRequest(<ToWidgetRequest>payload, {});
                     });
-                    this.terminatePromiseResolve();
                 } else {
                     console.warn(`[WidgetAPI] Got unexpected action: ${payload.action}`);
                 }
@@ -125,10 +134,6 @@ export class WidgetApi {
 
     public waitReady(): Promise<any> {
         return this.readyPromise;
-    }
-
-    public addTerminateCallback(action) {
-        this.terminatePromise = this.terminatePromise.then(action);
     }
 
     private replyToRequest(payload: ToWidgetRequest, reply: any) {

--- a/src/widgets/WidgetApi.ts
+++ b/src/widgets/WidgetApi.ts
@@ -23,6 +23,7 @@ export enum Capability {
     Screenshot = "m.capability.screenshot",
     Sticker = "m.sticker",
     AlwaysOnScreen = "m.always_on_screen",
+    ReceiveTerminate = "m.receive_terminate",
 }
 
 export enum KnownWidgetActions {


### PR DESCRIPTION
To allow widgets to clean up themselves, add a Terminate event to the widget API, and allow widgets to hook to it. This change allows e.g. Jitsi to hangup the conference when minimizing the widget, instead of abrupt disconnect that can leave ghost users behind.

In theory, widgets could use iframe unload/beforeunload events for cleanup, but in practice it seems browsers have restrictions on what can be done in those events which may not give sufficient time for clean termination.

On the client side, change `AppTile:_endWidgetActions` to wait for the widget cleanup. If the widget fails to terminate within a timeout, proceed with disposing the iframe nevertheless.

Comments welcome (first encounter with react...)!

See https://github.com/vector-im/riot-web/pull/13256 (for the Jitsi hook)