### PR TITLE
Don't try to reload profile information when closing the user panel

### DIFF
--- a/src/components/structures/RightPanel.js
+++ b/src/components/structures/RightPanel.js
@@ -227,7 +227,7 @@ export default class RightPanel extends React.Component {
                         if (this.props.user) {
                             // If we have a user prop then we're displaying a user from the 'user' page type
                             // in LoggedInView, so need to change the page type to close the panel (we switch
-                            // to the home page which is not obviosuly the correct thing to do, but I'm not sure
+                            // to the home page which is not obviously the correct thing to do, but I'm not sure
                             // anything else is - we could hide the close button altogether?)
                             dis.dispatch({
                                 action: "view_home_page",

--- a/src/components/structures/UserView.js
+++ b/src/components/structures/UserView.js
@@ -42,7 +42,10 @@ export default class UserView extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.userId !== this.props.userId) {
+        // XXX: We shouldn't need to null check the userId here, but we declare
+        // it as optional and MatrixChat sometimes fires in a way which results
+        // in an NPE when we try to update the profile info.
+        if (prevProps.userId !== this.props.userId && this.props.userId) {
             this._loadProfileInfo();
         }
     }

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -112,7 +112,10 @@ export default class SecurityUserSettingsTab extends React.Component {
     };
 
     _onGoToUserProfileClick = () => {
-        window.location.href = "#/user/" + MatrixClientPeg.get().getUserId();
+        dis.dispatch({
+            action: 'view_user_info',
+            userId: MatrixClientPeg.get().getUserId(),
+        });
         this.props.closeSettingsFn();
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13479

This looks to have been caused by something to do with the app load order, though where is a mystery. The view change seems to fire for the same page type despite a dispatch that says to change the view type.

Instead of debugging it too much further, we'll just patch around it.

This commit also makes the settings link use a more safe approach to viewing the user info - not going through the dispatcher means we are at the mercy of browser behaviour when we already have a loop which deals with this.