### PR TITLE
"ignore"/"unignore" commands: validate user ID

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -660,7 +660,7 @@ export const Commands = [
             if (args) {
                 const cli = MatrixClientPeg.get();
 
-                const matches = args.match(/^(\S+)$/);
+                const matches = args.match(/^(@[^:]+:\S+)$/);
                 if (matches) {
                     const userId = matches[1];
                     const ignoredUsers = cli.getIgnoredUsers();
@@ -690,7 +690,7 @@ export const Commands = [
             if (args) {
                 const cli = MatrixClientPeg.get();
 
-                const matches = args.match(/^(\S+)$/);
+                const matches = args.match(/(^@[^:]+:\S+$)/);
                 if (matches) {
                     const userId = matches[1];
                     const ignoredUsers = cli.getIgnoredUsers();


### PR DESCRIPTION
Extend the accepted patterns so that users are alerted about invalid
input. These patterns are approximations of the Matrix user ID grammer.

Resolves https://github.com/vector-im/riot-web/issues/12743

---

This is a partial solution because the RegExp is over-simplified. I was tempted to implement something more advanced, but that seems like something that belongs in the JavaScript SDK (along with tests). There are a couple other parts of the React SDK which could use that:

- https://github.com/matrix-org/matrix-react-sdk/blob/d98ba9b577d3293a261a2bb34dbf731c0c340a24/src/MatrixClientPeg.ts#L242
- https://github.com/matrix-org/matrix-react-sdk/blob/d98ba9b577d3293a261a2bb34dbf731c0c340a24/src/UserAddress.js#L19

If you folks like, I'd be happy to extend the JS SDK and then return to this one.