### PR TITLE
Remove context menu on invites in new room list

### DIFF
--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -32,7 +32,7 @@ import StyledCheckbox from "../elements/StyledCheckbox";
 import StyledRadioButton from "../elements/StyledRadioButton";
 import RoomListStore from "../../../stores/room-list/RoomListStore2";
 import { ListAlgorithm, SortAlgorithm } from "../../../stores/room-list/algorithms/models";
-import { TagID } from "../../../stores/room-list/models";
+import { DefaultTagID, TagID } from "../../../stores/room-list/models";
 
 // TODO: Remove banner on launch: https://github.com/vector-im/riot-web/issues/14231
 // TODO: Rename on launch: https://github.com/vector-im/riot-web/issues/14231
@@ -196,6 +196,11 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
     }
 
     private renderMenu(): React.ReactElement {
+        // TODO: Get a proper invite context menu, or take invites out of the room list.
+        if (this.props.tagId === DefaultTagID.Invite) {
+            return null;
+        }
+
         let contextMenu = null;
         if (this.state.menuDisplayed) {
             const elementRect = this.menuButtonRef.current.getBoundingClientRect();

--- a/src/components/views/rooms/RoomTile2.tsx
+++ b/src/components/views/rooms/RoomTile2.tsx
@@ -156,6 +156,11 @@ export default class RoomTile2 extends React.Component<IProps, IState> {
     private renderGeneralMenu(): React.ReactElement {
         if (this.props.isMinimized) return null; // no menu when minimized
 
+        // TODO: Get a proper invite context menu, or take invites out of the room list.
+        if (this.props.tag === DefaultTagID.Invite) {
+            return null;
+        }
+
         let contextMenu = null;
         if (this.state.generalMenuDisplayed) {
             // The context menu appears within the list, so use the room tile as a reference point


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14198
For https://github.com/vector-im/riot-web/issues/13635

For both, the decision has been made to not have a context menu pending further considerations of where invites should (and should not) be. Likely this will be dealt with in FTUE Notifications.