### PR TITLE
Don't destroy room notification states when replacing them

### DIFF
--- a/src/stores/notifications/ListNotificationState.ts
+++ b/src/stores/notifications/ListNotificationState.ts
@@ -55,11 +55,6 @@ export class ListNotificationState extends NotificationState {
         for (const newRoom of diff.added) {
             const state = this.getRoomFn(newRoom);
             state.on(NOTIFICATION_STATE_UPDATE, this.onRoomNotificationStateUpdate);
-            if (this.states[newRoom.roomId]) {
-                // "Should never happen" disclaimer.
-                console.warn("Overwriting notification state for room:", newRoom.roomId);
-                this.states[newRoom.roomId].destroy();
-            }
             this.states[newRoom.roomId] = state;
         }
 


### PR DESCRIPTION
The "should never happen" now happens a lot by design. We shouldn't destroy the state as it'll stop badge counts for everything.

Fixes https://github.com/vector-im/riot-web/issues/14391
For https://github.com/vector-im/riot-web/issues/13635