### PR TITLE
Hide inline images when preference disabled

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -29,6 +29,7 @@ import EMOJIBASE_REGEX from 'emojibase-regex';
 import url from 'url';
 
 import {MatrixClientPeg} from './MatrixClientPeg';
+import SettingsStore from './settings/SettingsStore';
 import {tryTransformPermalinkToLocalHref} from "./utils/permalinks/Permalinks";
 import {SHORTCODE_TO_EMOJI, getEmojiFromUnicode} from "./emoji";
 import ReplyThread from "./components/views/elements/ReplyThread";
@@ -171,7 +172,7 @@ const transformTags: IExtendedSanitizeOptions["transformTags"] = { // custom to 
         // Strip out imgs that aren't `mxc` here instead of using allowedSchemesByTag
         // because transformTags is used _before_ we filter by allowedSchemesByTag and
         // we don't want to allow images with `https?` `src`s.
-        if (!attribs.src || !attribs.src.startsWith('mxc://')) {
+        if (!attribs.src || !attribs.src.startsWith('mxc://') || !SettingsStore.getValue("showImages")) {
             return { tagName, attribs: {}};
         }
         attribs.src = MatrixClientPeg.get().mxcUrlToHttp(

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -172,6 +172,9 @@ const transformTags: IExtendedSanitizeOptions["transformTags"] = { // custom to 
         // Strip out imgs that aren't `mxc` here instead of using allowedSchemesByTag
         // because transformTags is used _before_ we filter by allowedSchemesByTag and
         // we don't want to allow images with `https?` `src`s.
+        // We also drops inline images (as if they were not present at all) when the "show
+        // images" preference is disabled. Future work might expose some UI to reveal them
+        // like standalone image events have.
         if (!attribs.src || !attribs.src.startsWith('mxc://') || !SettingsStore.getValue("showImages")) {
             return { tagName, attribs: {}};
         }

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -172,7 +172,7 @@ const transformTags: IExtendedSanitizeOptions["transformTags"] = { // custom to 
         // Strip out imgs that aren't `mxc` here instead of using allowedSchemesByTag
         // because transformTags is used _before_ we filter by allowedSchemesByTag and
         // we don't want to allow images with `https?` `src`s.
-        // We also drops inline images (as if they were not present at all) when the "show
+        // We also drop inline images (as if they were not present at all) when the "show
         // images" preference is disabled. Future work might expose some UI to reveal them
         // like standalone image events have.
         if (!attribs.src || !attribs.src.startsWith('mxc://') || !SettingsStore.getValue("showImages")) {


### PR DESCRIPTION
As a first attempt, this drops inline images (as if they were not present at
all) when the "show images" preference is disabled. Future work might expose
some UI to reveal them like standalone image events have.

Fixes https://github.com/vector-im/element-web/issues/15573