### PR TITLE
Add max-width to right and left panels

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -19,6 +19,7 @@ limitations under the License.
     display: flex;
     /* LeftPanel 260px */
     min-width: 260px;
+    max-width: 50%;
     flex: 0 0 auto;
 }
 

--- a/res/css/structures/_RightPanel.scss
+++ b/res/css/structures/_RightPanel.scss
@@ -20,6 +20,7 @@ limitations under the License.
     flex: 0 0 auto;
     position: relative;
     min-width: 264px;
+    max-width: 50%;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/8506

Note that the left panel is limited to 50% of the entire window while the right panel is 50% of the middle and right panels. Not sure if that is desired but still an improvement over having no max-width.