### PR TITLE
Fix copy button in share dialog

### DIFF
--- a/res/css/views/dialogs/_ShareDialog.scss
+++ b/res/css/views/dialogs/_ShareDialog.scss
@@ -55,7 +55,7 @@ limitations under the License.
     margin-left: 5px;
     width: 20px;
     height: 20px;
-    background-repeat: none;
+    background-repeat: no-repeat;
 }
 
 .mx_ShareDialog_split {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1834746/87654856-6475b180-c74f-11ea-9034-d37d57aa2b93.png)

![image](https://user-images.githubusercontent.com/1834746/87654873-6c355600-c74f-11ea-9fd9-0729450e73df.png)

Fixed the wrong attribute set on the copy-button

Signed-off-by: Swapnil Raj sr@sraj.me