### PR TITLE
Fix read receipt overlap

### DIFF
--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -23,7 +23,7 @@ import { _t } from '../../../languageHandler';
 import {formatDate} from '../../../DateUtils';
 import Velociraptor from "../../../Velociraptor";
 import * as sdk from "../../../index";
-import {toRem} from "../../../utils/units";
+import {toPx} from "../../../utils/units";
 
 let bounce = false;
 try {
@@ -149,7 +149,7 @@ export default createReactClass({
             // start at the old height and in the old h pos
 
             startStyles.push({ top: startTopOffset+"px",
-                               left: toRem(oldInfo.left) });
+                               left: toPx(oldInfo.left) });
 
             const reorderTransitionOpts = {
                 duration: 100,
@@ -182,7 +182,7 @@ export default createReactClass({
         }
 
         const style = {
-            left: toRem(this.props.leftOffset),
+            left: toPx(this.props.leftOffset),
             top: '0px',
             visibility: this.props.hidden ? 'hidden' : 'visible',
         };

--- a/src/settings/watchers/FontWatcher.ts
+++ b/src/settings/watchers/FontWatcher.ts
@@ -32,7 +32,7 @@ export class FontWatcher implements IWatcher {
     }
 
     public start() {
-        this.setRootFontSize(SettingsStore.getValue("baseFontSize") + FontWatcher.SIZE_DIFF);
+        this.setRootFontSize(SettingsStore.getValue("baseFontSize"));
         this.dispatcherRef = dis.register(this.onAction);
     }
 


### PR DESCRIPTION
All images had been reverted to constant width when they were breaking too many components because of font scaling. The read receipt offset calculation wasn't updated to reflect this change. 