### PR TITLE
ImageView make clicking off it easier

### DIFF
--- a/res/css/views/elements/_ImageView.scss
+++ b/res/css/views/elements/_ImageView.scss
@@ -37,7 +37,7 @@ limitations under the License.
     order: 2;
     /* min-width hack needed for FF */
     min-width: 0px;
-    height: 90%;
+    max-height: 90%;
     flex: 15 15 0;
     display: flex;
     align-items: center;


### PR DESCRIPTION
Currently this box prevents closing:
![image](https://user-images.githubusercontent.com/2403652/79741495-425bc700-82f9-11ea-9f3d-c2775c76fad8.png)
