### PR TITLE
Remove SSSS key upgrade check from rageshake

### DIFF
--- a/src/rageshake/submit-rageshake.ts
+++ b/src/rageshake/submit-rageshake.ts
@@ -133,7 +133,6 @@ export default async function sendBugReport(bugReportEndpoint: string, opts: IOp
             body.append("cross_signing_supported_by_hs",
                 String(await client.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")));
             body.append("cross_signing_ready", String(await client.isCrossSigningReady()));
-            body.append("ssss_key_needs_upgrade", String(await client.secretStorageKeyNeedsUpgrade()));
         }
     }
 


### PR DESCRIPTION
This code doesn't exist anymore as the SSSS symmetric upgrade stuff
has been removed (https://github.com/matrix-org/matrix-js-sdk/pull/1373).

Fixes https://github.com/vector-im/riot-web/issues/13715