### PR TITLE
Fix StopGapWidget infinitely recursing

### DIFF
--- a/src/components/views/elements/AccessibleTooltipButton.tsx
+++ b/src/components/views/elements/AccessibleTooltipButton.tsx
@@ -62,7 +62,8 @@ export default class AccessibleTooltipButton extends React.PureComponent<IToolti
     };
 
     render() {
-        const {title, tooltip, children, tooltipClassName, ...props} = this.props;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {title, tooltip, children, tooltipClassName, forceHide, ...props} = this.props;
 
         const tip = this.state.hover ? <Tooltip
             className="mx_AccessibleTooltipButton_container"

--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -437,6 +437,7 @@ export default class MessageComposer extends React.Component {
                     const canEndConf = WidgetUtils.canUserModifyWidgets(this.props.room.roomId);
                     controls.push(
                         <HangupButton
+                            key="controls_hangup"
                             roomId={this.props.room.roomId}
                             isConference={true}
                             canEndConference={canEndConf}

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -66,7 +66,7 @@ class ElementWidget extends Widget {
         if (WidgetType.JITSI.matches(this.type)) {
             return WidgetUtils.getLocalJitsiWrapperUrl({
                 forLocalRender: true,
-                auth: this.rawData?.auth,
+                auth: super.rawData?.auth, // this.rawData can call templateUrl, do this to prevent looping
             });
         }
         return super.templateUrl;


### PR DESCRIPTION
This would only happen for a Jitsi widget without a `data.conferenceId` which is some in-ideal but still supported format.