### PR TITLE
Ensure tag changes (leaving rooms) causes rooms to move between lists

### DIFF
--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -698,8 +698,8 @@ export class Algorithm extends EventEmitter {
             }
         }
 
+        let didTagChange = false;
         if (cause === RoomUpdateCause.PossibleTagChange) {
-            let didTagChange = false;
             const oldTags = this.roomIdsToTags[room.roomId] || [];
             const newTags = this.getTagsForRoom(room);
             const diff = arrayDiff(oldTags, newTags);
@@ -713,6 +713,11 @@ export class Algorithm extends EventEmitter {
                     if (!algorithm) throw new Error(`No algorithm for ${rmTag}`);
                     await algorithm.handleRoomUpdate(room, RoomUpdateCause.RoomRemoved);
                     this.cachedRooms[rmTag] = algorithm.orderedRooms;
+
+                    // Later on we won't update the filtered rooms or sticky room for removed
+                    // tags, so do so now.
+                    this.recalculateFilteredRoomsForTag(rmTag);
+                    this.recalculateStickyRoom(rmTag);
                 }
                 for (const addTag of diff.added) {
                     if (!window.mx_QuietRoomListLogging) {
@@ -812,7 +817,7 @@ export class Algorithm extends EventEmitter {
             return false;
         }
 
-        let changed = false;
+        let changed = didTagChange;
         for (const tag of tags) {
             const algorithm: OrderingAlgorithm = this.algorithms[tag];
             if (!algorithm) throw new Error(`No algorithm for ${tag}`);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14442
For https://github.com/vector-im/riot-web/issues/13635

Turns out that we are so good at moving a room that when it flows through as a TIMELINE update the algorithm no-ops and does nothing, so don't do that.