### PR TITLE
Fix event highlights not being updated to reflect edits

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -403,7 +403,7 @@ export default createReactClass({
     },
 
     shouldHighlight: function() {
-        const actions = this.context.getPushActionsForEvent(this.props.mxEvent);
+        const actions = this.context.getPushActionsForEvent(this.props.mxEvent.replacingEvent() || this.props.mxEvent);
         if (!actions || !actions.tweaks) { return false; }
 
         // don't show self-highlights from another of our clients


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13733

![image](https://user-images.githubusercontent.com/2403652/82825919-05f52b00-9ea4-11ea-8742-a50a5167a0e9.png)

See the event highlighted in the blurred background