### PR TITLE
User versions in the event index.

### DIFF
--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -144,6 +144,29 @@ export default abstract class BaseEventIndexManager {
         throw new Error("Unimplemented");
     }
 
+
+    /**
+     * Get the user version of the database.
+     * @return {Promise<number>} A promise that will resolve to the user stored
+     * version number.
+     */
+    async getUserVersion(): Promise<number> {
+        throw new Error("Unimplemented");
+    }
+
+    /**
+     * Set the user stored version to the given version number.
+     *
+     * @param {number} version The new version that should be stored in the
+     * database.
+     *
+     * @return {Promise<void>} A promise that will resolve once the new version
+     * is stored.
+     */
+    async setUserVersion(version: number): Promise<void> {
+        throw new Error("Unimplemented");
+    }
+
     /**
      * Commit the previously queued up events to the index.
      *

--- a/src/indexing/EventIndex.js
+++ b/src/indexing/EventIndex.js
@@ -42,9 +42,6 @@ export default class EventIndex extends EventEmitter {
     async init() {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
 
-        await indexManager.initEventIndex();
-        console.log("EventIndex: Successfully initialized the event index");
-
         this.crawlerCheckpoints = await indexManager.loadCheckpoints();
         console.log("EventIndex: Loaded checkpoints", this.crawlerCheckpoints);
 


### PR DESCRIPTION
This PR adds the ability to store user versions in the event index, we're also bumping our version and deleting the index if it's an old version to fix https://github.com/vector-im/riot-web/issues/11831.

The Riot-web side of this can be found at https://github.com/vector-im/riot-web/pull/14080, while the Riot-desktop side is at https://github.com/vector-im/riot-desktop/pull/102.

Requires a Seshat release with https://github.com/matrix-org/seshat/pull/67.