### PR TITLE
Disable use of account-level ordering options in new room list

### DIFF
--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -23,6 +23,7 @@ import SettingsStore from "../../../../../settings/SettingsStore";
 import Field from "../../../elements/Field";
 import * as sdk from "../../../../..";
 import PlatformPeg from "../../../../../PlatformPeg";
+import {RoomListStoreTempProxy} from "../../../../../stores/room-list/RoomListStoreTempProxy";
 
 export default class PreferencesUserSettingsTab extends React.Component {
     static ROOM_LIST_SETTINGS = [
@@ -30,6 +31,19 @@ export default class PreferencesUserSettingsTab extends React.Component {
         'RoomList.orderByImportance',
         'breadcrumbs',
     ];
+
+    // TODO: Remove temp structures: https://github.com/vector-im/riot-web/issues/14231
+    static ROOM_LIST_2_SETTINGS = [
+        'breadcrumbs',
+    ];
+
+    // TODO: Remove temp structures: https://github.com/vector-im/riot-web/issues/14231
+    static ELIGIBLE_ROOM_LIST_SETTINGS = () => {
+        if (RoomListStoreTempProxy.isUsingNewStore()) {
+            return PreferencesUserSettingsTab.ROOM_LIST_2_SETTINGS;
+        }
+        return PreferencesUserSettingsTab.ROOM_LIST_SETTINGS;
+    };
 
     static COMPOSER_SETTINGS = [
         'MessageComposerInput.autoReplaceEmoji',
@@ -175,7 +189,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
 
                 <div className="mx_SettingsTab_section">
                     <span className="mx_SettingsTab_subheading">{_t("Room list")}</span>
-                    {this._renderGroup(PreferencesUserSettingsTab.ROOM_LIST_SETTINGS)}
+                    {this._renderGroup(PreferencesUserSettingsTab.ELIGIBLE_ROOM_LIST_SETTINGS())}
                 </div>
 
                 <div className="mx_SettingsTab_section">

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -38,7 +38,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
     ];
 
     // TODO: Remove temp structures: https://github.com/vector-im/riot-web/issues/14231
-    static ELIGIBLE_ROOM_LIST_SETTINGS = () => {
+    static eligibleRoomListSettings = () => {
         if (RoomListStoreTempProxy.isUsingNewStore()) {
             return PreferencesUserSettingsTab.ROOM_LIST_2_SETTINGS;
         }
@@ -189,7 +189,7 @@ export default class PreferencesUserSettingsTab extends React.Component {
 
                 <div className="mx_SettingsTab_section">
                     <span className="mx_SettingsTab_subheading">{_t("Room list")}</span>
-                    {this._renderGroup(PreferencesUserSettingsTab.ELIGIBLE_ROOM_LIST_SETTINGS())}
+                    {this._renderGroup(PreferencesUserSettingsTab.eligibleRoomListSettings())}
                 </div>
 
                 <div className="mx_SettingsTab_section">

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -478,11 +478,13 @@ export const SETTINGS = {
             deny: [],
         },
     },
+    // TODO: Remove setting: https://github.com/vector-im/riot-web/issues/14231
     "RoomList.orderAlphabetically": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("Order rooms by name"),
         default: false,
     },
+    // TODO: Remove setting: https://github.com/vector-im/riot-web/issues/14231
     "RoomList.orderByImportance": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("Show rooms with unread notifications first"),

--- a/src/stores/room-list/RoomListStore2.ts
+++ b/src/stores/room-list/RoomListStore2.ts
@@ -50,8 +50,6 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
     private tagWatcher = new TagWatcher(this);
 
     private readonly watchedSettings = [
-        'RoomList.orderAlphabetically',
-        'RoomList.orderByImportance',
         'feature_custom_tags',
     ];
 
@@ -338,11 +336,8 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
     }
 
     private async updateAlgorithmInstances() {
-        const orderByImportance = SettingsStore.getValue("RoomList.orderByImportance");
-        const orderAlphabetically = SettingsStore.getValue("RoomList.orderAlphabetically");
-
-        const defaultSort = orderAlphabetically ? SortAlgorithm.Alphabetic : SortAlgorithm.Recent;
-        const defaultOrder = orderByImportance ? ListAlgorithm.Importance : ListAlgorithm.Natural;
+        const defaultSort = SortAlgorithm.Alphabetic;
+        const defaultOrder = ListAlgorithm.Natural;
 
         for (const tag of Object.keys(this.orderedLists)) {
             const definedSort = this.getTagSorting(tag);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14069
For https://github.com/vector-im/riot-web/issues/13635

We can't drop them completely for compatibility with the old room list.