### PR TITLE
Fix encryption icon miss-alignment

### DIFF
--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -41,7 +41,7 @@ $irc-line-height: $font-18px;
         }
 
         > .mx_EventTile_msgOption {
-            order: 4;
+            order: 5;
             flex-shrink: 0;
         }
 
@@ -90,12 +90,14 @@ $irc-line-height: $font-18px;
             text-align: right;
         }
 
-        .mx_EventTile_e2eIcon {
+        > .mx_EventTile_e2eIcon {
             position: relative;
             right: unset;
             left: unset;
-            top: -2px;
             padding: 0;
+            order: 3;
+            flex-shrink: 0;
+            flex-grow: 0;
         }
 
         .mx_EventTile_line {
@@ -113,7 +115,7 @@ $irc-line-height: $font-18px;
         }
 
         .mx_EventTile_reply {
-            order: 3;
+            order: 4;
         }
 
         .mx_EditMessageComposer_buttons {

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -802,6 +802,8 @@ export default createReactClass({
 
         const groupTimestamp = !this.props.useIRCLayout ? linkedTimestamp : null;
         const ircTimestamp = this.props.useIRCLayout ? linkedTimestamp : null;
+        const groupPadlock = !this.props.useIRCLayout && !isBubbleMessage && this._renderE2EPadlock();
+        const ircPadlock = this.props.useIRCLayout && !isBubbleMessage && this._renderE2EPadlock();
 
         switch (this.props.tileShape) {
             case 'notif': {
@@ -873,9 +875,10 @@ export default createReactClass({
                         { ircTimestamp }
                         { avatar }
                         { sender }
+                        { ircPadlock }
                         <div className="mx_EventTile_reply">
                             { groupTimestamp }
-                            { !isBubbleMessage && this._renderE2EPadlock() }
+                            { groupPadlock }
                             { thread }
                             <EventTileType ref={this._tile}
                                            mxEvent={this.props.mxEvent}
@@ -904,9 +907,10 @@ export default createReactClass({
                             { readAvatars }
                         </div>
                         { sender }
+                        { ircPadlock }
                         <div className="mx_EventTile_line">
                             { groupTimestamp }
-                            { !isBubbleMessage && this._renderE2EPadlock() }
+                            { groupPadlock }
                             { thread }
                             <EventTileType ref={this._tile}
                                            mxEvent={this.props.mxEvent}


### PR DESCRIPTION
fixes: https://github.com/vector-im/riot-web/issues/13721

![image](https://user-images.githubusercontent.com/23084468/82930270-04e3fc80-9f7d-11ea-82cd-347c03d15460.png)
