### PR TITLE
Load correct default font size

### DIFF
--- a/src/settings/watchers/FontWatcher.ts
+++ b/src/settings/watchers/FontWatcher.ts
@@ -32,7 +32,7 @@ export class FontWatcher implements IWatcher {
     }
 
     public start() {
-        this.setRootFontSize(SettingsStore.getValue("baseFontSize") + FontWatcher.SIZE_DIFF);
+        this.setRootFontSize(SettingsStore.getValue("baseFontSize"));
         this.dispatcherRef = dis.register(this.onAction);
     }
 


### PR DESCRIPTION
Originally I had changed the internal representation to 20px, missed this when I changed the representation again to 10px.