### PR TITLE
Trigger room-specific watchers whenever a higher level change happens

### DIFF
--- a/src/settings/WatchManager.js
+++ b/src/settings/WatchManager.js
@@ -51,8 +51,17 @@ export class WatchManager {
         const roomWatchers = this._watchers[settingName];
         const callbacks = [];
 
-        if (inRoomId !== null && roomWatchers[inRoomId]) callbacks.push(...roomWatchers[inRoomId]);
-        if (roomWatchers[null]) callbacks.push(...roomWatchers[null]);
+        if (inRoomId !== null && roomWatchers[inRoomId]) {
+            callbacks.push(...roomWatchers[inRoomId]);
+        }
+
+        if (!inRoomId) {
+            // Fire updates to all the individual room watchers too, as they probably
+            // care about the change higher up.
+            callbacks.push(...Object.values(roomWatchers).reduce((r, a) => [...r, ...a], []));
+        } else if (roomWatchers[null]) {
+            callbacks.push(...roomWatchers[null]);
+        }
 
         for (const callback of callbacks) {
             callback(inRoomId, atLevel, newValueAtLevel);


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/13635

Otherwise the room list badges end up having to listen to `null` for a room ID, meaning they have to filter.
This helps fix room list badges because they'd have to listen for `null` as a room ID, meaning they have to filter the fired events. The notification badge count setting will be the first ever setting to watch based on a room ID, so there are no compatibility concerns with this change.