### PR TITLE
fix link to classic yarn's `yarn link`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ yarn link matrix-js-sdk
 yarn install
 ```
 
-See the [help for `yarn link`](https://yarnpkg.com/docs/cli/link) for more
-details about this.
+See the [help for `yarn link`](https://classic.yarnpkg.com/docs/cli/link) for
+more details about this.
 
 Running tests
 =============


### PR DESCRIPTION
Following the README as of now leads to a 404 when trying to learn about `yarn link`. This lets the link point to the legacy / "classic" yarn docs. :)