### PR TITLE
Trim range when formatting so that it excludes leading/trailing spaces

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -619,13 +619,14 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     }
 
     private onFormatAction = (action: Formatting) => {
-        const range = getRangeForSelection(
-            this.editorRef.current,
-            this.props.model,
-            document.getSelection());
+        const range = getRangeForSelection(this.editorRef.current, this.props.model, document.getSelection());
+        // trim the range as we want it to exclude leading/trailing spaces
+        range.trim();
+
         if (range.length === 0) {
             return;
         }
+
         this.historyManager.ensureLastChangesPushed(this.props.model);
         this.modifiedFlag = true;
         switch (action) {

--- a/src/editor/range.ts
+++ b/src/editor/range.ts
@@ -18,8 +18,8 @@ import EditorModel from "./model";
 import DocumentPosition, {Predicate} from "./position";
 import {Part} from "./parts";
 
-const whileSpacePredicate: Predicate = (index, offset, part) => {
-    return part.text[offset] === " ";
+const whitespacePredicate: Predicate = (index, offset, part) => {
+    return part.text[offset].trim() === "";
 };
 
 export default class Range {
@@ -40,8 +40,8 @@ export default class Range {
     }
 
     trim() {
-        this._start = this._start.forwardsWhile(this.model, whileSpacePredicate);
-        this._end = this._end.backwardsWhile(this.model, whileSpacePredicate);
+        this._start = this._start.forwardsWhile(this.model, whitespacePredicate);
+        this._end = this._end.backwardsWhile(this.model, whitespacePredicate);
     }
 
     expandBackwardsWhile(predicate: Predicate) {

--- a/src/editor/range.ts
+++ b/src/editor/range.ts
@@ -18,6 +18,10 @@ import EditorModel from "./model";
 import DocumentPosition, {Predicate} from "./position";
 import {Part} from "./parts";
 
+const whileSpacePredicate: Predicate = (index, offset, part) => {
+    return part.text[offset] === " ";
+};
+
 export default class Range {
     private _start: DocumentPosition;
     private _end: DocumentPosition;
@@ -33,6 +37,11 @@ export default class Range {
             delta -= 1;
             return delta >= 0;
         });
+    }
+
+    trim() {
+        this._start = this._start.forwardsWhile(this.model, whileSpacePredicate);
+        this._end = this._end.backwardsWhile(this.model, whileSpacePredicate);
     }
 
     expandBackwardsWhile(predicate: Predicate) {

--- a/test/editor/range-test.js
+++ b/test/editor/range-test.js
@@ -88,4 +88,19 @@ describe('editor/range', function() {
         expect(model.parts[1].text).toBe("man");
         expect(model.parts.length).toBe(2);
     });
+    it('range trim spaces off both ends', () => {
+        const renderer = createRenderer();
+        const pc = createPartCreator();
+        const model = new EditorModel([
+            pc.plain("abc abc abc"),
+        ], pc, renderer);
+        const range = model.startRange(
+            model.positionForOffset(3, false), // at end of first `abc`
+            model.positionForOffset(8, false), // at start of last `abc`
+        );
+
+        expect(range.parts[0].text).toBe(" abc ");
+        range.trim();
+        expect(range.parts[0].text).toBe("abc");
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15310