### PR TITLE
Add communities v2 prototyping feature flag + initial tag panel prototypes

### DIFF
--- a/src/components/views/elements/TagTile.js
+++ b/src/components/views/elements/TagTile.js
@@ -30,6 +30,7 @@ import GroupStore from '../../../stores/GroupStore';
 import TagOrderStore from '../../../stores/TagOrderStore';
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import AccessibleButton from "./AccessibleButton";
+import SettingsStore from "../../../settings/SettingsStore";
 
 // A class for a child of TagPanel (possibly wrapped in a DNDTagTile) that represents
 // a thing to click on for the user to filter the visible rooms in the RoomList to:
@@ -112,6 +113,7 @@ export default createReactClass({
     },
 
     onMouseOver: function() {
+        if (SettingsStore.getValue("feature_communities_v2_prototypes")) return;
         this.setState({ hover: true });
     },
 
@@ -123,6 +125,7 @@ export default createReactClass({
         // Prevent the TagTile onClick event firing as well
         e.stopPropagation();
         e.preventDefault();
+        if (SettingsStore.getValue("feature_communities_v2_prototypes")) return;
         this.setState({ hover: false });
         this.props.openMenu();
     },

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -444,6 +444,7 @@
     "%(senderName)s: %(reaction)s": "%(senderName)s: %(reaction)s",
     "%(senderName)s: %(stickerName)s": "%(senderName)s: %(stickerName)s",
     "Change notification settings": "Change notification settings",
+    "Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution.": "Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution.",
     "New spinner design": "New spinner design",
     "Message Pinning": "Message Pinning",
     "Custom user status messages": "Custom user status messages",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -111,7 +111,10 @@ export interface ISetting {
 export const SETTINGS: {[setting: string]: ISetting} = {
     "feature_communities_v2_prototypes": {
         isFeature: true,
-        displayName: _td("Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution."),
+        displayName: _td(
+            "Communities v2 prototypes. Requires compatible homeserver. " +
+            "Highly experimental - use with caution.",
+        ),
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -109,6 +109,12 @@ export interface ISetting {
 }
 
 export const SETTINGS: {[setting: string]: ISetting} = {
+    "feature_communities_v2_prototypes": {
+        isFeature: true,
+        displayName: _td("Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution."),
+        supportedLevels: LEVELS_FEATURE,
+        default: false,
+    },
     "feature_new_spinner": {
         isFeature: true,
         displayName: _td("New spinner design"),

--- a/src/stores/TagOrderStore.js
+++ b/src/stores/TagOrderStore.js
@@ -115,9 +115,11 @@ class TagOrderStore extends Store {
                 break;
             }
             case 'select_tag': {
+                const allowMultiple = !SettingsStore.getValue("feature_communities_v2_prototypes")
+
                 let newTags = [];
                 // Shift-click semantics
-                if (payload.shiftKey) {
+                if (payload.shiftKey && allowMultiple) {
                     // Select range of tags
                     let start = this._state.orderedTags.indexOf(this._state.anchorTag);
                     let end = this._state.orderedTags.indexOf(payload.tag);
@@ -135,7 +137,7 @@ class TagOrderStore extends Store {
                         this._state.orderedTags.slice(start, end + 1).concat(newTags),
                     )];
                 } else {
-                    if (payload.ctrlOrCmdKey) {
+                    if (payload.ctrlOrCmdKey && allowMultiple) {
                         // Toggle individual tag
                         if (this._state.selectedTags.includes(payload.tag)) {
                             newTags = this._state.selectedTags.filter((t) => t !== payload.tag);

--- a/src/stores/TagOrderStore.js
+++ b/src/stores/TagOrderStore.js
@@ -115,7 +115,7 @@ class TagOrderStore extends Store {
                 break;
             }
             case 'select_tag': {
-                const allowMultiple = !SettingsStore.getValue("feature_communities_v2_prototypes")
+                const allowMultiple = !SettingsStore.getValue("feature_communities_v2_prototypes");
 
                 let newTags = [];
                 // Shift-click semantics


### PR DESCRIPTION
**Requires https://github.com/vector-im/element-web/pull/15013**

Prototype behaviour (all the PRs in the series will have something like this so we can look back on it):
* CTRL and SHIFT click no longer work in the tag panel (limited to one community selected at a time)
  * Rationale: Filtering over multiple communities has high cognitive load - experiment a simpler option.
* User menu changes to show the selected community
  * Rationale: It's important to know where you're at
* No context menu on communities
  * Rationale: We'll be replacing much of the UI it exposes with other means

This is all behind a newly-introduced labs flag to avoid confusing/conflicting with current expectations.

