### PR TITLE
Fix persistent widgets on desktop / http

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -430,7 +430,7 @@ export default class AppTile extends React.Component {
         // is used for is to determine the origin we're talking to, and therefore we don't need the
         // fully templated URL.
         const widgetMessaging = new WidgetMessaging(
-            this.props.app.id, this.props.app.url, this.props.userWidget, this._appFrame.current.contentWindow);
+            this.props.app.id, this._getRenderedUrl(), this.props.userWidget, this._appFrame.current.contentWindow);
         ActiveWidgetStore.setWidgetMessaging(this.props.app.id, widgetMessaging);
         widgetMessaging.getCapabilities().then((requestedCapabilities) => {
             console.log(`Widget ${this.props.app.id} requested capabilities: ` + requestedCapabilities);


### PR DESCRIPTION
WidgetMessaging needs the URL of the widget that gets rendered into
the iframe because that's where the postmessages will be coming from.

Fixes https://github.com/vector-im/riot-web/issues/13369