### PR TITLE
Retry loading i18n language if it fails

### DIFF
--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -1,4 +1,5 @@
 const en = require("../src/i18n/strings/en_EN");
+const de = require("../src/i18n/strings/de_DE");
 
 module.exports = jest.fn((opts, cb) => {
     const url = opts.url || opts.uri;
@@ -8,9 +9,15 @@ module.exports = jest.fn((opts, cb) => {
                 "fileName": "en_EN.json",
                 "label": "English",
             },
+            "de": {
+                "fileName": "de_DE.json",
+                "label": "German",
+            },
         }));
     } else if (url && url.endsWith("en_EN.json")) {
         cb(undefined, {status: 200}, JSON.stringify(en));
+    } else if (url && url.endsWith("de_DE.json")) {
+        cb(undefined, {status: 200}, JSON.stringify(de));
     } else {
         cb(true, {status: 404}, "");
     }

--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -1,6 +1,10 @@
 const en = require("../src/i18n/strings/en_EN");
 const de = require("../src/i18n/strings/de_DE");
 
+// Mock the browser-request for the languageHandler tests to return
+// Fake languages.json containing references to en_EN and de_DE
+// en_EN.json
+// de_DE.json
 module.exports = jest.fn((opts, cb) => {
     const url = opts.url || opts.uri;
     if (url && url.endsWith("languages.json")) {

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -68,3 +68,21 @@ export function allSettled<T>(promises: Promise<T>[]): Promise<Array<ISettledFul
         }));
     }));
 }
+
+// Helper method to retry a Promise a given number of times or until a predicate fails
+export async function retry<T, E extends Error>(fn: () => Promise<T>, num: number, predicate?: (e: E) => boolean) {
+    let lastErr: E;
+    for (let i = 0; i < num; i++) {
+        try {
+            const v = await fn();
+            // If `await fn()` throws then we won't reach here
+            return v;
+        } catch (err) {
+            if (predicate && !predicate(err)) {
+                throw err;
+            }
+            lastErr = err;
+        }
+    }
+    throw lastErr;
+}

--- a/test/i18n-test/languageHandler-test.js
+++ b/test/i18n-test/languageHandler-test.js
@@ -12,11 +12,11 @@ describe('languageHandler', function() {
         languageHandler.setMissingEntryGenerator(key => key.split("|", 2)[1]);
     });
 
-    it('translates a string to german', function() {
+    it('translates a string to german', function(done) {
         languageHandler.setLanguage('de').then(function() {
             const translated = languageHandler._t('Rooms');
             expect(translated).toBe('Räume');
-        });
+        }).then(done);
     });
 
     it('handles plurals', function() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/10965
Based on https://github.com/matrix-org/matrix-react-sdk/pull/5204

The German test was always broken due to it calling expect inside the async