### PR TITLE
Fix e2e icon alignment in irc-layout

### DIFF
--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -96,10 +96,16 @@ $irc-line-height: $font-18px;
             position: relative;
             right: unset;
             left: unset;
+            top: 0;
+
             padding: 0;
-            order: 3;
+
             flex-shrink: 0;
             flex-grow: 0;
+
+            height: $font-18px;
+
+            background-position: center;
         }
 
         .mx_EventTile_line {


### PR DESCRIPTION
Things got misaligned after some iterations

![image](https://user-images.githubusercontent.com/23084468/84376389-fb8f9c80-abd8-11ea-9589-b4f650bc8522.png)

![image](https://user-images.githubusercontent.com/23084468/84376397-fe8a8d00-abd8-11ea-8b9b-b77460b8b946.png)

