### PR TITLE
Reduce maximum width of toasts & allow multiple lines

### DIFF
--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -91,10 +91,7 @@ limitations under the License.
         }
 
         .mx_Toast_description {
-            max-width: 400px;
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
+            max-width: 272px;
             margin: 4px 0 11px 0;
             font-size: $font-12px;
         }


### PR DESCRIPTION
Before:
<img width="463" alt="Screenshot 2020-04-29 at 16 37 12" src="https://user-images.githubusercontent.com/986903/80621336-0b935880-8a3f-11ea-9a70-39c2ef2b1847.png">

After:
<img width="369" alt="Screenshot 2020-04-29 at 17 24 19" src="https://user-images.githubusercontent.com/986903/80621347-0fbf7600-8a3f-11ea-94fe-5b4c084a6d78.png">

This was probably added to deal with long device names or similar. Toasts no longer contain device names, but here's what it does with a verification request from a long username:
![Uploading Screenshot 2020-04-29 at 17.28.09.png…]()
