### PR TITLE
Mark messages with a black shield if the megolm session isn't trusted

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -354,6 +354,11 @@ limitations under the License.
     opacity: 1;
 }
 
+.mx_EventTile_e2eIcon_unauthenticated {
+    background-image: url('$(res)/img/e2e/normal.svg');
+    opacity: 1;
+}
+
 .mx_EventTile_e2eIcon_hidden {
     display: none;
 }

--- a/src/components/views/rooms/E2EIcon.js
+++ b/src/components/views/rooms/E2EIcon.js
@@ -28,6 +28,7 @@ export const E2E_STATE = {
     WARNING: "warning",
     UNKNOWN: "unknown",
     NORMAL: "normal",
+    UNAUTHENTICATED: "unauthenticated",
 };
 
 const crossSigningUserTitles = {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1023,6 +1023,7 @@
     "Encrypted by an unverified session": "Encrypted by an unverified session",
     "Unencrypted": "Unencrypted",
     "Encrypted by a deleted session": "Encrypted by a deleted session",
+    "The authenticity of this encrypted message can't be guaranteed on this device.": "The authenticity of this encrypted message can't be guaranteed on this device.",
     "Please select the destination room for this message": "Please select the destination room for this message",
     "Invite only": "Invite only",
     "Scroll to most recent messages": "Scroll to most recent messages",


### PR DESCRIPTION
depends on https://github.com/matrix-org/matrix-js-sdk/pull/1406

In the screenshot below, the first two messages were decrypted with keys from backup.
![unauthenticated](https://user-images.githubusercontent.com/1012976/85089021-7ba49c00-b1af-11ea-92bf-2c15cf45bd8f.png)
