### PR TITLE
Internalize algorithm updates in the new room list store

### DIFF
--- a/src/stores/room-list/RoomListStore2.ts
+++ b/src/stores/room-list/RoomListStore2.ts
@@ -368,10 +368,14 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
     }
 
     public async setTagSorting(tagId: TagID, sort: SortAlgorithm) {
+        await this.setAndPersistTagSorting(tagId, sort);
+        this.updateFn.trigger();
+    }
+
+    private async setAndPersistTagSorting(tagId: TagID, sort: SortAlgorithm) {
         await this.algorithm.setTagSorting(tagId, sort);
         // TODO: Per-account? https://github.com/vector-im/riot-web/issues/14114
         localStorage.setItem(`mx_tagSort_${tagId}`, sort);
-        this.updateFn.triggerIfWillMark();
     }
 
     public getTagSorting(tagId: TagID): SortAlgorithm {
@@ -407,10 +411,14 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
     }
 
     public async setListOrder(tagId: TagID, order: ListAlgorithm) {
+        await this.setAndPersistListOrder(tagId, order);
+        this.updateFn.trigger();
+    }
+
+    private async setAndPersistListOrder(tagId: TagID, order: ListAlgorithm) {
         await this.algorithm.setListOrdering(tagId, order);
         // TODO: Per-account? https://github.com/vector-im/riot-web/issues/14114
         localStorage.setItem(`mx_listOrder_${tagId}`, order);
-        this.updateFn.triggerIfWillMark();
     }
 
     public getListOrder(tagId: TagID): ListAlgorithm {
@@ -458,10 +466,10 @@ export class RoomListStore2 extends AsyncStore<ActionPayload> {
             const listOrder = this.calculateListOrder(tag);
 
             if (tagSort !== definedSort) {
-                await this.setTagSorting(tag, tagSort);
+                await this.setAndPersistTagSorting(tag, tagSort);
             }
             if (listOrder !== definedOrder) {
-                await this.setListOrder(tag, listOrder);
+                await this.setAndPersistListOrder(tag, listOrder);
             }
         }
     }

--- a/src/utils/MarkedExecution.ts
+++ b/src/utils/MarkedExecution.ts
@@ -53,15 +53,4 @@ export class MarkedExecution {
         this.reset(); // reset first just in case the fn() causes a trigger()
         this.fn();
     }
-
-    /**
-     * Triggers the function if a mark() call would mark it. If the function
-     * has already been marked this will do nothing.
-     */
-    public triggerIfWillMark() {
-        if (!this.marked) {
-            this.mark();
-            this.trigger();
-        }
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14411
For https://github.com/vector-im/riot-web/issues/13635

The act of setting/changing the algorithm was causing the update function to be marked, meaning we wouldn't trigger an update until something else happened later. To get around this, and still support internal functions spamming calls without multiple updates, we simply move the guts to an internalized function and make the public interface do a trigger.