### PR TITLE
Query Matcher use unhomoglyph for a little bit more leniency

### DIFF
--- a/src/autocomplete/QueryMatcher.ts
+++ b/src/autocomplete/QueryMatcher.ts
@@ -45,14 +45,10 @@ interface IOptions<T extends {}> {
  */
 export default class QueryMatcher<T extends Object> {
     private _options: IOptions<T>;
-    private _keys: IOptions<T>["keys"];
-    private _funcs: Required<IOptions<T>["funcs"]>;
     private _items: Map<string, {object: T, keyWeight: number}[]>;
 
     constructor(objects: T[], options: IOptions<T> = { keys: [] }) {
         this._options = options;
-        this._keys = options.keys;
-        this._funcs = options.funcs || [];
 
         this.setObjects(objects);
 
@@ -77,10 +73,12 @@ export default class QueryMatcher<T extends Object> {
             // type for their values. We assume that those values who's keys have
             // been specified will be string. Also, we cannot infer all the
             // types of the keys of the objects at compile.
-            const keyValues = _at<string>(<any>object, this._keys);
+            const keyValues = _at<string>(<any>object, this._options.keys);
 
-            for (const f of this._funcs) {
-                keyValues.push(f(object));
+            if (this._options.funcs) {
+                for (const f of this._options.funcs) {
+                    keyValues.push(f(object));
+                }
             }
 
             for (const [index, keyValue] of Object.entries(keyValues)) {


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1420
For https://github.com/vector-im/riot-web/issues/1294

![image](https://user-images.githubusercontent.com/2403652/87502159-ca334200-c658-11ea-9891-73ec63f6c5ec.png)

Helps if you mis-see an `m` as an `rn` like normal people do, right?