### PR TITLE
Renamed 'riot' targets in ci scripts and npm package to 'element'

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,120 @@
+steps:
+  - label: ":eslint: JS Lint"
+    command:
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
+      - "yarn lint:js"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+
+  - label: ":eslint: TS Lint"
+    command:
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
+      - "yarn lint:ts"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+
+  - label: ":eslint: Types Lint"
+    command:
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
+      - "yarn lint:types"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+
+  - label: ":jest: Tests"
+    agents:
+      # We use a medium sized instance instead of the normal small ones because
+      # webpack loves to gorge itself on resources.
+      queue: "medium"
+    command:
+      - "echo '--- Install js-sdk'"
+      # TODO: Remove hacky chmod for BuildKite
+      - "chmod +x ./scripts/ci/*.sh"
+      - "chmod +x ./scripts/*"
+      - "echo '--- Installing Dependencies'"
+      - "./scripts/ci/install-deps.sh"
+      - "echo '--- Running initial build steps'"
+      - "yarn build"
+      - "echo '+++ Running Tests'"
+      - "yarn test"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+
+  - label: "🛠 Build"
+    command:
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
+      - "echo '+++ Building Project'"
+      - "yarn build"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+
+  - label: ":chains: End-to-End Tests"
+    agents:
+      # We use a xlarge sized instance instead of the normal small ones because
+      # e2e tests otherwise take +-8min
+      queue: "xlarge"
+    command:
+      # TODO: Remove hacky chmod for BuildKite
+      - "echo '--- Setup'"
+      - "chmod +x ./scripts/ci/*.sh"
+      - "chmod +x ./scripts/*"
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh"
+      - "echo '--- Running initial build steps'"
+      - "yarn build"
+      - "echo '+++ Running Tests'"
+      - "./scripts/ci/end-to-end-tests.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/riotweb-ci-e2etests-env:latest"
+          propagate-environment: true
+          workdir: "/workdir/matrix-react-sdk"
+    retry:
+      automatic:
+        - exit_status: 1 # retry end-to-end tests once as Puppeteer sometimes fails
+          limit: 1
+
+  - label: "🔧 Element Tests"
+    agents:
+      # We use a medium sized instance instead of the normal small ones because
+      # webpack loves to gorge itself on resources.
+      queue: "medium"
+    command:
+      # TODO: Remove hacky chmod for BuildKite
+      - "chmod +x ./scripts/ci/*.sh"
+      - "chmod +x ./scripts/*"
+      - "echo '+++ Running Tests'"
+      - "./scripts/ci/element-unit-tests.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:10"
+          propagate-environment: true
+          workdir: "/workdir/matrix-react-sdk"
+
+  - label: "🌐 i18n"
+    command:
+      - "echo '--- Fetching Dependencies'"
+      - "yarn install"
+      - "echo '+++ Testing i18n output'"
+      - "yarn diff-i18n"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:10"
+
+  - wait
+
+  - label: "🐴 Trigger element-web"
+    trigger: "element-web"
+    branches: "develop"
+    build:
+        branch: "develop"
+        message: "[react-sdk] ${BUILDKITE_MESSAGE}"
+    async: true

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:types": "tsc --noEmit --jsx react",
     "lint:style": "stylelint 'res/css/**/*.scss'",
     "test": "jest",
-    "test:e2e": "./test/end-to-end-tests/run.sh --riot-url http://localhost:8080"
+    "test:e2e": "./test/end-to-end-tests/run.sh --element-url http://localhost:8080"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",

--- a/scripts/ci/element-unit-tests.sh
+++ b/scripts/ci/element-unit-tests.sh
@@ -2,11 +2,11 @@
 #
 # script which is run by the CI build (after `yarn test`).
 #
-# clones riot-web develop and runs the tests against our version of react-sdk.
+# clones element-web develop and runs the tests against our version of react-sdk.
 
 set -ev
 
