### PR TITLE
Fix right panel hiding when viewing room member

### DIFF
--- a/src/stores/RightPanelStore.js
+++ b/src/stores/RightPanelStore.js
@@ -139,7 +139,7 @@ export default class RightPanelStore extends Store {
                 let targetPhase = payload.phase;
                 let refireParams = payload.refireParams;
                 // redirect to EncryptionPanel if there is an ongoing verification request
-                if (targetPhase === RIGHT_PANEL_PHASES.RoomMemberInfo) {
+                if (targetPhase === RIGHT_PANEL_PHASES.RoomMemberInfo && payload.refireParams) {
                     const {member} = payload.refireParams;
                     const pendingRequest = pendingVerificationRequestForUser(member);
                     if (pendingRequest) {


### PR DESCRIPTION
If you clicked on the header button whilst the right panel was
showing a room member, it would NPE because there was no
refireParams.member. It fires the same phase with no refireParams to
toggle the panel visibility (apparently), so detect that case.

Fixes https://github.com/vector-im/riot-web/issues/13571