### PR TITLE
Update read receipt remainder for internal font size change

### DIFF
--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -19,7 +19,7 @@ limitations under the License.
 
 // converts a pixel value to rem.
 export function toRem(pixelValue: number): string {
-    return pixelValue / 15 + "rem";
+    return pixelValue / 10 + "rem";
 }
 
 export function toPx(pixelValue: number): string {


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-react-sdk/pull/4725, we changed the
internal font size from 15 to 10, but the `toRem` function (currently only used
for read receipts remainders curiously) was not updated. This updates the
function, which restores the remainders.

<img width="110" alt="image" src="https://user-images.githubusercontent.com/279572/85320664-51a6ee80-b4bb-11ea-826b-89aa97ddbb6d.png">

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/4725
Fixes https://github.com/vector-im/riot-web/issues/14127