### PR TITLE
Increase width for country code dropdown

### DIFF
--- a/res/css/_font-sizes.scss
+++ b/res/css/_font-sizes.scss
@@ -68,5 +68,6 @@ $font-49px: 4.9rem;
 $font-50px: 5.0rem;
 $font-51px: 5.1rem;
 $font-52px: 5.2rem;
+$font-78px: 7.8rem;
 $font-88px: 8.8rem;
 $font-400px: 40rem;

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -191,5 +191,5 @@ limitations under the License.
 }
 
 .mx_Field .mx_CountryDropdown {
-    width: 67px;
+    width: 78px;
 }

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -16,6 +16,8 @@ limitations under the License.
 
 /* TODO: Consider unifying with general input styles in _light.scss */
 
+@import "../../_font-sizes.scss";
+
 .mx_Field {
     display: flex;
     flex: 1;
@@ -191,5 +193,5 @@ limitations under the License.
 }
 
 .mx_Field .mx_CountryDropdown {
-    width: 78px;
+    width: $font-78px;
 }

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -16,8 +16,6 @@ limitations under the License.
 
 /* TODO: Consider unifying with general input styles in _light.scss */
 
-@import "../../_font-sizes.scss";
-
 .mx_Field {
     display: flex;
     flex: 1;


### PR DESCRIPTION
#### 3 digit country code
![image](https://user-images.githubusercontent.com/1834746/87678353-bed43980-c772-11ea-8507-7b825c38a8a8.png)
![image](https://user-images.githubusercontent.com/1834746/87678374-c398ed80-c772-11ea-92a5-a3f6f6d7f11e.png)

#### 2 digit country code
![image](https://user-images.githubusercontent.com/1834746/87678700-28544800-c773-11ea-806f-cf647f429d8d.png)
![image](https://user-images.githubusercontent.com/1834746/87678723-2f7b5600-c773-11ea-9124-81f680bd29a1.png)

#### 1 digit country code
![image](https://user-images.githubusercontent.com/1834746/87678745-36a26400-c773-11ea-8d76-d35992dc991b.png)
![image](https://user-images.githubusercontent.com/1834746/87678767-3d30db80-c773-11ea-84ea-90bbf4f0b682.png)

Fixes the width of the drop-down menu for country code.
The initial width seems like an arbitrary number, so I just increased it to fit.

Signed-off-by: Swapnil Raj sr@sraj.me