### PR TITLE
Fix sublist sizing regression

### DIFF
--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -20,7 +20,7 @@ limitations under the License.
     flex-direction: row;
     align-items: center;
     cursor: pointer;
-    height: 32px;
+    height: 34px;
     margin: 0;
     padding: 0 8px 0 10px;
     position: relative;


### PR DESCRIPTION
fixes: https://github.com/vector-im/riot-web/issues/13748

Just a px value mismatch. Would be nicer to get the item height from the components in the list. 