### PR TITLE
Developer tool: a decoder ring for stack traces

### DIFF
--- a/res/decoder-ring/datatypes.js
+++ b/res/decoder-ring/datatypes.js
@@ -1,3 +1,16 @@
+/*
+ * Quick-n-dirty algebraic datatypes.
+ *
+ * These let us handle the possibility of failure without having to constantly write code to check for it.
+ * We can apply all of the transformations we need as if the data is present using `map`.
+ * If there's a None, or a FetchError, or a Pending, those are left untouched.
+ *
+ * I've used perhaps an odd bit of terminology from scalaz in `fold`.  This is basically a `switch` statement:
+ * You pass it a set of functions to handle the various different states of the datatype, and if it finds the
+ * function it'll call it on its value.
+ */
+
+
 class Optional {
     static from(value) {
         return value && Some.of(value) || None;

--- a/res/decoder-ring/datatypes.js
+++ b/res/decoder-ring/datatypes.js
@@ -1,0 +1,98 @@
+'use strict';
+(function (global) {
+    class Optional {
+        static from(value) {
+            return value && Some.of(value) || None;
+        }
+        map(f) {
+            return this;
+        }
+        flatMap(f) {
+            return this;
+        }
+        fold({ none }) {
+            return none && none();
+        }
+    }
+    class Some extends Optional {
+        constructor(value) {
+            super();
+            this.value = value;
+        }
+        map(f) {
+            return Some.of(f(this.value));
+        }
+        flatMap(f) {
+            return f(this.value);
+        }
+        fold({ some }) {
+            return some && some(this.value);
+        }
+        static of(value) {
+            return new Some(value);
+        }
+    }
+    const None = new Optional();
+
+    class FetchStatus {
+        constructor(opt = {}) {
+            this.opt = { at: Date.now(), ...opt };
+        }
+        map(f) {
+            return this;
+        }
+        flatMap(f) {
+            return this;
+        }
+    }
+    class Success extends FetchStatus {
+        static of(value) {
+            return new Success(value);
+        }
+        constructor(value, opt) {
+            super(opt);
+            this.value = value;
+        }
+        map(f) {
+            return new Success(f(this.value), this.opt);
+        }
+        flatMap(f) {
+            return f(this.value, this.opt);
+        }
+        fold({ success }) {
+            return success instanceof Function ? success(this.value, this.opt) : undefined;
+        }
+    }
+    class Pending extends FetchStatus {
+        static of(opt) {
+            return new Pending(opt);
+        }
+        constructor(opt) {
+            super(opt);
+        }
+        fold({ pending }) {
+            return pending instanceof Function ? pending(this.opt) : undefined;
+        }
+    }
+    class FetchError extends FetchStatus {
+        static of(reason, opt) {
+            return new FetchError(reason, opt);
+        }
+        constructor(reason, opt) {
+            super(opt);
+            this.reason = reason;
+        }
+        fold({ error }) {
+            return error instanceof Function ? error(this.reason, this.opt) : undefined;
+        }
+    }
+
+    global.Datatypes = {
+        Optional,
+        Some,
+        None,
+        Success,
+        Pending,
+        FetchError,
+    };
+})(window);

--- a/res/decoder-ring/datatypes.js
+++ b/res/decoder-ring/datatypes.js
@@ -1,98 +1,86 @@
-'use strict';
-(function(global) {
-    class Optional {
-        static from(value) {
-            return value && Some.of(value) || None;
-        }
-        map(f) {
-            return this;
-        }
-        flatMap(f) {
-            return this;
-        }
-        fold({ none }) {
-            return none && none();
-        }
+class Optional {
+    static from(value) {
+        return value && Some.of(value) || None;
     }
-    class Some extends Optional {
-        constructor(value) {
-            super();
-            this.value = value;
-        }
-        map(f) {
-            return Some.of(f(this.value));
-        }
-        flatMap(f) {
-            return f(this.value);
-        }
-        fold({ some }) {
-            return some && some(this.value);
-        }
-        static of(value) {
-            return new Some(value);
-        }
+    map(f) {
+        return this;
     }
-    const None = new Optional();
+    flatMap(f) {
+        return this;
+    }
+    fold({ none }) {
+        return none && none();
+    }
+}
+class Some extends Optional {
+    constructor(value) {
+        super();
+        this.value = value;
+    }
+    map(f) {
+        return Some.of(f(this.value));
+    }
+    flatMap(f) {
+        return f(this.value);
+    }
+    fold({ some }) {
+        return some && some(this.value);
+    }
+    static of(value) {
+        return new Some(value);
+    }
+}
+const None = new Optional();
 
-    class FetchStatus {
-        constructor(opt = {}) {
-            this.opt = { at: Date.now(), ...opt };
-        }
-        map(f) {
-            return this;
-        }
-        flatMap(f) {
-            return this;
-        }
+class FetchStatus {
+    constructor(opt = {}) {
+        this.opt = { at: Date.now(), ...opt };
     }
-    class Success extends FetchStatus {
-        static of(value) {
-            return new Success(value);
-        }
-        constructor(value, opt) {
-            super(opt);
-            this.value = value;
-        }
-        map(f) {
-            return new Success(f(this.value), this.opt);
-        }
-        flatMap(f) {
-            return f(this.value, this.opt);
-        }
-        fold({ success }) {
-            return success instanceof Function ? success(this.value, this.opt) : undefined;
-        }
+    map(f) {
+        return this;
     }
-    class Pending extends FetchStatus {
-        static of(opt) {
-            return new Pending(opt);
-        }
-        constructor(opt) {
-            super(opt);
-        }
-        fold({ pending }) {
-            return pending instanceof Function ? pending(this.opt) : undefined;
-        }
+    flatMap(f) {
+        return this;
     }
-    class FetchError extends FetchStatus {
-        static of(reason, opt) {
-            return new FetchError(reason, opt);
-        }
-        constructor(reason, opt) {
-            super(opt);
-            this.reason = reason;
-        }
-        fold({ error }) {
-            return error instanceof Function ? error(this.reason, this.opt) : undefined;
-        }
+}
+class Success extends FetchStatus {
+    static of(value) {
+        return new Success(value);
     }
-
-    global.Datatypes = {
-        Optional,
-        Some,
-        None,
-        Success,
-        Pending,
-        FetchError,
-    };
-})(window);
+    constructor(value, opt) {
+        super(opt);
+        this.value = value;
+    }
+    map(f) {
+        return new Success(f(this.value), this.opt);
+    }
+    flatMap(f) {
+        return f(this.value, this.opt);
+    }
+    fold({ success }) {
+        return success instanceof Function ? success(this.value, this.opt) : undefined;
+    }
+}
+class Pending extends FetchStatus {
+    static of(opt) {
+        return new Pending(opt);
+    }
+    constructor(opt) {
+        super(opt);
+    }
+    fold({ pending }) {
+        return pending instanceof Function ? pending(this.opt) : undefined;
+    }
+}
+class FetchError extends FetchStatus {
+    static of(reason, opt) {
+        return new FetchError(reason, opt);
+    }
+    constructor(reason, opt) {
+        super(opt);
+        this.reason = reason;
+    }
+    fold({ error }) {
+        return error instanceof Function ? error(this.reason, this.opt) : undefined;
+    }
+}

--- a/res/decoder-ring/datatypes.js
+++ b/res/decoder-ring/datatypes.js
@@ -8,6 +8,14 @@
  * I've used perhaps an odd bit of terminology from scalaz in `fold`.  This is basically a `switch` statement:
  * You pass it a set of functions to handle the various different states of the datatype, and if it finds the
  * function it'll call it on its value.
+ *
+ * It's handy to have this in functional style when dealing with React as we can dispatch different ways of rendering
+ * really simply:
+ * ```
+ * bundleFetchStatus.fold({
+ *     some: (fetchStatus) => <ProgressBar fetchsStatus={fetchStatus} />,
+ * }),
+ * ```
  */
 
 

--- a/res/decoder-ring/datatypes.js
+++ b/res/decoder-ring/datatypes.js
@@ -1,5 +1,5 @@
 'use strict';
-(function (global) {
+(function(global) {
     class Optional {
         static from(value) {
             return value && Some.of(value) || None;

--- a/res/decoder-ring/decoder.js
+++ b/res/decoder-ring/decoder.js
@@ -1,288 +1,280 @@
-'use strict';
+class StartupError extends Error {}
 
-(function(global) {
-    const { Some, None, Success, Pending, FetchError } = global.Datatypes;
+async function getBundleName() {
+    const res = await fetch("../index.html");
+    if (!res.ok) {
+        throw new StartupError(`Couldn't fetch index.html to prefill bundle; ${res.status} ${res.statusText}`);
+    }
+    const index = await res.text();
+    return index.split("\n").map((line) =>
+        line.match(/<script src="bundles\/([^/]+)\/bundle.js"/),
+    )
+    .filter((result) => result)
+    .map((result) => result[1])[0];
+}
 
-    class StartupError extends Error {}
+function validateBundle(value) {
+    return value.match(/^[0-9a-f]{20}$/) ? Some.of(value) : None;
+}
 
-    async function getBundleName() {
-        const res = await fetch("../index.html");
+/* A custom fetcher that abandons immediately upon getting a response.
+    * The purpose of this is just to validate that the user entered a real bundle, and provide feedback.
+    */
+const bundleCache = new Map();
+function bundleSubject(bundle) {
+    if (!bundle.match(/^[0-9a-f]{20}$/)) throw new Error("Bad input");
+    if (bundleCache.has(bundle)) {
+        return bundleCache.get(bundle);
+    }
+    const fetcher = new rxjs.BehaviorSubject(Pending.of());
+    bundleCache.set(bundle, fetcher);
+
+    fetch(`/bundles/${bundle}/bundle.js.map`).then((res) => {
+        res.body.cancel(); /* Bail on the download immediately - it could be big! */
+        const status = res.ok;
+        if (status) {
+            fetcher.next(Success.of());
+        } else {
+            fetcher.next(FetchError.of(`Failed to fetch: ${res.status} ${res.statusText}`));
+        }
+    });
+
+    return fetcher;
+}
+
+/*
+    * Convert a ReadableStream of bytes into an Observable of a string
+    * The observable will emit a stream of Pending objects and will concatenate
+    * the number of bytes received with whatever pendingContext has been supplied.
+    * Finally, it will emit a Success containing the result.
+    * You'd use this on a Response.body.
+    */
+function observeReadableStream(readableStream, pendingContext = {}) {
+    let bytesReceived = 0;
+    let buffer = "";
+    const pendingSubject = new rxjs.BehaviorSubject(Pending.of({ ...pendingContext, bytesReceived }));
+    const throttledPending = pendingSubject.pipe(rxjs.operators.throttleTime(100));
+    const resultObservable = new rxjs.Subject();
+    const reader = readableStream.getReader();
+    const utf8Decoder = new TextDecoder("utf-8");
+    function readNextChunk() {
+        reader.read().then(({ done, value }) => {
+            if (done) {
+                pendingSubject.complete();
+                resultObservable.next(Success.of(buffer));
+                return;
+            }
+            bytesReceived += value.length;
+            pendingSubject.next(Pending.of({...pendingContext, bytesReceived }));
+            /* string concatenation is apparently the most performant way to do this */
+            buffer += utf8Decoder.decode(value);
+            readNextChunk();
+        });
+    }
+    readNextChunk();
+    return rxjs.concat(throttledPending, resultObservable);
+}
+
+/*
+    * A helper for fetching values, caching them and representing them as a subject that follows the state changes
+    */
+const fetchCache = new Map();
+function fetchAsSubject(endpoint) {
+    if (fetchCache.has(endpoint)) {
+        // TODO: expiry/retry logic here?
+        return fetchCache.get(endpoint);
+    }
+    const fetcher = new rxjs.BehaviorSubject(Pending.of());
+    fetchCache.set(endpoint, fetcher);
+
+    fetch(endpoint).then((res) => {
         if (!res.ok) {
-            throw new StartupError(`Couldn't fetch index.html to prefill bundle; ${res.status} ${res.statusText}`);
+            fetcher.next(FetchError.of(`Failed to fetch endpoint ${endpoint}: ${res.status} ${res.statusText}`));
+            return;
         }
-        const index = await res.text();
-        return index.split("\n").map((line) =>
-          line.match(/<script src="bundles\/([^/]+)\/bundle.js"/),
-        )
-        .filter((result) => result)
-        .map((result) => result[1])[0];
-    }
 
-    function validateBundle(value) {
-        return value.match(/^[0-9a-f]{20}$/) ? Some.of(value) : None;
-    }
+        const contentLength = res.headers.get("content-length");
+        const context = contentLength ? { length: parseInt(contentLength) } : {};
 
-    /* A custom fetcher that abandons immediately upon getting a response.
-     * The purpose of this is just to validate that the user entered a real bundle, and provide feedback.
-     */
-    const bundleCache = new Map();
-    function bundleSubject(bundle) {
-        if (!bundle.match(/^[0-9a-f]{20}$/)) throw new Error("Bad input");
-        if (bundleCache.has(bundle)) {
-            return bundleCache.get(bundle);
-        }
-        const fetcher = new rxjs.BehaviorSubject(Pending.of());
-        bundleCache.set(bundle, fetcher);
-
-        fetch(`/bundles/${bundle}/bundle.js.map`).then((res) => {
-            res.body.cancel(); /* Bail on the download immediately - it could be big! */
-            const status = res.ok;
-            if (status) {
-                fetcher.next(Success.of());
-            } else {
-                fetcher.next(FetchError.of(`Failed to fetch: ${res.status} ${res.statusText}`));
-            }
+        const streamer = observeReadableStream(res.body, context, endpoint);
+        streamer.subscribe((value) => {
+            fetcher.next(value);
         });
+    });
+    return fetcher;
+}
 
-        return fetcher;
-    }
+/* React stuff */
+const e = React.createElement;
 
-    /*
-     * Convert a ReadableStream of bytes into an Observable of a string
-     * The observable will emit a stream of Pending objects and will concatenate
-     * the number of bytes received with whatever pendingContext has been supplied.
-     * Finally, it will emit a Success containing the result.
-     * You'd use this on a Response.body.
-     */
-    function observeReadableStream(readableStream, pendingContext = {}) {
-        let bytesReceived = 0;
-        let buffer = "";
-        const pendingSubject = new rxjs.BehaviorSubject(Pending.of({ ...pendingContext, bytesReceived }));
-        const throttledPending = pendingSubject.pipe(rxjs.operators.throttleTime(100));
-        const resultObservable = new rxjs.Subject();
-        const reader = readableStream.getReader();
-        const utf8Decoder = new TextDecoder("utf-8");
-        function readNextChunk() {
-            reader.read().then(({ done, value }) => {
-                if (done) {
-                    pendingSubject.complete();
-                    resultObservable.next(Success.of(buffer));
-                    return;
-                }
-                bytesReceived += value.length;
-                pendingSubject.next(Pending.of({...pendingContext, bytesReceived }));
-                /* string concatenation is apparently the most performant way to do this */
-                buffer += utf8Decoder.decode(value);
-                readNextChunk();
-            });
-        }
-        readNextChunk();
-        return rxjs.concat(throttledPending, resultObservable);
-    }
-
-    /*
-     * A helper for fetching values, caching them and representing them as a subject that follows the state changes
-     */
-    const fetchCache = new Map();
-    function fetchAsSubject(endpoint) {
-        if (fetchCache.has(endpoint)) {
-            // TODO: expiry/retry logic here?
-            return fetchCache.get(endpoint);
-        }
-        const fetcher = new rxjs.BehaviorSubject(Pending.of());
-        fetchCache.set(endpoint, fetcher);
-
-        fetch(endpoint).then((res) => {
-            if (!res.ok) {
-                fetcher.next(FetchError.of(`Failed to fetch endpoint ${endpoint}: ${res.status} ${res.statusText}`));
-                return;
+function ProgressBar({ fetchStatus }) {
+    return e('span', { className: "progress "},
+        fetchStatus.fold({
+        pending: ({ bytesReceived, length }) => {
+            if (!bytesReceived) {
+                return e('span', { className: "spinner" }, "\u29b5");
             }
+            const kB = Math.floor(10 * bytesReceived / 1024) / 10;
+            if (!length) {
+                return e('span', null, `Fetching (${kB}kB)`);
+            }
+            const percent = Math.floor(100 * bytesReceived / length);
+            return e('span', null, `Fetching (${kB}kB) ${percent}%`);
+        },
+        success: () => e('span', null, "\u2713"),
+        error: (reason) => {
+            return e('span', { className: 'error'}, `\u2717 ${reason}`);
+        },
+    }));
+}
 
-            const contentLength = res.headers.get("content-length");
-            const context = contentLength ? { length: parseInt(contentLength) } : {};
+function BundlePicker() {
+    const [bundle, setBundle] = React.useState("");
+    const [file, setFile] = React.useState("");
+    const [line, setLine] = React.useState("1");
+    const [column, setColumn] = React.useState("");
+    const [result, setResult] = React.useState(None);
+    const [bundleFetchStatus, setBundleFetchStatus] = React.useState(None);
+    const [fileFetchStatus, setFileFetchStatus] = React.useState(None);
 
-            const streamer = observeReadableStream(res.body, context, endpoint);
-            streamer.subscribe((value) => {
-                fetcher.next(value);
-            });
+    React.useEffect(() => {
+        getBundleName().then((name) => {
+            if (bundle === "" && validateBundle(name) !== None) {
+                setBundle(name);
+            }
+        }, console.log.bind(console));
+    }, []);
+
+    const onBundleChange = React.useCallback((event) => {
+        const value = event.target.value;
+        setBundle(value);
+    }, []);
+
+    const onFileChange = React.useCallback((event) => {
+        const value = event.target.value;
+        setFile(value);
+    }, []);
+
+    const onLineChange = React.useCallback((event) => {
+        const value = event.target.value;
+        setLine(value);
+    }, []);
+
+    const onColumnChange = React.useCallback((event) => {
+        const value = event.target.value;
+        setColumn(value);
+    }, []);
+
+    React.useEffect(() =>
+        validateBundle(bundle).fold({
+            some: (value) => {
+                const subscription = bundleSubject(value)
+                    .pipe(rxjs.operators.map(Some.of))
+                    .subscribe(setBundleFetchStatus);
+                return () => subscription.unsubscribe();
+            },
+            none: () => setBundleFetchStatus(None),
+        }),
+    [bundle]);
+
+    React.useEffect(() => {
+        if (!file.match(/.\.js$/) || validateBundle(bundle) === None) {
+            setFileFetchStatus(None);
+            return;
+        }
+        const observable = fetchAsSubject(`/bundles/${bundle}/${file}.map`)
+            .pipe(
+                rxjs.operators.map((fetchStatus) => fetchStatus.flatMap(value => {
+                    try {
+                        return Success.of(JSON.parse(value));
+                    } catch (e) {
+                        return FetchError.of(e);
+                    }
+                })),
+                rxjs.operators.map(Some.of),
+            );
+        const subscription = observable.subscribe(setFileFetchStatus);
+        return () => subscription.unsubscribe();
+    }, [bundle, file]);
+
+    React.useEffect(() => {
+        fileFetchStatus.fold({
+            some: (fetchStatus) =>
+                fetchStatus.fold({
+                    success: (value) => {
+                        if (!line) return setResult(None);
+                        const pLine = parseInt(line);
+                        const pCol = parseInt(column);
+                        sourceMap.SourceMapConsumer.with(value, undefined, (consumer) =>
+                            consumer.originalPositionFor({ line: pLine, column: pCol }),
+                        ).then((result) => setResult(Some.of(JSON.stringify(result))));
+                    },
+                }),
+            none: () => setResult(None),
         });
-        return fetcher;
-    }
+    }, [fileFetchStatus, line, column]);
 
-    /* React stuff */
-    const e = React.createElement;
-
-    function ProgressBar({ fetchStatus }) {
-        return e('span', { className: "progress "},
-            fetchStatus.fold({
-            pending: ({ bytesReceived, length }) => {
-                if (!bytesReceived) {
-                    return e('span', { className: "spinner" }, "\u29b5");
-                }
-                const kB = Math.floor(10 * bytesReceived / 1024) / 10;
-                if (!length) {
-                    return e('span', null, `Fetching (${kB}kB)`);
-                }
-                const percent = Math.floor(100 * bytesReceived / length);
-                return e('span', null, `Fetching (${kB}kB) ${percent}%`);
-            },
-            success: () => e('span', null, "\u2713"),
-            error: (reason) => {
-                return e('span', { className: 'error'}, `\u2717 ${reason}`);
-            },
-        }));
-    }
-
-    function BundlePicker() {
-        const [bundle, setBundle] = React.useState("");
-        const [file, setFile] = React.useState("");
-        const [line, setLine] = React.useState("1");
-        const [column, setColumn] = React.useState("");
-        const [result, setResult] = React.useState(None);
-        const [bundleFetchStatus, setBundleFetchStatus] = React.useState(None);
-        const [fileFetchStatus, setFileFetchStatus] = React.useState(None);
-
-        React.useEffect(() => {
-            getBundleName().then((name) => {
-                if (bundle === "" && validateBundle(name) !== None) {
-                    setBundle(name);
-                }
-            }, console.log.bind(console));
-        }, []);
-
-        const onBundleChange = React.useCallback((event) => {
-            const value = event.target.value;
-            setBundle(value);
-        }, []);
-
-        const onFileChange = React.useCallback((event) => {
-            const value = event.target.value;
-            setFile(value);
-        }, []);
-
-        const onLineChange = React.useCallback((event) => {
-            const value = event.target.value;
-            setLine(value);
-        }, []);
-
-        const onColumnChange = React.useCallback((event) => {
-            const value = event.target.value;
-            setColumn(value);
-        }, []);
-
-        React.useEffect(() =>
-            validateBundle(bundle).fold({
-                some: (value) => {
-                    const subscription = bundleSubject(value)
-                      .pipe(rxjs.operators.map(Some.of))
-                      .subscribe(setBundleFetchStatus);
-                    return () => subscription.unsubscribe();
-                },
-                none: () => setBundleFetchStatus(None),
-            }),
-        [bundle]);
-
-        React.useEffect(() => {
-            if (!file.match(/.\.js$/) || validateBundle(bundle) === None) {
-                setFileFetchStatus(None);
-                return;
-            }
-            const observable = fetchAsSubject(`/bundles/${bundle}/${file}.map`)
-                .pipe(
-                    rxjs.operators.map((fetchStatus) => fetchStatus.flatMap(value => {
-                        try {
-                            return Success.of(JSON.parse(value));
-                        } catch (e) {
-                            return FetchError.of(e);
-                        }
-                    })),
-                    rxjs.operators.map(Some.of),
-                );
-            const subscription = observable.subscribe(setFileFetchStatus);
-            return () => subscription.unsubscribe();
-        }, [bundle, file]);
-
-        React.useEffect(() => {
-            fileFetchStatus.fold({
-                some: (fetchStatus) =>
-                    fetchStatus.fold({
-                        success: (value) => {
-                            if (!line) return setResult(None);
-                            const pLine = parseInt(line);
-                            const pCol = parseInt(column);
-                            sourceMap.SourceMapConsumer.with(value, undefined, (consumer) =>
-                                consumer.originalPositionFor({ line: pLine, column: pCol }),
-                            ).then((result) => setResult(Some.of(JSON.stringify(result))));
-                        },
-                    }),
-                none: () => setResult(None),
-            });
-        }, [fileFetchStatus, line, column]);
-
-        return e('div', {},
-            e('div', { className: 'inputs' },
-                e('div', { className: 'bundle' },
-                    e('label', { htmlFor: 'bundle'}, 'Bundle'),
-                    e('input', {
-                        name: 'bundle',
-                        required: true,
-                        pattern: "[0-9a-f]{20}",
-                        onChange: onBundleChange,
-                        value: bundle,
-                    }),
-                    bundleFetchStatus.fold({
-                        some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
-                        none: () => null,
-                    }),
-                ),
-                e('div', { className: 'file' },
-                    e('label', { htmlFor: 'file' }, 'File'),
-                    e('input', {
-                        name: 'file',
-                        required: true,
-                        pattern: ".+\\.js",
-                        onChange: onFileChange,
-                        value: file,
-                    }),
-                    fileFetchStatus.fold({
-                        some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
-                        none: () => null,
-                    }),
-                ),
-                e('div', { className: 'line' },
-                    e('label', { htmlFor: 'line' }, 'Line'),
-                    e('input', {
-                        name: 'line',
-                        required: true,
-                        pattern: "[0-9]+",
-                        onChange: onLineChange,
-                        value: line,
-                    }),
-                ),
-                e('div', { className: 'column' },
-                    e('label', { htmlFor: 'column' }, 'Column'),
-                    e('input', {
-                        name: 'column',
-                        required: true,
-                        pattern: "[0-9]+",
-                        onChange: onColumnChange,
-                        value: column,
-                    }),
-                ),
-            ),
-            e('div', null,
-                result.fold({
-                    none: () => "Select a bundle, file and line",
-                    some: (value) => e('pre', null, value),
+    return e('div', {},
+        e('div', { className: 'inputs' },
+            e('div', { className: 'bundle' },
+                e('label', { htmlFor: 'bundle'}, 'Bundle'),
+                e('input', {
+                    name: 'bundle',
+                    required: true,
+                    pattern: "[0-9a-f]{20}",
+                    onChange: onBundleChange,
+                    value: bundle,
+                }),
+                bundleFetchStatus.fold({
+                    some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
+                    none: () => null,
                 }),
             ),
-        );
-    }
+            e('div', { className: 'file' },
+                e('label', { htmlFor: 'file' }, 'File'),
+                e('input', {
+                    name: 'file',
+                    required: true,
+                    pattern: ".+\\.js",
+                    onChange: onFileChange,
+                    value: file,
+                }),
+                fileFetchStatus.fold({
+                    some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
+                    none: () => null,
+                }),
+            ),
+            e('div', { className: 'line' },
+                e('label', { htmlFor: 'line' }, 'Line'),
+                e('input', {
+                    name: 'line',
+                    required: true,
+                    pattern: "[0-9]+",
+                    onChange: onLineChange,
+                    value: line,
+                }),
+            ),
+            e('div', { className: 'column' },
+                e('label', { htmlFor: 'column' }, 'Column'),
+                e('input', {
+                    name: 'column',
+                    required: true,
+                    pattern: "[0-9]+",
+                    onChange: onColumnChange,
+                    value: column,
+                }),
+            ),
+        ),
+        e('div', null,
+            result.fold({
+                none: () => "Select a bundle, file and line",
+                some: (value) => e('pre', null, value),
+            }),
+        ),
+    );
+}
 
-    /* Global stuff */
-    const Decoder = {
-        BundlePicker,
-    };
-
-    global.Decoder = Decoder;
-})(window);
+/* Global stuff */
+window.Decoder = {
+    BundlePicker,
+};

--- a/res/decoder-ring/decoder.js
+++ b/res/decoder-ring/decoder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-(function (global) {
+(function(global) {
     const { Some, None, Success, Pending, FetchError } = global.Datatypes;
 
     class StartupError extends Error {}
@@ -11,12 +11,11 @@
             throw new StartupError(`Couldn't fetch index.html to prefill bundle; ${res.status} ${res.statusText}`);
         }
         const index = await res.text();
-        return index.split("\n").map((line) => 
-          line.match(/<script src="bundles\/([^/]+)\/bundle.js"/)
+        return index.split("\n").map((line) =>
+          line.match(/<script src="bundles\/([^/]+)\/bundle.js"/),
         )
         .filter((result) => result)
-        .map((result) => result[1])
-        [0];
+        .map((result) => result[1])[0];
     }
 
     function validateBundle(value) {
@@ -70,18 +69,14 @@
                     resultObservable.next(Success.of(buffer));
                     return;
                 }
-                if (!value) {
-                    console.log("empty chunk?", value);
-                    readNextChunk();
-                }
                 bytesReceived += value.length;
-                pendingSubject.next(Pending.of({bytesReceived, ...pendingContext}));
+                pendingSubject.next(Pending.of({...pendingContext, bytesReceived }));
                 /* string concatenation is apparently the most performant way to do this */
                 buffer += utf8Decoder.decode(value);
                 readNextChunk();
             });
         }
-        readNextChunk();        
+        readNextChunk();
         return rxjs.concat(throttledPending, resultObservable);
     }
 
@@ -129,12 +124,12 @@
                     return e('span', null, `Fetching (${kB}kB)`);
                 }
                 const percent = Math.floor(100 * bytesReceived / length);
-                return e('span', null, `Fetching (${kB}kB) ${percent}%`)
+                return e('span', null, `Fetching (${kB}kB) ${percent}%`);
             },
             success: () => e('span', null, `✓`),
             error: (reason) => {
-                return e('span', { className: 'error'}, `✗ ${reason}`)
-            }
+                return e('span', { className: 'error'}, `✗ ${reason}`);
+            },
         }));
     }
 
@@ -180,10 +175,10 @@
                 some: (value) => {
                     const subscription = bundleSubject(value)
                       .pipe(rxjs.operators.map(Some.of))
-                      .subscribe(setBundleFetchStatus)
+                      .subscribe(setBundleFetchStatus);
                     return () => subscription.unsubscribe();
                 },
-                none: () => setBundleFetchStatus(None)
+                none: () => setBundleFetchStatus(None),
             }),
         [bundle]);
 
@@ -201,10 +196,10 @@
                             return FetchError.of(e);
                         }
                     })),
-                    rxjs.operators.map(Some.of)
-                )
-            const subscription = observable.subscribe(setFileFetchStatus)
-            return () => subscription.unsubscribe()
+                    rxjs.operators.map(Some.of),
+                );
+            const subscription = observable.subscribe(setFileFetchStatus);
+            return () => subscription.unsubscribe();
         }, [bundle, file]);
 
         React.useEffect(() => {
@@ -216,12 +211,12 @@
                             const pLine = parseInt(line);
                             const pCol = parseInt(column);
                             sourceMap.SourceMapConsumer.with(value, undefined, (consumer) =>
-                                consumer.originalPositionFor({ line: pLine, column: pCol })
+                                consumer.originalPositionFor({ line: pLine, column: pCol }),
                             ).then((result) => setResult(Some.of(JSON.stringify(result))));
-                        }
+                        },
                     }),
-                none: () => setResult(None)
-            })
+                none: () => setResult(None),
+            });
         }, [fileFetchStatus, line, column]);
 
         return e('div', {},
@@ -247,7 +242,7 @@
                         required: true,
                         pattern: ".+\\.js",
                         onChange: onFileChange,
-                        value: file
+                        value: file,
                     }),
                     fileFetchStatus.fold({
                         some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
@@ -261,7 +256,7 @@
                         required: true,
                         pattern: "[0-9]+",
                         onChange: onLineChange,
-                        value: line
+                        value: line,
                     }),
                 ),
                 e('div', { className: 'column' },
@@ -271,15 +266,15 @@
                         required: true,
                         pattern: "[0-9]+",
                         onChange: onColumnChange,
-                        value: column
+                        value: column,
                     }),
                 ),
             ),
             e('div', null,
                 result.fold({
                     none: () => "Select a bundle, file and line",
-                    some: (value) => e('pre', null, value)
-                })
+                    some: (value) => e('pre', null, value),
+                }),
             ),
         );
     }

