### PR TITLE
Only wait for public keys during verification

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -220,7 +220,10 @@ export default class DeviceListener {
             await cli.downloadKeys([cli.getUserId()]);
             // cross signing isn't enabled - nag to enable it
             // There are 3 different toasts for:
-            if (cli.getStoredCrossSigningForUser(cli.getUserId())) {
+            if (
+                !cli.getCrossSigningId() &&
+                cli.getStoredCrossSigningForUser(cli.getUserId())
+            ) {
                 // Cross-signing on account but this device doesn't trust the master key (verify this session)
                 showSetupEncryptionToast(SetupKind.VERIFY_THIS_SESSION);
             } else {

--- a/src/stores/SetupEncryptionStore.js
+++ b/src/stores/SetupEncryptionStore.js
@@ -137,10 +137,10 @@ export class SetupEncryptionStore extends EventEmitter {
         }
     }
 
-    _onUserTrustStatusChanged = async (userId) => {
+    _onUserTrustStatusChanged = (userId) => {
         if (userId !== MatrixClientPeg.get().getUserId()) return;
-        const crossSigningReady = await MatrixClientPeg.get().isCrossSigningReady();
-        if (crossSigningReady) {
+        const publicKeysTrusted = MatrixClientPeg.get().getCrossSigningId();
+        if (publicKeysTrusted) {
             this.phase = PHASE_DONE;
             this.emit("update");
         }
@@ -150,7 +150,7 @@ export class SetupEncryptionStore extends EventEmitter {
         this._setActiveVerificationRequest(request);
     }
 
-    onVerificationRequestChange = async () => {
+    onVerificationRequestChange = () => {
         if (this.verificationRequest.cancelled) {
             this.verificationRequest.off("change", this.onVerificationRequestChange);
             this.verificationRequest = null;
@@ -161,8 +161,8 @@ export class SetupEncryptionStore extends EventEmitter {
             // At this point, the verification has finished, we just need to wait for
             // cross signing to be ready to use, so wait for the user trust status to
             // change (or change to DONE if it's already ready).
-            const crossSigningReady = await MatrixClientPeg.get().isCrossSigningReady();
-            this.phase = crossSigningReady ? PHASE_DONE : PHASE_BUSY;
+            const publicKeysTrusted = MatrixClientPeg.get().getCrossSigningId();
+            this.phase = publicKeysTrusted ? PHASE_DONE : PHASE_BUSY;
             this.emit("update");
         }
     }


### PR DESCRIPTION
As part of new device verification, we were waiting for "cross-signing ready"
which means _both_ the public keys are trusted by this device _and_ private keys
are available. There's no guarantee that the private keys will ever arrive, so
it's too strict to wait for this as a blocking flow. This relaxes things to wait
only for the current device to trust public keys.

Fixes https://github.com/vector-im/element-web/issues/14970