### PR TITLE
Fixes button overflow in the .mx_MessageComposerFormatBar

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_MessageComposerFormatBar {
     display: none;
-    width: calc(26px * 5);
+    width: calc(27px * 5);
     height: 24px;
     position: absolute;
     cursor: pointer;
@@ -36,7 +36,6 @@ limitations under the License.
         display: inline-block;
         position: relative;
         border: 1px solid $message-action-bar-border-color;
-        margin-left: -1px;
 
         &:hover {
             border-color: $message-action-bar-hover-border-color;


### PR DESCRIPTION
Fixes this bug (https://github.com/vector-im/element-web/issues/12390) for some installs of element desktop on Linux.

Makes the math of adding up all the button widths work out better as well.