### PR TITLE
Update openid_credentials Widget API action for MSC1960 updates

### DIFF
--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -186,7 +186,14 @@ export default class WidgetMessaging {
                 isUserWidget: this.isUserWidget,
 
                 onFinished: async (confirm) => {
-                    const responseBody = {success: confirm};
+                    const responseBody = {
+                        // Legacy (early draft) fields
+                        success: confirm,
+
+                        // New style MSC1961 fields
+                        state: confirm ? "allowed" : "blocked",
+                        original_request_id: ev.requestId, // eslint-disable-line camelcase
+                    };
                     if (confirm) {
                         const credentials = await MatrixClientPeg.get().getOpenIdToken();
                         Object.assign(responseBody, credentials);

--- a/src/WidgetMessaging.js
+++ b/src/WidgetMessaging.js
@@ -190,7 +190,7 @@ export default class WidgetMessaging {
                         // Legacy (early draft) fields
                         success: confirm,
 
-                        // New style MSC1961 fields
+                        // New style MSC1960 fields
                         state: confirm ? "allowed" : "blocked",
                         original_request_id: ev.requestId, // eslint-disable-line camelcase
                     };


### PR DESCRIPTION
We now need to send a `state` and `original_request_id` per MSC1960's recent adjustments.

I expect that this smaller PR will be easier to get through than https://github.com/matrix-org/matrix-react-sdk/pull/5171 given time pressure.