### PR TITLE
Hide room list show less button if it would do nothing

### DIFF
--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -393,7 +393,7 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
                         {showMoreText}
                     </div>
                 );
-            } else if (tiles.length <= nVisible && tiles.length > this.props.layout.minVisibleTiles) {
+            } else if (tiles.length <= nVisible && tiles.length > this.props.layout.defaultVisibleTiles) {
                 // we have all tiles visible - add a button to show less
                 let showLessText = (
                     <span className='mx_RoomSublist2_showNButtonText'>


### PR DESCRIPTION
Signed-off-by: ☕ Tim <tim@wants.coffee>

On the new rooms list, if the show less button wouldn't result in a
smaller list, don't show it.

Fixes vector-im/riot-web#14219