### PR TITLE
Fix exceptions from Tooltip

### DIFF
--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -94,7 +94,7 @@ export default class Tooltip extends React.Component<IProps> {
         return style;
     }
 
-    private renderTooltip() {
+    private renderTooltip = () => {
         // Add the parent's position to the tooltips, so it's correctly
         // positioned, also taking into account any window zoom
         // NOTE: The additional 6 pixels for the left position, is to take account of the


### PR DESCRIPTION
renderTooltip was not a bound function and so was failing to find
the parent when called from the 'scroll' event listener because
'this' was the window object rather than the Tooltip object.

Looks like this broke in the recent typescript conversion since it
was using createReactClass before.