### PR TITLE
Fix exceptions from Tooltip

### DIFF
--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -94,7 +94,7 @@ export default class Tooltip extends React.Component<IProps> {
         return style;
     }
 
-    private renderTooltip() {
+    private renderTooltip = () => {
         // Add the parent's position to the tooltips, so it's correctly
         // positioned, also taking into account any window zoom
         // NOTE: The additional 6 pixels for the left position, is to take account of the


### PR DESCRIPTION
renderTooltip was not a bound function and so was failing to find
the parent when called from the 'scroll' event listener because
'this' was the window object rather than the Tooltip object.

Unsure at what point this broke - I assumed it was in thr recent
typescript conversion but it looks like it would have had the same
problem before.

https://github.com/matrix-org/matrix-react-sdk/pull/4708 to Release
(cherry picked from commit 5e569d75b641c68e973f123f1fea6c633ba1247d)