### PR TITLE
Ensure triggered updates get fired for filters in the new room list

### DIFF
--- a/src/stores/room-list/RoomListStore2.ts
+++ b/src/stores/room-list/RoomListStore2.ts
@@ -481,8 +481,9 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
     };
 
     private onAlgorithmFilterUpdated = () => {
-        // The filter can happen off-cycle, so trigger an update if we need to.
-        this.updateFn.triggerIfWillMark();
+        // The filter can happen off-cycle, so trigger an update. The filter will have
+        // already caused a mark.
+        this.updateFn.trigger();
     };
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14404
For https://github.com/vector-im/riot-web/issues/13635

`recalculateFilteredRooms()` causes a mark to happen, so we just need to trigger instead.