### PR TITLE
Add option to be sole admin when creating new DM

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -218,13 +218,30 @@ limitations under the License.
     // Prevent the dialog from jumping around randomly when elements change.
     height: 590px;
     padding-left: 20px; // the design wants some padding on the left
+
+    .mx_SettingsFlag {
+        display: flex;
+        margin-top: 20px;
+        padding-right: 45px;
+    }
+
+    .mx_SettingsFlag_label {
+        flex: 1 1 0;
+        min-width: 0;
+        font-weight: 600;
+    }
+
+    .mx_ToggleSwitch {
+        flex: 0 0 auto;
+        margin-left: 30px;
+    }
 }
 
 .mx_InviteDialog_userSections {
     margin-top: 10px;
     overflow-y: auto;
     padding-right: 45px;
-    height: 455px; // mx_InviteDialog's height minus some for the upper elements
+    height: 405px; // mx_InviteDialog's height minus some for the upper elements
 }
 
 // Right margin for the design. We could apply this to the whole dialog, but then the scrollbar

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1731,6 +1731,7 @@
     "Start a conversation with someone using their name or username (like <userId/>).": "Start a conversation with someone using their name or username (like <userId/>).",
     "This won't invite them to %(communityName)s. To invite someone to %(communityName)s, click <a>here</a>": "This won't invite them to %(communityName)s. To invite someone to %(communityName)s, click <a>here</a>",
     "Go": "Go",
+    "Make me the sole administrator of the new room": "Make me the sole administrator of the new room",
     "Invite someone using their name, username (like <userId/>), email address or <a>share this room</a>.": "Invite someone using their name, username (like <userId/>), email address or <a>share this room</a>.",
     "Invite someone using their name, username (like <userId/>) or <a>share this room</a>.": "Invite someone using their name, username (like <userId/>) or <a>share this room</a>.",
     "a new master key signature": "a new master key signature",


### PR DESCRIPTION
This PR adds an option to override the power levels when creating a new room via the "Direct Messages" dialog in a way that the room creator will be the sole administrator (power level 100) of the new room and the other participants will have the `Standard` role (Power level 0). This adds a bit more flexibility in 'asymmetrical' relationships where the initiator of the chat wants to restrict the permissions of his counterpart (e. g. a teacher wants his student to be able to send him text messages, but doesn't want him to be able to call him).
This PR should be considered as a PoC and I'm not sure whether this is the best way to implement this, I'd appreciate any feedback!
![dm_permission](https://user-images.githubusercontent.com/18017241/94196378-8d839280-feb4-11ea-88f6-3ac28203e75a.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add option to be sole admin when creating new DM ([\#5250](https://github.com/matrix-org/matrix-react-sdk/pull/5250)). Contributed by @enzingerm.<!-- CHANGELOG_PREVIEW_END -->