### PR TITLE
Fix some appearance tab crash and implement style nits

### DIFF
--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -30,7 +30,7 @@ limitations under the License.
     flex-direction: row;
     align-items: center;
     padding: 15px;
-    background: $font-slider-bg-color;
+    background: rgba($appearance-tab-border-color, 0.2);
     border-radius: 10px;
     font-size: 10px;
     margin-top: 24px;
@@ -38,7 +38,7 @@ limitations under the License.
 }
 
 .mx_AppearanceUserSettingsTab_fontSlider_preview {
-    border: 1px solid $input-darker-bg-color;
+    border: 1px solid $appearance-tab-border-color;
     border-radius: 10px;
     padding: 0 16px 9px 16px;
     pointer-events: none;
@@ -56,12 +56,14 @@ limitations under the License.
     font-size: 15px;
     padding-right: 20px;
     padding-left: 5px;
+    font-weight: 500;
 }
 
 .mx_AppearanceUserSettingsTab_fontSlider_largeText {
     font-size: 18px;
     padding-left: 20px;
     padding-right: 5px;
+    font-weight: 500;
 }
 
 .mx_AppearanceUserSettingsTab {
@@ -115,7 +117,8 @@ limitations under the License.
             }
 
             &.mx_ThemeSelector_dark {
-                background-color: #181b21;
+                // 5% lightened version of 181b21
+                background-color: #25282e;
                 color: #f3f8fd;
 
                 > input > div {
@@ -163,10 +166,11 @@ limitations under the License.
 
         width: 300px;
 
-        border: 1px solid $input-darker-bg-color;
+        border: 1px solid $appearance-tab-border-color;
         border-radius: 10px;
 
-        .mx_EventTile_msgOption {
+        .mx_EventTile_msgOption,
+        .mx_MessageActionBar {
             display: none;
         }
 
@@ -175,6 +179,7 @@ limitations under the License.
             display: flex;
             align-items: center;
             padding: 10px;
+            pointer-events: none;
         }
 
         .mx_RadioButton {
@@ -188,7 +193,7 @@ limitations under the License.
     }
 
     .mx_RadioButton {
-        border-top: 1px solid $input-darker-bg-color;
+        border-top: 1px solid $appearance-tab-border-color;
 
         > input + div {
             border-color: rgba($muted-fg-color, 0.2);

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -198,8 +198,8 @@ $breadcrumb-placeholder-bg-color: #272c35;
 
 $user-tile-hover-bg-color: $header-panel-bg-color;
 
-// FontSlider colors
-$font-slider-bg-color: $room-highlight-color;
+// Appearance tab colors
+$appearance-tab-border-color: $room-highlight-color;
 
 // ***** Mixins! *****
 

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -327,7 +327,7 @@ $breadcrumb-placeholder-bg-color: #e8eef5;
 $user-tile-hover-bg-color: $header-panel-bg-color;
 
 // FontSlider colors
-$font-slider-bg-color: rgba($input-darker-bg-color, 0.2);
+$appearance-tab-border-color: $input-darker-bg-color;
 
 // ***** Mixins! *****
 

--- a/src/components/views/elements/EventTilePreview.tsx
+++ b/src/components/views/elements/EventTilePreview.tsx
@@ -108,7 +108,7 @@ export default class EventTilePreview extends React.Component<IProps, IState> {
             },
         };
 
-
+        return event;
     }
 
     public render() {


### PR DESCRIPTION
Fix border colours in dark theme. It used to be the same colour as the background making it look janky.

![image](https://user-images.githubusercontent.com/23084468/85282728-20f79280-b484-11ea-8031-090af0eaa4d0.png)

Lighten dark theme preview background

![image](https://user-images.githubusercontent.com/23084468/85282855-569c7b80-b484-11ea-88e5-eec38a34d004.png)

Add missing return statement

Since there is no styling for the appearance tab and I think these are both logical changes I'm not requesting design review