### PR TITLE
Updated link and added:Yarn two is not yet used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Development
 Ensure you have the latest LTS version of Node.js installed.
 
 Using `yarn` instead of `npm` is recommended. Please see the Yarn [install
-guide](https://yarnpkg.com/docs/install/) if you do not have it already.
+guide](https://classic.yarnpkg.com/en/docs/install) to "Yarn 1" if you do not have it already. This project has not yet been migrated to Yarn 2, so please ensure yarn --version shows a version from the 1.x series.
 
 `matrix-react-sdk` depends on `matrix-js-sdk`. To make use of changes in the
 latter and to ensure tests run against the develop branch of `matrix-js-sdk`,


### PR DESCRIPTION
the link was broken and there was no mention of the version of yarn being used.