### PR TITLE
Move e2e icon

### DIFF
--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -97,7 +97,7 @@ $irc-line-height: $font-18px;
         }
 
         > .mx_EventTile_e2eIcon {
-            position: relative;
+            position: absolute;
             right: unset;
             left: unset;
             top: 0;


### PR DESCRIPTION
Make the e2e icon absolute so that it doesn't misalign the text on irc layout

![image](https://user-images.githubusercontent.com/23084468/87621314-6b350200-c718-11ea-86e8-7a60aba828aa.png)


![image](https://user-images.githubusercontent.com/23084468/87621381-928bcf00-c718-11ea-9316-36e50e2ef28c.png)

Since this is still an 'advanced' layout and design will be giving the whole thing a once over I think we can skip design review for the moment.