### PR TITLE
Make avatars in pills occupy the entire space using cropping

### DIFF
--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -252,7 +252,11 @@ class RoomPillPart extends PillPart {
 
     setAvatar(node) {
         let initialLetter = "";
-        let avatarUrl = Avatar.avatarUrlForRoom(this._room, 16 * window.devicePixelRatio, 16 * window.devicePixelRatio);
+        let avatarUrl = Avatar.avatarUrlForRoom(
+            this._room,
+            16 * window.devicePixelRatio,
+            16 * window.devicePixelRatio,
+            "crop");
         if (!avatarUrl) {
             initialLetter = Avatar.getInitialLetter(this._room ? this._room.name : this.resourceId);
             avatarUrl = `../../${Avatar.defaultAvatarUrlForString(this._room ? this._room.roomId : this.resourceId)}`;
@@ -290,7 +294,8 @@ class UserPillPart extends PillPart {
         let avatarUrl = Avatar.avatarUrlForMember(
             this._member,
             16 * window.devicePixelRatio,
-            16 * window.devicePixelRatio);
+            16 * window.devicePixelRatio,
+            "crop");
         let initialLetter = "";
         if (avatarUrl === defaultAvatarUrl) {
             // the url from defaultAvatarUrlForString is meant to go in an img element,


### PR DESCRIPTION
Pills in the editor don't use the crop method for resize and non-square avatars look ugly because of that. They display fine in the timeline though. This simple patch fixes it.
Before:
![2020-04-23_10-46-46](https://user-images.githubusercontent.com/184066/80073305-374ea400-8550-11ea-916b-6fd90e29d72c.png)
After:
![2020-04-23_10-44-37](https://user-images.githubusercontent.com/184066/80073308-387fd100-8550-11ea-929e-90be84f65fd1.png)