### PR TITLE
Use grid-based resizing in the new room list

### DIFF
--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -105,8 +105,10 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
     };
 
     private onResize = (e: React.MouseEvent, data: ResizeCallbackData) => {
+        // TODO: Clean up if we switch back to pixel resizing
         const direction = e.movementY < 0 ? -1 : +1;
-        const tileDiff = this.props.layout.pixelsToTiles(Math.abs(e.movementY)) * direction;
+        //const tileDiff = this.props.layout.pixelsToTiles(Math.abs(e.movementY)) * direction;
+        const tileDiff = direction;
         this.props.layout.visibleTiles += tileDiff;
         this.forceUpdate(); // because the layout doesn't trigger a re-render
     };
@@ -435,6 +437,7 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
                     axis="y"
                     minConstraints={[-1, minTilesPx]}
                     maxConstraints={[-1, maxTilesPx]}
+                    draggableOpts={{grid: [-1, layout.tileHeight]}}
                     resizeHandles={handles}
                     onResize={this.onResize}
                     className="mx_RoomSublist2_resizeBox"


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/13635

**This is currently receiving pushback, I just don't want to lose the code.**