### PR TITLE
Remove defunct "always show encryption icons" setting

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -394,16 +394,6 @@ $left-gutter: 64px;
     opacity: 1;
 }
 
-.mx_EventTile_e2eIcon_hidden {
-    display: none;
-}
-
-/* always override hidden attribute for blocked and warning */
-.mx_EventTile_e2eIcon_hidden[src*="img/e2e-blocked.svg"],
-.mx_EventTile_e2eIcon_hidden[src*="img/e2e-warning.svg"] {
-    display: block;
-}
-
 .mx_EventTile_keyRequestInfo {
     font-size: $font-12px;
 }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -1027,11 +1027,7 @@ class E2ePadlock extends React.Component {
             tooltip = <Tooltip className="mx_EventTile_e2eIcon_tooltip" label={this.props.title} dir="auto" />;
         }
 
-        let classes = `mx_EventTile_e2eIcon mx_EventTile_e2eIcon_${this.props.icon}`;
-        if (!SettingsStore.getValue("alwaysShowEncryptionIcons")) {
-            classes += ' mx_EventTile_e2eIcon_hidden';
-        }
-
+        const classes = `mx_EventTile_e2eIcon mx_EventTile_e2eIcon_${this.props.icon}`;
         return (
             <div
                 className={classes}

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.js
@@ -52,7 +52,6 @@ export default class PreferencesUserSettingsTab extends React.Component {
     ];
 
     static ADVANCED_SETTINGS = [
-        'alwaysShowEncryptionIcons',
         'Pill.shouldShowPillAvatar',
         'TagPanel.enableTagPanel',
         'promptBeforeInviteUnknownUsers',

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -474,7 +474,6 @@
     "Show timestamps in 12 hour format (e.g. 2:30pm)": "Show timestamps in 12 hour format (e.g. 2:30pm)",
     "Always show message timestamps": "Always show message timestamps",
     "Autoplay GIFs and videos": "Autoplay GIFs and videos",
-    "Always show encryption icons": "Always show encryption icons",
     "Show a reminder to enable Secure Message Recovery in encrypted rooms": "Show a reminder to enable Secure Message Recovery in encrypted rooms",
     "Enable automatic language detection for syntax highlighting": "Enable automatic language detection for syntax highlighting",
     "Show avatars in user and room mentions": "Show avatars in user and room mentions",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -275,11 +275,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         displayName: _td('Autoplay GIFs and videos'),
         default: false,
     },
-    "alwaysShowEncryptionIcons": {
-        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
-        displayName: _td('Always show encryption icons'),
-        default: true,
-    },
     "showRoomRecoveryReminder": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Show a reminder to enable Secure Message Recovery in encrypted rooms'),


### PR DESCRIPTION
It doesn't do anything in practice.

Fixes https://github.com/vector-im/element-web/issues/8725