### PR TITLE
Fix action bar safe area regression

### DIFF
--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -41,7 +41,7 @@ limitations under the License.
         width: calc(10px + 48px + 100% + 8px);
         // safe area + action bar
         height: calc(20px + 100%);
-        top: -20px;
+        top: -12px;
         left: -58px;
         z-index: -1;
         cursor: initial;


### PR DESCRIPTION
The action bar was recently moved, but the safe area was not, which left a gap
between the event and the action bar, making it quite easy to trigger hover on a
different event instead of reaching the action bar.

For review, here's a screenshot with a debugging border enabled:

<img width="230" alt="image" src="https://user-images.githubusercontent.com/279572/90172512-06aea680-dd9b-11ea-8d9d-90456a0bb9ca.png">

Fixes https://github.com/vector-im/element-web/issues/14953
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/5056