### PR TITLE
Take encrypted message search out of labs

### DIFF
--- a/src/components/views/settings/EventIndexPanel.js
+++ b/src/components/views/settings/EventIndexPanel.js
@@ -163,7 +163,7 @@ export default class EventIndexPanel extends React.Component {
             );
 
             eventIndexingSettings = (
-                <div>
+                <div className='mx_SettingsTab_subsectionText'>
                     {
                         _t( "Riot is missing some components required for securely " +
                             "caching encrypted messages locally. If you'd like to " +
@@ -180,7 +180,7 @@ export default class EventIndexPanel extends React.Component {
             );
         } else {
             eventIndexingSettings = (
-                <div>
+                <div className='mx_SettingsTab_subsectionText'>
                     {
                         _t( "Riot can't securely cache encrypted messages locally " +
                             "while running in a web browser. Use <riotLink>Riot Desktop</riotLink> " +

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -254,15 +254,12 @@ export default class SecurityUserSettingsTab extends React.Component {
             </div>
         );
 
-        let eventIndex;
-        if (SettingsStore.isFeatureEnabled("feature_event_indexing")) {
-            eventIndex = (
-                <div className="mx_SettingsTab_section">
-                    <span className="mx_SettingsTab_subheading">{_t("Message search")}</span>
-                    <EventIndexPanel />
-                </div>
-            );
-        }
+        let eventIndex = (
+            <div className="mx_SettingsTab_section">
+                <span className="mx_SettingsTab_subheading">{_t("Message search")}</span>
+                <EventIndexPanel />
+            </div>
+        );
 
         // XXX: There's no such panel in the current cross-signing designs, but
         // it's useful to have for testing the feature. If there's no interest

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -254,7 +254,7 @@ export default class SecurityUserSettingsTab extends React.Component {
             </div>
         );
 
-        let eventIndex = (
+        const eventIndex = (
             <div className="mx_SettingsTab_section">
                 <span className="mx_SettingsTab_subheading">{_t("Message search")}</span>
                 <EventIndexPanel />

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -403,7 +403,6 @@
     "Try out new ways to ignore people (experimental)": "Try out new ways to ignore people (experimental)",
     "Support adding custom themes": "Support adding custom themes",
     "Enable cross-signing to verify per-user instead of per-session": "Enable cross-signing to verify per-user instead of per-session",
-    "Enable local event indexing and E2EE search (requires restart)": "Enable local event indexing and E2EE search (requires restart)",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
     "Show padlocks on invite only rooms": "Show padlocks on invite only rooms",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -37,10 +37,6 @@ class EventIndexPeg {
      * EventIndex was successfully initialized, false otherwise.
      */
     async init() {
-        if (!SettingsStore.isFeatureEnabled("feature_event_indexing")) {
-            return false;
-        }
-
         const indexManager = PlatformPeg.get().getEventIndexingManager();
         if (!indexManager) {
             console.log("EventIndex: Platform doesn't support event indexing, not initializing.");

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -152,12 +152,6 @@ export const SETTINGS = {
         supportedLevels: ['device', 'config'], // we shouldn't use LEVELS_FEATURE for non-features, so copy it here.
         default: true,
     },
-    "feature_event_indexing": {
-        isFeature: true,
-        supportedLevels: LEVELS_FEATURE,
-        displayName: _td("Enable local event indexing and E2EE search (requires restart)"),
-        default: false,
-    },
     "feature_bridge_state": {
         isFeature: true,
         supportedLevels: LEVELS_FEATURE,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13262
Requires https://github.com/vector-im/riot-web/pull/13325
Requires https://github.com/vector-im/riot-desktop/pull/74

This is part of the cross-signing shipping master plan. Known issues relating to this feature are:
* https://github.com/vector-im/riot-web/issues/12896
* https://github.com/vector-im/riot-web/issues/12385
* https://github.com/vector-im/riot-web/issues/11831
* https://github.com/vector-im/riot-web/issues/11155

In theory, these are issues we're comfortable with shipping as we're already enabling it by default. This just makes it easier on everyone by removing the flag (making it still enabled by default).