### PR TITLE
Fix gaps under resize handle

### DIFF
--- a/res/css/views/rooms/_RoomSublist2.scss
+++ b/res/css/views/rooms/_RoomSublist2.scss
@@ -203,10 +203,11 @@ limitations under the License.
             // Update the render() function for RoomSublist2 if these change
             // Update the ListLayout class for minVisibleTiles if these change.
             //
-            // At 28px high and 8px padding on the top this equates to 0.73 of
+            // At 24px high, 8px padding on the top and 4px padding on the bottom  this equates to 0.73 of
             // a tile due to how the padding calculations work.
-            height: 28px;
+            height: 24px;
             padding-top: 8px;
+            padding-bottom: 4px;
 
             // We force this to the bottom so it will overlap rooms as needed.
             // We account for the space it takes up (24px) in the code through padding.

--- a/res/css/views/rooms/_RoomSublist2.scss
+++ b/res/css/views/rooms/_RoomSublist2.scss
@@ -203,15 +203,15 @@ limitations under the License.
             // Update the render() function for RoomSublist2 if these change
             // Update the ListLayout class for minVisibleTiles if these change.
             //
-            // At 24px high and 8px padding on the top this equates to 0.65 of
+            // At 28px high and 8px padding on the top this equates to 0.73 of
             // a tile due to how the padding calculations work.
-            height: 24px;
+            height: 28px;
             padding-top: 8px;
 
             // We force this to the bottom so it will overlap rooms as needed.
             // We account for the space it takes up (24px) in the code through padding.
             position: absolute;
-            bottom: 4px; // the height of the resize handle
+            bottom: 0; // the height of the resize handle
             left: 0;
             right: 0;
 


### PR DESCRIPTION
I don't know why this fixes it but it does make it go away.

fixes: https://github.com/vector-im/riot-web/issues/14303

relates to:  https://github.com/vector-im/riot-web/issues/13635