### PR TITLE
Stop checkbox styling bleeding through room address selector

### DIFF
--- a/res/css/views/elements/_AddressSelector.scss
+++ b/res/css/views/elements/_AddressSelector.scss
@@ -23,6 +23,7 @@ limitations under the License.
     border-radius: 3px;
     border: solid 1px $accent-color;
     cursor: pointer;
+    z-index: 1;
 }
 
 .mx_AddressSelector.mx_AddressSelector_empty {


### PR DESCRIPTION
fixes: https://github.com/vector-im/riot-web/issues/13879

There's only one instance where the checkbox styled is poking through. The selector should be rendered on top of everything by default.