### PR TITLE
Fix reaction event crashes in message previews

### DIFF
--- a/src/stores/room-list/previews/ReactionEventPreview.ts
+++ b/src/stores/room-list/previews/ReactionEventPreview.ts
@@ -22,8 +22,11 @@ import { _t } from "../../../languageHandler";
 
 export class ReactionEventPreview implements IPreview {
     public getTextFor(event: MatrixEvent, tagId?: TagID): string {
-        const reaction = event.getRelation().key;
-        if (!reaction) return;
+        const relation = event.getRelation();
+        if (!relation) return null; // invalid reaction (probably redacted)
+
+        const reaction = relation.key;
+        if (!reaction) return null; // invalid reaction (unknown format)
 
         if (isSelf(event) || !shouldPrefixMessagesIn(event.getRoomId(), tagId)) {
             return reaction;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14224
For https://github.com/vector-im/riot-web/issues/13635

This typically happens when a reaction is removed (redacted).