### PR TITLE
Prohibit WebRTC call when permissions are insufficient

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -396,9 +396,19 @@ export default class CallHandler {
                         });
                         return;
                     } else if (members.length === 2) {
-                        console.info("Place %s call in %s", payload.type, payload.room_id);
+                        const maySendCallEvents = ['m.call.invite', 'm.call.candidates', 'm.call.hangup'].every(
+                            event => room.currentState.maySendEvent(event, MatrixClientPeg.get().getUserId()),
+                        );
 
-                        this.placeCall(payload.room_id, payload.type, payload.local_element, payload.remote_element);
+                        if (maySendCallEvents) {
+                            console.info("Place %s call in %s", payload.type, payload.room_id);
+                            this.placeCall(payload.room_id, payload.type, payload.local_element,
+                                payload.remote_element);
+                        } else {
+                            Modal.createTrackedDialog('Call Handler', 'Not authorized to place call', ErrorDialog, {
+                                description: _t('You are not authorized to start a call.'),
+                            });
+                        }
                     } else { // > 2
                         dis.dispatch({
                             action: "place_conference_call",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -50,6 +50,7 @@
     "VoIP is unsupported": "VoIP is unsupported",
     "You cannot place VoIP calls in this browser.": "You cannot place VoIP calls in this browser.",
     "You cannot place a call with yourself.": "You cannot place a call with yourself.",
+    "You are not authorized to start a call.": "You are not authorized to start a call.",
     "Call in Progress": "Call in Progress",
     "A call is currently being placed!": "A call is currently being placed!",
     "Permission Required": "Permission Required",


### PR DESCRIPTION
This PR forbids a user to start a WebRTC call in rooms with 2 participants when his power level is not sufficient to send `m.call.invite` events.