### PR TITLE
Add border-radius for video

### DIFF
--- a/res/css/views/messages/_MVideoBody.scss
+++ b/res/css/views/messages/_MVideoBody.scss
@@ -18,5 +18,6 @@ span.mx_MVideoBody {
     video.mx_MVideoBody {
         max-width: 100%;
         height: auto;
+        border-radius: 4px;
     }
 }


### PR DESCRIPTION
Images have a rounded border, so we may as well add it to videos.
Works fine in Chrome, and in other spec-compliant browsers.

Signed-off-by: Resynth <resynth1943@tutanota.com>