### PR TITLE
Send mx_local_settings in rageshake

### DIFF
--- a/src/rageshake/submit-rageshake.ts
+++ b/src/rageshake/submit-rageshake.ts
@@ -182,6 +182,8 @@ export default async function sendBugReport(bugReportEndpoint: string, opts: IOp
         }
     }
 
+    body.append("mx_local_settings", localStorage.getItem('mx_local_settings'));
+
     if (opts.sendLogs) {
         progressCallback(_t("Collecting logs"));
         const logs = await rageshake.getLogsForReport();


### PR DESCRIPTION
Perhaps ideally we should get a complete dump of the settings in
effect out of the settings manager, but all I want for now is the
webrtc audio inputs and outputs, so let's send the ones stored locally.