### PR TITLE
Fix key backup warning on soft logout page

### DIFF
--- a/src/components/structures/auth/SoftLogout.js
+++ b/src/components/structures/auth/SoftLogout.js
@@ -72,7 +72,7 @@ export default class SoftLogout extends React.Component {
 
         this._initLogin();
 
-        MatrixClientPeg.get().flagAllGroupSessionsForBackup().then(remaining => {
+        MatrixClientPeg.get().countSessionsNeedingBackup().then(remaining => {
             this.setState({keyBackupNeeded: remaining > 0});
         });
     }


### PR DESCRIPTION
It always showed the warning (if you had at least one session key
in your store) because flagAllGroupSessionsForBackup returns the
number of keys pending backup after flagging them all for backup,
ie. all of them. Seems like the intention was to only show the
warning if there were keys that had not yet been backed up.

Fixes https://github.com/vector-im/riot-web/issues/14829
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1429