### PR TITLE
EventIndex: Filter out events that don't have a propper content value.

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -275,6 +275,7 @@ export default class EventIndex extends EventEmitter {
         const validEventType = isUsefulType && !ev.isRedacted() && !ev.isDecryptionFailure();
 
         let validMsgType = true;
+        let hasContentValue = true;
 
         if (ev.getType() === "m.room.message" && !ev.isRedacted()) {
             // Expand this if there are more invalid msgtypes.
@@ -282,9 +283,15 @@ export default class EventIndex extends EventEmitter {
 
             if (!msgtype) validMsgType = false;
             else validMsgType = !msgtype.startsWith("m.key.verification");
+
+            if (!ev.getContent().body) hasContentValue = false
+        } else if (ev.getType() === "m.room.topic" && !ev.isRedacted()) {
+            if (!ev.getContent().topic) hasContentValue = false;
+        } else if (ev.getType() === "m.room.name" && !ev.isRedacted()) {
+            if (!ev.getContent().name) hasContentValue = false;
         }
 
-        return validEventType && validMsgType;
+        return validEventType && validMsgType && hasContentValue;
     }
 
     /**

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -284,7 +284,7 @@ export default class EventIndex extends EventEmitter {
             if (!msgtype) validMsgType = false;
             else validMsgType = !msgtype.startsWith("m.key.verification");
 
-            if (!ev.getContent().body) hasContentValue = false
+            if (!ev.getContent().body) hasContentValue = false;
         } else if (ev.getType() === "m.room.topic" && !ev.isRedacted()) {
             if (!ev.getContent().topic) hasContentValue = false;
         } else if (ev.getType() === "m.room.name" && !ev.isRedacted()) {


### PR DESCRIPTION
Some events may miss the content value (body, topic, name) and trying to add them will end up in an error thrown by Seshat.

This is especially troublesome for historic events since we retry the checkpoint ending up in a infinite loop.

This fixes https://github.com/vector-im/riot-web/issues/13259.