### PR TITLE
fix: fall back to default state power level

### DIFF
--- a/src/components/views/right_panel/UserInfo.js
+++ b/src/components/views/right_panel/UserInfo.js
@@ -743,10 +743,13 @@ const RoomAdminToolsContainer = ({room, children, member, startUpdating, stopUpd
     let muteButton;
     let redactButton;
 
-    const editPowerLevel = (
-        (powerLevels.events ? powerLevels.events["m.room.power_levels"] : null) ||
-        powerLevels.state_default
-    );
+    let editPowerLevel = (powerLevels.events ? powerLevels.events["m.room.power_levels"] : null);
+    if (editPowerLevel == null) {
+        editPowerLevel = powerLevels.state_default;
+    }
+    if (editPowerLevel == null) {
+        editPowerLevel = 50;
+    }
 
     // if these do not exist in the event then they should default to 50 as per the spec
     const {
@@ -929,10 +932,14 @@ function useRoomPermissions(cli, room, user) {
 
         let modifyLevelMax = -1;
         if (canAffectUser) {
-            const editPowerLevel = (
-                (powerLevels.events ? powerLevels.events["m.room.power_levels"] : null) ||
-                powerLevels.state_default
-            );
+            let editPowerLevel = (powerLevels.events ? powerLevels.events["m.room.power_levels"] : null);
+            if (editPowerLevel == null) {
+                editPowerLevel = powerLevels.state_default;
+            }
+            if (editPowerLevel == null) {
+                editPowerLevel = 50;
+            }
+
             if (me.powerLevel >= editPowerLevel && (isMe || me.powerLevel > them.powerLevel)) {
                 modifyLevelMax = me.powerLevel;
             }


### PR DESCRIPTION
I also fixed the use of || on powerLevels.events["m.room.power_levels"] because that falls back to the other values if it is 0.
Thanks to @tulir and @joepie91!

PS from joepie:
> normally you should only do data normalization like this at the point of entry