### PR TITLE
Fix full screen video call scale problem

### DIFF
--- a/res/css/views/voip/_VideoView.scss
+++ b/res/css/views/voip/_VideoView.scss
@@ -21,11 +21,13 @@ limitations under the License.
 }
 
 .mx_VideoView video {
-    width: 100%;
+    height: 100%;
 }
 
 .mx_VideoView_remoteVideoFeed {
     width: 100%;
+    height: 100%;
+    text-align: -webkit-center;
     background-color: #000;
     z-index: 50;
 }


### PR DESCRIPTION
When video call is recieved from mobile device there is a scaling problem in full screen mode. This bug is caused by full width approach to not break the aspect ratio. I changed the approach to full height. With this approach both desktop and mobile will be covered with same behaviour.

~~This pull request will also solve this issue~~ Fixes [#7130](https://github.com/vector-im/element-web/issues/7130)

Signed-off-by: Ozan Batuhan Ceylan <ozanbatuhanceylan@gmail.com>