### PR TITLE
Fix OpenID requests from widgets

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -423,8 +423,13 @@ export default class AppTile extends React.Component {
     _setupWidgetMessaging() {
         // FIXME: There's probably no reason to do this here: it should probably be done entirely
         // in ActiveWidgetStore.
+
+        // We use the app's URL over the rendered URL so that anything the widget does which could
+        // lead to requesting a "security key" will pass accordingly. The only other thing this URL
+        // is used for is to determine the origin we're talking to, and therefore we don't need the
+        // fully templated URL.
         const widgetMessaging = new WidgetMessaging(
-            this.props.app.id, this._getRenderedUrl(), this.props.userWidget, this._appFrame.current.contentWindow);
+            this.props.app.id, this.props.app.url, this.props.userWidget, this._appFrame.current.contentWindow);
         ActiveWidgetStore.setWidgetMessaging(this.props.app.id, widgetMessaging);
         widgetMessaging.getCapabilities().then((requestedCapabilities) => {
             console.log(`Widget ${this.props.app.id} requested capabilities: ` + requestedCapabilities);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13131

*The rest of this PR description is additional information not defined in the diff. It's largely for reference by those who might have no idea what this is.*

Widgets can request an OpenID token to authenticate the user when the widget is missing authentication information. A common case for this is the Dimension sticker picker: sometimes the Riot is running in doesn't have the configuration to match the Dimension instance, so Riot rightly refuses to send an auth token to the widget. When this happens, it requests a token through postMessage().

There's a toggle on the permission dialog to remember the setting, which is the widget's security key. As an added measure, the security key generation ensures the widget URL matches as the 'remember this choice' toggle will silently work in the background, and it could be dangerous if the widget's URL changed and Riot secretly allows the widget to identify the user. This check was failing because the WidgetMessaging class was being set up with the rendered URL, which will not match the widget's URL at all. To fix this, we simply use the widget's URL to set up the messaging, which by proxy uses the right URL in calculating the security key.

Edit: the dialog, though irrelevant for this PR:
![image](https://user-images.githubusercontent.com/1190097/79948627-6e7a6380-8431-11ea-9d6a-cc812fb7a749.png)
