### PR TITLE
Handle remaining cases for room updates in new room list

### DIFF
--- a/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
+++ b/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
@@ -189,6 +189,13 @@ export class ImportanceAlgorithm extends Algorithm {
     }
 
     public async handleRoomUpdate(room: Room, cause: RoomUpdateCause): Promise<boolean> {
+        if (cause === RoomUpdateCause.PossibleTagChange) {
+            // TODO: Be smarter and splice rather than regen the planet.
+            // TODO: No-op if no change.
+            await this.setKnownRooms(this.rooms);
+            return;
+        }
+
         if (cause === RoomUpdateCause.NewRoom) {
             // TODO: Be smarter and insert rather than regen the planet.
             await this.setKnownRooms([room, ...this.rooms]);

--- a/src/stores/room-list/models.ts
+++ b/src/stores/room-list/models.ts
@@ -38,6 +38,7 @@ export type TagID = string | DefaultTagID;
 
 export enum RoomUpdateCause {
     Timeline = "TIMELINE",
-    RoomRead = "ROOM_READ", // TODO: Use this.
+    PossibleTagChange = "POSSIBLE_TAG_CHANGE",
+    ReadReceipt = "READ_RECEIPT",
     NewRoom = "NEW_ROOM",
 }


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/13635

This adds support for:
* Tag changes
* DM changes
* Marking our own rooms as read
* Our own membership changes

The remaining branch we didn't need was the alternate 'new room' branch, so it was removed.

This is not optimized - optimization is deferred.