### PR TITLE
Add a checkpoint to index newly encrypted rooms.

### DIFF
--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -135,6 +135,19 @@ export default abstract class BaseEventIndexManager {
     }
 
     /**
+     * Check if the room with the given id is already indexed.
+     *
+     * @param {string} roomId The ID of the room which we want to check if it
+     * has been already indexed.
+     *
+     * @return {Promise<boolean>} Returns true if the index contains events for
+     * the given room, false otherwise.
+     */
+    isRoomIndexed(roomId: string): Promise<boolean> {
+        throw new Error("Unimplemented");
+    }
+
+    /**
      * Get statistical information of the index.
      *
      * @return {Promise<IndexStats>} A promise that will resolve to the index

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -244,8 +244,8 @@ export default class EventIndex extends EventEmitter {
         if (room === null) return;
         if (!MatrixClientPeg.get().isRoomEncrypted(room.roomId)) return;
 
-        console.log("EventIndex: Added checkpoint because of a limited timeline",
-            backwardsCheckpoint);
+        console.log("EventIndex: Adding a checkpoint because of a limited timeline",
+            room.roomId);
 
         this.addRoomCheckpoint(room.roomId, false);
     }
@@ -314,7 +314,7 @@ export default class EventIndex extends EventEmitter {
     }
 
     async addEventsFromLiveTimeline(timeline) {
-        let events = timeline.getEvents();
+        const events = timeline.getEvents();
 
         for (let i = 0; i < events.length; i++) {
             const ev = events[i];
@@ -330,9 +330,9 @@ export default class EventIndex extends EventEmitter {
         if (!room) return;
 
         const timeline = room.getLiveTimeline();
-        let token = timeline.getPaginationToken("b");
+        const token = timeline.getPaginationToken("b");
 
-        if(!token) {
+        if (!token) {
             // The room doesn't contain any tokens, meaning the live timeline
             // contains all the events, add those to the index.
             await this.addEventsFromLiveTimeline(timeline);
@@ -348,7 +348,7 @@ export default class EventIndex extends EventEmitter {
 
         console.log("EventIndex: Adding checkpoint", checkpoint);
 
-        try{
+        try {
             await indexManager.addCrawlerCheckpoint(checkpoint);
         } catch (e) {
             console.log("EventIndex: Error adding new checkpoint for room",

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -302,7 +302,7 @@ export default class EventIndex extends EventEmitter {
             avatar_url: ev.sender.getMxcAvatarUrl(),
         };
 
-        indexManager.addEventToIndex(e, profile);
+        await indexManager.addEventToIndex(e, profile);
     }
 
     /**

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -200,7 +200,7 @@ export default class EventIndex extends EventEmitter {
         if (!MatrixClientPeg.get().isRoomEncrypted(state.roomId)) return;
 
         if (ev.getType() === "m.room.encryption" && !await this.isRoomIndexed(state.roomId)) {
-            console.log("EventIndex: Adding a checkpoint for a newly encrypted room", room.roomId);
+            console.log("EventIndex: Adding a checkpoint for a newly encrypted room", state.roomId);
             this.addRoomCheckpoint(state.roomId, true);
         }
     }


### PR DESCRIPTION
This intends to fix https://github.com/vector-im/riot-web/issues/13682, it waits for `m.room.encryption` events in the timeline and indexes a room if one is received. Though if a limited timeline was received the `m.room.encryption` event will be missed.

A suggestion was made to use the `RoomState.events` event and catch a `m.room.encryption` event there, but due to the way our locally cached sync gets stored/restored that event will be fired every time Riot gets started.

Suggestions on how to handle a limited sync there are welcome.