### PR TITLE
Use theme-capable icons in the user menu

### DIFF
--- a/res/css/structures/_UserMenuButton.scss
+++ b/res/css/structures/_UserMenuButton.scss
@@ -100,15 +100,14 @@ limitations under the License.
     }
 
     .mx_IconizedContextMenu_icon {
-        position: relative;
         width: 16px;
         height: 16px;
+        display: block;
 
         &::before {
             content: '';
             width: 16px;
             height: 16px;
-            position: absolute;
             mask-position: center;
             mask-size: contain;
             mask-repeat: no-repeat;

--- a/res/css/structures/_UserMenuButton.scss
+++ b/res/css/structures/_UserMenuButton.scss
@@ -15,7 +15,26 @@ limitations under the License.
 */
 
 .mx_UserMenuButton {
-    // No special styles on the button itself
+    > span {
+        width: 16px;
+        height: 16px;
+        position: relative;
+        display: block;
+
+        &::before {
+            content: '';
+            width: 16px;
+            height: 16px;
+            position: absolute;
+            top: 0;
+            left: 0;
+            mask-position: center;
+            mask-size: contain;
+            mask-repeat: no-repeat;
+            background: $primary-fg-color;
+            mask-image: url('$(res)/img/feather-customised/more-horizontal.svg');
+        }
+    }
 }
 
 .mx_UserMenuButton_contextMenu {
@@ -78,5 +97,50 @@ limitations under the License.
             align-items: center;
             justify-content: center;
         }
+    }
+
+    .mx_IconizedContextMenu_icon {
+        position: relative;
+        width: 16px;
+        height: 16px;
+
+        &::before {
+            content: '';
+            width: 16px;
+            height: 16px;
+            position: absolute;
+            mask-position: center;
+            mask-size: contain;
+            mask-repeat: no-repeat;
+            background: $primary-fg-color;
+        }
+    }
+
+    .mx_UserMenuButton_iconHome::before {
+        mask-image: url('$(res)/img/feather-customised/home.svg');
+    }
+
+    .mx_UserMenuButton_iconBell::before {
+        mask-image: url('$(res)/img/feather-customised/notifications.svg');
+    }
+
+    .mx_UserMenuButton_iconLock::before {
+        mask-image: url('$(res)/img/feather-customised/lock.svg');
+    }
+
+    .mx_UserMenuButton_iconSettings::before {
+        mask-image: url('$(res)/img/feather-customised/settings.svg');
+    }
+
+    .mx_UserMenuButton_iconArchive::before {
+        mask-image: url('$(res)/img/feather-customised/archive.svg');
+    }
+
+    .mx_UserMenuButton_iconMessage::before {
+        mask-image: url('$(res)/img/feather-customised/message-circle.svg');
+    }
+
+    .mx_UserMenuButton_iconSignOut::before {
+        mask-image: url('$(res)/img/feather-customised/sign-out.svg');
     }
 }

--- a/src/components/structures/UserMenuButton.tsx
+++ b/src/components/structures/UserMenuButton.tsx
@@ -190,7 +190,7 @@ export default class UserMenuButton extends React.Component<IProps, IState> {
                 homeButton = (
                     <li>
                         <AccessibleButton onClick={this.onHomeClick}>
-                            <img src={require("../../../res/img/feather-customised/home.svg")} width={16} />
+                            <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconHome" />
                             <span>{_t("Home")}</span>
                         </AccessibleButton>
                     </li>
@@ -233,31 +233,31 @@ export default class UserMenuButton extends React.Component<IProps, IState> {
                                 {homeButton}
                                 <li>
                                     <AccessibleButton onClick={(e) => this.onSettingsOpen(e, USER_NOTIFICATIONS_TAB)}>
-                                        <img src={require("../../../res/img/feather-customised/notifications.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconBell" />
                                         <span>{_t("Notification settings")}</span>
                                     </AccessibleButton>
                                 </li>
                                 <li>
                                     <AccessibleButton onClick={(e) => this.onSettingsOpen(e, USER_SECURITY_TAB)}>
-                                        <img src={require("../../../res/img/feather-customised/lock.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconLock" />
                                         <span>{_t("Security & privacy")}</span>
                                     </AccessibleButton>
                                 </li>
                                 <li>
                                     <AccessibleButton onClick={(e) => this.onSettingsOpen(e, null)}>
-                                        <img src={require("../../../res/img/feather-customised/settings.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconSettings" />
                                         <span>{_t("All settings")}</span>
                                     </AccessibleButton>
                                 </li>
                                 <li>
                                     <AccessibleButton onClick={this.onShowArchived}>
-                                        <img src={require("../../../res/img/feather-customised/archive.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconArchive" />
                                         <span>{_t("Archived rooms")}</span>
                                     </AccessibleButton>
                                 </li>
                                 <li>
                                     <AccessibleButton onClick={this.onProvideFeedback}>
-                                        <img src={require("../../../res/img/feather-customised/message-circle.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconMessage" />
                                         <span>{_t("Feedback")}</span>
                                     </AccessibleButton>
                                 </li>
@@ -267,7 +267,7 @@ export default class UserMenuButton extends React.Component<IProps, IState> {
                             <ul>
                                 <li>
                                     <AccessibleButton onClick={this.onSignOutClick}>
-                                        <img src={require("../../../res/img/feather-customised/sign-out.svg")} width={16} />
+                                        <span className="mx_IconizedContextMenu_icon mx_UserMenuButton_iconSignOut" />
                                         <span>{_t("Sign out")}</span>
                                     </AccessibleButton>
                                 </li>
@@ -287,7 +287,7 @@ export default class UserMenuButton extends React.Component<IProps, IState> {
                     label={_t("Account settings")}
                     isExpanded={this.state.menuDisplayed}
                 >
-                    <img src={require("../../../res/img/feather-customised/more-horizontal.svg")} alt="..." width={14} />
+                    <span>{/* masked image in CSS */}</span>
                 </ContextMenuButton>
                 {contextMenu}
             </React.Fragment>


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/13635

They're still inconsistent weights, but at least they are the right color on non-light-theme clients.

![image](https://user-images.githubusercontent.com/1190097/85495057-0cf08580-b597-11ea-8d4e-f2ff02b08f01.png)
