### PR TITLE
Fix topic dialog not supporting escape as it didn't have a "Close"

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -365,6 +365,7 @@ export const Commands = [
             Modal.createTrackedDialog('Slash Commands', 'Topic', InfoDialog, {
                 title: room.name,
                 description: <div dangerouslySetInnerHTML={{ __html: topicHtml }} />,
+                hasCloseButton: true,
             });
             return success();
         },


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13452