### PR TITLE
Only set title when it changes

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1843,6 +1843,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         } else {
             subtitle = `${this.subTitleStatus} ${subtitle}`;
         }
+
         const title = `${SdkConfig.get().brand} ${subtitle}`;
 
         if (document.title !== title) {

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1843,7 +1843,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         } else {
             subtitle = `${this.subTitleStatus} ${subtitle}`;
         }
-        document.title = `${SdkConfig.get().brand} ${subtitle}`;
+        const title = `${SdkConfig.get().brand} ${subtitle}`;
+
+        if (document.title !== title) {
+            document.title = title;
+        }
     }
 
     updateStatusIndicator(state: string, prevState: string) {


### PR DESCRIPTION
I've seen Chromium constantly refresh the title in the developer tools,
when the title hasn't actually changed.
To be honest, I'm not sure if this means Chromium wastes CPU
time changing a title, but this may introduce better performance.

Signed-off-by: Resynth <resynth1943@tutanota.com>