### PR TITLE
padding the timeline so that its scrollbar has its own space from the resizer

### DIFF
--- a/res/css/structures/_MainSplit.scss
+++ b/res/css/structures/_MainSplit.scss
@@ -23,6 +23,8 @@ limitations under the License.
 
 .mx_MainSplit > .mx_RightPanel_ResizeWrapper {
     padding: 5px;
+    // margin left to not allow the handle to not encroach on the space for the scrollbar
+    margin-left: 8px;
 
     &:hover .mx_RightPanel_ResizeHandle {
         // Need to use important to override element style attributes


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/14910
![14910](https://user-images.githubusercontent.com/2403652/90034077-13a69980-dcb8-11ea-8c7d-2cab5b2d84c2.gif)
