### PR TITLE
Fix Emoji Picker footer being too small if text overflows

### DIFF
--- a/res/css/views/emojipicker/_EmojiPicker.scss
+++ b/res/css/views/emojipicker/_EmojiPicker.scss
@@ -190,7 +190,7 @@ limitations under the License.
 
 .mx_EmojiPicker_footer {
     border-top: 1px solid $message-action-bar-border-color;
-    height: 72px;
+    min-height: 72px;
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13754

![image](https://user-images.githubusercontent.com/2403652/82762486-3764ec80-9df9-11ea-8f65-eb4337f42414.png)

makes it grow only if it needs to