### PR TITLE
Fix key backup restore with SSSS

### DIFF
--- a/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
+++ b/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
@@ -201,7 +201,7 @@ export default class RestoreKeyBackupDialog extends React.PureComponent {
             // `accessSecretStorage` may prompt for storage access as needed.
             const recoverInfo = await accessSecretStorage(async () => {
                 return MatrixClientPeg.get().restoreKeyBackupWithSecretStorage(
-                    this.state.backupInfo,
+                    this.state.backupInfo, undefined, undefined,
                     { progressCallback: this._progressCallback },
                 );
             });


### PR DESCRIPTION
The room / session ID params come after the backupInfo for restoring
from SSSS so the options object was being passed into the wrong param.
Roll on TypeScript.

This meant restoring backups worked fine when the key was cached but
failed when it wasn't.

Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/4507