### PR TITLE
Improve RoomTile performance

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -67,7 +67,6 @@ interface IProps {
 type PartialDOMRect = Pick<DOMRect, "left" | "bottom">;
 
 interface IState {
-    hover: boolean;
     notificationState: NotificationState;
     selected: boolean;
     notificationsMenuPosition: PartialDOMRect;
@@ -119,7 +118,6 @@ export default class RoomTile extends React.Component<IProps, IState> {
         super(props);
 
         this.state = {
-            hover: false,
             notificationState: RoomNotificationStateStore.instance.getRoomState(this.props.room),
             selected: ActiveRoomObserver.activeRoomId === this.props.room.roomId,
             notificationsMenuPosition: null,
@@ -204,14 +202,6 @@ export default class RoomTile extends React.Component<IProps, IState> {
             block: "nearest",
             behavior: "auto",
         });
-    };
-
-    private onTileMouseEnter = () => {
-        this.setState({hover: true});
-    };
-
-    private onTileMouseLeave = () => {
-        this.setState({hover: false});
     };
 
     private onTileClick = (ev: React.KeyboardEvent) => {
@@ -592,8 +582,6 @@ export default class RoomTile extends React.Component<IProps, IState> {
                             tabIndex={isActive ? 0 : -1}
                             inputRef={ref}
                             className={classes}
-                            onMouseEnter={this.onTileMouseEnter}
-                            onMouseLeave={this.onTileMouseLeave}
                             onClick={this.onTileClick}
                             onContextMenu={this.onContextMenu}
                             role="treeitem"

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -55,7 +55,6 @@ import {ActionPayload} from "../../../dispatcher/payloads";
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import { NotificationState } from "../../../stores/notifications/NotificationState";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
-import { objectDiff, objectHasValueChange } from "../../../utils/objects";
 
 interface IProps {
     room: Room;
@@ -110,7 +109,7 @@ const NotifOption: React.FC<INotifOptionProps> = ({active, onClick, iconClassNam
     );
 };
 
-export default class RoomTile extends React.Component<IProps, IState> {
+export default class RoomTile extends React.PureComponent<IProps, IState> {
     private dispatcherRef: string;
     private roomTileRef = createRef<HTMLDivElement>();
 
@@ -153,22 +152,6 @@ export default class RoomTile extends React.Component<IProps, IState> {
         }
         defaultDispatcher.unregister(this.dispatcherRef);
         MessagePreviewStore.instance.off(ROOM_PREVIEW_CHANGED, this.onRoomPreviewChanged);
-    }
-
-    public shouldComponentUpdate(nextProps: Readonly<IProps>, nextState: Readonly<IState>): boolean {
-        // Whenever a prop change happens (or our parent updates) we can get told to update too. Try
-        // to minimize that by seeing if anything actually changed.
-        if (objectHasValueChange(this.props, nextProps)) {
-            return true;
-        }
-
-        // Do the same for state
-        if (objectHasValueChange(this.state, nextState)) {
-            return true;
-        }
-
-        // Finally, nothing changed so say so.
-        return false;
     }
 
     private onAction = (payload: ActionPayload) => {

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -55,14 +55,13 @@ import {ActionPayload} from "../../../dispatcher/payloads";
 import { RoomNotificationStateStore } from "../../../stores/notifications/RoomNotificationStateStore";
 import { NotificationState } from "../../../stores/notifications/NotificationState";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
+import { objectDiff, objectHasValueChange } from "../../../utils/objects";
 
 interface IProps {
     room: Room;
     showMessagePreview: boolean;
     isMinimized: boolean;
     tag: TagID;
-
-    // TODO: Incoming call boxes: https://github.com/vector-im/riot-web/issues/14177
 }
 
 type PartialDOMRect = Pick<DOMRect, "left" | "bottom">;
@@ -152,6 +151,24 @@ export default class RoomTile extends React.Component<IProps, IState> {
         }
         defaultDispatcher.unregister(this.dispatcherRef);
         MessagePreviewStore.instance.off(ROOM_PREVIEW_CHANGED, this.onRoomPreviewChanged);
+    }
+
+    public shouldComponentUpdate(nextProps: Readonly<IProps>, nextState: Readonly<IState>): boolean {
+        // Whenever a prop change happens (or our parent updates) we can get told to update too. Try
+        // to minimize that by seeing if anything actually changed.
+        if (objectHasValueChange(this.props, nextProps)) {
+            console.log(`DIFF_PROPS@${this.props.room.roomId}`, objectDiff(this.props, nextProps));
+            return true;
+        }
+
+        // Do the same for state
+        if (objectHasValueChange(this.state, nextState)) {
+            console.log(`DIFF_STATE@${this.props.room.roomId}`, objectDiff(this.state, nextState));
+            return true;
+        }
+
+        // Finally, nothing changed so say so.
+        return false;
     }
 
     private onAction = (payload: ActionPayload) => {

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -72,6 +72,7 @@ interface IState {
     selected: boolean;
     notificationsMenuPosition: PartialDOMRect;
     generalMenuPosition: PartialDOMRect;
+    messagePreview?: string;
 }
 
 const messagePreviewId = (roomId: string) => `mx_RoomTile_messagePreview_${roomId}`;
@@ -123,6 +124,9 @@ export default class RoomTile extends React.Component<IProps, IState> {
             selected: ActiveRoomObserver.activeRoomId === this.props.room.roomId,
             notificationsMenuPosition: null,
             generalMenuPosition: null,
+
+            // generatePreview() will return nothing if the user has previews disabled
+            messagePreview: this.generatePreview(),
         };
 
         ActiveRoomObserver.addListener(this.props.room.roomId, this.onActiveRoomUpdate);
@@ -157,13 +161,13 @@ export default class RoomTile extends React.Component<IProps, IState> {
         // Whenever a prop change happens (or our parent updates) we can get told to update too. Try
         // to minimize that by seeing if anything actually changed.
         if (objectHasValueChange(this.props, nextProps)) {
-            console.log(`DIFF_PROPS@${this.props.room.roomId}`, objectDiff(this.props, nextProps));
+            console.log(`DIFF_PROPS@${this.props.room.roomId}`, JSON.stringify(objectDiff(this.props, nextProps)));
             return true;
         }
 
         // Do the same for state
         if (objectHasValueChange(this.state, nextState)) {
-            console.log(`DIFF_STATE@${this.props.room.roomId}`, objectDiff(this.state, nextState));
+            console.log(`DIFF_STATE@${this.props.room.roomId}`, JSON.stringify(objectDiff(this.state, nextState)));
             return true;
         }
 
@@ -181,9 +185,18 @@ export default class RoomTile extends React.Component<IProps, IState> {
 
     private onRoomPreviewChanged = (room: Room) => {
         if (this.props.room && room.roomId === this.props.room.roomId) {
-            this.forceUpdate(); // we don't have any state to set, so just complain that we need an update
+            // generatePreview() will return nothing if the user has previews disabled
+            this.setState({messagePreview: this.generatePreview()});
         }
     };
+
+    private generatePreview(): string | null {
+        if (!this.showMessagePreview) {
+            return null;
+        }
+
+        return MessagePreviewStore.instance.getPreviewForRoom(this.props.room, this.props.tag);
+    }
 
     private scrollIntoView = () => {
         if (!this.roomTileRef.current) return;
@@ -520,18 +533,12 @@ export default class RoomTile extends React.Component<IProps, IState> {
         name = name.replace(":", ":\u200b"); // add a zero-width space to allow linewrapping after the colon
 
         let messagePreview = null;
-        if (this.showMessagePreview) {
-            // The preview store heavily caches this info, so should be safe to hammer.
-            const text = MessagePreviewStore.instance.getPreviewForRoom(this.props.room, this.props.tag);
-
-            // Only show the preview if there is one to show.
-            if (text) {
-                messagePreview = (
-                    <div className="mx_RoomTile_messagePreview" id={messagePreviewId(this.props.room.roomId)}>
-                        {text}
-                    </div>
-                );
-            }
+        if (this.showMessagePreview && this.state.messagePreview) {
+            messagePreview = (
+                <div className="mx_RoomTile_messagePreview" id={messagePreviewId(this.props.room.roomId)}>
+                    {this.state.messagePreview}
+                </div>
+            );
         }
 
         const nameClasses = classNames({

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -159,13 +159,11 @@ export default class RoomTile extends React.Component<IProps, IState> {
         // Whenever a prop change happens (or our parent updates) we can get told to update too. Try
         // to minimize that by seeing if anything actually changed.
         if (objectHasValueChange(this.props, nextProps)) {
-            console.log(`DIFF_PROPS@${this.props.room.roomId}`, JSON.stringify(objectDiff(this.props, nextProps)));
             return true;
         }
 
         // Do the same for state
         if (objectHasValueChange(this.state, nextState)) {
-            console.log(`DIFF_STATE@${this.props.room.roomId}`, JSON.stringify(objectDiff(this.state, nextState)));
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14539 (for the most part)
  * Remaining: https://github.com/vector-im/riot-web/issues/14709 
  * Remaining: https://github.com/vector-im/riot-web/issues/14574
  * Remaining: https://github.com/vector-im/riot-web/issues/14750

By no-oping more often, we gain performance. See commits for details. This reduces the 350ms render time of the room list down to just 40ms at worst.