### PR TITLE
UserView, show Welcome page in the mid panel instead of empty space

### DIFF
--- a/src/components/structures/UserView.js
+++ b/src/components/structures/UserView.js
@@ -22,6 +22,7 @@ import {MatrixClientPeg} from "../../MatrixClientPeg";
 import * as sdk from "../../index";
 import Modal from '../../Modal';
 import { _t } from '../../languageHandler';
+import HomePage from "./HomePage";
 
 export default class UserView extends React.Component {
     static get propTypes() {
@@ -79,7 +80,7 @@ export default class UserView extends React.Component {
             const RightPanel = sdk.getComponent('structures.RightPanel');
             const MainSplit = sdk.getComponent('structures.MainSplit');
             const panel = <RightPanel user={this.state.member} />;
-            return (<MainSplit panel={panel}><div style={{flex: "1"}} /></MainSplit>);
+            return (<MainSplit panel={panel}><HomePage /></MainSplit>);
         } else {
             return (<div />);
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13421

![image](https://user-images.githubusercontent.com/2403652/81802836-b3645800-950e-11ea-8ab8-66d656c1f080.png)
![image](https://user-images.githubusercontent.com/2403652/81802837-b4958500-950e-11ea-81bd-1473c8b4367c.png)
![image](https://user-images.githubusercontent.com/2403652/81802843-b5c6b200-950e-11ea-819e-c7beb4c9f4f6.png)
