### PR TITLE
Lighten blockquote colour in dark mode

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -272,6 +272,10 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
             background-color: #080808;
         }
     }
+
+    blockquote {
+        
+    }
 }
 
 // diff highlight colors

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -272,6 +272,10 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
             background-color: #080808;
         }
     }
+
+    blockquote {
+        color: #919191;
+    }
 }
 
 // diff highlight colors

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -272,10 +272,6 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
             background-color: #080808;
         }
     }
-
-    blockquote {
-        
-    }
 }
 
 // diff highlight colors


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/5154

![image](https://user-images.githubusercontent.com/49915996/97113376-e166de80-16e1-11eb-8ac6-728fd0b801f8.png)

![image](https://user-images.githubusercontent.com/49915996/97113386-e7f55600-16e1-11eb-8131-90e0c888caa0.png)


Signed-off-by: Resynth <resynth1943@tutanota.com>