### PR TITLE
Make checkboxes a11y friendly

### DIFF
--- a/res/css/views/elements/_StyledCheckbox.scss
+++ b/res/css/views/elements/_StyledCheckbox.scss
@@ -24,7 +24,7 @@ limitations under the License.
     align-items: flex-start;
 
     input[type=checkbox] {
-        display: none;
+        appearance: none;
 
         & + label {
             display: flex;


### PR DESCRIPTION
Using display: none was breaking the accessibility of checkboxes