### PR TITLE
Have the theme switcher set the device-level theme to match settings

### DIFF
--- a/src/components/structures/UserMenuButton.tsx
+++ b/src/components/structures/UserMenuButton.tsx
@@ -117,7 +117,7 @@ export default class UserMenuButton extends React.Component<IProps, IState> {
         SettingsStore.setValue("use_system_theme", null, SettingLevel.DEVICE, false);
 
         const newTheme = this.state.isDarkTheme ? "light" : "dark";
-        SettingsStore.setValue("theme", null, SettingLevel.ACCOUNT, newTheme);
+        SettingsStore.setValue("theme", null, SettingLevel.DEVICE, newTheme); // set at same level as Appearance tab
     };
 
     private onSettingsOpen = (ev: ButtonEvent, tabId: string) => {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14111
For https://github.com/vector-im/riot-web/issues/13635

This is a shortcut into the Appearance tab, so use the same level. It was an explicit decision to have the tab set the theme at the device level.