### PR TITLE
Fix jumping to read marker for events without tiles

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -517,10 +517,14 @@ export default class MessagePanel extends React.Component {
                     // replacing all of the DOM elements every time we paginate.
                     ret.push(...this._getTilesForEvent(prevEvent, mxEv, last));
                     prevEvent = mxEv;
-                }
 
-                const readMarker = this._readMarkerForEvent(eventId, i >= lastShownNonLocalEchoIndex);
-                if (readMarker) ret.push(readMarker);
+                    // Only consider drawing the read marker for events that also have a
+                    // tile. When scrolling to the read marker, we assume that if the read
+                    // marker node is present, then there is also an event tile with a
+                    // matching scroll token as well.
+                    const readMarker = this._readMarkerForEvent(eventId, i >= lastShownNonLocalEchoIndex);
+                    if (readMarker) ret.push(readMarker);
+                }
             }
         }
 


### PR DESCRIPTION
It is possible for your read marker to be set to an event without a tile (like a
reaction). We would still render the read marker at the position of those events
in the timeline, even though there's no matching tile, which breaks a core
assumption of jump to read marker path: it assumes that if the read marker node
is present in the DOM, then there must also be an event tile with a scroll token
matching the event ID.

This fixes the situation by no longer attempting to draw a read marker for
events without tiles.

Fixes https://github.com/vector-im/riot-web/issues/10975