### PR TITLE
Fix Room Tile Icon to not ignore DMs in other tags

### DIFF
--- a/src/components/views/avatars/DecoratedRoomAvatar.tsx
+++ b/src/components/views/avatars/DecoratedRoomAvatar.tsx
@@ -66,7 +66,7 @@ export default class DecoratedRoomAvatar extends React.PureComponent<IProps, ISt
                 oobData={this.props.oobData}
                 viewAvatarOnClick={this.props.viewAvatarOnClick}
             />
-            <RoomTileIcon room={this.props.room} tag={this.props.tag} />
+            <RoomTileIcon room={this.props.room} />
             {badge}
         </div>;
     }

--- a/src/components/views/rooms/RoomTileIcon.tsx
+++ b/src/components/views/rooms/RoomTileIcon.tsx
@@ -49,7 +49,6 @@ function tooltipText(variant: Icon) {
 
 interface IProps {
     room: Room;
-    tag: TagID;
 }
 
 interface IState {
@@ -137,10 +136,11 @@ export default class RoomTileIcon extends React.Component<IProps, IState> {
     private calculateIcon(): Icon {
         let icon = Icon.None;
 
-        if (this.props.tag === DefaultTagID.DM && this.props.room.getJoinedMemberCount() === 2) {
+        // We look at the DMRoomMap and not the tag here so that we don't exclude DMs in Favourites
+        const otherUserId = DMRoomMap.shared().getUserIdForRoomId(this.props.room.roomId);
+        if (otherUserId && this.props.room.getJoinedMemberCount() === 2) {
             // Track presence, if available
             if (isPresenceEnabled()) {
-                const otherUserId = DMRoomMap.shared().getUserIdForRoomId(this.props.room.roomId);
                 if (otherUserId) {
                     this.dmUser = MatrixClientPeg.get().getUser(otherUserId);
                     icon = this.getPresenceIcon();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14503

![image](https://user-images.githubusercontent.com/2403652/87666526-ab1fd780-c760-11ea-8e1d-05ee9eee82d7.png)
