### PR TITLE
cap width of editable item list item to leave space for its X button

### DIFF
--- a/res/css/views/elements/_EditableItemList.scss
+++ b/res/css/views/elements/_EditableItemList.scss
@@ -53,6 +53,9 @@ limitations under the License.
 .mx_EditableItem_item {
     flex: auto 1 0;
     order: 1;
+    width: calc(100% - 14px); // leave space for the remove button
+    overflow-x: hidden;
+    text-overflow: ellipsis;
 }
 
 .mx_EditableItemList_label {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13383

![image](https://user-images.githubusercontent.com/2403652/80306727-e8597680-87bc-11ea-8029-6ce689bff128.png)
