### PR TITLE
Account for via in pill matching regex

### DIFF
--- a/src/components/views/elements/Pill.js
+++ b/src/components/views/elements/Pill.js
@@ -29,7 +29,7 @@ import {Action} from "../../../dispatcher/actions";
 
 // For URLs of matrix.to links in the timeline which have been reformatted by
 // HttpUtils transformTags to relative links. This excludes event URLs (with `[^\/]*`)
-const REGEX_LOCAL_PERMALINK = /^#\/(?:user|room|group)\/(([#!@+])[^/]*)$/;
+const REGEX_LOCAL_PERMALINK = /^#\/(?:user|room|group)\/(([#!@+]).*?)(?=\/|\?|$)/;
 
 class Pill extends React.Component {
     static isPillUrl(url) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15133

Regression first appeared in a80bcaa292addfc04eb895a3f371e540b3e02c91

This also affects room IDs.

Proofs of this working:
![image](https://user-images.githubusercontent.com/1190097/92651900-3e314580-f2aa-11ea-8ab7-de03832e82a6.png)

![image](https://user-images.githubusercontent.com/1190097/92651309-117d2e00-f2aa-11ea-9905-57f198f1e7d6.png)
![image](https://user-images.githubusercontent.com/1190097/92651447-1b069600-f2aa-11ea-910f-ac67081014ac.png)
![image](https://user-images.githubusercontent.com/1190097/92651576-248ffe00-f2aa-11ea-8cbd-f83a26535960.png)
![image](https://user-images.githubusercontent.com/1190097/92651732-31aced00-f2aa-11ea-9f84-b46bb7082c1e.png)
