### PR TITLE
Make the room list labs setting reload on change

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -432,7 +432,7 @@
     "Render simple counters in room header": "Render simple counters in room header",
     "Multiple integration managers": "Multiple integration managers",
     "Try out new ways to ignore people (experimental)": "Try out new ways to ignore people (experimental)",
-    "Use the improved room list (in development - refresh to apply changes)": "Use the improved room list (in development - refresh to apply changes)",
+    "Use the improved room list (in development - will refresh to apply changes)": "Use the improved room list (in development - will refresh to apply changes)",
     "Support adding custom themes": "Support adding custom themes",
     "Use IRC layout": "Use IRC layout",
     "Show info about bridges in room settings": "Show info about bridges in room settings",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -140,9 +140,10 @@ export const SETTINGS = {
     },
     "feature_new_room_list": {
         isFeature: true,
-        displayName: _td("Use the improved room list (in development - refresh to apply changes)"),
+        displayName: _td("Use the improved room list (in development - will refresh to apply changes)"),
         supportedLevels: LEVELS_FEATURE,
         default: false,
+        controller: new ReloadOnChangeController(),
     },
     "feature_custom_themes": {
         isFeature: true,


### PR DESCRIPTION
Should fix confusing signals sent by having the room list visible but non-functional.

For https://github.com/vector-im/riot-web/issues/13635