### PR TITLE
Remove width limit on widgets

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -78,10 +78,6 @@ $MiniAppTileHeight: 114px;
     font-size: $font-12px;
 }
 
-.mx_AddWidget_button_full_width {
-    max-width: 960px;
-}
-
 .mx_SetAppURLDialog_input {
     border-radius: 3px;
     border: 1px solid $input-border-color;
@@ -92,7 +88,6 @@ $MiniAppTileHeight: 114px;
 }
 
 .mx_AppTile {
-    max-width: 960px;
     width: 50%;
     border: 5px solid $widget-menu-bar-bg-color;
     border-radius: 4px;
@@ -105,7 +100,6 @@ $MiniAppTileHeight: 114px;
 }
 
 .mx_AppTileFullWidth {
-    max-width: 960px;
     width: 100%;
     margin: 0;
     padding: 0;
@@ -116,7 +110,6 @@ $MiniAppTileHeight: 114px;
 }
 
 .mx_AppTile_mini {
-    max-width: 960px;
     width: 100%;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

![image](https://user-images.githubusercontent.com/2403652/94567120-042ce100-0263-11eb-81f2-09f4964eebb7.png)

To avoid pillarboxing the widget which causes things like Jitsi to massively letterbox you.

![image](https://user-images.githubusercontent.com/2403652/94567272-2de60800-0263-11eb-8a7e-24130ae8a096.png)

