### PR TITLE
Use the correct timeline reference for message previews

### DIFF
--- a/src/stores/MessagePreviewStore.ts
+++ b/src/stores/MessagePreviewStore.ts
@@ -78,9 +78,8 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
     }
 
     private generatePreview(room: Room) {
-        const timeline = room.getLiveTimeline();
-        if (!timeline) return; // usually only happens in tests
-        const events = timeline.getEvents();
+        const events = room.timeline;
+        if (!events) return; // should only happen in tests
 
         for (let i = events.length - 1; i >= 0; i--) {
             if (i === events.length - MAX_EVENTS_BACKWARDS) return; // limit reached


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14083 (hopefully)
For https://github.com/vector-im/riot-web/issues/13635

This is the same logic used by `Unread.js`, so should be correct.