### PR TITLE
Fix rough badge alignment for community invite tiles again

### DIFF
--- a/res/css/views/avatars/_DecoratedRoomAvatar.scss
+++ b/res/css/views/avatars/_DecoratedRoomAvatar.scss
@@ -24,7 +24,7 @@ limitations under the License.
         right: 0;
     }
 
-    .mx_NotificationBadge {
+    .mx_NotificationBadge, .mx_RoomTile2_badgeContainer {
         position: absolute;
         top: 0;
         right: 0;

--- a/res/css/views/rooms/_RoomTile2.scss
+++ b/res/css/views/rooms/_RoomTile2.scss
@@ -89,7 +89,6 @@ limitations under the License.
         height: 16px;
         // don't set width so that it takes no space when there is no badge to show
         margin: auto 0; // vertically align
-        position: relative; // fixes badge alignment in some scenarios
 
         // Create a flexbox to make aligning dot badges easier
         display: flex;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14392
For https://github.com/vector-im/riot-web/issues/13635

![image](https://user-images.githubusercontent.com/1190097/87066923-924b7b00-c1d0-11ea-8e2e-8c2620cca940.png)
