### PR TITLE
Send read marker updates immediately after moving visually

### DIFF
--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -798,6 +798,9 @@ const TimelinePanel = createReactClass({
                 readMarkerVisible: false,
             });
         }
+
+        // Send the updated read marker (along with read receipt) to the server
+        this.sendReadReceipt();
     },
 
 


### PR DESCRIPTION
The `TimelinePanel` uses two timers to coordinate read marker and read receipt
updates. When the read receipt timer fires, we advance the receipt and send the
latest state of both your receipt and marker to the server. When the read marker
timer fires, we advance the marker visually, but do not send anything to the
server: we were relying on the slightly different schedule of the read receipt
to actually send the updated read marker. This means there's a time window where
it's possible to visually advance the read marker without ever sending it to the
server (if you change rooms before the receipt timer fires again).

To simplify the behaviour here and ensure we always commit the updated marker
when we move it, this change sends an update to the server at the same time as
moving the marker.

It's possible this may improve some of the behaviour reported in https://github.com/vector-im/riot-web/issues/12338.