### PR TITLE
Add some resource leak protection to new room list badges

### DIFF
--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -84,6 +84,10 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
         this.state.notificationState.setRooms(this.props.rooms);
     }
 
+    public componentWillUnmount() {
+        this.state.notificationState.destroy();
+    }
+
     private onAddRoom = (e) => {
         e.stopPropagation();
         if (this.props.onAddRoom) this.props.onAddRoom();


### PR DESCRIPTION
Most of the leaks were because we never set `this.rooms` in the notification state, which meant we were constantly triggering the `diff.added` loop.

For https://github.com/vector-im/riot-web/issues/13635