### PR TITLE
get screen type from app prop

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -314,13 +314,13 @@ export default class AppTile extends React.Component {
             if (SettingsStore.isFeatureEnabled("feature_many_integration_managers")) {
                 IntegrationManagers.sharedInstance().openAll(
                     this.props.room,
-                    'type_' + this.props.type,
+                    'type_' + this.props.app.type,
                     this.props.app.id,
                 );
             } else {
                 IntegrationManagers.sharedInstance().getPrimaryManager().open(
                     this.props.room,
-                    'type_' + this.props.type,
+                    'type_' + this.props.app.type,
                     this.props.app.id,
                 );
             }


### PR DESCRIPTION
This PR fixes a a bug in `_onEditClick` in `AppTile.js` where the `screen` parameter for `IntegrationManager.open()` gets pulled from the wrong prop.

See also vector-im/element-web#14771