### PR TITLE
Reward users for using stable ordering in their room list

### DIFF
--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -81,7 +81,7 @@ interface ITagAesthetics {
     sectionLabel: string;
     sectionLabelRaw?: string;
     addRoomLabel?: string;
-    onAddRoom?: (dispatcher: Dispatcher<ActionPayload>) => void;
+    onAddRoom?: (dispatcher?: Dispatcher<ActionPayload>) => void;
     isInvite: boolean;
     defaultHidden: boolean;
 }
@@ -105,14 +105,18 @@ const TAG_AESTHETICS: {
         isInvite: false,
         defaultHidden: false,
         addRoomLabel: _td("Start chat"),
-        onAddRoom: (dispatcher: Dispatcher<ActionPayload>) => dispatcher.dispatch({action: 'view_create_chat'}),
+        onAddRoom: (dispatcher?: Dispatcher<ActionPayload>) => {
+            (dispatcher || defaultDispatcher).dispatch({action: 'view_create_chat'});
+        },
     },
     [DefaultTagID.Untagged]: {
         sectionLabel: _td("Rooms"),
         isInvite: false,
         defaultHidden: false,
         addRoomLabel: _td("Create room"),
-        onAddRoom: (dispatcher: Dispatcher<ActionPayload>) => dispatcher.dispatch({action: 'view_create_room'}),
+        onAddRoom: (dispatcher?: Dispatcher<ActionPayload>) => {
+            (dispatcher || defaultDispatcher).dispatch({action: 'view_create_room'})
+        },
     },
     [DefaultTagID.LowPriority]: {
         sectionLabel: _td("Low priority"),
@@ -304,7 +308,6 @@ export default class RoomList extends React.Component<IProps, IState> {
                 : TAG_AESTHETICS[orderedTagId];
             if (!aesthetics) throw new Error(`Tag ${orderedTagId} does not have aesthetics`);
 
-            const onAddRoomFn = aesthetics.onAddRoom ? () => aesthetics.onAddRoom(dis) : null;
             components.push(
                 <RoomSublist
                     key={`sublist-${orderedTagId}`}
@@ -312,7 +315,7 @@ export default class RoomList extends React.Component<IProps, IState> {
                     forRooms={true}
                     startAsHidden={aesthetics.defaultHidden}
                     label={aesthetics.sectionLabelRaw ? aesthetics.sectionLabelRaw : _t(aesthetics.sectionLabel)}
-                    onAddRoom={onAddRoomFn}
+                    onAddRoom={aesthetics.onAddRoom}
                     addRoomLabel={aesthetics.addRoomLabel ? _t(aesthetics.addRoomLabel) : aesthetics.addRoomLabel}
                     isMinimized={this.props.isMinimized}
                     onResize={this.props.onResize}

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -42,6 +42,7 @@ import { ViewRoomDeltaPayload } from "../../../dispatcher/payloads/ViewRoomDelta
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import SettingsStore from "../../../settings/SettingsStore";
 import CustomRoomTagStore from "../../../stores/CustomRoomTagStore";
+import { arrayHasDiff } from "../../../utils/arrays";
 
 interface IProps {
     onKeyDown: (ev: React.KeyboardEvent) => void;
@@ -231,9 +232,14 @@ export default class RoomList extends React.Component<IProps, IState> {
             console.log("new lists", newLists);
         }
 
-        this.setState({sublists: newLists}, () => {
-            this.props.onResize();
-        });
+        const previousListIds = Object.keys(this.state.sublists);
+        const newListIds = Object.keys(newLists);
+
+        if (arrayHasDiff(previousListIds, newListIds)) {
+            this.setState({sublists: newLists}, () => {
+                this.props.onResize();
+            });
+        }
     };
 
     private renderCommunityInvites(): React.ReactElement[] {
@@ -304,7 +310,6 @@ export default class RoomList extends React.Component<IProps, IState> {
                     key={`sublist-${orderedTagId}`}
                     tagId={orderedTagId}
                     forRooms={true}
-                    rooms={orderedRooms}
                     startAsHidden={aesthetics.defaultHidden}
                     label={aesthetics.sectionLabelRaw ? aesthetics.sectionLabelRaw : _t(aesthetics.sectionLabel)}
                     onAddRoom={onAddRoomFn}

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -42,7 +42,8 @@ import { ViewRoomDeltaPayload } from "../../../dispatcher/payloads/ViewRoomDelta
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import SettingsStore from "../../../settings/SettingsStore";
 import CustomRoomTagStore from "../../../stores/CustomRoomTagStore";
-import { arrayHasDiff } from "../../../utils/arrays";
+import { arrayFastClone, arrayHasDiff } from "../../../utils/arrays";
+import { objectShallowClone } from "../../../utils/objects";
 
 interface IProps {
     onKeyDown: (ev: React.KeyboardEvent) => void;
@@ -255,7 +256,11 @@ export default class RoomList extends React.Component<IProps, IState> {
         }
 
         if (doUpdate) {
-            this.setState({sublists: newLists}, () => {
+            // We have to break our reference to the room list store if we want to be able to
+            // diff the object for changes, so do that.
+            const sublists = objectShallowClone(newLists, (k, v) => arrayFastClone(v));
+
+            this.setState({sublists: sublists}, () => {
                 this.props.onResize();
             });
         }

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -260,7 +260,7 @@ export default class RoomList extends React.Component<IProps, IState> {
             // diff the object for changes, so do that.
             const sublists = objectShallowClone(newLists, (k, v) => arrayFastClone(v));
 
-            this.setState({sublists: sublists}, () => {
+            this.setState({sublists}, () => {
                 this.props.onResize();
             });
         }

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -239,7 +239,22 @@ export default class RoomList extends React.Component<IProps, IState> {
         const previousListIds = Object.keys(this.state.sublists);
         const newListIds = Object.keys(newLists);
 
-        if (arrayHasDiff(previousListIds, newListIds)) {
+        let doUpdate = arrayHasDiff(previousListIds, newListIds);
+        if (!doUpdate) {
+            // so we didn't have the visible sublists change, but did the contents of those
+            // sublists change significantly enough to break the sticky headers? Probably, so
+            // let's check the length of each.
+            for (const tagId of newListIds) {
+                const oldRooms = this.state.sublists[tagId];
+                const newRooms = newLists[tagId];
+                if (oldRooms.length !== newRooms.length) {
+                    doUpdate = true;
+                    break;
+                }
+            }
+        }
+
+        if (doUpdate) {
             this.setState({sublists: newLists}, () => {
                 this.props.onResize();
             });

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -47,7 +47,7 @@ import { Direction } from "re-resizable/lib/resizer";
 import { polyfillTouchEvent } from "../../../@types/polyfill";
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import RoomListLayoutStore from "../../../stores/room-list/RoomListLayoutStore";
-import { arrayHasDiff, arrayHasOrderChange } from "../../../utils/arrays";
+import { arrayHasOrderChange } from "../../../utils/arrays";
 import { objectExcluding, objectHasValueChange } from "../../../utils/objects";
 
 const SHOW_N_BUTTON_HEIGHT = 28; // As defined by CSS
@@ -202,6 +202,11 @@ export default class RoomSublist extends React.Component<IProps, IState> {
             return true;
         }
 
+        // Quickly double check we're not about to break something due to the number of rooms changing.
+        if (this.state.rooms.length !== nextState.rooms.length) {
+            return true;
+        }
+
         // Finally, determine if the room update (as presumably that's all that's left) is within
         // our visible range. If it is, then do a render. If the update is outside our visible range
         // then we can skip the update.
@@ -212,11 +217,6 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         const prevSlicedRooms = this.state.rooms.slice(0, this.numVisibleTiles);
         const nextSlicedRooms = nextState.rooms.slice(0, this.numVisibleTiles);
         if (arrayHasOrderChange(prevSlicedRooms, nextSlicedRooms)) {
-            return true;
-        }
-
-        // Quickly double check we're not about to break something due to the number of rooms changing.
-        if (arrayHasDiff(this.state.rooms, nextState.rooms)) {
             return true;
         }
 

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -32,7 +32,7 @@ import {
     StyledMenuItemCheckbox,
     StyledMenuItemRadio,
 } from "../../structures/ContextMenu";
-import RoomListStore from "../../../stores/room-list/RoomListStore";
+import RoomListStore, { LISTS_UPDATE_EVENT } from "../../../stores/room-list/RoomListStore";
 import { ListAlgorithm, SortAlgorithm } from "../../../stores/room-list/algorithms/models";
 import { DefaultTagID, TagID } from "../../../stores/room-list/models";
 import dis from "../../../dispatcher/dispatcher";
@@ -47,6 +47,7 @@ import { Direction } from "re-resizable/lib/resizer";
 import { polyfillTouchEvent } from "../../../@types/polyfill";
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import RoomListLayoutStore from "../../../stores/room-list/RoomListLayoutStore";
+import { arrayHasDiff, arrayHasOrderChange } from "../../../utils/arrays";
 
 const SHOW_N_BUTTON_HEIGHT = 28; // As defined by CSS
 const RESIZE_HANDLE_HEIGHT = 4; // As defined by CSS
@@ -59,7 +60,6 @@ polyfillTouchEvent();
 
 interface IProps {
     forRooms: boolean;
-    rooms?: Room[];
     startAsHidden: boolean;
     label: string;
     onAddRoom?: () => void;
@@ -90,6 +90,7 @@ interface IState {
     isResizing: boolean;
     isExpanded: boolean; // used for the for expand of the sublist when the room list is being filtered
     height: number;
+    rooms: Room[];
 }
 
 export default class RoomSublist extends React.Component<IProps, IState> {
@@ -104,16 +105,19 @@ export default class RoomSublist extends React.Component<IProps, IState> {
 
         this.layout = RoomListLayoutStore.instance.getLayoutFor(this.props.tagId);
         this.heightAtStart = 0;
-        const height = this.calculateInitialHeight();
         this.state = {
             notificationState: RoomNotificationStateStore.instance.getListState(this.props.tagId),
             contextMenuPosition: null,
             isResizing: false,
             isExpanded: this.props.isFiltered ? this.props.isFiltered : !this.layout.isCollapsed,
-            height,
+            height: 0, // to be fixed in a moment, we need `rooms` to calculate this.
+            rooms: RoomListStore.instance.orderedLists[this.props.tagId] || [],
         };
-        this.state.notificationState.setRooms(this.props.rooms);
+        // Why Object.assign() and not this.state.height? Because TypeScript says no.
+        this.state = Object.assign(this.state, {height: this.calculateInitialHeight()});
+        this.state.notificationState.setRooms(this.state.rooms);
         this.dispatcherRef = defaultDispatcher.register(this.onAction);
+        RoomListStore.instance.on(LISTS_UPDATE_EVENT, this.onListsUpdated);
     }
 
     private calculateInitialHeight() {
@@ -142,11 +146,11 @@ export default class RoomSublist extends React.Component<IProps, IState> {
     }
 
     private get numTiles(): number {
-        return RoomSublist.calcNumTiles(this.props);
+        return RoomSublist.calcNumTiles(this.state.rooms, this.props.extraBadTilesThatShouldntExist);
     }
 
-    private static calcNumTiles(props) {
-        return (props.rooms || []).length + (props.extraBadTilesThatShouldntExist || []).length;
+    private static calcNumTiles(rooms: Room[], extraTiles: any[]) {
+        return (rooms || []).length + (extraTiles || []).length;
     }
 
     private get numVisibleTiles(): number {
@@ -154,8 +158,8 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         return Math.min(nVisible, this.numTiles);
     }
 
-    public componentDidUpdate(prevProps: Readonly<IProps>) {
-        this.state.notificationState.setRooms(this.props.rooms);
+    public componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
+        this.state.notificationState.setRooms(this.state.rooms);
         if (prevProps.isFiltered !== this.props.isFiltered) {
             if (this.props.isFiltered) {
                 this.setState({isExpanded: true});
@@ -165,7 +169,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         }
         // as the rooms can come in one by one we need to reevaluate
         // the amount of available rooms to cap the amount of requested visible rooms by the layout
-        if (RoomSublist.calcNumTiles(prevProps) !== this.numTiles) {
+        if (RoomSublist.calcNumTiles(prevState.rooms, prevProps.extraBadTilesThatShouldntExist) !== this.numTiles) {
             this.setState({height: this.calculateInitialHeight()});
         }
     }
@@ -173,14 +177,23 @@ export default class RoomSublist extends React.Component<IProps, IState> {
     public componentWillUnmount() {
         this.state.notificationState.destroy();
         defaultDispatcher.unregister(this.dispatcherRef);
+        RoomListStore.instance.off(LISTS_UPDATE_EVENT, this.onListsUpdated);
     }
 
+    private onListsUpdated = () => {
+        const currentRooms = this.state.rooms;
+        const newRooms = RoomListStore.instance.orderedLists[this.props.tagId] || [];
+        if (arrayHasOrderChange(currentRooms, newRooms)) {
+            this.setState({rooms: newRooms});
+        }
+    };
+
     private onAction = (payload: ActionPayload) => {
-        if (payload.action === "view_room" && payload.show_room_tile && this.props.rooms) {
+        if (payload.action === "view_room" && payload.show_room_tile && this.state.rooms) {
             // XXX: we have to do this a tick later because we have incorrect intermediate props during a room change
             // where we lose the room we are changing from temporarily and then it comes back in an update right after.
             setImmediate(() => {
-                const roomIndex = this.props.rooms.findIndex((r) => r.roomId === payload.room_id);
+                const roomIndex = this.state.rooms.findIndex((r) => r.roomId === payload.room_id);
 
                 if (!this.state.isExpanded && roomIndex > -1) {
                     this.toggleCollapsed();
@@ -302,10 +315,10 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         let room;
         if (this.props.tagId === DefaultTagID.Invite) {
             // switch to first room as that'll be the top of the list for the user
-            room = this.props.rooms && this.props.rooms[0];
+            room = this.state.rooms && this.state.rooms[0];
         } else {
             // find the first room with a count of the same colour as the badge count
-            room = this.props.rooms.find((r: Room) => {
+            room = this.state.rooms.find((r: Room) => {
                 const notifState = this.state.notificationState.getForRoom(r);
                 return notifState.count > 0 && notifState.color === this.state.notificationState.color;
             });
@@ -399,8 +412,8 @@ export default class RoomSublist extends React.Component<IProps, IState> {
 
         const tiles: React.ReactElement[] = [];
 
-        if (this.props.rooms) {
-            const visibleRooms = this.props.rooms.slice(0, this.numVisibleTiles);
+        if (this.state.rooms) {
+            const visibleRooms = this.state.rooms.slice(0, this.numVisibleTiles);
             for (const room of visibleRooms) {
                 tiles.push(
                     <RoomTile

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -202,6 +202,13 @@ export default class RoomSublist extends React.Component<IProps, IState> {
             return true;
         }
 
+        // Before we go analyzing the rooms, we can see if we're collapsed. If we're collapsed, we don't need
+        // to render anything. We do this after the height check though to ensure that the height gets appropriately
+        // calculated for when/if we become uncollapsed.
+        if (!nextState.isExpanded) {
+            return false;
+        }
+
         // Quickly double check we're not about to break something due to the number of rooms changing.
         if (this.state.rooms.length !== nextState.rooms.length) {
             return true;

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -35,7 +35,7 @@ import {
     MenuItem,
 } from "../../structures/ContextMenu";
 import { DefaultTagID, TagID } from "../../../stores/room-list/models";
-import { MessagePreviewStore } from "../../../stores/room-list/MessagePreviewStore";
+import { MessagePreviewStore, ROOM_PREVIEW_CHANGED } from "../../../stores/room-list/MessagePreviewStore";
 import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar";
 import {
     getRoomNotifsState,
@@ -128,6 +128,7 @@ export default class RoomTile extends React.Component<IProps, IState> {
 
         ActiveRoomObserver.addListener(this.props.room.roomId, this.onActiveRoomUpdate);
         this.dispatcherRef = defaultDispatcher.register(this.onAction);
+        MessagePreviewStore.instance.on(ROOM_PREVIEW_CHANGED, this.onRoomPreviewChanged);
     }
 
     private get showContextMenu(): boolean {
@@ -150,6 +151,7 @@ export default class RoomTile extends React.Component<IProps, IState> {
             ActiveRoomObserver.removeListener(this.props.room.roomId, this.onActiveRoomUpdate);
         }
         defaultDispatcher.unregister(this.dispatcherRef);
+        MessagePreviewStore.instance.off(ROOM_PREVIEW_CHANGED, this.onRoomPreviewChanged);
     }
 
     private onAction = (payload: ActionPayload) => {
@@ -157,6 +159,12 @@ export default class RoomTile extends React.Component<IProps, IState> {
             setImmediate(() => {
                 this.scrollIntoView();
             });
+        }
+    };
+
+    private onRoomPreviewChanged = (room: Room) => {
+        if (this.props.room && room.roomId === this.props.room.roomId) {
+            this.forceUpdate(); // we don't have any state to set, so just complain that we need an update
         }
     };
 

--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -28,6 +28,10 @@ import { StickerEventPreview } from "./previews/StickerEventPreview";
 import { ReactionEventPreview } from "./previews/ReactionEventPreview";
 import { UPDATE_EVENT } from "../AsyncStore";
 
+// Emitted event for when a room's preview has changed. First argument will the room for which
+// the change happened.
+export const ROOM_PREVIEW_CHANGED = "room_preview_changed";
+
 const PREVIEWS = {
     'm.room.message': {
         isState: false,
@@ -146,6 +150,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
                 // We've muted the underlying Map, so just emit that we've changed.
                 this.previews.set(room.roomId, map);
                 this.emit(UPDATE_EVENT, this);
+                this.emit(ROOM_PREVIEW_CHANGED, room);
             }
             return; // we're done
         }
@@ -153,6 +158,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
         // At this point, we didn't generate a preview so clear it
         this.previews.set(room.roomId, new Map<TagID|TAG_ANY, string|null>());
         this.emit(UPDATE_EVENT, this);
+        this.emit(ROOM_PREVIEW_CHANGED, room);
     }
 
     protected async onAction(payload: ActionPayload) {

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -15,6 +15,15 @@ limitations under the License.
 */
 
 /**
+ * Clones an array as fast as possible, retaining references of the array's values.
+ * @param a The array to clone. Must be defined.
+ * @returns A copy of the array.
+ */
+export function arrayFastClone(a: any[]): any[] {
+    return a.slice(0, a.length);
+}
+
+/**
  * Determines if the two arrays are different either in length, contents,
  * or order of those contents.
  * @param a The first array. Must be defined.

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -15,10 +15,28 @@ limitations under the License.
 */
 
 /**
+ * Determines if the two arrays are different either in length, contents,
+ * or order of those contents.
+ * @param a The first array. Must be defined.
+ * @param b The second array. Must be defined.
+ * @returns True if they are different, false otherwise.
+ */
+export function arrayHasOrderChange(a: any[], b: any[]): boolean {
+    if (a.length === b.length) {
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) return true;
+        }
+        return false;
+    } else {
+        return true; // like arrayHasDiff, a difference in length is a natural change
+    }
+}
+
+/**
  * Determines if two arrays are different through a shallow comparison.
  * @param a The first array. Must be defined.
  * @param b The second array. Must be defined.
- * @returns True if they are the same, false otherwise.
+ * @returns True if they are different, false otherwise.
  */
 export function arrayHasDiff(a: any[], b: any[]): boolean {
     if (a.length === b.length) {

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -14,7 +14,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { arrayDiff, arrayMerge, arrayUnion } from "./arrays";
+import { arrayDiff, arrayHasDiff, arrayMerge, arrayUnion } from "./arrays";
+
+/**
+ * Gets a new object which represents the provided object, excluding some properties.
+ * @param a The object to strip properties of. Must be defined.
+ * @param props The property names to remove.
+ * @returns The new object without the provided properties.
+ */
+export function objectExcluding(a: any, props: string[]): any {
+    // We use a Map to avoid hammering the `delete` keyword, which is slow and painful.
+    const tempMap = new Map<string, any>(Object.entries(a));
+    for (const prop of props) {
+        tempMap.delete(prop);
+    }
+
+    // Convert the map to an object again
+    return Array.from(tempMap.entries()).reduce((c, [k, v]) => {
+        c[k] = v;
+        return c;
+    }, {});
+}
+
+/**
+ * Determines if the two objects, which are assumed to be of the same
+ * key shape, have a difference in their values. If a difference is
+ * determined, true is returned.
+ * @param a The first object. Must be defined.
+ * @param b The second object. Must be defined.
+ * @returns True if there's a perceptual difference in the object's values.
+ */
+export function objectHasValueChange(a: any, b: any): boolean {
+    const aValues = Object.values(a);
+    const bValues = Object.values(b);
+    return arrayHasDiff(aValues, bValues);
+}
 
 /**
  * Determines the keys added, changed, and removed between two objects.

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -37,6 +37,28 @@ export function objectExcluding(a: any, props: string[]): any {
 }
 
 /**
+ * Clones an object to a caller-controlled depth. When a propertyCloner is supplied, the
+ * object's properties will be passed through it with the return value used as the new
+ * object's type. This is intended to be used to deep clone a reference, but without
+ * having to deep clone the entire object. This function is safe to call recursively within
+ * the propertyCloner.
+ * @param a The object to clone. Must be defined.
+ * @param propertyCloner The function to clone the properties of the object with, optionally.
+ * First argument is the property key with the second being the current value.
+ * @returns A cloned object.
+ */
+export function objectShallowClone(a: any, propertyCloner?: (k: string, v: any) => any): any {
+    const newObj = {};
+    for (const [k, v] of Object.entries(a)) {
+        newObj[k] = v;
+        if (propertyCloner) {
+            newObj[k] = propertyCloner(k, v);
+        }
+    }
+    return newObj;
+}
+
+/**
  * Determines if the two objects, which are assumed to be of the same
  * key shape, have a difference in their values. If a difference is
  * determined, true is returned.


### PR DESCRIPTION
This is probably best reviewed commit-by-commit, however a ~~summary~~ small novel explaining the theory is included here.

This optimizes the path for room list renders by ensuring that the scope of those renders is limited to only what is absolutely required. Users with a stable room list ordering will see the most benefit of this change, however large accounts with the activity & unread first options selected will see some gain too. Users with stable ordering will see the most benefit as they have the highest chance of getting updates to their rooms which are out of view or can be no-oped (no order change means we don't need to remount the entire sublist).

Larger accounts (particularly those with activity sorting and unread first enabled) will still see a hit for a delta in their room list, but changes which don't reorder their list should be a lot better. Due to account size this is expected to be relatively rare though: it is more likely that an argument will break out in a room and cause it to stay in the same position at the top of the room list, reducing the impact of renders. The happy paths for larger accounts are still improved (~100ms in gains in my testing, all told) though we are reaching diminishing returns on handling this use case. Large accounts are still recommended to show as little rooms as possible to rely on filtering instead.

However, this regresses filtering slightly in that it now can take 2x as long on the initial filter, with subsequent iterations being a whole lot faster. This is expected to be improved in a later commit.