### PR TITLE
Support prioritized room list filters

### DIFF
--- a/src/stores/room-list/filters/CommunityFilterCondition.ts
+++ b/src/stores/room-list/filters/CommunityFilterCondition.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Room } from "matrix-js-sdk/src/models/room";
-import { FILTER_CHANGED, IFilterCondition } from "./IFilterCondition";
+import { FILTER_CHANGED, FilterPriority, IFilterCondition } from "./IFilterCondition";
 import { Group } from "matrix-js-sdk/src/models/group";
 import { EventEmitter } from "events";
 import GroupStore from "../../GroupStore";
@@ -35,6 +35,11 @@ export class CommunityFilterCondition extends EventEmitter implements IFilterCon
 
         // noinspection JSIgnoredPromiseFromCall
         this.onStoreUpdate(); // trigger a false update to seed the store
+    }
+
+    public get relativePriority(): FilterPriority {
+        // Lowest priority so we can coarsely find rooms.
+        return FilterPriority.Lowest;
     }
 
     public isVisible(room: Room): boolean {

--- a/src/stores/room-list/filters/IFilterCondition.ts
+++ b/src/stores/room-list/filters/IFilterCondition.ts
@@ -19,6 +19,12 @@ import { EventEmitter } from "events";
 
 export const FILTER_CHANGED = "filter_changed";
 
+export enum FilterPriority {
+    Lowest,
+    // in the middle would be Low, Normal, and High if we had a need
+    Highest,
+}
+
 /**
  * A filter condition for the room list, determining if a room
  * should be shown or not.
@@ -32,6 +38,12 @@ export const FILTER_CHANGED = "filter_changed";
  * as a change in the user's input), this emits FILTER_CHANGED.
  */
 export interface IFilterCondition extends EventEmitter {
+    /**
+     * The relative priority that this filter should be applied with.
+     * Lower priorities get applied first.
+     */
+    relativePriority: FilterPriority;
+
     /**
      * Determines if a given room should be visible under this
      * condition.

--- a/src/stores/room-list/filters/NameFilterCondition.ts
+++ b/src/stores/room-list/filters/NameFilterCondition.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Room } from "matrix-js-sdk/src/models/room";
-import { FILTER_CHANGED, IFilterCondition } from "./IFilterCondition";
+import { FILTER_CHANGED, FilterPriority, IFilterCondition } from "./IFilterCondition";
 import { EventEmitter } from "events";
 
 /**
@@ -27,6 +27,11 @@ export class NameFilterCondition extends EventEmitter implements IFilterConditio
 
     constructor() {
         super();
+    }
+
+    public get relativePriority(): FilterPriority {
+        // We want this one to be at the highest priority so it can search within other filters.
+        return FilterPriority.Highest;
     }
 
     public get search(): string {

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -45,3 +45,63 @@ export function arrayDiff<T>(a: T[], b: T[]): { added: T[], removed: T[] } {
         removed: a.filter(i => !b.includes(i)),
     };
 }
+
+/**
+ * Helper functions to perform LINQ-like queries on arrays.
+ */
+export class ArrayUtil<T> {
+    /**
+     * Create a new array helper.
+     * @param a The array to help. Can be modified in-place.
+     */
+    constructor(private a: T[]) {
+    }
+
+    /**
+     * The value of this array, after all appropriate alterations.
+     */
+    public get value(): T[] {
+        return this.a;
+    }
+
+    /**
+     * Groups an array by keys.
+     * @param fn The key-finding function.
+     * @returns This.
+     */
+    public groupBy<K>(fn: (a: T) => K): GroupedArray<K, T> {
+        const obj = this.a.reduce((rv: Map<K, T[]>, val: T) => {
+            const k = fn(val);
+            if (!rv.has(k)) rv.set(k, []);
+            rv.get(k).push(val);
+            return rv;
+        }, new Map<K, T[]>());
+        return new GroupedArray(obj);
+    }
+}
+
+/**
+ * Helper functions to perform LINQ-like queries on groups (maps).
+ */
+export class GroupedArray<K, T> {
+    /**
+     * Creates a new group helper.
+     * @param val The group to help. Can be modified in-place.
+     */
+    constructor(private val: Map<K, T[]>) {
+    }
+
+    /**
+     * Orders the grouping into an array using the provided key order.
+     * @param keyOrder The key order.
+     * @returns An array helper of the result.
+     */
+    public orderBy(keyOrder: K[]): ArrayUtil<T> {
+        const a: T[] = [];
+        for (const k of keyOrder) {
+            if (!this.val.has(k)) continue;
+            a.push(...this.val.get(k));
+        }
+        return new ArrayUtil(a);
+    }
+}

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type EnumValue = string | number;
+
+/**
+ * Get the values for an enum.
+ * @param e The enum.
+ * @returns The enum values.
+ */
+export function getEnumValues<T>(e: any): T[] {
+    const keys = Object.keys(e);
+    return keys
+        .filter(k => ['string', 'number'].includes(typeof(e[k])))
+        .map(k => e[k]);
+}

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export type EnumValue = string | number;
-
 /**
  * Get the values for an enum.
  * @param e The enum.


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/13635

This is to fix an issue where when using both the community filter panel and the search box it's an AND rather than further refining the results.

This makes the search box further refine the community filter panel results.

Screenshot proof (ignore the ugly CSS - that's not important here):
![image](https://user-images.githubusercontent.com/1190097/84103536-8f424c80-a9d0-11ea-8c86-5b327b99285f.png)
