### PR TITLE
Fix ordering of recent rooms in the new room list

### DIFF
--- a/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
+++ b/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
@@ -75,7 +75,7 @@ export class RecentAlgorithm implements IAlgorithm {
         };
 
         return rooms.sort((a, b) => {
-            return getLastTs(a) - getLastTs(b);
+            return getLastTs(b) - getLastTs(a);
         });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14009
For https://github.com/vector-im/riot-web/issues/13635

Turns out math is hard.