### PR TITLE
EventIndex: Handle invalid m.room.redaction events correctly.

### DIFF
--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -512,8 +512,7 @@ export default class EventIndex extends EventEmitter {
                     if (eventId) {
                         await indexManager.deleteEvent(eventId);
                     } else {
-                        console.log("EventIndex: Redaction event doesn't contain a",
-                                    "valid associated event id", ev);
+                        console.warn("EventIndex: Redaction event doesn't contain a valid associated event id", ev);
                     }
                 }
 

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -507,7 +507,14 @@ export default class EventIndex extends EventEmitter {
             try {
                 for (let i = 0; i < redactionEvents.length; i++) {
                     const ev = redactionEvents[i];
-                    await indexManager.deleteEvent(ev.getAssociatedId());
+                    const eventId = ev.getAssociatedId();
+
+                    if (eventId) {
+                        await indexManager.deleteEvent(eventId);
+                    } else {
+                        console.log("EventIndex: Redaction event doesn't contain a",
+                                    "valid associated event id", ev);
+                    }
                 }
 
                 const eventsAlreadyAdded = await indexManager.addHistoricEvents(


### PR DESCRIPTION
Clients might send invalid redaction events, such events will not have a
valid redacts field containing the event id of the associated event that
was redacted.

Skip such events instead of ending up looping over the checkpoint
forever.