### PR TITLE
Fix alignment of checkboxes in new room list's context menu

### DIFF
--- a/res/css/views/rooms/_RoomSublist2.scss
+++ b/res/css/views/rooms/_RoomSublist2.scss
@@ -320,8 +320,4 @@ limitations under the License.
     .mx_RadioButton, .mx_Checkbox {
         margin-top: 8px;
     }
-
-    .mx_Checkbox {
-        margin-left: -8px; // to counteract the indent from the component
-    }
 }


### PR DESCRIPTION
At somepoint the checkbox lost its padding, so we don't need to counteract it.

![image](https://user-images.githubusercontent.com/1190097/84842764-380d2f00-b003-11ea-98c8-5748164793fc.png)
