### PR TITLE
Add security customisation points

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -23,6 +23,7 @@ import { InvalidStoreError } from "matrix-js-sdk/src/errors";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 
 import {IMatrixClientCreds, MatrixClientPeg} from './MatrixClientPeg';
+import SecurityCustomisations from "./customisations/Security";
 import EventIndexPeg from './indexing/EventIndexPeg';
 import createMatrixClient from './utils/createMatrixClient';
 import Analytics from './Analytics';
@@ -566,6 +567,8 @@ function persistCredentialsToLocalStorage(credentials: IMatrixClientCreds): void
     if (credentials.deviceId) {
         localStorage.setItem("mx_device_id", credentials.deviceId);
     }
+
+    SecurityCustomisations.persistCredentials?.(credentials);
 
     console.log(`Session persisted for ${credentials.userId}`);
 }

--- a/src/Login.ts
+++ b/src/Login.ts
@@ -22,6 +22,7 @@ limitations under the License.
 import Matrix from "matrix-js-sdk";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 import { IMatrixClientCreds } from "./MatrixClientPeg";
+import SecurityCustomisations from "./customisations/Security";
 
 interface ILoginOptions {
     defaultDeviceDisplayName?: string;
@@ -222,11 +223,15 @@ export async function sendLoginRequest(
         }
     }
 
-    return {
+    const creds: IMatrixClientCreds = {
         homeserverUrl: hsUrl,
         identityServerUrl: isUrl,
         userId: data.user_id,
         deviceId: data.device_id,
         accessToken: data.access_token,
     };
+
+    SecurityCustomisations.examineLoginResponse?.(data, creds);
+
+    return creds;
 }

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.js
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.js
@@ -32,6 +32,7 @@ import DialogButtons from "../../../../components/views/elements/DialogButtons";
 import InlineSpinner from "../../../../components/views/elements/InlineSpinner";
 import RestoreKeyBackupDialog from "../../../../components/views/dialogs/security/RestoreKeyBackupDialog";
 import { getSecureBackupSetupMethods, isSecureBackupRequired } from '../../../../utils/WellKnownUtils';
+import SecurityCustomisations from "../../../../customisations/Security";
 
 const PHASE_LOADING = 0;
 const PHASE_LOADERROR = 1;
@@ -99,7 +100,8 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
 
         this._passphraseField = createRef();
 
-        this._fetchBackupInfo();
+        MatrixClientPeg.get().on('crypto.keyBackupStatus', this._onKeyBackupStatusChange);
+
         if (this.state.accountPassword) {
             // If we have an account password in memory, let's simplify and
             // assume it means password auth is also supported for device
@@ -110,11 +112,25 @@ export default class CreateSecretStorageDialog extends React.PureComponent {
             this._queryKeyUploadAuth();
         }
 
-        MatrixClientPeg.get().on('crypto.keyBackupStatus', this._onKeyBackupStatusChange);
+        this._getInitialPhase();
     }
 
     componentWillUnmount() {
         MatrixClientPeg.get().removeListener('crypto.keyBackupStatus', this._onKeyBackupStatusChange);
+    }
+
+    _getInitialPhase() {
+        const keyFromCustomisations = SecurityCustomisations.createSecretStorageKey?.();
+        if (keyFromCustomisations) {
+            console.log("Created key via customisations, jumping to bootstrap step");
+            this._recoveryKey = {
+                privateKey: keyFromCustomisations,
+            };
+            this._bootstrapSecretStorage();
+            return;
+        }
+
+        this._fetchBackupInfo();
     }
 
     async _fetchBackupInfo() {

--- a/src/customisations/Security.ts
+++ b/src/customisations/Security.ts
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IMatrixClientCreds } from "../MatrixClientPeg";
+import { Kind as SetupEncryptionKind } from "../toasts/SetupEncryptionToast";
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function examineLoginResponse(
+    response: any,
+    credentials: IMatrixClientCreds,
+): void {
+    // E.g. add additional data to the persisted credentials
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function persistCredentials(
+    credentials: IMatrixClientCreds,
+): void {
+    // E.g. store any additional credential fields
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function createSecretStorageKey(): Uint8Array {
+    // E.g. generate or retrieve secret storage key somehow
+    return null;
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function getSecretStorageKey(): Uint8Array {
+    // E.g. retrieve secret storage key from some other place
+    return null;
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function catchAccessSecretStorageError(e: Error): void {
+    // E.g. notify the user in some way
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function setupEncryptionNeeded(kind: SetupEncryptionKind): boolean {
+    // E.g. trigger some kind of setup
+    return false;
+}
+
+// This interface summarises all available customisation points and also marks
+// them all as optional. This allows customisers to only define and export the
+// customisations they need while still maintaining type safety.
+export interface ISecurityCustomisations {
+    examineLoginResponse?: (
+        response: any,
+        credentials: IMatrixClientCreds,
+    ) => void;
+    persistCredentials?: (
+        credentials: IMatrixClientCreds,
+    ) => void;
+    createSecretStorageKey?: () => Uint8Array,
+    getSecretStorageKey?: () => Uint8Array,
+    catchAccessSecretStorageError?: (
+        e: Error,
+    ) => void,
+    setupEncryptionNeeded?: (
+        kind: SetupEncryptionKind,
+    ) => boolean,
+}
+
+// A real customisation module will define and export one or more of the
+// customisation points that make up `ISecurityCustomisations`.
+export default {} as ISecurityCustomisations;

--- a/src/toasts/SetupEncryptionToast.ts
+++ b/src/toasts/SetupEncryptionToast.ts
@@ -22,6 +22,7 @@ import SetupEncryptionDialog from "../components/views/dialogs/security/SetupEnc
 import { accessSecretStorage } from "../SecurityManager";
 import ToastStore from "../stores/ToastStore";
 import GenericToast from "../components/views/toasts/GenericToast";
+import SecurityCustomisations from "../customisations/Security";
 
 const TOAST_KEY = "setupencryption";
 
@@ -78,6 +79,10 @@ const onReject = () => {
 };
 
 export const showToast = (kind: Kind) => {
+    if (SecurityCustomisations.setupEncryptionNeeded?.(kind)) {
+        return;
+    }
+
     const onAccept = async () => {
         if (kind === Kind.VERIFY_THIS_SESSION) {
             Modal.createTrackedDialog("Verify session", "Verify session", SetupEncryptionDialog,


### PR DESCRIPTION
This adds various customisations point in the app for security related
decisions. By default, these do nothing, but would be customised at the
app level via module replacement (so that no changes are needed here in the
SDK).

See also https://github.com/vector-im/element-web/pull/15475 for usage documentation.

Fixes https://github.com/vector-im/element-web/issues/15350