### PR TITLE
Minor improvements to filtering performance

### DIFF
--- a/src/components/structures/LeftPanel.tsx
+++ b/src/components/structures/LeftPanel.tsx
@@ -44,7 +44,6 @@ interface IProps {
 }
 
 interface IState {
-    searchFilter: string;
     showBreadcrumbs: boolean;
     showTagPanel: boolean;
 }
@@ -69,7 +68,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
         super(props);
 
         this.state = {
-            searchFilter: "",
             showBreadcrumbs: BreadcrumbsStore.instance.visible,
             showTagPanel: SettingsStore.getValue('TagPanel.enableTagPanel'),
         };
@@ -96,10 +94,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
         OwnProfileStore.instance.off(UPDATE_EVENT, this.onBackgroundImageUpdate);
         this.props.resizeNotifier.off("middlePanelResizedNoisy", this.onResize);
     }
-
-    private onSearch = (term: string): void => {
-        this.setState({searchFilter: term});
-    };
 
     private onExplore = () => {
         dis.fire(Action.ViewRoomDirectory);
@@ -366,7 +360,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
                 onKeyDown={this.onKeyDown}
             >
                 <RoomSearch
-                    onQueryUpdate={this.onSearch}
                     isMinimized={this.props.isMinimized}
                     onVerticalArrow={this.onKeyDown}
                     onEnter={this.onEnter}
@@ -392,7 +385,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
             onKeyDown={this.onKeyDown}
             resizeNotifier={null}
             collapsed={false}
-            searchFilter={this.state.searchFilter}
             onFocus={this.onFocus}
             onBlur={this.onBlur}
             isMinimized={this.props.isMinimized}

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -266,12 +266,11 @@ export default class RoomList extends React.Component<IProps, IState> {
         }
     };
 
