### PR TITLE
Communities v2 prototype: Associate created rooms with the selected community

### DIFF
--- a/src/components/views/dialogs/CreateCommunityPrototypeDialog.tsx
+++ b/src/components/views/dialogs/CreateCommunityPrototypeDialog.tsx
@@ -24,6 +24,7 @@ import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import InfoTooltip from "../elements/InfoTooltip";
 import dis from "../../../dispatcher/dispatcher";
 import {showCommunityRoomInviteDialog} from "../../../RoomInvite";
+import GroupStore from "../../../stores/GroupStore";
 
 interface IProps extends IDialogProps {
 }
@@ -92,6 +93,8 @@ export default class CreateCommunityPrototypeDialog extends React.PureComponent<
             this.props.onFinished(true);
 
             if (result.room_id) {
+                // Force the group store to update as it might have missed the general chat
+                await GroupStore.refreshGroupRooms(result.group_id);
                 dis.dispatch({
                     action: 'view_room',
                     room_id: result.room_id,

--- a/src/components/views/dialogs/CreateGroupDialog.js
+++ b/src/components/views/dialogs/CreateGroupDialog.js
@@ -83,25 +83,11 @@ export default createReactClass({
             localpart: this.state.groupId,
             profile: profile,
         }).then((result) => {
-            if (result.room_id) {
-                dis.dispatch({
-                    action: 'view_room',
-                    room_id: result.room_id,
-                });
-
-                // Ensure the tag gets selected now that we've created it
-                dis.dispatch({action: 'deselect_tags'}, true);
-                dis.dispatch({
-                    action: 'select_tag',
-                    tag: result.group_id,
-                });
-            } else {
-                dis.dispatch({
-                    action: 'view_group',
-                    group_id: result.group_id,
-                    group_is_new: true,
-                });
-            }
+            dis.dispatch({
+                action: 'view_group',
+                group_id: result.group_id,
+                group_is_new: true,
+            });
             this.props.onFinished(true);
         }).catch((e) => {
             this.setState({createError: e});

--- a/src/components/views/dialogs/CreateRoomDialog.js
+++ b/src/components/views/dialogs/CreateRoomDialog.js
@@ -25,6 +25,8 @@ import { _t } from '../../../languageHandler';
 import {MatrixClientPeg} from '../../../MatrixClientPeg';
 import {Key} from "../../../Keyboard";
 import {privateShouldBeEncrypted} from "../../../createRoom";
+import TagOrderStore from "../../../stores/TagOrderStore";
+import GroupStore from "../../../stores/GroupStore";
 
 export default createReactClass({
     displayName: 'CreateRoomDialog',
@@ -68,6 +70,10 @@ export default createReactClass({
 
         if (!this.state.isPublic) {
             opts.encryption = this.state.isEncrypted;
+        }
+
+        if (TagOrderStore.getSelectedPrototypeTag()) {
+            opts.associatedWithCommunity = TagOrderStore.getSelectedPrototypeTag();
         }
 
         return opts;
@@ -212,7 +218,12 @@ export default createReactClass({
             </React.Fragment>;
         }
 
-        const title = this.state.isPublic ? _t('Create a public room') : _t('Create a private room');
+        let title = this.state.isPublic ? _t('Create a public room') : _t('Create a private room');
+        if (TagOrderStore.getSelectedPrototypeTag()) {
+            const summary = GroupStore.getSummary(TagOrderStore.getSelectedPrototypeTag());
+            const name = summary?.profile?.name || TagOrderStore.getSelectedPrototypeTag();
+            title = _t("Create a room in %(communityName)s", {communityName: name});
+        }
         return (
             <BaseDialog className="mx_CreateRoomDialog" onFinished={this.props.onFinished}
                 title={title}

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -45,6 +45,7 @@ import { arrayFastClone, arrayHasDiff } from "../../../utils/arrays";
 import { objectShallowClone, objectWithOnly } from "../../../utils/objects";
 import { IconizedContextMenuOption, IconizedContextMenuOptionList } from "../context_menus/IconizedContextMenu";
 import AccessibleButton from "../elements/AccessibleButton";
+import TagOrderStore from "../../../stores/TagOrderStore";
 
 interface IProps {
     onKeyDown: (ev: React.KeyboardEvent) => void;
@@ -129,7 +130,9 @@ const TAG_AESTHETICS: {
                     }}
                 />
                 <IconizedContextMenuOption
-                    label={_t("Explore public rooms")}
+                    label={TagOrderStore.getSelectedPrototypeTag()
+                        ? _t("Explore community rooms")
+                        : _t("Explore public rooms")}
                     iconClassName="mx_RoomList_iconExplore"
                     onClick={(e) => {
                         e.preventDefault();

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -27,6 +27,7 @@ import * as Rooms from "./Rooms";
 import DMRoomMap from "./utils/DMRoomMap";
 import {getAddressType} from "./UserAddress";
 import { getE2EEWellKnown } from "./utils/WellKnownUtils";
+import GroupStore from "./stores/GroupStore";
 
 // we define a number of interfaces which take their names from the js-sdk
 /* eslint-disable camelcase */
@@ -79,6 +80,7 @@ interface IOpts {
     encryption?: boolean;
     inlineErrors?: boolean;
     andView?: boolean;
+    associatedWithCommunity?: string;
 }
 
 /**
@@ -180,6 +182,10 @@ export default function createRoom(opts: IOpts): Promise<string | null> {
             return Rooms.setDMRoom(roomId, opts.dmUserId);
         } else {
             return Promise.resolve();
+        }
+    }).then(() => {
+        if (opts.associatedWithCommunity) {
+            return GroupStore.addRoomToGroup(opts.associatedWithCommunity, roomId, false);
         }
     }).then(function() {
         // NB createRoom doesn't block on the client seeing the echo that the

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1643,6 +1643,7 @@
     "Enable end-to-end encryption": "Enable end-to-end encryption",
     "Create a public room": "Create a public room",
     "Create a private room": "Create a private room",
+    "Create a room in %(communityName)s": "Create a room in %(communityName)s",
     "Name": "Name",
     "Topic (optional)": "Topic (optional)",
     "Make this room public": "Make this room public",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1121,6 +1121,7 @@
     "Rooms": "Rooms",
     "Add room": "Add room",
     "Create new room": "Create new room",
+    "Explore community rooms": "Explore community rooms",
     "Explore public rooms": "Explore public rooms",
     "Low priority": "Low priority",
     "System Alerts": "System Alerts",

--- a/src/stores/TagOrderStore.js
+++ b/src/stores/TagOrderStore.js
@@ -285,6 +285,13 @@ class TagOrderStore extends Store {
     getSelectedTags() {
         return this._state.selectedTags;
     }
+
+    getSelectedPrototypeTag() {
+        if (SettingsStore.getValue("feature_communities_v2_prototypes")) {
+            return this.getSelectedTags()[0];
+        }
+        return null; // no selection as far as this function is concerned
+    }
 }
 
 if (global.singletonTagOrderStore === undefined) {


### PR DESCRIPTION
Prototype behaviour:
* Rooms created while looking at a community get associated with that community
  * Rationale: This is a user expectation.
  * The create room dialog title uses the community name to make it clear
  * The 'explore public rooms' option when clicking the `+` button changes slightly to hint at the community

Bug fix: After creating a community, the general room isn't always selected.

Improvement: Some prototype support code in the now-unused `CreateGroupDialog` has been removed.

![image](https://user-images.githubusercontent.com/1190097/91334413-2a56f100-e78c-11ea-906b-118d47362425.png)
![image](https://user-images.githubusercontent.com/1190097/91334424-2dea7800-e78c-11ea-872a-6648252a50bd.png)

