### PR TITLE
Re-fix OpenID requests from widgets

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -424,13 +424,13 @@ export default class AppTile extends React.Component {
     _setupWidgetMessaging() {
         // FIXME: There's probably no reason to do this here: it should probably be done entirely
         // in ActiveWidgetStore.
-
-        // We use the app's URL over the rendered URL so that anything the widget does which could
-        // lead to requesting a "security key" will pass accordingly. The only other thing this URL
-        // is used for is to determine the origin we're talking to, and therefore we don't need the
-        // fully templated URL.
         const widgetMessaging = new WidgetMessaging(
-            this.props.app.id, this._getRenderedUrl(), this.props.userWidget, this._appFrame.current.contentWindow);
+            this.props.app.id,
+            this.props.app.url,
+            this._getRenderedUrl(),
+            this.props.userWidget,
+            this._appFrame.current.contentWindow,
+        );
         ActiveWidgetStore.setWidgetMessaging(this.props.app.id, widgetMessaging);
         widgetMessaging.getCapabilities().then((requestedCapabilities) => {
             console.log(`Widget ${this.props.app.id} requested capabilities: ` + requestedCapabilities);


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/4591 reverted
https://github.com/matrix-org/matrix-react-sdk/pull/4459. We need
to pass both URLs as we need both the wURL (for the widget's 'identity'
ie. OpenID) and the URL that's actually in the iframe (for the
messaging).