### PR TITLE
Use OpenType tabular numbers in timestamps

### DIFF
--- a/res/css/views/messages/_MessageTimestamp.scss
+++ b/res/css/views/messages/_MessageTimestamp.scss
@@ -17,4 +17,5 @@ limitations under the License.
 .mx_MessageTimestamp {
     color: $event-timestamp-color;
     font-size: $font-10px;
+    font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14686