### PR TITLE
Remove prefixes for composer avatar urls

### DIFF
--- a/src/editor/parts.js
+++ b/src/editor/parts.js
@@ -259,7 +259,7 @@ class RoomPillPart extends PillPart {
             "crop");
         if (!avatarUrl) {
             initialLetter = Avatar.getInitialLetter(this._room ? this._room.name : this.resourceId);
-            avatarUrl = `../../${Avatar.defaultAvatarUrlForString(this._room ? this._room.roomId : this.resourceId)}`;
+            avatarUrl = Avatar.defaultAvatarUrlForString(this._room ? this._room.roomId : this.resourceId);
         }
         this._setAvatarVars(node, avatarUrl, initialLetter);
     }
@@ -291,18 +291,13 @@ class UserPillPart extends PillPart {
         }
         const name = this._member.name || this._member.userId;
         const defaultAvatarUrl = Avatar.defaultAvatarUrlForString(this._member.userId);
-        let avatarUrl = Avatar.avatarUrlForMember(
+        const avatarUrl = Avatar.avatarUrlForMember(
             this._member,
             16 * window.devicePixelRatio,
             16 * window.devicePixelRatio,
             "crop");
         let initialLetter = "";
         if (avatarUrl === defaultAvatarUrl) {
-            // the url from defaultAvatarUrlForString is meant to go in an img element,
-            // which has the base of the document. we're using it in css,
-            // which has the base of the theme css file, two levels deeper than the document,
-            // so go up to the level of the document.
-            avatarUrl = `../../${avatarUrl}`;
             initialLetter = Avatar.getInitialLetter(name);
         }
         this._setAvatarVars(node, avatarUrl, initialLetter);


### PR DESCRIPTION
As we're using data urls now for default avatars.

Fixes https://github.com/vector-im/riot-web/issues/13478