### PR TITLE
set the meta tag for theme-color to the same theme css background

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -242,6 +242,10 @@ export async function setTheme(theme) {
                 if (a == styleElements[stylesheetName]) return;
                 a.disabled = true;
             });
+            const bodyStyles = global.getComputedStyle(document.getElementsByTagName("body")[0]);
+            if (bodyStyles.backgroundColor) {
+                document.querySelector('meta[name="theme-color"]').content = bodyStyles.backgroundColor;
+            }
             Tinter.setTheme(theme);
             resolve();
         };


### PR DESCRIPTION
closes vector-im/riot-web#13536

Signed-off-by: Dan Jenkins <dan@nimblea.pe>