### PR TITLE
Clear `top` when not sticking headers to the top

### DIFF
--- a/src/components/structures/LeftPanel2.tsx
+++ b/src/components/structures/LeftPanel2.tsx
@@ -108,6 +108,7 @@ export default class LeftPanel2 extends React.Component<IProps, IState> {
                 header.classList.add("mx_RoomSublist2_headerContainer_sticky");
                 header.classList.add("mx_RoomSublist2_headerContainer_stickyBottom");
                 header.style.width = `${headerStickyWidth}px`;
+                header.style.top = "unset";
                 gotBottom = true;
             } else if (slRect.top < top) {
                 header.classList.add("mx_RoomSublist2_headerContainer_sticky");
@@ -119,6 +120,7 @@ export default class LeftPanel2 extends React.Component<IProps, IState> {
                 header.classList.remove("mx_RoomSublist2_headerContainer_stickyTop");
                 header.classList.remove("mx_RoomSublist2_headerContainer_stickyBottom");
                 header.style.width = `unset`;
+                header.style.top = "unset";
             }
         }
     };

--- a/src/components/structures/LeftPanel2.tsx
+++ b/src/components/structures/LeftPanel2.tsx
@@ -108,7 +108,7 @@ export default class LeftPanel2 extends React.Component<IProps, IState> {
                 header.classList.add("mx_RoomSublist2_headerContainer_sticky");
                 header.classList.add("mx_RoomSublist2_headerContainer_stickyBottom");
                 header.style.width = `${headerStickyWidth}px`;
-                header.style.top = "unset";
+                header.style.top = `unset`;
                 gotBottom = true;
             } else if (slRect.top < top) {
                 header.classList.add("mx_RoomSublist2_headerContainer_sticky");
@@ -120,7 +120,7 @@ export default class LeftPanel2 extends React.Component<IProps, IState> {
                 header.classList.remove("mx_RoomSublist2_headerContainer_stickyTop");
                 header.classList.remove("mx_RoomSublist2_headerContainer_stickyBottom");
                 header.style.width = `unset`;
-                header.style.top = "unset";
+                header.style.top = `unset`;
             }
         }
     };


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14070
For https://github.com/vector-im/riot-web/issues/13635