### PR TITLE
Escape single quotes in composer placeholder

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -219,7 +219,9 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     };
 
     private showPlaceholder() {
-        this.editorRef.current.style.setProperty("--placeholder", `'${this.props.placeholder}'`);
+        // escape single quotes
+        const placeholder = this.props.placeholder.replace(/'/g, '\\\'');
+        this.editorRef.current.style.setProperty("--placeholder", `'${placeholder}'`);
         this.editorRef.current.classList.add("mx_BasicMessageComposer_inputEmpty");
     }
 


### PR DESCRIPTION
Closes vector-im/riot-web#14687.