### PR TITLE
Fix crash when filtering new room list too fast

### DIFF
--- a/src/components/views/rooms/NotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge.tsx
@@ -240,6 +240,7 @@ export class ListNotificationState extends EventEmitter implements IDestroyable 
         this.rooms = rooms;
         for (const oldRoom of diff.removed) {
             const state = this.states[oldRoom.roomId];
+            if (!state) continue; // We likely just didn't have a badge (race condition)
             delete this.states[oldRoom.roomId];
             state.off(NOTIFICATION_STATE_UPDATE, this.onRoomNotificationStateUpdate);
             state.destroy();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14092
For https://github.com/vector-im/riot-web/issues/13635

We were simply assuming we had a reference to a notification state, which might not be the case if we're between renders.