### PR TITLE
Fix jumping to read marker for events without tiles

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -388,8 +388,11 @@ export default class MessagePanel extends React.Component {
             }
 
             return (
-                <li key={"readMarker_"+eventId} ref={this._readMarkerNode}
-                      className="mx_RoomView_myReadMarker_container">
+                <li key={"readMarker_"+eventId}
+                    ref={this._readMarkerNode}
+                    className="mx_RoomView_myReadMarker_container"
+                    data-scroll-tokens={eventId}
+                >
                     { hr }
                 </li>
             );


### PR DESCRIPTION
It is possible for your read marker to be set to an event without a tile (like a
reaction). We would still render the read marker at the position of those events
in the timeline, even though there's no matching tile, which breaks a core
assumption of jump to read marker path: it assumes that if the read marker node
is present in the DOM, then there must also be an event tile with a scroll token
matching the event ID.

This fixes the situation by setting a scroll token on the read marker so it can
always be scrolled to, no matter what kind of event it might represent.

Fixes vector-im/riot-web#10975