### PR TITLE
Fix Query Matcher regression with certain unhomoglyph'd characters

### DIFF
--- a/src/autocomplete/QueryMatcher.ts
+++ b/src/autocomplete/QueryMatcher.ts
@@ -142,7 +142,8 @@ export default class QueryMatcher<T extends Object> {
 
     private processQuery(query: string): string {
         if (this._options.fuzzy !== false) {
-            return removeHiddenChars(query).toLowerCase();
+            // lower case both the input and the output for consistency
+            return removeHiddenChars(query.toLowerCase()).toLowerCase();
         }
         return query.toLowerCase();
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14774