### PR TITLE
Fix slider toggle regression.

### DIFF
--- a/res/css/_font-sizes.scss
+++ b/res/css/_font-sizes.scss
@@ -34,7 +34,7 @@ $font-16px: 1.067rem;
 $font-17px: 1.133rem;
 $font-18px: 1.200rem;
 $font-19px: 1.267rem;
-$font-20px: 1.333rem;
+$font-20px: 1.3333333rem;
 $font-21px: 1.400rem;
 $font-22px: 1.467rem;
 $font-23px: 1.533rem;

--- a/res/css/views/elements/_ToggleSwitch.scss
+++ b/res/css/views/elements/_ToggleSwitch.scss
@@ -24,11 +24,6 @@ limitations under the License.
 
     background-color: $togglesw-off-color;
     opacity: 0.5;
-
-    display: flex;
-    flex-direction: row;
-    flex: 0 0 auto;
-    align-items: center;
 }
 
 .mx_ToggleSwitch_enabled {
@@ -38,16 +33,18 @@ limitations under the License.
 
 .mx_ToggleSwitch.mx_ToggleSwitch_on {
     background-color: $togglesw-on-color;
+
+    > .mx_ToggleSwitch_ball {
+        left: calc(100% - $font-20px);
+    }
 }
 
 .mx_ToggleSwitch_ball {
-    transition: left 0.15s ease-out 0.1s;
+    position: relative;
     width: $font-20px;
     height: $font-20px;
     border-radius: $font-20px;
     background-color: $togglesw-ball-color;
-}
-
-.mx_ToggleSwitch_on {
-    flex-direction: row-reverse;
+    transition: left 0.15s ease-out 0.1s;
+    left: 0;
 }


### PR DESCRIPTION
The left right toggle animation was broken due to the font scaling pr. This fixes that.

![toggle](https://user-images.githubusercontent.com/23084468/80998940-b50d8c00-8e3b-11ea-99f4-4df7cf219580.gif)


Fixes https://github.com/vector-im/riot-web/issues/13491