### PR TITLE
Use connection error to detect network problem

### DIFF
--- a/src/stores/RoomViewStore.js
+++ b/src/stores/RoomViewStore.js
@@ -273,9 +273,7 @@ class RoomViewStore extends Store {
             });
             let msg = err.message ? err.message : JSON.stringify(err);
             console.log("Failed to join room:", msg);
-            // XXX: We are relying on the error message returned by browsers here.
-            // This isn't great, but it does generalize the error being shown to users.
-            if (msg && msg.startsWith("CORS request rejected")) {
+            if (err.name === "ConnectionError") {
                 msg = _t("There was an error joining the room");
             }
             if (err.errcode === 'M_INCOMPATIBLE_ROOM_VERSION') {


### PR DESCRIPTION
This stopped working since https://github.com/matrix-org/matrix-js-sdk/pull/1345 where ConnectionError was introduced. Use that to detect a network problem.