### PR TITLE
Unignored in settings

### DIFF
--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -109,7 +109,7 @@ export default class SecurityUserSettingsTab extends React.Component {
 
     _onUserUnignored = async (userId) => {
         const {ignoredUserIds, waitingUnignored} = this.state;
-        const currentlyIgnoredUserIds = ignoredUserIds.filter(e=> !waitingUnignored.includes(e));
+        const currentlyIgnoredUserIds = ignoredUserIds.filter(e => !waitingUnignored.includes(e));
 
         const index = currentlyIgnoredUserIds.indexOf(userId);
         if (index !== -1) {

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -89,13 +89,13 @@ export default class SecurityUserSettingsTab extends React.Component {
         // Don't use this.state to get the ignored user list as it might be
         // ever so slightly outdated. Instead, prefer to get a fresh list and
         // update that.
-        const ignoredUsers = MatrixClientPeg.get().getIgnoredUsers();
-        const index = ignoredUsers.indexOf(userId);
+        const ignoredUserIds = MatrixClientPeg.get().getIgnoredUsers();
+        const index = ignoredUserIds.indexOf(userId);
         if (index !== -1) {
-            ignoredUsers.splice(index, 1);
-            MatrixClientPeg.get().setIgnoredUsers(ignoredUsers);
+            ignoredUserIds.splice(index, 1);
+            MatrixClientPeg.get().setIgnoredUsers(ignoredUserIds);
         }
-        this.setState({ignoredUsers});
+        this.setState({ignoredUserIds});
     };
 
     _getInvitedRooms = () => {

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -25,13 +25,13 @@ import Analytics from "../../../../../Analytics";
 import Modal from "../../../../../Modal";
 import * as sdk from "../../../../..";
 import {sleep} from "../../../../../utils/promise";
-import dis from "../../../../../dispatcher"
+import dis from "../../../../../dispatcher";
 
 export class IgnoredUser extends React.Component {
     static propTypes = {
         userId: PropTypes.string.isRequired,
         onUnignored: PropTypes.func.isRequired,
-        inProgress: PropTypes.bool.isRequired
+        inProgress: PropTypes.bool.isRequired,
     };
 
     _onUnignoreClicked = (e) => {
@@ -69,17 +69,16 @@ export default class SecurityUserSettingsTab extends React.Component {
     }
 
 
-
     _onAction({action}) {
-        if (action === "ignore_state_changed"){
-            const ignoredUserIds =  MatrixClientPeg.get().getIgnoredUsers();
-            const newWaitingUnignored = this.state.waitingUnignored.filter(e=> ignoredUserIds.includes(e))
-            this.setState({ignoredUserIds, waitingUnignored: newWaitingUnignored})
+        if (action === "ignore_state_changed") {
+            const ignoredUserIds = MatrixClientPeg.get().getIgnoredUsers();
+            const newWaitingUnignored = this.state.waitingUnignored.filter(e=> ignoredUserIds.includes(e));
+            this.setState({ignoredUserIds, waitingUnignored: newWaitingUnignored});
         }
     }
 
     componentDidMount() {
-        this.dispatcherRef = dis.register(this._onAction)
+        this.dispatcherRef = dis.register(this._onAction);
     }
 
     componentWillUnmount() {
@@ -109,17 +108,15 @@ export default class SecurityUserSettingsTab extends React.Component {
     };
 
     _onUserUnignored = async (userId) => {
-        
-        const {ignoredUserIds, waitingUnignored} = this.state
+        const {ignoredUserIds, waitingUnignored} = this.state;
         const currentlyIgnoredUserIds = ignoredUserIds.filter(e=> !waitingUnignored.includes(e));
 
         const index = currentlyIgnoredUserIds.indexOf(userId);
         if (index !== -1) {
             currentlyIgnoredUserIds.splice(index, 1);
-            this.setState(({waitingUnignored})=>({waitingUnignored:[...waitingUnignored, userId]}))
+            this.setState(({waitingUnignored})=>({waitingUnignored: [...waitingUnignored, userId]}));
             MatrixClientPeg.get().setIgnoredUsers(currentlyIgnoredUserIds);
         }
-        
     };
 
     _getInvitedRooms = () => {
@@ -230,7 +227,12 @@ export default class SecurityUserSettingsTab extends React.Component {
         if (!ignoredUserIds || ignoredUserIds.length === 0) return null;
 
         const userIds = ignoredUserIds
-            .map((u) => <IgnoredUser userId={u} onUnignored={this._onUserUnignored} key={u} inProgress={waitingUnignored.includes(u)} />);
+            .map((u) => <IgnoredUser
+             userId={u}
+             onUnignored={this._onUserUnignored}
+             key={u}
+             inProgress={waitingUnignored.includes(u)}
+             />);
 
         return (
             <div className='mx_SettingsTab_section'>

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -114,7 +114,7 @@ export default class SecurityUserSettingsTab extends React.Component {
         const index = currentlyIgnoredUserIds.indexOf(userId);
         if (index !== -1) {
             currentlyIgnoredUserIds.splice(index, 1);
-            this.setState(({waitingUnignored})=>({waitingUnignored: [...waitingUnignored, userId]}));
+            this.setState(({waitingUnignored}) => ({waitingUnignored: [...waitingUnignored, userId]}));
             MatrixClientPeg.get().setIgnoredUsers(currentlyIgnoredUserIds);
         }
     };

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -68,15 +68,12 @@ export default class SecurityUserSettingsTab extends React.Component {
         this._onAction = this._onAction.bind(this);
     }
 
+
+
     _onAction({action}) {
         if (action === "ignore_state_changed"){
             const ignoredUserIds =  MatrixClientPeg.get().getIgnoredUsers();
             const newWaitingUnignored = this.state.waitingUnignored.filter(e=> ignoredUserIds.includes(e))
-            console.log("-------------")
-            console.log("Got new ignored users", ignoredUserIds)
-            console.log("We were waiting for", this.state.waitingUnignored)
-            console.log("Now we wait for", newWaitingUnignored)
-            console.log("-------------")
             this.setState({ignoredUserIds, waitingUnignored: newWaitingUnignored})
         }
     }
@@ -114,17 +111,12 @@ export default class SecurityUserSettingsTab extends React.Component {
     _onUserUnignored = async (userId) => {
         
         const {ignoredUserIds, waitingUnignored} = this.state
-        console.log("--------GO IGNORE---")
-        console.log("ignored:", ignoredUserIds)
-        console.log("waiting for:", waitingUnignored)
         const currentlyIgnoredUserIds = ignoredUserIds.filter(e=> !waitingUnignored.includes(e));
-        console.log("currentlyIgnored:", currentlyIgnoredUserIds)
 
         const index = currentlyIgnoredUserIds.indexOf(userId);
         if (index !== -1) {
             currentlyIgnoredUserIds.splice(index, 1);
             this.setState(({waitingUnignored})=>({waitingUnignored:[...waitingUnignored, userId]}))
-            console.log("Sending to server", currentlyIgnoredUserIds)
             MatrixClientPeg.get().setIgnoredUsers(currentlyIgnoredUserIds);
         }
         
@@ -236,10 +228,6 @@ export default class SecurityUserSettingsTab extends React.Component {
         const {waitingUnignored, ignoredUserIds} = this.state;
 
         if (!ignoredUserIds || ignoredUserIds.length === 0) return null;
-
-
-        console.log("Rendering, waiting", waitingUnignored)
-        console.log("Rendering, ignored", ignoredUserIds)
 
         const userIds = ignoredUserIds
             .map((u) => <IgnoredUser userId={u} onUnignored={this._onUserUnignored} key={u} inProgress={waitingUnignored.includes(u)} />);

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -25,6 +25,7 @@ import Analytics from "../../../../../Analytics";
 import Modal from "../../../../../Modal";
 import * as sdk from "../../../../..";
 import {sleep} from "../../../../../utils/promise";
+import dis from "../../../../../dispatcher"
 
 export class IgnoredUser extends React.Component {
     static propTypes = {
@@ -61,6 +62,23 @@ export default class SecurityUserSettingsTab extends React.Component {
             managingInvites: false,
             invitedRoomAmt: invitedRooms.length,
         };
+
+        this._onAction = this._onAction.bind(this);
+    }
+
+    _onAction({action}) {
+        if (action === "ignore_state_changed"){
+            const ignoredUserIds =  MatrixClientPeg.get().getIgnoredUsers();
+            this.setState({ignoredUserIds})
+        }
+    }
+
+    componentDidMount() {
+        this.dispatcherRef = dis.register(this._onAction)
+    }
+
+    componentWillUnmount() {
+        dis.unregister(this.dispatcherRef);
     }
 
     _updateBlacklistDevicesFlag = (checked) => {
@@ -89,13 +107,13 @@ export default class SecurityUserSettingsTab extends React.Component {
         // Don't use this.state to get the ignored user list as it might be
         // ever so slightly outdated. Instead, prefer to get a fresh list and
         // update that.
-        const ignoredUserIds = MatrixClientPeg.get().getIgnoredUsers();
+        const ignoredUserIds = this.state.ignoredUserIds;
         const index = ignoredUserIds.indexOf(userId);
         if (index !== -1) {
             ignoredUserIds.splice(index, 1);
             MatrixClientPeg.get().setIgnoredUsers(ignoredUserIds);
         }
-        this.setState({ignoredUserIds});
+        
     };
 
     _getInvitedRooms = () => {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13309

Initially, it was because of a mismatch in the state property name ( ignoredUsers vs ignoredUserIds )
Then:
Added action listener to sync settings page with global state
Disabled Unignore button when unignoring is in progress