### PR TITLE
event-index: Pass the user/device id pair when initializing the event index.

### DIFF
--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -105,10 +105,13 @@ export default abstract class BaseEventIndexManager {
     /**
      * Initialize the event index for the given user.
      *
+     * @param {string} user_id The event that should be added to the index.
+     * @param {string} device_id The profile of the event sender at the
+     *
      * @return {Promise} A promise that will resolve when the event index is
      * initialized.
      */
-    async initEventIndex(): Promise<void> {
+    async initEventIndex(user_id: string, device_id: string): Promise<void> {
         throw new Error("Unimplemented");
     }
 

--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -105,13 +105,13 @@ export default abstract class BaseEventIndexManager {
     /**
      * Initialize the event index for the given user.
      *
-     * @param {string} user_id The event that should be added to the index.
-     * @param {string} device_id The profile of the event sender at the
+     * @param {string} userId The event that should be added to the index.
+     * @param {string} deviceId The profile of the event sender at the
      *
      * @return {Promise} A promise that will resolve when the event index is
      * initialized.
      */
-    async initEventIndex(user_id: string, device_id: string): Promise<void> {
+    async initEventIndex(userId: string, deviceId: string): Promise<void> {
         throw new Error("Unimplemented");
     }
 

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -21,6 +21,7 @@ limitations under the License.
 
 import PlatformPeg from "../PlatformPeg";
 import EventIndex from "../indexing/EventIndex";
+import {MatrixClientPeg} from "../MatrixClientPeg";
 import SettingsStore from '../settings/SettingsStore';
 import {SettingLevel} from "../settings/SettingLevel";
 
@@ -70,9 +71,13 @@ class EventIndexPeg {
     async initEventIndex() {
         const index = new EventIndex();
         const indexManager = PlatformPeg.get().getEventIndexingManager();
+        const client = MatrixClientPeg.get();
+
+        const user_id = client.getUserId();
+        const device_id = client.getDeviceId();
 
         try {
-            await indexManager.initEventIndex();
+            await indexManager.initEventIndex(user_id, device_id);
 
             const userVersion = await indexManager.getUserVersion();
             const eventIndexIsEmpty = await indexManager.isEventIndexEmpty();
@@ -83,7 +88,7 @@ class EventIndexPeg {
                 await indexManager.closeEventIndex();
                 await this.deleteEventIndex();
 
-                await indexManager.initEventIndex();
+                await indexManager.initEventIndex(user_id, device_id);
                 await indexManager.setUserVersion(INDEX_VERSION);
             }
 

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -73,11 +73,11 @@ class EventIndexPeg {
         const indexManager = PlatformPeg.get().getEventIndexingManager();
         const client = MatrixClientPeg.get();
 
-        const user_id = client.getUserId();
-        const device_id = client.getDeviceId();
+        const userId = client.getUserId();
+        const deviceId = client.getDeviceId();
 
         try {
-            await indexManager.initEventIndex(user_id, device_id);
+            await indexManager.initEventIndex(userId, deviceId);
 
             const userVersion = await indexManager.getUserVersion();
             const eventIndexIsEmpty = await indexManager.isEventIndexEmpty();
@@ -88,7 +88,7 @@ class EventIndexPeg {
                 await indexManager.closeEventIndex();
                 await this.deleteEventIndex();
 
-                await indexManager.initEventIndex(user_id, device_id);
+                await indexManager.initEventIndex(userId, deviceId);
                 await indexManager.setUserVersion(INDEX_VERSION);
             }
 


### PR DESCRIPTION
This extends the base event index manager to pass the user id and device id when initializing the event index, this is needed so we store the passphrase under a per user/device specific key.

This is a breaking change.

The element web part is found at https://github.com/vector-im/element-web/pull/15455.
The element desktop part is found at https://github.com/vector-im/element-desktop/pull/147.