-scripts/ci/layered-riot-web.sh
-cd ../riot-web
+scripts/ci/layered-element-web.sh
+cd ../element-web
 yarn build:genfiles # so the tests can run. Faster version of `build`
 yarn test

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -2,7 +2,7 @@
 #
 # script which is run by the CI build (after `yarn test`).
 #
-# clones riot-web develop and runs the tests against our version of react-sdk.
+# clones element-web develop and runs the tests against our version of react-sdk.
 
 set -ev
 
@@ -14,23 +14,24 @@ handle_error() {
 trap 'handle_error' ERR
 
 echo "--- Building Element"
-scripts/ci/layered-riot-web.sh
-cd ../riot-web
-riot_web_dir=`pwd`
+scripts/ci/layered-element-web.sh
+cd ../element-web
+element_web_dir=`pwd`
 CI_PACKAGE=true yarn build
 cd ../matrix-react-sdk
 # run end to end tests
 pushd test/end-to-end-tests
-ln -s $riot_web_dir riot/riot-web
+ln -s $element_web_dir element/element-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
 # CHROME_PATH=$(which google-chrome-stable) ./run.sh
 echo "--- Install synapse & other dependencies"
 ./install.sh
-# install static webserver to server symlinked local copy of riot
-./riot/install-webserver.sh
+# install static webserver to server symlinked local copy of element
+./element/install-webserver.sh
 rm -r logs || true
 mkdir logs
 echo "+++ Running end-to-end tests"
 TESTS_STARTED=1
 ./run.sh --no-sandbox --log-directory logs/
 popd
+

--- a/scripts/ci/layered-element-web.sh
+++ b/scripts/ci/layered-element-web.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Creates an environment similar to one that riot-web would expect for
+# Creates an environment similar to one that element-web would expect for
 # development. This means going one directory up (and assuming we're in
-# a directory like /workdir/matrix-react-sdk) and putting riot-web and
+# a directory like /workdir/matrix-react-sdk) and putting element-web and
 # the js-sdk there.
 
 cd ../  # Assume we're at something like /workdir/matrix-react-sdk
@@ -21,9 +21,9 @@ yarn link
 yarn install
 popd
 
-# Finally, set up riot-web
-matrix-react-sdk/scripts/fetchdep.sh vector-im riot-web
-pushd riot-web
+# Finally, set up element-web
+matrix-react-sdk/scripts/fetchdep.sh vector-im element-web
+pushd element-web
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk
 yarn install

--- a/test/end-to-end-tests/run.sh
+++ b/test/end-to-end-tests/run.sh
@@ -9,16 +9,16 @@ echo "Please first run $BASE_DIR/install.sh"
     exit 1
 fi
 
-has_custom_riot=$(node has_custom_riot.js $@)
+has_custom_element=$(node has_custom_element.js $@)
 
-if [ ! -d "riot/riot-web" ] && [ $has_custom_riot -ne "1" ]; then
-    echo "Please provide an instance of riot to test against by passing --riot-url <url> or running $BASE_DIR/riot/install.sh"
+if [ ! -d "element/element-web" ] && [ $has_custom_element -ne "1" ]; then
+    echo "Please provide an instance of element to test against by passing --element-url <url> or running $BASE_DIR/element/install.sh"
     exit 1
 fi
 
 stop_servers() {
-    if [ $has_custom_riot -ne "1" ]; then
-	   ./riot/stop.sh
+    if [ $has_custom_element -ne "1" ]; then
+	   ./element/stop.sh
 	fi
     ./synapse/stop.sh
 }
@@ -32,8 +32,8 @@ handle_error() {
 trap 'handle_error' ERR
 
 ./synapse/start.sh
-if [ $has_custom_riot -ne "1" ]; then
-    ./riot/start.sh
+if [ $has_custom_element -ne "1" ]; then
+    ./element/start.sh
 fi
 node start.js $@
 stop_servers


### PR DESCRIPTION
This PR would need to be done in coordination with [element-web #14850](https://github.com/vector-im/element-web/pull/14850), otherwise scripts will bomb out.