### PR TITLE
Generate previews for rooms when the option changes

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -120,6 +120,12 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
         return !this.props.isMinimized && this.props.showMessagePreview;
     }
 
+    public componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
+        if (prevProps.showMessagePreview !== this.props.showMessagePreview && this.showMessagePreview) {
+            this.setState({messagePreview: this.generatePreview()});
+        }
+    }
+
     public componentDidMount() {
         // when we're first rendered (or our sublist is expanded) make sure we are visible if we're active
         if (this.state.selected) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/14853

This likely regressed in https://github.com/matrix-org/matrix-react-sdk/pull/5048 when the message preview information was made state, and the component wasn't updating the preview when the control flags changed.

Done with a community hat on:
```
Signed-off-by: Travis Ralston <travis@t2bot.io>
```