### PR TITLE
null-guard defaultAvatarUrlForString

### DIFF
--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -82,7 +82,7 @@ function urlForColor(color) {
 const colorToDataURLCache = new Map();
 
 export function defaultAvatarUrlForString(s) {
-    if (!s) return "";
+    if (!s) return ""; // XXX: should never happen but empirically does by evidence of a rageshake
     const defaultColors = ['#0DBD8B', '#368bd6', '#ac3ba8'];
     let total = 0;
     for (let i = 0; i < s.length; ++i) {

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -82,6 +82,7 @@ function urlForColor(color) {
 const colorToDataURLCache = new Map();
 
 export function defaultAvatarUrlForString(s) {
+    if (!s) return "";
     const defaultColors = ['#0DBD8B', '#368bd6', '#ac3ba8'];
     let total = 0;
     for (let i = 0; i < s.length; ++i) {


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

Because a rageshake showed a soft-crash where one of the callers tried to call it with `null`