### PR TITLE
Skip auth flow test for signing upload when password present

### DIFF
--- a/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
@@ -83,7 +83,15 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
         };
 
         this._fetchBackupInfo();
-        this._queryKeyUploadAuth();
+        if (this.state.accountPassword) {
+            // If we have an account password in memory, let's simplify and
+            // assume it means password auth is also supported for device
+            // signing key upload as well. This avoids hitting the server to
+            // test auth flows, which may be slow under high load.
+            this.state.canUploadKeysWithPasswordOnly = true;
+        } else {
+            this._queryKeyUploadAuth();
+        }
 
         MatrixClientPeg.get().on('crypto.keyBackupStatus', this._onKeyBackupStatusChange);
     }


### PR DESCRIPTION
If we already have an account password to use during secret storage setup, then
it's highly likely that the homeserver accepts passwords for device signing key
upload as well. This change then assumes password auth will work without
checking to avoid a request when the server is under high load.

Fixes https://github.com/vector-im/riot-web/issues/13286

Please also review https://github.com/matrix-org/matrix-react-sdk/pull/4465 for release.