### PR TITLE
Stop safari from aggressively shrinking flex items

### DIFF
--- a/res/css/structures/_LeftPanel2.scss
+++ b/res/css/structures/_LeftPanel2.scss
@@ -55,6 +55,7 @@ $tagPanelWidth: 70px; // only applies in this file, used for calculations
 
         .mx_LeftPanel2_userHeader {
             padding: 12px 12px 20px; // 12px top, 12px sides, 20px bottom
+            flex-shrink: 0;
 
             // Create another flexbox column for the rows to stack within
             display: flex;
@@ -79,6 +80,8 @@ $tagPanelWidth: 70px; // only applies in this file, used for calculations
         .mx_LeftPanel2_filterContainer {
             margin-left: 12px;
             margin-right: 12px;
+
+            flex-shrink: 0;
 
             // Create a flexbox to organize the inputs
             display: flex;

--- a/res/css/views/rooms/_RoomSublist2.scss
+++ b/res/css/views/rooms/_RoomSublist2.scss
@@ -24,6 +24,8 @@ limitations under the License.
     margin-left: 8px;
     width: 100%;
 
+    flex-shrink: 0;
+
     .mx_RoomSublist2_headerContainer {
         // Create a flexbox to make alignment easy
         display: flex;


### PR DESCRIPTION
fixes: https://github.com/vector-im/riot-web/issues/14393

for:  https://github.com/vector-im/riot-web/issues/13635

Safari was aggressively shrinking flex items in the room list causing all sort of visual artefacts. This helps safari by clearly marking that which should not be shrunk.

![image](https://user-images.githubusercontent.com/23084468/87105724-ae443080-c253-11ea-950a-60b229f33338.png)
