### PR TITLE
EventIndex: Store and restore the encryption info for encrypted events.

### DIFF
--- a/src/Searching.js
+++ b/src/Searching.js
@@ -123,6 +123,9 @@ async function localSearch(searchTerm, roomId = undefined) {
                 ev._forwardingCurve25519KeyChain = ev.event.forwardingCurve25519KeyChain;
 
                 delete ev.event.curve25519Key;
+                delete ev.event.ed25519Key;
+                delete ev.event.algorithm;
+                delete ev.event.forwardingCurve25519KeyChain;
             }
         }
     }

--- a/src/Searching.js
+++ b/src/Searching.js
@@ -107,6 +107,26 @@ async function localSearch(searchTerm, roomId = undefined) {
     const result = MatrixClientPeg.get()._processRoomEventsSearch(
         emptyResult, response);
 
+    // Restore our encryption info so we can properly re-verify the events.
+    for (let i = 0; i < result.results.length; i++) {
+        const timeline = result.results[i].context.getTimeline();
+
+        for (let j = 0; j < timeline.length; j++) {
+            const ev = timeline[j];
+            if (ev.event.curve25519Key) {
+                ev.makeEncrypted(
+                    "m.room.encrypted",
+                    { algorithm: ev.event.algorithm },
+                    ev.event.curve25519Key,
+                    ev.event.ed25519Key,
+                );
+                ev._forwardingCurve25519KeyChain = ev.event.forwardingCurve25519KeyChain;
+
+                delete ev.event.curve25519Key;
+            }
+        }
+    }
+
     return result;
 }
 


### PR DESCRIPTION
This PR implements verification state restoring for events that come out of the event index.

For this to become fixed for everyone the event index will need to be completely wiped and rebuild. If this should happen in Riot, the matrix-react-sdk or in Seshat is an open question as of now. This can be safely merged as is since it's backwards compatible.

Once https://github.com/matrix-org/matrix-react-sdk/pull/4705 lands it will need to be adapted for restore the relevant fields for the paginated results as well.

This closes: https://github.com/vector-im/riot-web/issues/11831.