### PR TITLE
Remove escape backslashes in non-Markdown messages

### DIFF
--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -175,14 +175,6 @@ export default class Markdown {
         const renderer = new commonmark.HtmlRenderer({safe: false});
         const real_paragraph = renderer.paragraph;
 
-        // The default `out` function only sends the input through an XML
-        // escaping function, which causes messages to be entity encoded,
-        // which we don't want in this case.
-        renderer.out = function(s) {
-            // The `lit` function adds a string literal to the output buffer.
-            this.lit(s);
-        };
-
         renderer.paragraph = function(node, entering) {
             // as with toHTML, only append lines to paragraphs if there are
             // multiple paragraphs

--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -42,6 +42,10 @@ export function htmlSerializeIfNeeded(model: EditorModel, {forceHTML = false} = 
     if (!parser.isPlainText() || forceHTML) {
         return parser.toHTML();
     }
+    // ensure removal of escape backslashes in non-Markdown messages
+    if (md.indexOf("\\") > -1) {
+        return parser.toPlaintext();
+    }
 }
 
 export function textSerialize(model: EditorModel) {

--- a/test/editor/serialize-test.js
+++ b/test/editor/serialize-test.js
@@ -61,4 +61,16 @@ describe('editor/serialize', function() {
         const html = htmlSerializeIfNeeded(model, {});
         expect(html).toBe("<a href=\"https://matrix.to/#/@user:server\">Displayname]</a>");
     });
+    it('escaped markdown should not retain backslashes', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain('\\*hello\\* world')]);
+        const html = htmlSerializeIfNeeded(model, {});
+        expect(html).toBe('*hello* world');
+    });
+    it('escaped markdown should convert HTML entities', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.plain('\\*hello\\* world < hey world!')]);
+        const html = htmlSerializeIfNeeded(model, {});
+        expect(html).toBe('*hello* world &lt; hey world!');
+    });
 });


### PR DESCRIPTION
Iterating on #4008, fixes vector-im/riot-web#11230. A couple of changes:

1. I only call `toPlaintext` if there's a backslash present in the message.
2. I attempt to account for [HTML entities not being converted](https://github.com/matrix-org/matrix-react-sdk/pull/4008#issuecomment-590282297) by removing the override of HtmlRenderer's `out` function. As far as I can tell, we *do* want the messages to be entity-encoded when calling `toPlaintext` (at least, none of the tests broke! :smile:).