### PR TITLE
Support creation of Jitsi widgets with "openidtoken-jwt" auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-focus-lock": "^2.4.1",
     "react-transition-group": "^4.4.1",
     "resize-observer-polyfill": "^1.5.1",
+    "rfc4648": "^1.4.0",
     "sanitize-html": "^1.27.1",
     "tar-js": "^0.3.0",
     "text-encoding-utf-8": "^1.0.2",

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -405,13 +405,12 @@ async function _startCallApp(roomId, type) {
         confId = `JitsiConference${generateHumanReadableId()}`;
     }
 
-    let widgetUrl = WidgetUtils.getLocalJitsiWrapperUrl();
+    let widgetUrl = WidgetUtils.getLocalJitsiWrapperUrl({auth: jitsiAuth});
 
     // TODO: Remove URL hacks when the mobile clients eventually support v2 widgets
     const parsedUrl = new URL(widgetUrl);
     parsedUrl.search = ''; // set to empty string to make the URL class use searchParams instead
     parsedUrl.searchParams.set('confId', confId);
-    parsedUrl.searchParams.set('auth', jitsiAuth);
     widgetUrl = parsedUrl.toString();
 
     const widgetData = {
@@ -419,6 +418,7 @@ async function _startCallApp(roomId, type) {
         isAudioOnly: type === 'voice',
         domain: jitsiDomain,
         auth: jitsiAuth,
+        roomId: roomId,
     };
 
     const widgetId = (

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -416,7 +416,6 @@ async function _startCallApp(roomId, type) {
         isAudioOnly: type === 'voice',
         domain: jitsiDomain,
         auth: jitsiAuth,
-        roomId: roomId,
     };
 
     const widgetId = (

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -411,12 +411,14 @@ async function _startCallApp(roomId, type) {
     const parsedUrl = new URL(widgetUrl);
     parsedUrl.search = ''; // set to empty string to make the URL class use searchParams instead
     parsedUrl.searchParams.set('confId', confId);
+    parsedUrl.searchParams.set('auth', jitsiAuth);
     widgetUrl = parsedUrl.toString();
 
     const widgetData = {
         conferenceId: confId,
         isAudioOnly: type === 'voice',
         domain: jitsiDomain,
+        auth: jitsiAuth,
     };
 
     const widgetId = (

--- a/src/CallHandler.js
+++ b/src/CallHandler.js
@@ -395,10 +395,8 @@ async function _startCallApp(roomId, type) {
     if (jitsiAuth === 'openidtoken-jwt') {
         // Create conference ID from room ID
         // For compatibility with Jitsi, use base32 without padding.
-        // If the room ID needs to be decoded from the conference ID,
-        // the receiver should first uppercase it if needed and then add padding.
         // More details here:
-        // TODO add link
+        // https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification
         confId = base32.stringify(Buffer.from(roomId), { pad: false });
     } else {
         // Create a random human readable conference ID

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -603,6 +603,7 @@ export default class AppTile extends React.Component {
             // TODO: Namespace themes through some standard
             'theme': SettingsStore.getValue("theme"),
         });
+        console.log("DEBUG TEMPLATEDURL APPTILE", vars);
 
         if (vars.conferenceId === undefined) {
             // we'll need to parse the conference ID out of the URL for v1 Jitsi widgets
@@ -626,7 +627,10 @@ export default class AppTile extends React.Component {
 
         if (WidgetType.JITSI.matches(this.props.app.type)) {
             console.log("Replacing Jitsi widget URL with local wrapper");
-            url = WidgetUtils.getLocalJitsiWrapperUrl({forLocalRender: true});
+            url = WidgetUtils.getLocalJitsiWrapperUrl({
+                forLocalRender: true,
+                auth: this.props.app.data ? this.props.app.data.auth : null,
+            });
             url = this._addWurlParams(url);
         } else {
             url = this._getSafeUrl(this.state.widgetUrl);
@@ -637,7 +641,10 @@ export default class AppTile extends React.Component {
     _getPopoutUrl() {
         if (WidgetType.JITSI.matches(this.props.app.type)) {
             return this._templatedUrl(
-                WidgetUtils.getLocalJitsiWrapperUrl({forLocalRender: false}),
+                WidgetUtils.getLocalJitsiWrapperUrl({
+                    forLocalRender: false,
+                    auth: this.props.app.data ? this.props.app.data.auth : null,
+                }),
                 this.props.app.type,
             );
         } else {

--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -603,7 +603,6 @@ export default class AppTile extends React.Component {
             // TODO: Namespace themes through some standard
             'theme': SettingsStore.getValue("theme"),
         });
-        console.log("DEBUG TEMPLATEDURL APPTILE", vars);
 
         if (vars.conferenceId === undefined) {
             // we'll need to parse the conference ID out of the URL for v1 Jitsi widgets

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -448,16 +448,21 @@ export default class WidgetUtils {
         return encodeURIComponent(`${widgetLocation}::${widgetUrl}`);
     }
 
-    static getLocalJitsiWrapperUrl(opts: {forLocalRender?: boolean}={}) {
+    static getLocalJitsiWrapperUrl(opts: {forLocalRender?: boolean, auth?: string}={}) {
         // NB. we can't just encodeURIComponent all of these because the $ signs need to be there
-        const queryString = [
+        const queryParts = [
             'conferenceDomain=$domain',
             'conferenceId=$conferenceId',
             'isAudioOnly=$isAudioOnly',
             'displayName=$matrix_display_name',
             'avatarUrl=$matrix_avatar_url',
             'userId=$matrix_user_id',
-        ].join('&');
+            'roomId=$matrix_room_id',
+        ];
+        if (opts.auth) {
+            queryParts.push(`auth=${opts.auth}`);
+        }
+        const queryString = queryParts.join('&');
 
         let baseUrl = window.location;
         if (window.location.protocol !== "https:" && !opts.forLocalRender) {

--- a/src/utils/WidgetUtils.js
+++ b/src/utils/WidgetUtils.js
@@ -450,7 +450,7 @@ export default class WidgetUtils {
 
     static getLocalJitsiWrapperUrl(opts: {forLocalRender?: boolean, auth?: string}={}) {
         // NB. we can't just encodeURIComponent all of these because the $ signs need to be there
-        const queryParts = [
+        const queryStringParts = [
             'conferenceDomain=$domain',
             'conferenceId=$conferenceId',
             'isAudioOnly=$isAudioOnly',
@@ -460,9 +460,9 @@ export default class WidgetUtils {
             'roomId=$matrix_room_id',
         ];
         if (opts.auth) {
-            queryParts.push(`auth=${opts.auth}`);
+            queryStringParts.push(`auth=${opts.auth}`);
         }
-        const queryString = queryParts.join('&');
+        const queryString = queryStringParts.join('&');
 
         let baseUrl = window.location;
         if (window.location.protocol !== "https:" && !opts.forLocalRender) {

--- a/src/widgets/Jitsi.ts
+++ b/src/widgets/Jitsi.ts
@@ -34,6 +34,30 @@ export class Jitsi {
         return this.domain || 'jitsi.riot.im';
     }
 
+    /**
+     * Checks for auth needed by looking up a well-known file
+     *
+     * If the file does not exist, we assume no auth.
+     *
+     * See TODO add link
+     */
+    public async getJitsiAuth(): Promise<string|null> {
+        if (!this.preferredDomain) {
+            return null;
+        }
+        let data;
+        try {
+            const response = await fetch(`https://${this.preferredDomain}/.well-known/element/jitsi`);
+            data = await response.json();
+        } catch (error) {
+            return null;
+        }
+        if (data.auth) {
+            return data.auth;
+        }
+        return null;
+    }
+
     public start() {
         const cli = MatrixClientPeg.get();
         cli.on("WellKnown.client", this.update);

--- a/src/widgets/Jitsi.ts
+++ b/src/widgets/Jitsi.ts
@@ -39,7 +39,7 @@ export class Jitsi {
      *
      * If the file does not exist, we assume no auth.
      *
-     * See TODO add link
+     * See https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification
      */
     public async getJitsiAuth(): Promise<string|null> {
         if (!this.preferredDomain) {

--- a/src/widgets/WidgetApi.ts
+++ b/src/widgets/WidgetApi.ts
@@ -34,6 +34,7 @@ export enum KnownWidgetActions {
     GetCapabilities = "capabilities",
     SendEvent = "send_event",
     UpdateVisibility = "visibility",
+    GetOpenIDCredentials = "get_openid",
     ReceiveOpenIDCredentials = "openid_credentials",
     SetAlwaysOnScreen = "set_always_on_screen",
     ClientReady = "im.vector.ready",

--- a/src/widgets/WidgetApi.ts
+++ b/src/widgets/WidgetApi.ts
@@ -81,9 +81,9 @@ export interface OpenIDCredentials {
  *   the given promise resolves.
  */
 export class WidgetApi extends EventEmitter {
-    private origin: string;
+    private readonly origin: string;
     private inFlightRequests: { [requestId: string]: (reply: FromWidgetRequest) => void } = {};
-    private readyPromise: Promise<any>;
+    private readonly readyPromise: Promise<any>;
     private readyPromiseResolve: () => void;
     private openIDCredentialsCallback: () => void;
     public openIDCredentials: OpenIDCredentials;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7557,6 +7557,11 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
+rfc4648@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.4.0.tgz#c75b2856ad2e2d588b6ddb985d556f1f7f2a2abd"
+  integrity sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"


### PR DESCRIPTION
This PR adds the react-sdk parts for supporting Synapse OpenID token based auth for Jitsi widgets. This auth enables locking Jitsi widgets to particular homeserver users and rooms. The whole flow is described here: https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification

The auth flow is only used when the Jitsi server has a well-known file indicating the requirement of auth.

Element Web PR side for the Jitsi widget code PR: https://github.com/vector-im/element-web/pull/15114