### PR TITLE
Search through the list of unfiltered rooms rather than the rooms in the state which are already filtered by the search text

### DIFF
--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -420,7 +420,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
             room = this.state.rooms && this.state.rooms[0];
         } else {
             // find the first room with a count of the same colour as the badge count
-            room = this.state.rooms.find((r: Room) => {
+            room = RoomListStore.instance.unfilteredLists[this.props.tagId].find((r: Room) => {
                 const notifState = this.notificationState.getForRoom(r);
                 return notifState.count > 0 && notifState.color === this.notificationState.color;
             });


### PR DESCRIPTION
Fixes vector-im/element-web#15414 by implementing the latter of "Either the counter needs to be adjusted according to the filter criteria, or clicking on it should still get the room displayed in the main window, even if it isn't in the list on the left. I think the latter would be better."

Signed-off-by: Bryan Kok <bryan.wyern1@gmail.com>