### PR TITLE
Remove redundant scroll-margins and fix RoomTile wrongly scrolling

### DIFF
--- a/res/css/views/rooms/_RoomTile2.scss
+++ b/res/css/views/rooms/_RoomTile2.scss
@@ -21,10 +21,6 @@ limitations under the License.
     margin-bottom: 4px;
     padding: 4px;
 
-    // allow scrollIntoView to ignore the sticky headers, must match combined height of .mx_RoomSublist2_headerContainer
-    scroll-margin-top: 32px;
-    scroll-margin-bottom: 32px;
-
     // The tile is also a flexbox row itself
     display: flex;
 
@@ -166,11 +162,6 @@ limitations under the License.
             margin-right: 0;
         }
     }
-}
-
-// do not apply scroll-margin-bottom to the sublist which will not have a sticky header below it
-.mx_RoomSublist2:last-child .mx_RoomTile2 {
-    scroll-margin-bottom: 0;
 }
 
 // We use these both in context menus and the room tiles

--- a/src/components/views/rooms/RoomSublist2.tsx
+++ b/src/components/views/rooms/RoomSublist2.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import * as React from "react";
-import { createRef } from "react";
+import {createRef, UIEventHandler} from "react";
 import { Room } from "matrix-js-sdk/src/models/room";
 import classNames from 'classnames';
 import { RovingAccessibleButton, RovingTabIndexWrapper } from "../../../accessibility/RovingTabIndex";
@@ -595,6 +595,12 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
         );
     }
 
+    private onScrollPrevent(e: React.UIEvent<HTMLDivElement>) {
+        // the RoomTile calls scrollIntoView and the browser may scroll a div we do not wish to be scrollable
+        // this fixes https://github.com/vector-im/riot-web/issues/14413
+        (e.target as HTMLDivElement).scrollTop = 0;
+    }
+
     public render(): React.ReactElement {
         // TODO: Error boundary: https://github.com/vector-im/riot-web/issues/14185
 
@@ -704,7 +710,7 @@ export default class RoomSublist2 extends React.Component<IProps, IState> {
                         className="mx_RoomSublist2_resizeBox"
                         enable={handles}
                     >
-                        <div className="mx_RoomSublist2_tiles">
+                        <div className="mx_RoomSublist2_tiles" onScroll={this.onScrollPrevent}>
                             {visibleTiles}
                         </div>
                         {showNButton}


### PR DESCRIPTION
Now that the sticky headers are rendered outside of the main div the scroll-margins create redundant space and are not needed.

![image](https://user-images.githubusercontent.com/2403652/87241588-a84d7b80-c41c-11ea-94f4-b6a5f29f15f9.png)

Fixes https://github.com/vector-im/riot-web/issues/14413

It is quite an ugly solution but the alternative is much much more complex scrolling code instead of being able to rely on `scrollIntoView` or the RoomTile updating the DOM properties of its parent with a similarly ugly hack.

Tested on Firefox this produces no visual jumping/glitching/artifacting.

For https://github.com/vector-im/riot-web/issues/13635