### PR TITLE
Don't recheck DeviceListener until after initial sync is finished

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -52,6 +52,7 @@ export default class DeviceListener {
         MatrixClientPeg.get().on('userTrustStatusChanged', this._onUserTrustStatusChanged);
         MatrixClientPeg.get().on('crossSigning.keysChanged', this._onCrossSingingKeysChanged);
         MatrixClientPeg.get().on('accountData', this._onAccountData);
+        MatrixClientPeg.get().on('sync', this._onSync);
         this._recheck();
     }
 
@@ -62,6 +63,7 @@ export default class DeviceListener {
             MatrixClientPeg.get().removeListener('userTrustStatusChanged', this._onUserTrustStatusChanged);
             MatrixClientPeg.get().removeListener('crossSigning.keysChanged', this._onCrossSingingKeysChanged);
             MatrixClientPeg.get().removeListener('accountData', this._onAccountData);
+            MatrixClientPeg.get().removeListener('sync', this._onSync);
         }
         this._dismissed.clear();
     }
@@ -109,6 +111,10 @@ export default class DeviceListener {
         }
     }
 
+    _onSync = (state, prevState) => {
+        if (state === 'PREPARED' && prevState === null) this._recheck();
+    }
+
     // The server doesn't tell us when key backup is set up, so we poll
     // & cache the result
     async _getKeyBackupInfo() {
@@ -129,6 +135,10 @@ export default class DeviceListener {
         ) return;
 
         if (!cli.isCryptoEnabled()) return;
+        // don't recheck until the initial sync is complete: lots of account data events will fire
+        // while the initial sync is processing and we don't need to recheck on each one of them
+        // (we add a listener on sync to do once check after the initial sync is done)
+        if (!cli.isInitialSyncComplete()) return;
 
         const crossSigningReady = await cli.isCrossSigningReady();
 


### PR DESCRIPTION
Each recheck caused a GET to account data to see if the master key
exists if done before the initial sync, which is unnecessary here.
This just makes it wait until the initial sync is done to recheck.

Fixes https://github.com/vector-im/riot-web/issues/13279