--- a/res/decoder-ring/decoder.js
+++ b/res/decoder-ring/decoder.js
@@ -1,0 +1,293 @@
+'use strict';
+
+(function (global) {
+    const { Some, None, Success, Pending, FetchError } = global.Datatypes;
+
+    class StartupError extends Error {}
+
+    async function getBundleName() {
+        const res = await fetch("../index.html");
+        if (!res.ok) {
+            throw new StartupError(`Couldn't fetch index.html to prefill bundle; ${res.status} ${res.statusText}`);
+        }
+        const index = await res.text();
+        return index.split("\n").map((line) => 
+          line.match(/<script src="bundles\/([^/]+)\/bundle.js"/)
+        )
+        .filter((result) => result)
+        .map((result) => result[1])
+        [0];
+    }
+
+    function validateBundle(value) {
+        return value.match(/^[0-9a-f]{20}$/) ? Some.of(value) : None;
+    }
+
+    /* A custom fetcher that abandons immediately upon getting a response.
+     * The purpose of this is just to validate that the user entered a real bundle, and provide feedback.
+     */
+    const bundleCache = new Map();
+    function bundleSubject(bundle) {
+        if (!bundle.match(/^[0-9a-f]{20}$/)) throw new Error("Bad input");
+        if (bundleCache.has(bundle)) {
+            return bundleCache.get(bundle);
+        }
+        const fetcher = new rxjs.BehaviorSubject(Pending.of());
+        bundleCache.set(bundle, fetcher);
+
+        fetch(`/bundles/${bundle}/bundle.js.map`).then((res) => {
+            res.body.cancel(); /* Bail on the download immediately - it could be big! */
+            const status = res.ok;
+            if (status) {
+                fetcher.next(Success.of());
+            } else {
+                fetcher.next(FetchError.of(`Failed to fetch: ${res.status} ${res.statusText}`));
+            }
+        });
+
+        return fetcher;
+    }
+
+    /*
+     * Convert a ReadableStream of bytes into an Observable of a string
+     * The observable will emit a stream of Pending objects and will concatenate
+     * the number of bytes received with whatever pendingContext has been supplied.
+     * Finally, it will emit a Success containing the result.
+     * You'd use this on a Response.body.
+     */
+    function observeReadableStream(readableStream, pendingContext = {}) {
+        let bytesReceived = 0;
+        let buffer = "";
+        const pendingSubject = new rxjs.BehaviorSubject(Pending.of({ ...pendingContext, bytesReceived }));
+        const throttledPending = pendingSubject.pipe(rxjs.operators.throttleTime(100));
+        const resultObservable = new rxjs.Subject();
+        const reader = readableStream.getReader();
+        const utf8Decoder = new TextDecoder("utf-8");
+        function readNextChunk() {
+            reader.read().then(({ done, value }) => {
+                if (done) {
+                    pendingSubject.complete();
+                    resultObservable.next(Success.of(buffer));
+                    return;
+                }
+                if (!value) {
+                    console.log("empty chunk?", value);
+                    readNextChunk();
+                }
+                bytesReceived += value.length;
+                pendingSubject.next(Pending.of({bytesReceived, ...pendingContext}));
+                /* string concatenation is apparently the most performant way to do this */
+                buffer += utf8Decoder.decode(value);
+                readNextChunk();
+            });
+        }
+        readNextChunk();        
+        return rxjs.concat(throttledPending, resultObservable);
+    }
+
+    /*
+     * A helper for fetching values, caching them and representing them as a subject that follows the state changes
+     */
+    const fetchCache = new Map();
+    function fetchAsSubject(endpoint) {
+        if (fetchCache.has(endpoint)) {
+            // TODO: expiry/retry logic here?
+            return fetchCache.get(endpoint);
+        }
+        const fetcher = new rxjs.BehaviorSubject(Pending.of());
+        fetchCache.set(endpoint, fetcher);
+
+        fetch(endpoint).then((res) => {
+            if (!res.ok) {
+                fetcher.next(FetchError.of(`Failed to fetch endpoint ${endpoint}: ${res.status} ${res.statusText}`));
+                return;
+            }
+
+            const contentLength = res.headers.get("content-length");
+            const context = contentLength ? { length: parseInt(contentLength) } : {};
+
+            const streamer = observeReadableStream(res.body, context, endpoint);
+            streamer.subscribe((value) => {
+                fetcher.next(value);
+            });
+        });
+        return fetcher;
+    }
+
+    /* React stuff */
+    const e = React.createElement;
+
+    function ProgressBar({ fetchStatus }) {
+        return e('span', { className: "progress "},
+            fetchStatus.fold({
+            pending: ({ bytesReceived, length }) => {
+                if (!bytesReceived) {
+                    return e('span', { className: "spinner" }, "⦶");
+                }
+                const kB = Math.floor(10 * bytesReceived / 1024) / 10;
+                if (!length) {
+                    return e('span', null, `Fetching (${kB}kB)`);
+                }
+                const percent = Math.floor(100 * bytesReceived / length);
+                return e('span', null, `Fetching (${kB}kB) ${percent}%`)
+            },
+            success: () => e('span', null, `✓`),
+            error: (reason) => {
+                return e('span', { className: 'error'}, `✗ ${reason}`)
+            }
+        }));
+    }
+
+    function BundlePicker() {
+        const [bundle, setBundle] = React.useState("");
+        const [file, setFile] = React.useState("");
+        const [line, setLine] = React.useState("1");
+        const [column, setColumn] = React.useState("");
+        const [result, setResult] = React.useState(None);
+        const [bundleFetchStatus, setBundleFetchStatus] = React.useState(None);
+        const [fileFetchStatus, setFileFetchStatus] = React.useState(None);
+
+        React.useEffect(() => {
+            getBundleName().then((name) => {
+                if (bundle === "" && validateBundle(name) !== None) {
+                    setBundle(bundleName);
+                }
+            }, console.log.bind(console));
+        }, []);
+
+        const onBundleChange = React.useCallback((event) => {
+            const value = event.target.value;
+            setBundle(value);
+        }, []);
+
+        const onFileChange = React.useCallback((event) => {
+            const value = event.target.value;
+            setFile(value);
+        }, []);
+
+        const onLineChange = React.useCallback((event) => {
+            const value = event.target.value;
+            setLine(value);
+        }, []);
+
+        const onColumnChange = React.useCallback((event) => {
+            const value = event.target.value;
+            setColumn(value);
+        }, []);
+
+        React.useEffect(() =>
+            validateBundle(bundle).fold({
+                some: (value) => {
+                    const subscription = bundleSubject(value)
+                      .pipe(rxjs.operators.map(Some.of))
+                      .subscribe(setBundleFetchStatus)
+                    return () => subscription.unsubscribe();
+                },
+                none: () => setBundleFetchStatus(None)
+            }),
+        [bundle]);
+
+        React.useEffect(() => {
+            if (!file.match(/.\.js$/) || validateBundle(bundle) === None) {
+                setFileFetchStatus(None);
+                return;
+            }
+            const observable = fetchAsSubject(`/bundles/${bundle}/${file}.map`)
+                .pipe(
+                    rxjs.operators.map((fetchStatus) => fetchStatus.flatMap(value => {
+                        try {
+                            return Success.of(JSON.parse(value));
+                        } catch (e) {
+                            return FetchError.of(e);
+                        }
+                    })),
+                    rxjs.operators.map(Some.of)
+                )
+            const subscription = observable.subscribe(setFileFetchStatus)
+            return () => subscription.unsubscribe()
+        }, [bundle, file]);
+
+        React.useEffect(() => {
+            fileFetchStatus.fold({
+                some: (fetchStatus) =>
+                    fetchStatus.fold({
+                        success: (value) => {
+                            if (!line) return setResult(None);
+                            const pLine = parseInt(line);
+                            const pCol = parseInt(column);
+                            sourceMap.SourceMapConsumer.with(value, undefined, (consumer) =>
+                                consumer.originalPositionFor({ line: pLine, column: pCol })
+                            ).then((result) => setResult(Some.of(JSON.stringify(result))));
+                        }
+                    }),
+                none: () => setResult(None)
+            })
+        }, [fileFetchStatus, line, column]);
+
+        return e('div', {},
+            e('div', { className: 'inputs' },
+                e('div', { className: 'bundle' },
+                    e('label', { htmlFor: 'bundle'}, 'Bundle'),
+                    e('input', {
+                        name: 'bundle',
+                        required: true,
+                        pattern: "[0-9a-f]{20}",
+                        onChange: onBundleChange,
+                        value: bundle,
+                    }),
+                    bundleFetchStatus.fold({
+                        some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
+                        none: () => null,
+                    }),
+                ),
+                e('div', { className: 'file' },
+                    e('label', { htmlFor: 'file' }, 'File'),
+                    e('input', {
+                        name: 'file',
+                        required: true,
+                        pattern: ".+\\.js",
+                        onChange: onFileChange,
+                        value: file
+                    }),
+                    fileFetchStatus.fold({
+                        some: (fetchStatus) => e(ProgressBar, { fetchStatus }),
+                        none: () => null,
+                    }),
+                ),
+                e('div', { className: 'line' },
+                    e('label', { htmlFor: 'line' }, 'Line'),
+                    e('input', {
+                        name: 'line',
+                        required: true,
+                        pattern: "[0-9]+",
+                        onChange: onLineChange,
+                        value: line
+                    }),
+                ),
+                e('div', { className: 'column' },
+                    e('label', { htmlFor: 'column' }, 'Column'),
+                    e('input', {
+                        name: 'column',
+                        required: true,
+                        pattern: "[0-9]+",
+                        onChange: onColumnChange,
+                        value: column
+                    }),
+                ),
+            ),
+            e('div', null,
+                result.fold({
+                    none: () => "Select a bundle, file and line",
+                    some: (value) => e('pre', null, value)
+                })
+            ),
+        );
+    }
+
+    /* Global stuff */
+    const Decoder = {
+        BundlePicker,
+    };
+
+    global.Decoder = Decoder;
+})(window);

