### PR TITLE
Fix minor issues with the badges in the new room list

### DIFF
--- a/res/css/views/rooms/_RoomSublist2.scss
+++ b/res/css/views/rooms/_RoomSublist2.scss
@@ -92,7 +92,7 @@ limitations under the License.
 
             // Apply the width and margin to the badge so the container doesn't occupy dead space
             .mx_NotificationBadge {
-                width: 16px;
+                // Do not set a width so the badges get properly sized
                 margin-left: 8px; // same as menu+aux buttons
             }
         }

--- a/res/css/views/rooms/_RoomTile2.scss
+++ b/res/css/views/rooms/_RoomTile2.scss
@@ -85,6 +85,7 @@ limitations under the License.
         height: 16px;
         // don't set width so that it takes no space when there is no badge to show
         margin: auto 0; // vertically align
+        position: relative; // fixes badge alignment in some scenarios
 
         // Create a flexbox to make aligning dot badges easier
         display: flex;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14225
For https://github.com/vector-im/riot-web/issues/13635

This intentionally does not fix the off-by-1 alignment on the whole list.

Before (community badge weird, 99+ stuck in a circle):
![image](https://user-images.githubusercontent.com/1190097/86496211-8461aa00-bd39-11ea-9e2b-fdce7ba379d7.png)

After: 
![image](https://user-images.githubusercontent.com/1190097/86496213-875c9a80-bd39-11ea-9521-4a92a0811fd9.png)
