### PR TITLE
Allow avatar image view for 1:1 rooms

### DIFF
--- a/src/components/views/avatars/RoomAvatar.tsx
+++ b/src/components/views/avatars/RoomAvatar.tsx
@@ -114,9 +114,12 @@ export default class RoomAvatar extends React.Component<IProps, IState> {
     }
 
     private onRoomAvatarClick = () => {
-        const avatarUrl = this.props.room.getAvatarUrl(
-            MatrixClientPeg.get().getHomeserverUrl(),
-            null, null, null, false);
+        const avatarUrl = Avatar.avatarUrlForRoom(
+            this.props.room,
+            null,
+            null,
+            null,
+        );
         const params = {
             src: avatarUrl,
             name: this.props.room.name,


### PR DESCRIPTION
Clicking on the header avatar in a 1:1 room in element currently does not behave the same as clicking on it in a room with a set avatar. In both cases a filling modal is opened but in the case of 1:1 room it is simply empty instead of showing the avatar of the other user. This pr fixes that by switching to `Avatar.avatarUrlForRoom` method for fetching the room avatar, which has an automatic fallback implemented for 1:1 rooms.

Before:
![image](https://user-images.githubusercontent.com/4395770/90877619-a7f1ba00-e3a4-11ea-9b03-a91779179721.png)
After:
![image](https://user-images.githubusercontent.com/4395770/90877653-b7710300-e3a4-11ea-9189-739df2333c13.png)

