### PR TITLE
Revert default font size to 15px

### DIFF
--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -180,7 +180,7 @@ export const SETTINGS = {
     "fontSize": {
         displayName: _td("Font size"),
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
-        default: 16,
+        default: 15,
         controller: new FontSizeController(),
     },
     "useCustomFontSize": {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13785