### PR TITLE
Assert type of domNode as HTMLElement to fix build

### DIFF
--- a/src/components/views/rooms/Autocomplete.tsx
+++ b/src/components/views/rooms/Autocomplete.tsx
@@ -259,7 +259,7 @@ export default class Autocomplete extends React.PureComponent<IProps, IState> {
         const selectedCompletion = this.refs[`completion${this.state.selectionOffset}`];
         if (selectedCompletion && this.containerRef.current) {
             const domNode = ReactDOM.findDOMNode(selectedCompletion);
-            const offsetTop = domNode && domNode.offsetTop;
+            const offsetTop = domNode && (domNode as HTMLElement).offsetTop;
             if (offsetTop > this.containerRef.current.scrollTop + this.containerRef.current.offsetHeight ||
                 offsetTop < this.containerRef.current.scrollTop) {
                 this.containerRef.current.scrollTop = offsetTop - this.containerRef.current.offsetTop;


### PR DESCRIPTION
I can't build the project with `yarn install` getting
```
Successfully compiled 580 files with Babel.                                                               
$ tsc --emitDeclarationOnly --jsx react                                                                   
src/components/views/rooms/Autocomplete.tsx:262:50 - error TS2339: Property 'offsetTop' does not exist on type 'Element | Text'.                                                                                    
  Property 'offsetTop' does not exist on type 'Element'.                                        
                                                                                                          
262             const offsetTop = domNode && domNode.offsetTop;                                           
                                                     ~~~~~~~~~                                            
```
Looks like asserting `domNode` type as `HTMLElement` (as per https://github.com/microsoft/TypeScript/issues/34694) fixes the issue.