### PR TITLE
Make max thumbnails height 200px

### DIFF
--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -177,8 +177,8 @@ export default class MImageBody extends React.Component {
         // thumbnail resolution will be unnecessarily reduced.
         // custom timeline widths seems preferable.
         const pixelRatio = window.devicePixelRatio;
-        const thumbWidth = Math.round(800 * pixelRatio);
-        const thumbHeight = Math.round(600 * pixelRatio);
+        const thumbWidth = Math.round(200 * pixelRatio);
+        const thumbHeight = Math.round(200 * pixelRatio);
 
         const content = this.props.mxEvent.getContent();
         if (content.file !== undefined) {
@@ -354,7 +354,7 @@ export default class MImageBody extends React.Component {
         }
 
         // The maximum height of the thumbnail as it is rendered as an <img>
-        const maxHeight = Math.min(this.props.maxImageHeight || 600, infoHeight);
+        const maxHeight = Math.min(this.props.maxImageHeight || 200, infoHeight);
         // The maximum width of the thumbnail, as dictated by its natural
         // maximum height.
         const maxWidth = infoWidth * maxHeight / infoHeight;


### PR DESCRIPTION
As said in https://github.com/vector-im/riot-web/issues/1520, the default thumbnails size is too big. A single image easily takes half the screen or even all vertical space (on laptops) and distracts greatly. 200px height looks much better to me so that the uploaded image isn't distracting and if you want to see the details you can always click it.
![2020-04-22_21-21-47](https://user-images.githubusercontent.com/184066/80019318-00d94080-84e0-11ea-8620-6e06d41d8620.jpg)

Fixes https://github.com/vector-im/riot-web/issues/1520