### PR TITLE
Don't erase password confirm on registration error

### DIFF
--- a/src/components/views/auth/RegistrationForm.js
+++ b/src/components/views/auth/RegistrationForm.js
@@ -76,7 +76,7 @@ export default createReactClass({
             email: this.props.defaultEmail || "",
             phoneNumber: this.props.defaultPhoneNumber || "",
             password: this.props.defaultPassword || "",
-            passwordConfirm: "",
+            passwordConfirm: this.props.defaultPassword || "",
             passwordComplexity: null,
             passwordSafe: false,
         };


### PR DESCRIPTION
Fixes: https://github.com/vector-im/riot-web/issues/11395

Problem here was that the form gets re-mounted but there wasn't a facility
to preserve the password confirmation field.  Since the form validates
that the passwords are equal, if we mount with a password supplied we
just copy it over.