### PR TITLE
Fix device verification toasts not disappearing

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -223,7 +223,6 @@ export default class DeviceListener {
                         });
                     }
                 }
-                return;
             } else if (await cli.secretStorageKeyNeedsUpgrade()) {
                 ToastStore.sharedInstance().addOrReplaceToast({
                     key: THIS_DEVICE_TOAST_KEY,


### PR DESCRIPTION
recheck in DeviceListener returned early if cross-signing wasn't
ready, but this was unnecessary and prevented it from hiding the
device verification toasts (which also appeared above the toast
to verify yourself).