### PR TITLE
Don't include empty badge container in minimized view

### DIFF
--- a/src/components/views/rooms/RoomTile2.tsx
+++ b/src/components/views/rooms/RoomTile2.tsx
@@ -369,11 +369,15 @@ export default class RoomTile2 extends React.Component<IProps, IState> {
 
         let badge: React.ReactNode;
         if (!this.props.isMinimized) {
-        badge = <NotificationBadge
-                notification={this.state.notificationState}
-                forceCount={false}
-                roomId={this.props.room.roomId}
-            />;
+            badge = (
+                <div className="mx_RoomTile2_badgeContainer">
+                    <NotificationBadge
+                        notification={this.state.notificationState}
+                        forceCount={false}
+                        roomId={this.props.room.roomId}
+                    />
+                </div>
+            );
         }
 
         // TODO: the original RoomTile uses state for the room name. Do we need to?
@@ -429,9 +433,7 @@ export default class RoomTile2 extends React.Component<IProps, IState> {
                         >
                             {roomAvatar}
                             {nameContainer}
-                            <div className="mx_RoomTile2_badgeContainer">
-                                {badge}
-                            </div>
+                            {badge}
                             {this.renderNotificationsMenu()}
                             {this.renderGeneralMenu()}
                         </AccessibleButton>


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14294
For https://github.com/vector-im/riot-web/issues/13635

It takes up space, and it won't hold anything anyways.

Red is for visibility:
![image](https://user-images.githubusercontent.com/1190097/86405125-0f756e00-bc6e-11ea-9c45-d05a9f63eaa8.png)
