### PR TITLE
Add a minimum width to the RoomView for mobile devices with narrow screens

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -18,6 +18,7 @@ limitations under the License.
     word-wrap: break-word;
     display: flex;
     flex-direction: column;
+    min-width: 350px;
 }
 
 .mx_RoomView_fileDropTarget {


### PR DESCRIPTION
My setup involves a PinePhone running a variant of Debian Linux. The screen is very narrow.

I have been using a user CSS file in Firefox to force a minimum width on the mx_RoomView so that it doesn't squeeze the text messages onto one word per line and make the attach file, emoji, voice, video call buttons disappear. You can see this effect even on desktop if you make your firefox window verry narrow.

With this minimum width on PinePhone there is still a bit of wasted screen real-estate on the left with the communities bar, but at least the user can scroll the whole panel right to see the full text messages in a reasonable width and access some of the less frequently used buttons like voice call, video call, members, notifications.