### PR TITLE
Make the PIP Jitsi look and feel like the 1:1 PIP

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-$MiniAppTileHeight: 114px;
+$MiniAppTileHeight: 200px;
 
 .mx_AppsDrawer {
     margin: 5px 5px 5px 18px;
@@ -220,7 +220,7 @@ $MiniAppTileHeight: 114px;
 }
 
 .mx_AppTileBody_mini {
-    height: 112px;
+    height: $MiniAppTileHeight;
     width: 100%;
     overflow: hidden;
 }

--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -223,6 +223,7 @@ $MiniAppTileHeight: 200px;
     height: $MiniAppTileHeight;
     width: 100%;
     overflow: hidden;
+    border-radius: 8px;
 }
 
 .mx_AppTile .mx_AppTileBody,

--- a/res/css/views/voip/_CallContainer.scss
+++ b/res/css/views/voip/_CallContainer.scss
@@ -23,9 +23,16 @@ limitations under the License.
     z-index: 100;
     box-shadow: 0px 14px 24px rgba(0, 0, 0, 0.08);
 
-    cursor: pointer;
+    // Disable pointer events for Jitsi widgets to function. Direct
+    // calls have their own cursor and behaviour, but we need to make
+    // sure the cursor hits the iframe for Jitsi which will be at a
+    // different level.
+    pointer-events: none;
 
     .mx_CallPreview {
+        pointer-events: initial; // restore pointer events so the user can leave/interact
+        cursor: pointer;
+
         .mx_VideoView {
             width: 350px;
         }
@@ -37,13 +44,16 @@ limitations under the License.
     }
 
     .mx_AppTile_persistedWrapper div {
-        min-width: 300px;
+        min-width: 350px;
     }
 
     .mx_IncomingCallBox {
         min-width: 250px;
         background-color: $primary-bg-color;
         padding: 8px;
+
+        pointer-events: initial; // restore pointer events so the user can accept/decline
+        cursor: pointer;
 
         .mx_IncomingCallBox_CallerInfo {
             display: flex;

--- a/src/components/views/elements/PersistentApp.js
+++ b/src/components/views/elements/PersistentApp.js
@@ -82,6 +82,7 @@ export default class PersistentApp extends React.Component {
                     showDelete={false}
                     showMinimise={false}
                     miniMode={true}
+                    showMenubar={false}
                 />;
             }
         }


### PR DESCRIPTION
*This is developer design, so is certainly subject to opinions.*

* Similar sizing
* Fix pointers so the jitsi widget doesn't feel clickable when it's not
  * We might want to introduce click-to-visit-room for the Jitsi widget (like the 1:1 call), however the Jitsi widget has many more controls to worry about
* Remove the menu bar from the widget to avoid accidents

For scale, here is the current 1:1 call window size:
![image](https://user-images.githubusercontent.com/1190097/93420964-63572280-f86d-11ea-8428-bdff11d6351f.png)

and this is a Jitsi widget after this PR:
![image](https://user-images.githubusercontent.com/1190097/93527525-3c90fe80-f8f6-11ea-88e2-4fb38483a55c.png)

here is the before image, where none of the controls shown can be interacted with:
![image](https://user-images.githubusercontent.com/1190097/93421032-8e417680-f86d-11ea-972b-1189b9d8649b.png)
