### PR TITLE
Bring back option to hide invite only padlocks

### DIFF
--- a/src/components/views/rooms/InviteOnlyIcon.js
+++ b/src/components/views/rooms/InviteOnlyIcon.js
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import { _t } from '../../../languageHandler';
 import * as sdk from '../../../index';
+import SettingsStore from '../../../settings/SettingsStore';
 
 export default class InviteOnlyIcon extends React.Component {
     constructor() {
@@ -37,6 +38,10 @@ export default class InviteOnlyIcon extends React.Component {
 
     render() {
         const classes = this.props.collapsedPanel ? "mx_InviteOnlyIcon_small": "mx_InviteOnlyIcon_large";
+
+        if (!SettingsStore.isFeatureEnabled("feature_invite_only_padlocks")) {
+            return null;
+        }
 
         const Tooltip = sdk.getComponent("elements.Tooltip");
         let tooltip;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -434,6 +434,7 @@
     "Support adding custom themes": "Support adding custom themes",
     "Use IRC layout": "Use IRC layout",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
+    "Show padlocks on invite only rooms": "Show padlocks on invite only rooms",
     "Font size": "Font size",
     "Custom font size": "Custom font size",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -170,6 +170,12 @@ export const SETTINGS = {
         displayName: _td("Show info about bridges in room settings"),
         default: false,
     },
+    "feature_invite_only_padlocks": {
+        isFeature: true,
+        supportedLevels: LEVELS_FEATURE,
+        displayName: _td("Show padlocks on invite only rooms"),
+        default: true,
+    },
     "fontSize": {
         displayName: _td("Font size"),
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13455

Now that I finally got cross signing working (🎉) I am seeing these again and it has not gotten any less confusing or annoying. I would have made this option hidden and only available via a manual edit of `im.vector.web.settings` but there doesn't seem to be a way to do that.