### PR TITLE
Fix visibility of message timestamps

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -98,6 +98,7 @@ limitations under the License.
 
 .mx_EventTile .mx_MessageTimestamp {
     display: block;
+    visibility: hidden;
     white-space: nowrap;
     left: 0px;
     text-align: center;
@@ -158,10 +159,16 @@ limitations under the License.
 }
 
 // Explicit relationships so that it doesn't apply to nested EventTile components (e.g in Replies)
+// The first set is to handle the 'group layout' (default) and the second for the IRC layout
 .mx_EventTile_last > div > a > .mx_MessageTimestamp,
 .mx_EventTile:hover > div > a > .mx_MessageTimestamp,
 .mx_EventTile.mx_EventTile_actionBarFocused > div > a > .mx_MessageTimestamp,
-.mx_EventTile.focus-visible:focus-within > div > a > .mx_MessageTimestamp {
+.mx_EventTile.focus-visible:focus-within > div > a > .mx_MessageTimestamp,
+
+.mx_IRCLayout .mx_EventTile_last > a > .mx_MessageTimestamp,
+.mx_IRCLayout .mx_EventTile:hover > a > .mx_MessageTimestamp,
+.mx_IRCLayout .mx_EventTile.mx_EventTile_actionBarFocused > a > .mx_MessageTimestamp,
+.mx_IRCLayout .mx_EventTile.focus-visible:focus-within > a > .mx_MessageTimestamp {
     visibility: visible;
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -164,7 +164,6 @@ limitations under the License.
 .mx_EventTile:hover > div > a > .mx_MessageTimestamp,
 .mx_EventTile.mx_EventTile_actionBarFocused > div > a > .mx_MessageTimestamp,
 .mx_EventTile.focus-visible:focus-within > div > a > .mx_MessageTimestamp,
-
 .mx_IRCLayout .mx_EventTile_last > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile:hover > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile.mx_EventTile_actionBarFocused > a > .mx_MessageTimestamp,

--- a/res/css/views/rooms/_GroupLayout.scss
+++ b/res/css/views/rooms/_GroupLayout.scss
@@ -34,7 +34,6 @@ $left-gutter: 65px;
         }
 
         .mx_MessageTimestamp {
-            visibility: hidden;
             position: absolute;
             width: 46px; /* 8 + 30 (avatar) + 8 */
         }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1127,7 +1127,6 @@
     "Low priority": "Low priority",
     "Historical": "Historical",
     "System Alerts": "System Alerts",
-    "Create room": "Create room",
     "This room": "This room",
     "Joining room …": "Joining room …",
     "Loading …": "Loading …",


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13736
Fixes https://github.com/vector-im/riot-web/issues/13759

~~This also fixes an unreported but complained about issue regarding the 'always show timestamps' option not working.~~

Looks like this regressed in https://github.com/matrix-org/matrix-react-sdk/pull/4531 when things got shuffled around.