### PR TITLE
Remove invite only padlocks feature flag

### DIFF
--- a/src/components/views/rooms/InviteOnlyIcon.js
+++ b/src/components/views/rooms/InviteOnlyIcon.js
@@ -17,7 +17,6 @@ limitations under the License.
 import React from 'react';
 import { _t } from '../../../languageHandler';
 import * as sdk from '../../../index';
-import SettingsStore from '../../../settings/SettingsStore';
 
 export default class InviteOnlyIcon extends React.Component {
     constructor() {
@@ -38,10 +37,6 @@ export default class InviteOnlyIcon extends React.Component {
 
     render() {
         const classes = this.props.collapsedPanel ? "mx_InviteOnlyIcon_small": "mx_InviteOnlyIcon_large";
-
-        if (!SettingsStore.isFeatureEnabled("feature_invite_only_padlocks")) {
-            return null;
-        }
 
         const Tooltip = sdk.getComponent("elements.Tooltip");
         let tooltip;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -404,7 +404,6 @@
     "Support adding custom themes": "Support adding custom themes",
     "Enable cross-signing to verify per-user instead of per-session": "Enable cross-signing to verify per-user instead of per-session",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
-    "Show padlocks on invite only rooms": "Show padlocks on invite only rooms",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",
     "Use compact timeline layout": "Use compact timeline layout",
     "Show a placeholder for removed messages": "Show a placeholder for removed messages",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -158,12 +158,6 @@ export const SETTINGS = {
         displayName: _td("Show info about bridges in room settings"),
         default: false,
     },
-    "feature_invite_only_padlocks": {
-        isFeature: true,
-        supportedLevels: LEVELS_FEATURE,
-        displayName: _td("Show padlocks on invite only rooms"),
-        default: true,
-    },
     "MessageComposerInput.suggestEmoji": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Enable Emoji suggestions while typing'),


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13366
Requires https://github.com/vector-im/riot-web/pull/13374
Requires https://github.com/vector-im/riot-desktop/pull/77

Only known issue on this is https://github.com/vector-im/riot-web/issues/12148

This has been pre-approved by Product.