-    private renderCommunityInvites(): React.ReactElement[] {
+    private renderCommunityInvites(): TemporaryTile[] {
         // TODO: Put community invites in a more sensible place (not in the room list)
         // See https://github.com/vector-im/riot-web/issues/14456
         return MatrixClientPeg.get().getGroups().filter(g => {
-           if (g.myMembership !== 'invite') return false;
-           return !this.searchFilter || this.searchFilter.matches(g.name || "");
+           return g.myMembership === 'invite';
         }).map(g => {
             const avatar = (
                 <GroupAvatar

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -31,7 +31,6 @@ import dis from "../../../dispatcher/dispatcher";
 import defaultDispatcher from "../../../dispatcher/dispatcher";
 import RoomSublist from "./RoomSublist";
 import { ActionPayload } from "../../../dispatcher/payloads";
-import { NameFilterCondition } from "../../../stores/room-list/filters/NameFilterCondition";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import GroupAvatar from "../avatars/GroupAvatar";
 import TemporaryTile from "./TemporaryTile";
@@ -52,7 +51,6 @@ interface IProps {
     onResize: () => void;
     resizeNotifier: ResizeNotifier;
     collapsed: boolean;
-    searchFilter: string;
     isMinimized: boolean;
 }
 
@@ -150,8 +148,7 @@ function customTagAesthetics(tagId: TagID): ITagAesthetics {
     };
 }
 
-export default class RoomList extends React.Component<IProps, IState> {
-    private searchFilter: NameFilterCondition = new NameFilterCondition();
+export default class RoomList extends React.PureComponent<IProps, IState> {
     private dispatcherRef;
     private customTagStoreRef;
 
@@ -163,21 +160,6 @@ export default class RoomList extends React.Component<IProps, IState> {
         };
 
         this.dispatcherRef = defaultDispatcher.register(this.onAction);
-    }
-
-    public componentDidUpdate(prevProps: Readonly<IProps>): void {
-        if (prevProps.searchFilter !== this.props.searchFilter) {
-            const hadSearch = !!this.searchFilter.search.trim();
-            const haveSearch = !!this.props.searchFilter.trim();
-            this.searchFilter.search = this.props.searchFilter;
-            if (!hadSearch && haveSearch) {
-                // started a new filter - add the condition
-                RoomListStore.instance.addFilter(this.searchFilter);
-            } else if (hadSearch && !haveSearch) {
-                // cleared a filter - remove the condition
-                RoomListStore.instance.removeFilter(this.searchFilter);
-            } // else the filter hasn't changed enough for us to care here
-        }
     }
 
     public componentDidMount(): void {
@@ -339,7 +321,7 @@ export default class RoomList extends React.Component<IProps, IState> {
                     isMinimized={this.props.isMinimized}
                     onResize={this.props.onResize}
                     extraBadTilesThatShouldntExist={extraTiles}
-                    isFiltered={!!this.searchFilter.search}
+                    isFiltered={!!RoomListStore.instance.getFirstNameFilterCondition()}
                 />
             );
         }

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -321,7 +321,6 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
                     isMinimized={this.props.isMinimized}
                     onResize={this.props.onResize}
                     extraBadTilesThatShouldntExist={extraTiles}
-                    isFiltered={!!RoomListStore.instance.getFirstNameFilterCondition()}
                 />
             );
         }

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -49,7 +49,7 @@ import RoomListLayoutStore from "../../../stores/room-list/RoomListLayoutStore";
 import { arrayHasOrderChange } from "../../../utils/arrays";
 import { objectExcluding, objectHasValueChange } from "../../../utils/objects";
 import TemporaryTile from "./TemporaryTile";
-import { NotificationState } from "../../../stores/notifications/NotificationState";
+import { ListNotificationState } from "../../../stores/notifications/ListNotificationState";
 
 const SHOW_N_BUTTON_HEIGHT = 28; // As defined by CSS
 const RESIZE_HANDLE_HEIGHT = 4; // As defined by CSS
@@ -101,7 +101,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
     private layout: ListLayout;
     private heightAtStart: number;
     private isBeingFiltered: boolean;
-    private notificationState: NotificationState;
+    private notificationState: ListNotificationState;
 
     constructor(props: IProps) {
         super(props);

--- a/src/settings/SettingsStore.js
+++ b/src/settings/SettingsStore.js
@@ -148,7 +148,6 @@ export default class SettingsStore {
             callbackFn(originalSettingName, changedInRoomId, atLevel, newValAtLevel, newValue);
         };
 
-        console.log(`Starting watcher for ${settingName}@${roomId || '<null room>'} as ID ${watcherId}`);
         SettingsStore._watchers[watcherId] = localizedCallback;
         defaultWatchManager.watchSetting(settingName, roomId, localizedCallback);
 
@@ -167,7 +166,6 @@ export default class SettingsStore {
             return;
         }
 
-        console.log(`Ending watcher ID ${watcherReference}`);
         defaultWatchManager.unwatchSetting(SettingsStore._watchers[watcherReference]);
         delete SettingsStore._watchers[watcherReference];
     }

--- a/src/stores/CustomRoomTagStore.js
+++ b/src/stores/CustomRoomTagStore.js
@@ -22,6 +22,7 @@ import SettingsStore from "../settings/SettingsStore";
 import RoomListStore, {LISTS_UPDATE_EVENT} from "./room-list/RoomListStore";
 import {RoomNotificationStateStore} from "./notifications/RoomNotificationStateStore";
 import {isCustomTag} from "./room-list/models";
+import {objectHasDiff} from "../utils/objects";
 
 function commonPrefix(a, b) {
     const len = Math.min(a.length, b.length);
@@ -107,7 +108,10 @@ class CustomRoomTagStore extends EventEmitter {
     }
 
     _onListsUpdated = () => {
-        this._setState({tags: this._getUpdatedTags()});
+        const newTags = this._getUpdatedTags();
+        if (!this._state.tags || objectHasDiff(this._state.tags, newTags)) {
+            this._setState({tags: newTags});
+        }
     };
 
     _onDispatch(payload) {
@@ -134,7 +138,7 @@ class CustomRoomTagStore extends EventEmitter {
 
     _getUpdatedTags() {
         if (!SettingsStore.isFeatureEnabled("feature_custom_tags")) {
-            return;
+            return {}; // none
         }
 
         const newTagNames = Object.keys(RoomListStore.instance.orderedLists).filter(t => isCustomTag(t)).sort();

--- a/src/stores/notifications/RoomNotificationStateStore.ts
+++ b/src/stores/notifications/RoomNotificationStateStore.ts
@@ -29,6 +29,7 @@ export class RoomNotificationStateStore extends AsyncStoreWithClient<IState> {
     private static internalInstance = new RoomNotificationStateStore();
 
     private roomMap = new Map<Room, RoomNotificationState>();
+    private listMap = new Map<TagID, ListNotificationState>();
 
     private constructor() {
         super(defaultDispatcher, {});
@@ -52,21 +53,23 @@ export class RoomNotificationStateStore extends AsyncStoreWithClient<IState> {
     }
 
     /**
-     * Creates a new list notification state. The consumer is expected to set the rooms
-     * on the notification state, and destroy the state when it no longer needs it.
-     * @param tagId The tag to create the notification state for.
+     * Gets an instance of the list state class for the given tag.
+     * @param tagId The tag to get the notification state for.
      * @returns The notification state for the tag.
      */
     public getListState(tagId: TagID): ListNotificationState {
-        // Note: we don't cache these notification states as the consumer is expected to call
-        // .setRooms() on the returned object, which could confuse other consumers.
+        if (this.listMap.has(tagId)) {
+            return this.listMap.get(tagId);
+        }
 
         // TODO: Update if/when invites move out of the room list.
         const useTileCount = tagId === DefaultTagID.Invite;
         const getRoomFn: FetchRoomFn = (room: Room) => {
             return this.getRoomState(room);
         };
-        return new ListNotificationState(useTileCount, tagId, getRoomFn);
+        const state = new ListNotificationState(useTileCount, tagId, getRoomFn);
+        this.listMap.set(tagId, state);
+        return state;
     }
 
     /**

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -33,6 +33,7 @@ import RoomListLayoutStore from "./RoomListLayoutStore";
 import { MarkedExecution } from "../../utils/MarkedExecution";
 import { AsyncStoreWithClient } from "../AsyncStoreWithClient";
 import { NameFilterCondition } from "./filters/NameFilterCondition";
+import { RoomNotificationStateStore } from "../notifications/RoomNotificationStateStore";
 
 interface IState {
     tagsEnabled?: boolean;
@@ -55,7 +56,12 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     private algorithm = new Algorithm();
     private filterConditions: IFilterCondition[] = [];
     private tagWatcher = new TagWatcher(this);
-    private updateFn = new MarkedExecution(() => this.emit(LISTS_UPDATE_EVENT));
+    private updateFn = new MarkedExecution(() => {
+        for (const tagId of Object.keys(this.unfilteredLists)) {
+            RoomNotificationStateStore.instance.getListState(tagId).setRooms(this.unfilteredLists[tagId]);
+        }
+        this.emit(LISTS_UPDATE_EVENT);
+    });
 
     private readonly watchedSettings = [
         'feature_custom_tags',
@@ -70,6 +76,11 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
         RoomViewStore.addListener(() => this.handleRVSUpdate({}));
         this.algorithm.on(LIST_UPDATED_EVENT, this.onAlgorithmListUpdated);
         this.algorithm.on(FILTER_CHANGED, this.onAlgorithmFilterUpdated);
+    }
+
+    public get unfilteredLists(): ITagMap {
+        if (!this.algorithm) return {}; // No tags yet.
+        return this.algorithm.getUnfilteredRooms();
     }
 
     public get orderedLists(): ITagMap {

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -32,6 +32,7 @@ import { isNullOrUndefined } from "matrix-js-sdk/src/utils";
 import RoomListLayoutStore from "./RoomListLayoutStore";
 import { MarkedExecution } from "../../utils/MarkedExecution";
 import { AsyncStoreWithClient } from "../AsyncStoreWithClient";
+import { NameFilterCondition } from "./filters/NameFilterCondition";
 
 interface IState {
     tagsEnabled?: boolean;
@@ -586,6 +587,20 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
             }
         }
         this.updateFn.trigger();
+    }
+
+    /**
+     * Gets the first (and ideally only) name filter condition. If one isn't present,
+     * this returns null.
+     * @returns The first name filter condition, or null if none.
+     */
+    public getFirstNameFilterCondition(): NameFilterCondition | null {
+        for (const filter of this.filterConditions) {
+            if (filter instanceof NameFilterCondition) {
+                return filter;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -465,6 +465,10 @@ export class Algorithm extends EventEmitter {
         return this.filteredRooms;
     }
 
+    public getUnfilteredRooms(): ITagMap {
+        return this._cachedStickyRooms || this.cachedRooms;
+    }
+
     /**
      * This returns the same as getOrderedRooms(), but without the sticky room
      * map as it causes issues for sticky room handling (see sticky room handling

--- a/src/stores/room-list/filters/NameFilterCondition.ts
+++ b/src/stores/room-list/filters/NameFilterCondition.ts
@@ -18,6 +18,7 @@ import { Room } from "matrix-js-sdk/src/models/room";
 import { FILTER_CHANGED, FilterPriority, IFilterCondition } from "./IFilterCondition";
 import { EventEmitter } from "events";
 import { removeHiddenChars } from "matrix-js-sdk/src/utils";
+import { throttle } from "lodash";
 
 /**
  * A filter condition for the room list which reveals rooms of a particular
@@ -41,8 +42,12 @@ export class NameFilterCondition extends EventEmitter implements IFilterConditio
 
     public set search(val: string) {
         this._search = val;
-        this.emit(FILTER_CHANGED);
+        this.callUpdate();
     }
+
+    private callUpdate = throttle(() => {
+        this.emit(FILTER_CHANGED);
+    }, 200, {trailing: true, leading: true});
 
     public isVisible(room: Room): boolean {
         const lcFilter = this.search.toLowerCase();

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -55,7 +55,7 @@ export function arrayHasDiff(a: any[], b: any[]): boolean {
         if (a.some(i => !b.includes(i))) return true;
 
         // if all the keys are common, say so
-        return false
+        return false;
     } else {
         return true; // different lengths means they are naturally diverged
     }

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -53,6 +53,9 @@ export function arrayHasDiff(a: any[], b: any[]): boolean {
         // an element from the other.
         if (b.some(i => !a.includes(i))) return true;
         if (a.some(i => !b.includes(i))) return true;
+
+        // if all the keys are common, say so
+        return false
     } else {
         return true; // different lengths means they are naturally diverged
     }

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -73,6 +73,23 @@ export function objectHasValueChange(a: any, b: any): boolean {
 }
 
 /**
+ * Determines if any keys were added, removed, or changed between two objects.
+ * For changes, simple triple equal comparisons are done, not in-depth
+ * tree checking.
+ * @param a The first object. Must be defined.
+ * @param b The second object. Must be defined.
+ * @returns True if there's a difference between the objects, false otherwise
+ */
+export function objectHasDiff(a: any, b: any): boolean {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (arrayHasDiff(aKeys, bKeys)) return true;
+
+    const possibleChanges = arrayUnion(aKeys, bKeys);
+    return possibleChanges.some(k => a[k] !== b[k]);
+}
+
+/**
  * Determines the keys added, changed, and removed between two objects.
  * For changes, simple triple equal comparisons are done, not in-depth
  * tree checking.


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/14750

These changes are likely best reviewed commit-by-commit.

Collectively these do not improve the situation too well: on a test account they have reduced times for 2.0 seconds to 1.4 seconds per key. We do have some throttle logic in place in these changes, however in this account's case it does not help as the task overall takes longer than the keypress handling.

There is not much more we can do to improve this situation. We can't lazily load room tiles, can't render them elsewhere to put them into the DOM, and can't do much about how tooltips work. If we could somehow do one of these three, it could increase performance by 1-5x. For now though, this is likely going to have to be fine.