### PR TITLE
Re-apply theme after login

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1186,6 +1186,7 @@ export default createReactClass({
      */
     _onLoggedIn: async function() {
         ThemeController.isLogin = false;
+        this._themeWatcher.recheck();
         this.setStateForNewView({ view: VIEWS.LOGGED_IN });
         // If a specific screen is set to be shown after login, show that above
         // all else, as it probably means the user clicked on something already.


### PR DESCRIPTION
This fixes the custom theme not being applied after refreshing after a login.

In some circumstances, we view the last room that was viewed after riot has a valid login and don't go to the home view. So we never call `_viewHome` where we call `this._themeWatcher.recheck()`. I imagine also doing this in `_onLoggedIn` was just forgotten?