### PR TITLE
Font support in custom themes

### DIFF
--- a/res/themes/light-custom/css/_custom.scss
+++ b/res/themes/light-custom/css/_custom.scss
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+$font-family: var(--font-family, $font-family);
+$monospace-font-family: var(--font-family-monospace, $monospace-font-family);
 //
 // --accent-color
 $accent-color: var(--accent-color);

--- a/src/theme.js
+++ b/src/theme.js
@@ -59,7 +59,7 @@ const allowedFontFaceProps = [
     "font-feature-settings",
     "font-variation-settings",
     "src",
-    "unicode-range"
+    "unicode-range",
 ];
 
 function generateCustomFontFaceCSS(faces) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -60,6 +60,15 @@ function setCustomThemeVars(customTheme) {
             }
         }
     }
+    if (customTheme.fonts) {
+        const {fonts} = customTheme;
+        if (fonts.general) {
+            style.setProperty("--font-family", fonts.general);
+        }
+        if (fonts.monospace) {
+            style.setProperty("--font-family-monospace", fonts.monospace);
+        }
+    }
 }
 
 export function getCustomTheme(themeName) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -39,7 +39,7 @@ export function enumerateThemes() {
 function setCustomThemeVars(customTheme) {
     const {style} = document.body;
 
-    function setCSSVariable(name, hexColor, doPct = true) {
+    function setCSSColorVariable(name, hexColor, doPct = true) {
         style.setProperty(`--${name}`, hexColor);
         if (doPct) {
             // uses #rrggbbaa to define the color with alpha values at 0%, 15% and 50%
@@ -53,10 +53,10 @@ function setCustomThemeVars(customTheme) {
         for (const [name, value] of Object.entries(customTheme.colors)) {
             if (Array.isArray(value)) {
                 for (let i = 0; i < value.length; i += 1) {
-                    setCSSVariable(`${name}_${i}`, value[i], false);
+                    setCSSColorVariable(`${name}_${i}`, value[i], false);
                 }
             } else {
-                setCSSVariable(name, value);
+                setCSSColorVariable(name, value);
             }
         }
     }

--- a/src/theme.js
+++ b/src/theme.js
@@ -35,6 +35,16 @@ export function enumerateThemes() {
     return Object.assign({}, customThemeNames, BUILTIN_THEMES);
 }
 
+function clearCustomTheme() {
+    // remove all css variables, we assume these are there because of the custom theme
+    const inlineStyleProps = Object.values(document.body.style);
+    for (const prop of inlineStyleProps) {
+        if (prop.startsWith("--")) {
+            document.body.style.removeProperty(prop);
+        }
+    }
+}
+
 
 function setCustomThemeVars(customTheme) {
     const {style} = document.body;
@@ -97,6 +107,7 @@ export async function setTheme(theme) {
         const themeWatcher = new ThemeWatcher();
         theme = themeWatcher.getEffectiveTheme();
     }
+    clearCustomTheme();
     let stylesheetName = theme;
     if (theme.startsWith("custom-")) {
         const customTheme = getCustomTheme(theme.substr(7));

--- a/src/theme.js
+++ b/src/theme.js
@@ -43,8 +43,23 @@ function clearCustomTheme() {
             document.body.style.removeProperty(prop);
         }
     }
+    const customFontFaceStyle = document.querySelector("head > style[title='custom-theme-font-faces']");
+    if (customFontFaceStyle) {
+        customFontFaceStyle.remove();
+    }
 }
 
+function generateCustomFontFaceCSS(faces) {
+    return Object.entries(faces).map(([fontName, face]) => {
+        const src = Object.entries(face.src).map(([format, url]) => {
+            return `url('${url}') format('${format}')`;
+        }).join(", ");
+        return `@font-face {` +
+        `    font-family: '${fontName}';` +
+        `    src: ${src};` +
+        `}`;
+    }).join("\n");
+}
 
 function setCustomThemeVars(customTheme) {
     const {style} = document.body;
@@ -72,6 +87,14 @@ function setCustomThemeVars(customTheme) {
     }
     if (customTheme.fonts) {
         const {fonts} = customTheme;
+        if (fonts.faces) {
+            const css = generateCustomFontFaceCSS(fonts.faces);
+            const style = document.createElement("style");
+            style.setAttribute("title", "custom-theme-font-faces");
+            style.setAttribute("type", "text/css");
+            style.appendChild(document.createTextNode(css));
+            document.head.appendChild(style);
+        }
         if (fonts.general) {
             style.setProperty("--font-family", fonts.general);
         }

--- a/src/theme.js
+++ b/src/theme.js
@@ -49,15 +49,46 @@ function clearCustomTheme() {
     }
 }
 
+const allowedFontFaceProps = [
+    "font-display",
+    "font-family",
+    "font-stretch",
+    "font-style",
+    "font-weight",
+    "font-variant",
+    "font-feature-settings",
+    "font-variation-settings",
+    "src",
+    "unicode-range"
+];
+
 function generateCustomFontFaceCSS(faces) {
-    return Object.entries(faces).map(([fontName, face]) => {
-        const src = Object.entries(face.src).map(([format, url]) => {
-            return `url('${url}') format('${format}')`;
+    return faces.map(face => {
+        const src = face.src && face.src.map(srcElement => {
+            let format;
+            if (srcElement.format) {
+                format = `format("${srcElement.format}")`;
+            }
+            if (srcElement.url) {
+                return `url("${srcElement.url}") ${format}`;
+            } else if (srcElement.local) {
+                return `local("${srcElement.local}") ${format}`;
+            }
+            return "";
         }).join(", ");
-        return `@font-face {` +
-        `    font-family: '${fontName}';` +
-        `    src: ${src};` +
-        `}`;
+        const props = Object.keys(face).filter(prop => allowedFontFaceProps.includes(prop));
+        const body = props.map(prop => {
+            let value;
+            if (prop === "src") {
+                value = src;
+            } else if (prop === "font-family") {
+                value = `"${face[prop]}"`;
+            } else {
+                value = face[prop];
+            }
+            return `${prop}: ${value}`;
+        }).join(";");
+        return `@font-face {${body}}`;
     }).join("\n");
 }
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -179,7 +179,7 @@ export async function setTheme(theme) {
                 if (a == styleElements[stylesheetName]) return;
                 a.disabled = true;
             });
-            const bodyStyles = global.getComputedStyle(document.getElementsByTagName("body")[0]);
+            const bodyStyles = global.getComputedStyle(document.body);
             if (bodyStyles.backgroundColor) {
                 document.querySelector('meta[name="theme-color"]').content = bodyStyles.backgroundColor;
             }


### PR DESCRIPTION
Left to do:
 - [x] document
 - [x] have a think if the format is future-proof enough in allowing for all the `@font-face` flexibility. Also does the src list need to be ordered?