--- a/res/decoder-ring/decoder.js
+++ b/res/decoder-ring/decoder.js
@@ -117,7 +117,7 @@
             fetchStatus.fold({
             pending: ({ bytesReceived, length }) => {
                 if (!bytesReceived) {
-                    return e('span', { className: "spinner" }, "⦶");
+                    return e('span', { className: "spinner" }, "\u29b5");
                 }
                 const kB = Math.floor(10 * bytesReceived / 1024) / 10;
                 if (!length) {
@@ -126,9 +126,9 @@
                 const percent = Math.floor(100 * bytesReceived / length);
                 return e('span', null, `Fetching (${kB}kB) ${percent}%`);
             },
-            success: () => e('span', null, `✓`),
+            success: () => e('span', null, "\u2713"),
             error: (reason) => {
-                return e('span', { className: 'error'}, `✗ ${reason}`);
+                return e('span', { className: 'error'}, `\u2717 ${reason}`);
             },
         }));
     }
@@ -145,7 +145,7 @@
         React.useEffect(() => {
             getBundleName().then((name) => {
                 if (bundle === "" && validateBundle(name) !== None) {
-                    setBundle(bundleName);
+                    setBundle(name);
                 }
             }, console.log.bind(console));
         }, []);

--- a/res/decoder-ring/index.html
+++ b/res/decoder-ring/index.html
@@ -1,0 +1,79 @@
+<html>
+    <head>
+        <title>Rageshake decoder ring</title>
+        <script crossorigin src="https://unpkg.com/source-map@0.7.3/dist/source-map.js"></script>
+        <script>
+            sourceMap.SourceMapConsumer.initialize({
+                "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.3/lib/mappings.wasm"
+            });
+        </script>
+        <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+        <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+        <!--<script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+        <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>-->
+        <script crossorigin src="https://unpkg.com/rxjs/bundles/rxjs.umd.min.js"></script>
+        <script src="datatypes.js"></script>
+        <script src="decoder.js"></script>
+
+        <style>
+            @keyframes spin {
+                from {transform:rotate(0deg);}
+                to {transform:rotate(359deg);}
+            }
+
+            body {
+                font-family: sans-serif
+            }
+
+            .spinner {
+                animation: spin 4s infinite linear;
+                display: inline-block;
+                text-align: center;
+                vertical-align: middle;
+                font-size: larger;
+            }
+
+            .progress {
+                padding-left: 0.5em;
+                padding-right: 0.5em;
+            }
+
+            .bundle input {
+                width: 24ex;
+            }
+
+            .valid::after {
+                content: "✓"
+            }
+
+            label {
+                width: 3em;
+                margin-right: 1em;
+                display: inline-block;
+            }
+
+            input:valid {
+                border: 1px solid green;
+            }
+
+            .inputs > div {
+                margin-bottom: 0.5em;
+            }
+        </style>
+    </head>
+    <body>
+        <header><h2>Decoder ring</h2></header>
+        <content id="main">Waiting for javascript to run...</content>
+        <script type="text/javascript">
+            document.addEventListener("DOMContentLoaded", () => {
+                try {
+                    ReactDOM.render(React.createElement(Decoder.BundlePicker), document.getElementById("main"))
+                } catch (e) {
+                    const n = document.createElement("div");
+                    n.innerText = `Error starting: ${e.message}`;
+                    document.getElementById("main").appendChild(n);
+                }
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This relies on sourcemaps existing.

It should autodetect the bundle, so user just has to enter the filename, line and column.

Definitely needs polish, but for now I want to get the core functionality in place.

Since it's a tool, it's got a lot more of my own idiosyncratic style than usual, so, sorry about that.  `fold` is basically a `switch` statement for my datatypes.

This is deliberately written as bare js/html, so I didn't have to figure out an entire build system for this.  This does mean I've written raw element creation for React, rather than using JSX.

The broad design is to use RxJS to handle state changes, and React Hooks for rendering.  I use RxJS to create a stream of values for the result of a `fetch()`, consisting of progress values followed by a final successful chunk of data.  The idea is to feel snappy by providing user feedback as quickly as possible.

Land first.
Relates to https://github.com/vector-im/riot-web/issues/13359