### PR TITLE
Enable the new room list by default and trigger an initial render

### DIFF
--- a/src/components/views/rooms/RoomList2.tsx
+++ b/src/components/views/rooms/RoomList2.tsx
@@ -166,18 +166,25 @@ export default class RoomList2 extends React.Component<IProps, IState> {
     }
 
     public componentDidMount(): void {
-        RoomListStore.instance.on(LISTS_UPDATE_EVENT, (store: RoomListStore2) => {
-            const newLists = store.orderedLists;
-            console.log("new lists", newLists);
-
-            const layoutMap = new Map<TagID, ListLayout>();
-            for (const tagId of Object.keys(newLists)) {
-                layoutMap.set(tagId, new ListLayout(tagId));
-            }
-
-            this.setState({sublists: newLists, layouts: layoutMap});
-        });
+        RoomListStore.instance.on(LISTS_UPDATE_EVENT, this.updateLists);
+        this.updateLists(); // trigger the first update
     }
+
+    public componentWillUnmount() {
+        RoomListStore.instance.off(LISTS_UPDATE_EVENT, this.updateLists);
+    }
+
+    private updateLists = () => {
+        const newLists = RoomListStore.instance.orderedLists;
+        console.log("new lists", newLists);
+
+        const layoutMap = new Map<TagID, ListLayout>();
+        for (const tagId of Object.keys(newLists)) {
+            layoutMap.set(tagId, new ListLayout(tagId));
+        }
+
+        this.setState({sublists: newLists, layouts: layoutMap});
+    };
 
     private renderCommunityInvites(): React.ReactElement[] {
         // TODO: Put community invites in a more sensible place (not in the room list)

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -150,7 +150,7 @@ export const SETTINGS = {
         isFeature: true,
         displayName: _td("Use the improved room list (will refresh to apply changes)"),
         supportedLevels: LEVELS_FEATURE,
-        default: false,
+        default: true,
         controller: new ReloadOnChangeController(),
     },
     "feature_custom_themes": {


### PR DESCRIPTION
**Blocked by https://github.com/matrix-org/matrix-react-sdk/pull/4876**
Ideally lands close to https://github.com/matrix-org/matrix-react-sdk/pull/4877
Ideally lands close to https://github.com/matrix-org/matrix-react-sdk/pull/4878
Ideally lands close to https://github.com/matrix-org/matrix-react-sdk/pull/4879
Ideally lands close to https://github.com/matrix-org/matrix-react-sdk/pull/4880
Ideally lands close to https://github.com/matrix-org/matrix-react-sdk/pull/4864
For https://github.com/vector-im/riot-web/issues/13635

**This is pre-approved by product/design on a call, with the blocker above being identified.**

We have to trigger an initial render because during the login process the user will have started syncing (causing lists to generate) 
but the RoomList component won't be mounted & listening and therefore won't receive the initial lists. By generating them on mount, we ensure that the lists are present once the user gets through the login process.