### PR TITLE
Fix reply RR spacing getting doubled

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -126,7 +126,7 @@ limitations under the License.
 .mx_RoomView_timeline_rr_enabled,
 // on ELS we need the margin to allow interaction with the expand/collapse button which is normally in the RR gutter
 .mx_EventListSummary {
-    .mx_EventTile_line, .mx_EventTile_reply {
+    .mx_EventTile_line {
         /* ideally should be 100px, but 95px gives us a max thumbnail size of 800x600, which is nice */
         margin-right: 110px;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2403652/80914205-fcafed00-8d41-11ea-88bc-2420562c3d28.png)

`.mx_EventTile_reply` is present within `.mx_EventTile_line` so we ended up with two lots of `margin-right: 110px;` which caused too early wrapping in reply bodies

![image](https://user-images.githubusercontent.com/2403652/80914226-194c2500-8d42-11ea-96c7-ad5952e66ce4.png)
