### PR TITLE
Be consistent with the at-room pill avatar configurability

### DIFF
--- a/src/utils/pillify.js
+++ b/src/utils/pillify.js
@@ -111,7 +111,7 @@ export function pillifyLinks(nodes, mxEvent, pills) {
                             type={Pill.TYPE_AT_ROOM_MENTION}
                             inMessage={true}
                             room={room}
-                            shouldShowPillAvatar={true}
+                            shouldShowPillAvatar={shouldShowPillAvatar}
                         />;
 
                         ReactDOM.render(pill, pillContainer);


### PR DESCRIPTION
We were respecting the setting in the composer but not in the timeline:
![image](https://user-images.githubusercontent.com/2403652/87253750-8a603500-c475-11ea-8e7d-907a31e9b6de.png)

Fixes https://github.com/vector-im/riot-web/issues/13991