### PR TITLE
Fix message edits dialog being wrong and sometimes crashing

### DIFF
--- a/src/utils/MessageDiffUtils.js
+++ b/src/utils/MessageDiffUtils.js
@@ -77,8 +77,6 @@ function findRefNodes(root, route, isAddition) {
     const end = isAddition ? route.length - 1 : route.length;
     for (let i = 0; i < end; ++i) {
         refParentNode = refNode;
-        // Lists don't have appropriate child nodes we can use.
-        if (!refNode.childNodes[route[i]]) continue;
         refNode = refNode.childNodes[route[i]];
     }
     return {refNode, refParentNode};
@@ -190,10 +188,11 @@ function renderDifferenceInDOM(originalRootNode, diff, diffMathPatch) {
             break;
         }
         case "addTextElement": {
-            if (diff.value !== "\n") {
-                const insNode = wrapInsertion(stringAsTextNode(diff.value));
-                insertBefore(refParentNode, refNode, insNode);
-            }
+            // XXX: sometimes diffDOM says insert a newline when there shouldn't be one
+            // but we must insert the node anyway so that we don't break the route child IDs.
+            // See https://github.com/fiduswriter/diffDOM/issues/100
+            const insNode = wrapInsertion(stringAsTextNode(diff.value !== "\n" ? diff.value : ""));
+            insertBefore(refParentNode, refNode, insNode);
             break;
         }
         // e.g. when changing a the href of a link,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11661

# Story

The above issue is a regression caused by https://github.com/matrix-org/matrix-react-sdk/pull/3680
That PR solved the issue by masking over it without actually resolving the underlying cause and in fact that caused this regression.

diffDOM has some issues, namely one with adding redundant whitespace: https://github.com/fiduswriter/diffDOM/issues/100
We tried to work around this by not adding these newlines to the DOM but that would then offset all child IDs.

This issue fixes that so additionally fixes the diff for lists which was previously wrong:
![image](https://user-images.githubusercontent.com/2403652/81948240-6e692000-95f9-11ea-96f4-c71569e590ea.png)
Now:
![image](https://user-images.githubusercontent.com/2403652/81948253-71fca700-95f9-11ea-99a8-508520b9c04c.png)


Due to https://github.com/fiduswriter/diffDOM/issues/100 the spurious newline is there. diffDOM also doesn't always calculate the simplest diff but at least now its pretty much correct & doesn't crash.