### PR TITLE
Wait for user to be verified in e2e setup

### DIFF
--- a/src/DeviceListener.js
+++ b/src/DeviceListener.js
@@ -78,6 +78,8 @@ export default class DeviceListener {
         this._dismissedThisDeviceToast = false;
         this._keyBackupInfo = null;
         this._keyBackupFetchedAt = null;
+        this._ourDeviceIdsAtStart = null;
+        this._displayingToastsForDeviceIds = new Set();
     }
 
     /**

--- a/src/stores/SetupEncryptionStore.js
+++ b/src/stores/SetupEncryptionStore.js
@@ -17,6 +17,7 @@ limitations under the License.
 import EventEmitter from 'events';
 import { MatrixClientPeg } from '../MatrixClientPeg';
 import { accessSecretStorage, AccessCancelledError } from '../CrossSigningManager';
+import { PHASE_DONE as VERIF_PHASE_DONE } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
 
 export const PHASE_INTRO = 0;
 export const PHASE_BUSY = 1;
@@ -39,6 +40,7 @@ export class SetupEncryptionStore extends EventEmitter {
         this.verificationRequest = null;
         this.backupInfo = null;
         MatrixClientPeg.get().on("crypto.verification.request", this.onVerificationRequest);
+        MatrixClientPeg.get().on('userTrustStatusChanged', this._onUserTrustStatusChanged);
     }
 
     stop() {
@@ -51,6 +53,7 @@ export class SetupEncryptionStore extends EventEmitter {
         }
         if (MatrixClientPeg.get()) {
             MatrixClientPeg.get().removeListener("crypto.verification.request", this.onVerificationRequest);
+            MatrixClientPeg.get().removeListener('userTrustStatusChanged', this._onUserTrustStatusChanged);
         }
     }
 
@@ -102,6 +105,15 @@ export class SetupEncryptionStore extends EventEmitter {
         }
     }
 
+    _onUserTrustStatusChanged = async (userId) => {
+        if (userId !== MatrixClientPeg.get().getUserId()) return;
+        const crossSigningReady = await MatrixClientPeg.get().isCrossSigningReady();
+        if (crossSigningReady) {
+            this.phase = PHASE_DONE;
+            this.emit("update");
+        }
+    }
+
     onVerificationRequest = async (request) => {
         if (request.otherUserId !== MatrixClientPeg.get().getUserId()) return;
 
@@ -118,6 +130,14 @@ export class SetupEncryptionStore extends EventEmitter {
         if (this.verificationRequest.cancelled) {
             this.verificationRequest.off("change", this.onVerificationRequestChange);
             this.verificationRequest = null;
+            this.emit("update");
+        } else if (this.verificationRequest.phase === VERIF_PHASE_DONE) {
+            this.verificationRequest.off("change", this.onVerificationRequestChange);
+            this.verificationRequest = null;
+            // At this point, the verification has finished, we just need to wait for
+            // cross signing to be ready to use, so wait for the user trust status to
+            // change.
+            this.phase = PHASE_BUSY;
             this.emit("update");
         }
     }


### PR DESCRIPTION
Wait for our user to become verified and cross-signing to be ready
before declaring that we're finsihed, otherwise we could end up
prompting the user to verify again if we just wait for the verification
itself to complete.

Also a fix to DeviceListener, included because the two fixes together
should fix https://github.com/vector-im/riot-web/issues/13464

May be worth sending this to release branch: it's mostly noticeable
on slow servers.

Fixes https://github.com/vector-im/riot-web/issues/13464
Fixes https://github.com/vector-im/riot-web/issues/13463