### PR TITLE
Fix TextWithTooltip "leaking" tooltip wrappers

### DIFF
--- a/src/components/views/elements/TextWithTooltip.js
+++ b/src/components/views/elements/TextWithTooltip.js
@@ -47,11 +47,10 @@ export default class TextWithTooltip extends React.Component {
         return (
             <span onMouseOver={this.onMouseOver} onMouseLeave={this.onMouseLeave} className={this.props.class}>
                 {this.props.children}
-                <Tooltip
+                {this.state.hover && <Tooltip
                     label={this.props.tooltip}
-                    visible={this.state.hover}
                     tooltipClassName={this.props.tooltipClass}
-                    className={"mx_TextWithTooltip_tooltip"} />
+                    className={"mx_TextWithTooltip_tooltip"} /> }
             </span>
         );
     }


### PR DESCRIPTION
The way our Tooltip component works is hugely flawed, it uses two expensive operations and in one of its mode is very happy to litter loads of Tooltip wrappers into the DOM.

Fixes https://github.com/vector-im/riot-web/issues/14700
Alleviates / Fixes https://github.com/vector-im/riot-web/issues/14707

This PR moves to only mounting the Tooltip component when it will be shown like every other area we use it in the app.
Ideally we'd make a much smarter Tooltip component but that's outside of scope for these issues.