### PR TITLE
Enforce Secure Backup completion when requested by HS

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -27,10 +27,12 @@ import {ModalManager} from "../Modal";
 import SettingsStore from "../settings/SettingsStore";
 import {ActiveRoomObserver} from "../ActiveRoomObserver";
 import {Notifier} from "../Notifier";
+import type {Renderer} from "react-dom";
 
 declare global {
     interface Window {
         Modernizr: ModernizrStatic;
+        matrixChat: ReturnType<Renderer>;
         mxMatrixClientPeg: IMatrixClientPeg;
         Olm: {
             init: () => Promise<void>;

--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -35,6 +35,17 @@ function isCachingAllowed() {
     return secretStorageBeingAccessed;
 }
 
+/**
+ * This can be used by other components to check if secret storage access is in
+ * progress, so that we can e.g. avoid intermittently showing toasts during
+ * secret storage setup.
+ *
+ * @returns {bool}
+ */
+export function isSecretStorageBeingAccessed() {
+    return secretStorageBeingAccessed;
+}
+
 export class AccessCancelledError extends Error {
     constructor() {
         super("Secret storage access canceled");

--- a/src/CrossSigningManager.js
+++ b/src/CrossSigningManager.js
@@ -21,6 +21,7 @@ import { deriveKey } from 'matrix-js-sdk/src/crypto/key_passphrase';
 import { decodeRecoveryKey } from 'matrix-js-sdk/src/crypto/recoverykey';
 import { _t } from './languageHandler';
 import {encodeBase64} from "matrix-js-sdk/src/crypto/olmlib";
+import { isSecureBackupRequired } from './utils/WellKnownUtils';
 
 // This stores the secret storage private keys in memory for the JS SDK. This is
 // only meant to act as a cache to avoid prompting the user multiple times
@@ -208,7 +209,18 @@ export async function accessSecretStorage(func = async () => { }, forceReset = f
                 {
                     force: forceReset,
                 },
-                null, /* priority = */ false, /* static = */ true,
+                null,
+                /* priority = */ false,
+                /* static = */ true,
+                /* options = */ {
+                    onBeforeClose(reason) {
+                        // If Secure Backup is required, you cannot leave the modal.
+                        if (reason === "backgroundClick") {
+                            return !isSecureBackupRequired();
+                        }
+                        return true;
+                    },
+                },
             );
             const [confirmed] = await finished;
             if (!confirmed) {

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {MatrixClientPeg} from './MatrixClientPeg';
+import dis from "./dispatcher/dispatcher";
 import {
     hideToast as hideBulkUnverifiedSessionsToast,
     showToast as showBulkUnverifiedSessionsToast,
@@ -29,11 +30,15 @@ import {
     showToast as showUnverifiedSessionsToast,
 } from "./toasts/UnverifiedSessionToast";
 import { privateShouldBeEncrypted } from "./createRoom";
-import { isSecretStorageBeingAccessed } from "./CrossSigningManager";
+import { isSecretStorageBeingAccessed, accessSecretStorage } from "./CrossSigningManager";
+import { ensureClientWellKnown, isSecureBackupRequired } from './utils/WellKnownUtils';
+import { isLoggedIn } from './components/structures/MatrixChat';
+
 
 const KEY_BACKUP_POLL_INTERVAL = 5 * 60 * 1000;
 
 export default class DeviceListener {
+    private dispatcherRef: string;
     // device IDs for which the user has dismissed the verify toast ('Later')
     private dismissed = new Set<string>();
     // has the user dismissed any of the various nag toasts to setup encryption on this device?
@@ -61,6 +66,7 @@ export default class DeviceListener {
         MatrixClientPeg.get().on('crossSigning.keysChanged', this._onCrossSingingKeysChanged);
         MatrixClientPeg.get().on('accountData', this._onAccountData);
         MatrixClientPeg.get().on('sync', this._onSync);
+        this.dispatcherRef = dis.register(this._onAction);
         this._recheck();
     }
 
@@ -73,6 +79,10 @@ export default class DeviceListener {
             MatrixClientPeg.get().removeListener('crossSigning.keysChanged', this._onCrossSingingKeysChanged);
             MatrixClientPeg.get().removeListener('accountData', this._onAccountData);
             MatrixClientPeg.get().removeListener('sync', this._onSync);
+        }
+        if (this.dispatcherRef) {
+            dis.unregister(this.dispatcherRef);
+            this.dispatcherRef = null;
         }
         this.dismissed.clear();
         this.dismissedThisDeviceToast = false;
@@ -159,6 +169,11 @@ export default class DeviceListener {
         if (state === 'PREPARED' && prevState === null) this._recheck();
     };
 
+    _onAction = ({ action }) => {
+        if (action !== "on_logged_in") return;
+        this._recheck();
+    };
+
     // The server doesn't tell us when key backup is set up, so we poll
     // & cache the result
     async _getKeyBackupInfo() {
@@ -211,7 +226,15 @@ export default class DeviceListener {
                     showSetupEncryptionToast(SetupKind.UPGRADE_ENCRYPTION);
                 } else {
                     // No cross-signing or key backup on account (set up encryption)
-                    showSetupEncryptionToast(SetupKind.SET_UP_ENCRYPTION);
+                    await ensureClientWellKnown();
+                    if (isSecureBackupRequired() && isLoggedIn()) {
+                        // If we're meant to set up, and Secure Backup is required,
+                        // trigger the flow directly without a toast once logged in.
+                        hideSetupEncryptionToast();
+                        accessSecretStorage();
+                    } else {
+                        showSetupEncryptionToast(SetupKind.SET_UP_ENCRYPTION);
+                    }
                 }
             }
         }

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -31,7 +31,7 @@ import {
 } from "./toasts/UnverifiedSessionToast";
 import { privateShouldBeEncrypted } from "./createRoom";
 import { isSecretStorageBeingAccessed, accessSecretStorage } from "./CrossSigningManager";
-import { ensureClientWellKnown, isSecureBackupRequired } from './utils/WellKnownUtils';
+import { isSecureBackupRequired } from './utils/WellKnownUtils';
 import { isLoggedIn } from './components/structures/MatrixChat';
 
 
@@ -226,7 +226,7 @@ export default class DeviceListener {
                     showSetupEncryptionToast(SetupKind.UPGRADE_ENCRYPTION);
                 } else {
                     // No cross-signing or key backup on account (set up encryption)
-                    await ensureClientWellKnown();
+                    await cli.waitForClientWellKnown();
                     if (isSecureBackupRequired() && isLoggedIn()) {
                         // If we're meant to set up, and Secure Backup is required,
                         // trigger the flow directly without a toast once logged in.

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -28,7 +28,8 @@ import {
     hideToast as hideUnverifiedSessionsToast,
     showToast as showUnverifiedSessionsToast,
 } from "./toasts/UnverifiedSessionToast";
-import {privateShouldBeEncrypted} from "./createRoom";
+import { privateShouldBeEncrypted } from "./createRoom";
+import { isSecretStorageBeingAccessed } from "./CrossSigningManager";
 
 const KEY_BACKUP_POLL_INTERVAL = 5 * 60 * 1000;
 
@@ -170,6 +171,9 @@ export default class DeviceListener {
     }
 
     private shouldShowSetupEncryptionToast() {
+        // If we're in the middle of a secret storage operation, we're likely
+        // modifying the state involved here, so don't add new toasts to setup.
+        if (isSecretStorageBeingAccessed()) return false;
         // In a default configuration, show the toasts. If the well-known config causes e2ee default to be false
         // then do not show the toasts until user is in at least one encrypted room.
         if (privateShouldBeEncrypted()) return true;

--- a/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
@@ -30,6 +30,7 @@ import StyledRadioButton from '../../../../components/views/elements/StyledRadio
 import AccessibleButton from "../../../../components/views/elements/AccessibleButton";
 import DialogButtons from "../../../../components/views/elements/DialogButtons";
 import InlineSpinner from "../../../../components/views/elements/InlineSpinner";
+import { isSecureBackupRequired } from '../../../../utils/WellKnownUtils';
 
 const PHASE_LOADING = 0;
 const PHASE_LOADERROR = 1;
@@ -85,8 +86,8 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
             canUploadKeysWithPasswordOnly: null,
             accountPassword: props.accountPassword || "",
             accountPasswordCorrect: null,
-
             passPhraseKeySelected: CREATE_STORAGE_OPTION_KEY,
+            canSkip: !isSecureBackupRequired(),
         };
 
         this._passphraseField = createRef();
@@ -470,7 +471,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
                 primaryButton={_t("Continue")}
                 onPrimaryButtonClick={this._onChooseKeyPassphraseFormSubmit}
                 onCancel={this._onCancelClick}
-                hasCancel={true}
+                hasCancel={this.state.canSkip}
             />
         </form>;
     }
@@ -687,7 +688,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
             <div className="mx_Dialog_buttons">
                 <DialogButtons primaryButton={_t('Retry')}
                     onPrimaryButtonClick={this._onLoadRetryClick}
-                    hasCancel={true}
+                    hasCancel={this.state.canSkip}
                     onCancel={this._onCancel}
                 />
             </div>
@@ -742,7 +743,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
                 <div className="mx_Dialog_buttons">
                     <DialogButtons primaryButton={_t('Retry')}
                         onPrimaryButtonClick={this._bootstrapSecretStorage}
-                        hasCancel={true}
+                        hasCancel={this.state.canSkip}
                         onCancel={this._onCancel}
                     />
                 </div>

--- a/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/secretstorage/CreateSecretStorageDialog.js
@@ -714,7 +714,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
     _titleForPhase(phase) {
         switch (phase) {
             case PHASE_CHOOSE_KEY_PASSPHRASE:
-                return _t('Set up Secure backup');
+                return _t('Set up Secure Backup');
             case PHASE_MIGRATE:
                 return _t('Upgrade your encryption');
             case PHASE_PASSPHRASE:

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -2085,3 +2085,10 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         </ErrorBoundary>;
     }
 }
+
+export function isLoggedIn(): boolean {
+    // JRS: Maybe we should move the step that writes this to the window out of
+    // `element-web` and into this file?
+    const app = window.matrixChat;
+    return app && (app as MatrixChat).state.view === Views.LOGGED_IN;
+}

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -2088,7 +2088,9 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
 export function isLoggedIn(): boolean {
     // JRS: Maybe we should move the step that writes this to the window out of
-    // `element-web` and into this file?
+    // `element-web` and into this file? Better yet, we should probably create a
+    // store to hold this state.
+    // See also https://github.com/vector-im/element-web/issues/15034.
     const app = window.matrixChat;
     return app && (app as MatrixChat).state.view === Views.LOGGED_IN;
 }

--- a/src/components/views/settings/KeyBackupPanel.js
+++ b/src/components/views/settings/KeyBackupPanel.js
@@ -21,6 +21,7 @@ import * as sdk from '../../../index';
 import {MatrixClientPeg} from '../../../MatrixClientPeg';
 import { _t } from '../../../languageHandler';
 import Modal from '../../../Modal';
+import { isSecureBackupRequired } from '../../../utils/WellKnownUtils';
 
 export default class KeyBackupPanel extends React.PureComponent {
     constructor(props) {
@@ -315,14 +316,19 @@ export default class KeyBackupPanel extends React.PureComponent {
                 trustedLocally = _t("This backup is trusted because it has been restored on this session");
             }
 
+            let deleteBackupButton;
+            if (!isSecureBackupRequired()) {
+                deleteBackupButton = <AccessibleButton kind="danger" onClick={this._deleteBackup}>
+                    {_t("Delete Backup")}
+                </AccessibleButton>;
+            }
+
             const buttonRow = (
                 <div className="mx_KeyBackupPanel_buttonRow">
                     <AccessibleButton kind="primary" onClick={this._restoreBackup}>
                         {restoreButtonCaption}
                     </AccessibleButton>&nbsp;&nbsp;&nbsp;
-                    <AccessibleButton kind="danger" onClick={this._deleteBackup}>
-                        {_t("Delete Backup")}
-                    </AccessibleButton>
+                    {deleteBackupButton}
                 </div>
             );
 

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -26,9 +26,7 @@ import dis from "./dispatcher/dispatcher";
 import * as Rooms from "./Rooms";
 import DMRoomMap from "./utils/DMRoomMap";
 import {getAddressType} from "./UserAddress";
-
-const E2EE_WK_KEY = "im.vector.e2ee";
-const E2EE_WK_KEY_DEPRECATED = "im.vector.riot.e2ee";
+import { getE2EEWellKnown } from "./utils/WellKnownUtils";
 
 // we define a number of interfaces which take their names from the js-sdk
 /* eslint-disable camelcase */
@@ -295,16 +293,11 @@ export async function ensureDMExists(client: MatrixClient, userId: string): Prom
     return roomId;
 }
 
-export function privateShouldBeEncrypted() {
-    const clientWellKnown = MatrixClientPeg.get().getClientWellKnown();
-    if (clientWellKnown && clientWellKnown[E2EE_WK_KEY]) {
-        const defaultDisabled = clientWellKnown[E2EE_WK_KEY]["default"] === false;
+export function privateShouldBeEncrypted(): boolean {
+    const e2eeWellKnown = getE2EEWellKnown();
+    if (e2eeWellKnown) {
+        const defaultDisabled = e2eeWellKnown["default"] === false;
         return !defaultDisabled;
     }
-    if (clientWellKnown && clientWellKnown[E2EE_WK_KEY_DEPRECATED]) {
-        const defaultDisabled = clientWellKnown[E2EE_WK_KEY_DEPRECATED]["default"] === false;
-        return !defaultDisabled;
-    }
-
     return true;
 }

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -27,7 +27,8 @@ import * as Rooms from "./Rooms";
 import DMRoomMap from "./utils/DMRoomMap";
 import {getAddressType} from "./UserAddress";
 
-const E2EE_WK_KEY = "im.vector.riot.e2ee";
+const E2EE_WK_KEY = "im.vector.e2ee";
+const E2EE_WK_KEY_DEPRECATED = "im.vector.riot.e2ee";
 
 // we define a number of interfaces which take their names from the js-sdk
 /* eslint-disable camelcase */
@@ -298,6 +299,10 @@ export function privateShouldBeEncrypted() {
     const clientWellKnown = MatrixClientPeg.get().getClientWellKnown();
     if (clientWellKnown && clientWellKnown[E2EE_WK_KEY]) {
         const defaultDisabled = clientWellKnown[E2EE_WK_KEY]["default"] === false;
+        return !defaultDisabled;
+    }
+    if (clientWellKnown && clientWellKnown[E2EE_WK_KEY_DEPRECATED]) {
+        const defaultDisabled = clientWellKnown[E2EE_WK_KEY_DEPRECATED]["default"] === false;
         return !defaultDisabled;
     }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2241,7 +2241,7 @@
     "Retry": "Retry",
     "If you cancel now, you may lose encrypted messages & data if you lose access to your logins.": "If you cancel now, you may lose encrypted messages & data if you lose access to your logins.",
     "You can also set up Secure Backup & manage your keys in Settings.": "You can also set up Secure Backup & manage your keys in Settings.",
-    "Set up Secure backup": "Set up Secure backup",
+    "Set up Secure Backup": "Set up Secure Backup",
     "Upgrade your encryption": "Upgrade your encryption",
     "Set a Security Phrase": "Set a Security Phrase",
     "Confirm Security Phrase": "Confirm Security Phrase",

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -33,3 +33,8 @@ export function getE2EEWellKnown(): IE2EEWellKnown {
     }
     return null;
 }
+
+export function isSecureBackupRequired(): boolean {
+    const wellKnown = getE2EEWellKnown();
+    return wellKnown && wellKnown["secure_backup_required"] === true;
+}

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -23,14 +23,6 @@ export interface IE2EEWellKnown {
     default?: boolean;
 }
 
-export async function ensureClientWellKnown() {
-    const cli = MatrixClientPeg.get();
-    if (cli.haveAttemptedFetchingClientWellKnown()) return;
-    return new Promise(resolve => {
-        cli.once("WellKnown.attempted", resolve);
-    });
-}
-
 export function getE2EEWellKnown(): IE2EEWellKnown {
     const clientWellKnown = MatrixClientPeg.get().getClientWellKnown();
     if (clientWellKnown && clientWellKnown[E2EE_WK_KEY]) {

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import {MatrixClientPeg} from '../MatrixClientPeg';
 
-const E2EE_WK_KEY = "im.vector.e2ee";
+const E2EE_WK_KEY = "io.element.e2ee";
 const E2EE_WK_KEY_DEPRECATED = "im.vector.riot.e2ee";
 
 export interface IE2EEWellKnown {

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -23,6 +23,14 @@ export interface IE2EEWellKnown {
     default?: boolean;
 }
 
+export async function ensureClientWellKnown() {
+    const cli = MatrixClientPeg.get();
+    if (cli.haveAttemptedFetchingClientWellKnown()) return;
+    return new Promise(resolve => {
+        cli.once("WellKnown.attempted", resolve);
+    });
+}
+
 export function getE2EEWellKnown(): IE2EEWellKnown {
     const clientWellKnown = MatrixClientPeg.get().getClientWellKnown();
     if (clientWellKnown && clientWellKnown[E2EE_WK_KEY]) {

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {MatrixClientPeg} from '../MatrixClientPeg';
+
+const E2EE_WK_KEY = "im.vector.e2ee";
+const E2EE_WK_KEY_DEPRECATED = "im.vector.riot.e2ee";
+
+export interface IE2EEWellKnown {
+    default?: boolean;
+}
+
+export function getE2EEWellKnown(): IE2EEWellKnown {
+    const clientWellKnown = MatrixClientPeg.get().getClientWellKnown();
+    if (clientWellKnown && clientWellKnown[E2EE_WK_KEY]) {
+        return clientWellKnown[E2EE_WK_KEY];
+    }
+    if (clientWellKnown && clientWellKnown[E2EE_WK_KEY_DEPRECATED]) {
+        return clientWellKnown[E2EE_WK_KEY_DEPRECATED]
+    }
+    return null;
+}


### PR DESCRIPTION
This adds various measures to ensure users complete Secure Backup flows if required via `.well-known` by the HS. In particular, buttons to cancel are removed, and both the flow during registration as well as the logged in version (for anyone who may have missed it at registration) appear as blocking modals you must finish before proceeding.

(For clarify, there is no intention of this becoming the default, but it could be useful for certain use cases.)

**Reviewer:** Commit-by-commit is likely best.

During registration:

![image](https://user-images.githubusercontent.com/279572/90657328-8674bf00-e23a-11ea-9b68-aab50a1830d3.png)

Inside the app if not completed at registration:

![image](https://user-images.githubusercontent.com/279572/90656878-6513d300-e23a-11ea-97e8-ee83d735b7a8.png)

Fixes https://github.com/vector-im/element-web/issues/14954
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1444
Depends on https://github.com/vector-im/element-web/pull/15003