### PR TITLE
MImageBody thumbnail use thumbnail_info for max w and h

### DIFF
--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -324,10 +324,14 @@ export default class MImageBody extends React.Component {
         let infoWidth;
         let infoHeight;
 
-        if (content && content.info && content.info.w && content.info.h) {
-            infoWidth = content.info.w;
-            infoHeight = content.info.h;
-        } else {
+        const info = content && content.info;
+        if (info && info.thumbnail_info && info.thumbnail_info.w && info.thumbnail_info.h) {
+            infoWidth = info.thumbnail_info.w;
+            infoHeight = info.thumbnail_info.h;
+        } else if (info && info.w && info.h) {
+            infoWidth = info.w;
+            infoHeight = info.h;
+        } else if (!this.state.loadedImageDimensions) {
             // Whilst the image loads, display nothing.
             //
             // Once loaded, use the loaded image dimensions stored in `loadedImageDimensions`.
@@ -409,7 +413,7 @@ export default class MImageBody extends React.Component {
                 { showPlaceholder &&
                     <div className="mx_MImageBody_thumbnail" style={{
                         // Constrain width here so that spinner appears central to the loaded thumbnail
-                        maxWidth: infoWidth + "px",
+                        maxWidth: maxWidth + "px",
                     }}>
                         <div className="mx_MImageBody_thumbnail_spinner">
                             { placeholder }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13918
If the image was really wide such that it'd hit the Synapse limit of 800px wide but wasn't tall enough to hit our `maxImageHeight` of 600 then it'd get stretched horizontally causing blur.

Before:
![image](https://user-images.githubusercontent.com/2403652/83895426-95bf9280-a74a-11ea-814d-cda1cdaf6081.png)
![image](https://user-images.githubusercontent.com/2403652/83895438-9821ec80-a74a-11ea-90a3-55ae0afd7653.png)


After:
![image](https://user-images.githubusercontent.com/2403652/83895345-788ac400-a74a-11ea-863c-2e9a8da492a6.png)
![image](https://user-images.githubusercontent.com/2403652/83895352-7cb6e180-a74a-11ea-9483-e1df15deaf15.png)

(shows both encrypted and unencrypted [relying on server thumbs])
