### PR TITLE
Ensure RoomListStore2 gets reset when the client becomes invalidated

### DIFF
--- a/src/stores/room-list/RoomListStore2.ts
+++ b/src/stores/room-list/RoomListStore2.ts
@@ -101,7 +101,11 @@ export class RoomListStore2 extends AsyncStoreWithClient<ActionPayload> {
     }
 
     // Public for test usage. Do not call this.
-    public async makeReady() {
+    public async makeReady(forcedClient?: MatrixClient) {
+        if (forcedClient) {
+            super.matrixClient = forcedClient;
+        }
+
         // TODO: Remove with https://github.com/vector-im/riot-web/issues/14367
         this.checkEnabled();
         if (!this.enabled) return;

--- a/src/stores/room-list/RoomListStore2.ts
+++ b/src/stores/room-list/RoomListStore2.ts
@@ -78,6 +78,10 @@ export class RoomListStore2 extends AsyncStoreWithClient<ActionPayload> {
         return this.algorithm.getOrderedRooms();
     }
 
+    public get matrixClient(): MatrixClient {
+        return super.matrixClient;
+    }
+
     // Intended for test usage
     public async resetStore() {
         await this.reset();

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -109,7 +109,7 @@ describe('RoomList', () => {
         client.getRoom = (roomId) => roomMap[roomId];
 
         // Now that everything has been set up, prepare and update the store
-        await RoomListStore.instance.makeReady(client);
+        await RoomListStore.instance.makeReady();
 
         done();
     });

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -109,7 +109,7 @@ describe('RoomList', () => {
         client.getRoom = (roomId) => roomMap[roomId];
 
         // Now that everything has been set up, prepare and update the store
-        await RoomListStore.instance.makeReady();
+        await RoomListStore.instance.makeReady(client);
 
         done();
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14384
For https://github.com/vector-im/riot-web/issues/13635

We also make use of the new AsyncStore type to handle this more safely.