### PR TITLE
Only show key backup reminder when confirmed by server to be missing

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -1768,7 +1768,7 @@ export default createReactClass({
         const showRoomRecoveryReminder = (
             SettingsStore.getValue("showRoomRecoveryReminder") &&
             this.context.isRoomEncrypted(this.state.room.roomId) &&
-            !this.context.getKeyBackupEnabled()
+            this.context.getKeyBackupEnabled() === false
         );
 
         const hiddenHighlightCount = this._getHiddenHighlightCount();


### PR DESCRIPTION
The key backup reminder was being shown too eagerly in cases when we hadn't
actually checked with the homeserver on key backup status. This changes to only
show the reminder when we're sure a backup doesn't exist.

Fixes https://github.com/vector-im/riot-web/issues/13404
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1363