### PR TITLE
Prevent (double) 4S bootstrap from RestoreKeyBackupDialog

### DIFF
--- a/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
+++ b/src/components/views/dialogs/keybackup/RestoreKeyBackupDialog.js
@@ -227,8 +227,10 @@ export default class RestoreKeyBackupDialog extends React.PureComponent {
             loadError: null,
         });
         try {
-            const backupInfo = await MatrixClientPeg.get().getKeyBackupVersion();
-            const backupKeyStored = await MatrixClientPeg.get().isKeyBackupKeyStored();
+            const cli = MatrixClientPeg.get();
+            const backupInfo = await cli.getKeyBackupVersion();
+            const has4S = await cli.hasSecretStorageKey();
+            const backupKeyStored = has4S && await cli.isKeyBackupKeyStored();
             this.setState({
                 backupInfo,
                 backupKeyStored,


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/13481

When trying to restore a keyback that has its key in 4S, check if 4S will be readable

If the account data for the 4S key is cleared or lost somehow, don't attempt to
read the key and ask for the passphrase/recovery key instead, as doing so would trigger another
bootstrap from the restore key backup dialog, which shows a dialog underneath the RestoreKeyBackupDialog and would also start a new key backup I think? As riot only support restoring the most recent backup, that would make your whole e2ee history undecryptable.

Note that if your backup key is already in 4S (for example you got to `RestoreKeyBackupDialog` from `CreateSecretStorageDialog`), you will still be none the wiser, as it will ask for a recovery key you don't have, as it is only stored in 4S but that is unreadable because the 4S key is unreadable somehow (account data missing or never uploaded, still uncertain how this can happen ...) But at least you won't be looking at an infinite spinner.