### PR TITLE
Improve style of toasts to match Figma

### DIFF
--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -99,9 +99,10 @@ limitations under the License.
             }
 
             span {
+                padding-left: 8px;
                 float: right;
                 font-size: $font-12px;
-                line-height: $font-21px;
+                line-height: $font-22px;
                 color: $muted-fg-color;
             }
         }

--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -46,7 +46,6 @@ limitations under the License.
         column-gap: 10px;
         row-gap: 4px;
         padding: 8px;
-        padding-right: 16px;
 
         &.mx_Toast_hasIcon {
             &::after {
@@ -68,12 +67,27 @@ limitations under the License.
                 background-image: url("$(res)/img/e2e/warning.svg");
             }
 
-            h2, .mx_Toast_body {
+            .mx_Toast_title, .mx_Toast_body {
                 grid-column: 2;
             }
         }
+        &:not(.mx_Toast_hasIcon) {
+            padding-left: 12px;
+
+            .mx_Toast_title {
+                grid-column: 1 / -1;
+            }
+        }
+
+        .mx_Toast_title,
+        .mx_Toast_description {
+            padding-right: 8px;
+        }
 
         .mx_Toast_title {
+            width: 100%;
+            box-sizing: border-box;
+
             h2 {
                 grid-column: 1 / 3;
                 grid-row: 1;

--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -42,8 +42,8 @@ limitations under the License.
         border-radius: 8px;
         overflow: hidden;
         display: grid;
-        grid-template-columns: 20px 1fr;
-        column-gap: 10px;
+        grid-template-columns: 22px 1fr;
+        column-gap: 8px;
         row-gap: 4px;
         padding: 8px;
 
@@ -96,6 +96,7 @@ limitations under the License.
                 font-weight: 600;
                 display: inline;
                 width: auto;
+                vertical-align: middle;
             }
 
             span {

--- a/res/css/structures/_ToastContainer.scss
+++ b/res/css/structures/_ToastContainer.scss
@@ -28,8 +28,8 @@ limitations under the License.
         margin: 0 4px;
         grid-row: 2 / 4;
         grid-column: 1;
-        background-color: white;
-        box-shadow: 0px 4px 12px $menu-box-shadow-color;
+        background-color: $dark-panel-bg-color;
+        box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.5);
         border-radius: 8px;
     }
 
@@ -37,8 +37,8 @@ limitations under the License.
         grid-row: 1 / 3;
         grid-column: 1;
         color: $primary-fg-color;
-        background-color: $primary-bg-color;
-        box-shadow: 0px 4px 12px $menu-box-shadow-color;
+        background-color: $dark-panel-bg-color;
+        box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.5);
         border-radius: 8px;
         overflow: hidden;
         display: grid;
@@ -73,12 +73,23 @@ limitations under the License.
             }
         }
 
-        h2 {
-            grid-column: 1 / 3;
-            grid-row: 1;
-            margin: 0;
-            font-size: $font-15px;
-            font-weight: 600;
+        .mx_Toast_title {
+            h2 {
+                grid-column: 1 / 3;
+                grid-row: 1;
+                margin: 0;
+                font-size: $font-15px;
+                font-weight: 600;
+                display: inline;
+                width: auto;
+            }
+
+            span {
+                float: right;
+                font-size: $font-12px;
+                line-height: $font-21px;
+                color: $muted-fg-color;
+            }
         }
 
         .mx_Toast_body {
@@ -87,7 +98,13 @@ limitations under the License.
         }
 
         .mx_Toast_buttons {
+            float: right;
             display: flex;
+
+            .mx_FormButton {
+                min-width: 96px;
+                box-sizing: border-box;
+            }
         }
 
         .mx_Toast_description {
@@ -96,6 +113,15 @@ limitations under the License.
             text-overflow: ellipsis;
             margin: 4px 0 11px 0;
             font-size: $font-12px;
+
+            .mx_AccessibleButton_kind_link {
+                font-size: inherit;
+                padding: 0;
+            }
+
+            a {
+                text-decoration: none;
+            }
         }
 
         .mx_Toast_deviceID {

--- a/src/components/structures/ToastContainer.js
+++ b/src/components/structures/ToastContainer.js
@@ -50,7 +50,11 @@ export default class ToastContainer extends React.Component {
                 "mx_Toast_hasIcon": icon,
                 [`mx_Toast_icon_${icon}`]: icon,
             });
-            const countIndicator = isStacked ? _t(" (1/%(totalCount)s)", {totalCount}) : null;
+
+            let countIndicator;
+            if (isStacked) {
+                countIndicator = `1/${totalCount}`;
+            }
 
             const toastProps = Object.assign({}, props, {
                 key,

--- a/src/components/structures/ToastContainer.js
+++ b/src/components/structures/ToastContainer.js
@@ -52,7 +52,7 @@ export default class ToastContainer extends React.Component {
 
             let countIndicator;
             if (isStacked) {
-                countIndicator = `1/${totalCount}`;
+                countIndicator = `(1/${totalCount})`;
             }
 
             const toastProps = Object.assign({}, props, {

--- a/src/components/structures/ToastContainer.js
+++ b/src/components/structures/ToastContainer.js
@@ -57,7 +57,10 @@ export default class ToastContainer extends React.Component {
                 toastKey: key,
             });
             toast = (<div className={toastClasses}>
-                <h2>{title}{countIndicator}</h2>
+                <div className="mx_Toast_title">
+                    <h2>{title}</h2>
+                    <span>{countIndicator}</span>
+                </div>
                 <div className="mx_Toast_body">{React.createElement(component, toastProps)}</div>
             </div>);
         }

--- a/src/components/structures/ToastContainer.js
+++ b/src/components/structures/ToastContainer.js
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import * as React from "react";
-import { _t } from '../../languageHandler';
 import ToastStore from "../../stores/ToastStore";
 import classNames from "classnames";
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2073,7 +2073,6 @@
     "Tried to load a specific point in this room's timeline, but you do not have permission to view the message in question.": "Tried to load a specific point in this room's timeline, but you do not have permission to view the message in question.",
     "Tried to load a specific point in this room's timeline, but was unable to find it.": "Tried to load a specific point in this room's timeline, but was unable to find it.",
     "Failed to load timeline position": "Failed to load timeline position",
-    " (1/%(totalCount)s)": " (1/%(totalCount)s)",
     "Guest": "Guest",
     "Your profile": "Your profile",
     "Uploading %(filename)s and %(count)s others|other": "Uploading %(filename)s and %(count)s others",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11914
Fixes https://github.com/vector-im/riot-web/issues/11923
Subset of https://github.com/matrix-org/matrix-react-sdk/pull/4609


icon-less variant for future use
![image](https://user-images.githubusercontent.com/2403652/82579721-1c3e7680-9b86-11ea-9e49-c21b5a8fe205.png)

![image](https://user-images.githubusercontent.com/2403652/82583886-9b827900-9b8b-11ea-912a-31dcd58757ec.png)
![image](https://user-images.githubusercontent.com/2403652/82583761-670ebd00-9b8b-11ea-823f-2817ee7d9c98.png)





+ min-width of buttons
+ update style of the toast counter to be right-aligned, muted and smaller
+ disable text decoration of links inside the toasts
+ fix background colour, stacking background and the drop shadow
+ fixes padding to match Figma