### PR TITLE
Add unicode-bidi isolate to a.mx_Pill

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -19,6 +19,7 @@ a.mx_Pill {
     white-space: nowrap;
     overflow: hidden;
     max-width: calc(100% - 1ch);
+    unicode-bidi: isolate;
 }
 
 .mx_Pill {


### PR DESCRIPTION
Fixes a rendering bug where a username or room name with unicode control characters would effect the entire message.

![pre-patch](https://user-images.githubusercontent.com/16590431/81505971-27261b00-92eb-11ea-87af-b92d13ff0dfb.png)
![post-patch](https://user-images.githubusercontent.com/16590431/81505969-255c5780-92eb-11ea-805e-aebef4a84adb.png)