### PR TITLE
Use WidgetType more often to avoid breaking new sticker pickers

### DIFF
--- a/src/ScalarAuthClient.js
+++ b/src/ScalarAuthClient.js
@@ -23,6 +23,7 @@ import request from "browser-request";
 
 import * as Matrix from 'matrix-js-sdk';
 import SdkConfig from "./SdkConfig";
+import {WidgetType} from "./widgets/WidgetType";
 
 // The version of the integration manager API we're intending to work with
 const imApiVersion = "1.1";
@@ -233,20 +234,20 @@ export default class ScalarAuthClient {
      * Mark all assets associated with the specified widget as "disabled" in the
      * integration manager database.
      * This can be useful to temporarily prevent purchased assets from being displayed.
-     * @param  {string} widgetType [description]
-     * @param  {string} widgetId   [description]
+     * @param  {WidgetType} widgetType The Widget Type to disable assets for
+     * @param  {string} widgetId   The widget ID to disable assets for
      * @return {Promise}           Resolves on completion
      */
-    disableWidgetAssets(widgetType, widgetId) {
+    disableWidgetAssets(widgetType: WidgetType, widgetId) {
         let url = this.apiUrl + '/widgets/set_assets_state';
         url = this.getStarterLink(url);
         return new Promise((resolve, reject) => {
             request({
-                method: 'GET',
+                method: 'GET', // XXX: Actions shouldn't be GET requests
                 uri: url,
                 json: true,
                 qs: {
-                    'widget_type': widgetType,
+                    'widget_type': widgetType.preferred,
                     'widget_id': widgetId,
                     'state': 'disable',
                 },

--- a/src/components/views/rooms/Stickerpicker.js
+++ b/src/components/views/rooms/Stickerpicker.js
@@ -26,8 +26,7 @@ import PersistedElement from "../elements/PersistedElement";
 import {IntegrationManagers} from "../../../integrations/IntegrationManagers";
 import SettingsStore from "../../../settings/SettingsStore";
 import {ContextMenu} from "../../structures/ContextMenu";
-
-const widgetType = 'm.stickerpicker';
+import {WidgetType} from "../../../widgets/WidgetType";
 
 // This should be below the dialog level (4000), but above the rest of the UI (1000-2000).
 // We sit in a context menu, so this should be given to the context menu.
@@ -87,7 +86,7 @@ export default class Stickerpicker extends React.Component {
         console.log('Removing Stickerpicker widgets');
         if (this.state.widgetId) {
             if (scalarClient) {
-                scalarClient.disableWidgetAssets(widgetType, this.state.widgetId).then(() => {
+                scalarClient.disableWidgetAssets(WidgetType.STICKERPICKER, this.state.widgetId).then(() => {
                     console.log('Assets disabled');
                 }).catch((err) => {
                     console.error('Failed to disable assets');
@@ -364,13 +363,13 @@ export default class Stickerpicker extends React.Component {
         if (SettingsStore.isFeatureEnabled("feature_many_integration_managers")) {
             IntegrationManagers.sharedInstance().openAll(
                 this.props.room,
-                `type_${widgetType}`,
+                `type_${WidgetType.STICKERPICKER.preferred}`,
                 this.state.widgetId,
             );
         } else {
             IntegrationManagers.sharedInstance().getPrimaryManager().open(
                 this.props.room,
-                `type_${widgetType}`,
+                `type_${WidgetType.STICKERPICKER.preferred}`,
                 this.state.widgetId,
             );
         }

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -210,9 +210,9 @@ export default class WidgetUtils {
         });
     }
 
-    static setUserWidget(widgetId, widgetType, widgetUrl, widgetName, widgetData) {
+    static setUserWidget(widgetId, widgetType: WidgetType, widgetUrl, widgetName, widgetData) {
         const content = {
-            type: widgetType,
+            type: widgetType.preferred,
             url: widgetUrl,
             name: widgetName,
             data: widgetData,
@@ -369,7 +369,7 @@ export default class WidgetUtils {
     static addIntegrationManagerWidget(name: string, uiUrl: string, apiUrl: string) {
         return WidgetUtils.setUserWidget(
             "integration_manager_" + (new Date().getTime()),
-            "m.integration_manager",
+            WidgetType.INTEGRATION_MANAGER,
             uiUrl,
             "Integration Manager: " + name,
             {"api_url": apiUrl},

--- a/src/widgets/WidgetType.ts
+++ b/src/widgets/WidgetType.ts
@@ -16,6 +16,8 @@ limitations under the License.
 
 export class WidgetType {
     public static readonly JITSI = new WidgetType("m.jitsi", "jitsi");
+    public static readonly STICKERPICKER = new WidgetType("m.stickerpicker", "m.stickerpicker");
+    public static readonly INTEGRATION_MANAGER = new WidgetType("m.integration_manager", "m.integration_manager");
     public static readonly CUSTOM = new WidgetType("m.custom", "m.custom");
 
     constructor(public readonly preferred: string, public readonly legacy: string) {


### PR DESCRIPTION
Turns out that setUserWidget() wasn't updated to take a real WidgetType, but the code in ScalarMessaging thought it did. This leads to integration managers trying to add sticker widgets with an object `type` rather than a string `type`, which doesn't work.

This updates other code paths which call into the various widget classes to use WidgetType more often. The actual code path for fixing widgets is resolved in WidgetUtils for the setUserWidget function body.