### PR TITLE
Make new device toasts appear above review toasts

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -267,6 +267,7 @@ export default class DeviceListener {
                 key: OTHER_DEVICES_TOAST_KEY,
                 title: _t("Review where you’re logged in"),
                 icon: "verification_warning",
+                priority: ToastStore.PRIORITY_LOW,
                 props: {
                     deviceIds: oldUnverifiedDeviceIds,
                 },

--- a/src/stores/ToastStore.js
+++ b/src/stores/ToastStore.js
@@ -39,6 +39,15 @@ export default class ToastStore extends EventEmitter {
         this._toasts = [];
     }
 
+    /**
+     * Add or replace a toast
+     * If a toast with the same toastKey already exists, the given toast will replace it
+     * Toasts are always added underneath any toasts of the same priority, so existing
+     * toasts stay at the top unless a higher priority one arrives (better to not change the
+     * toast unless necessary).
+     *
+     * @param {boject} newToast The new toast
+     */
     addOrReplaceToast(newToast) {
         if (newToast.priority === undefined) newToast.priority = ToastStore.PRIORITY_DEFAULT;
 

--- a/src/stores/ToastStore.js
+++ b/src/stores/ToastStore.js
@@ -20,8 +20,9 @@ import EventEmitter from 'events';
  * Holds the active toasts
  */
 export default class ToastStore extends EventEmitter {
-    static PRIORITY_REALTIME = 1;
-    static PRIORITY_DEFAULT = 0;
+    static PRIORITY_REALTIME = 0;
+    static PRIORITY_DEFAULT = 1;
+    static PRIORITY_LOW = 2;
 
     static sharedInstance() {
         if (!global.mx_ToastStore) global.mx_ToastStore = new ToastStore();
@@ -43,12 +44,9 @@ export default class ToastStore extends EventEmitter {
 
         const oldIndex = this._toasts.findIndex(t => t.key === newToast.key);
         if (oldIndex === -1) {
-            // we only have two priorities so just push realtime ones onto the front
-            if (newToast.priority) {
-                this._toasts.unshift(newToast);
-            } else {
-                this._toasts.push(newToast);
-            }
+            let newIndex = this._toasts.length;
+            while (newIndex > 0 && this._toasts[newIndex - 1].priority > newToast.priority) --newIndex;
+            this._toasts.splice(newIndex, 0, newToast);
         } else {
             this._toasts[oldIndex] = newToast;
         }


### PR DESCRIPTION
...but below incoming verification toasts, which means we now need
to actually handle priority insertion correctly. Oh well.

Fixes https://github.com/vector-im/riot-web/issues/13442