### PR TITLE
Fix the 'complete security' screen

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1900,7 +1900,12 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             return setLoggedInPromise;
         }
 
-        if (await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")) {
+        // Test for the master cross-signing key in SSSS as a quick proxy for
+        // whether cross-signing has been set up on the account.
+        const masterKeyInStorage = !!cli.getAccountData("m.cross_signing.master");
+        if (masterKeyInStorage) {
+            this.setStateForNewView({ view: Views.COMPLETE_SECURITY });
+        } else if (await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")) {
             this.setStateForNewView({ view: Views.E2E_SETUP });
         } else {
             this.onLoggedIn();


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/4655 removed
the check for cross-signing account data where the cross-signing
labs flag was enabled if you had an existing cross-signing setup.
This also sent the user to the 'complete security' view rather than
the 'E2E Setup' view though, which meant new logins should always
see the E2E setup screen (ie. be prompted to upgrade encryption).

NB. We need to change this check for SSSS keys in account data
(https://github.com/vector-im/riot-web/issues/13894) but we should
put this back the way it was in the meantime.

Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/4655