### PR TITLE
Fix stuttering when typing in font name

### DIFF
--- a/src/settings/controllers/UseSystemFontController.ts
+++ b/src/settings/controllers/UseSystemFontController.ts
@@ -20,18 +20,19 @@ import dis from "../../dispatcher/dispatcher";
 import { UpdateSystemFontPayload } from "../../dispatcher/payloads/UpdateSystemFontPayload";
 import { Action } from "../../dispatcher/actions";
 import { SettingLevel } from "../SettingLevel";
+import debounce from 'lodash/debounce';
 
 export default class UseSystemFontController extends SettingController {
     constructor() {
         super();
     }
 
-    public onChange(level: SettingLevel, roomId: string, newValue: any) {
+    public onChange = debounce((level: SettingLevel, roomId: string, newValue: any) => {
         // Dispatch font size change so that everything open responds to the change.
         dis.dispatch<UpdateSystemFontPayload>({
             action: Action.UpdateSystemFont,
             useSystemFont: newValue,
             font: SettingsStore.getValue("systemFont"),
         });
-    }
+    }, 3000);
 }


### PR DESCRIPTION
This fixes a major point of lag when a user changes the font used
in Element. When the "use system font" input is updated (by a
keystroke), the client updates the font, by dispatching a font
change event to the central dispatcher. One then assumes that
this changes the font family in the style sheet, as there is quite a
substantial amount of lag on every keystroke.

This commit fixes that problem, by introducing a "debounce" to the
"use system font" controller's dispatcher method. After some testing,
3000 milliseconds seemed to work the best, but that's easily changed.

Would it be a good idea to move the milliseconds outside of the
call to debounce?

Can't find any issues about this. That's surprising.

Signed-off-by: resynth1943 <resynth1943@tutanota.com>