### PR TITLE
Allow the user to resize the new sublists to 1 tile

### DIFF
--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -117,7 +117,7 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
     };
 
     private onShowLessClick = () => {
-        this.props.layout.visibleTiles = this.props.layout.minVisibleTiles;
+        this.props.layout.visibleTiles = this.props.layout.defaultVisibleTiles;
         this.forceUpdate(); // because the layout doesn't trigger a re-render
     };
 

--- a/src/stores/room-list/ListLayout.ts
+++ b/src/stores/room-list/ListLayout.ts
@@ -67,6 +67,7 @@ export class ListLayout {
     }
 
     public get visibleTiles(): number {
+        if (this._n === 0) return this.defaultVisibleTiles;
         return Math.max(this._n, this.minVisibleTiles);
     }
 
@@ -78,7 +79,13 @@ export class ListLayout {
     public get minVisibleTiles(): number {
         // the .65 comes from the CSS where the show more button is
         // mathematically 65% of a tile when floating.
-        return 4.65;
+        return 1.65;
+    }
+
+    public get defaultVisibleTiles(): number {
+        // TODO: Remove dogfood flag
+        const val = Number(localStorage.getItem("mx_dogfood_rl_defTiles") || 4);
+        return val + 0.65; // see minVisibleTiles for where the .65 comes from
     }
 
     public calculateTilesToPixelsMin(maxTiles: number, n: number, possiblePadding: number): number {


### PR DESCRIPTION
For dogfooding https://github.com/vector-im/riot-web/issues/14137
For https://github.com/vector-im/riot-web/issues/13635

To change the default: `localStorage.setItem("mx_dogfood_rl_defTiles", 4);`