### PR TITLE
Clarify logout key backup warning dialog

### DIFF
--- a/src/components/views/dialogs/LogoutDialog.js
+++ b/src/components/views/dialogs/LogoutDialog.js
@@ -125,6 +125,7 @@ export default class LogoutDialog extends React.Component {
                     "Encrypted messages are secured with end-to-end encryption. " +
                     "Only you and the recipient(s) have the keys to read these messages.",
                 )}</p>
+                <p>{_t("When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.")}</p>
                 <p>{_t("Back up your keys before signing out to avoid losing them.")}</p>
             </div>;
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -755,6 +755,7 @@
     "Algorithm:": "Algorithm:",
     "Your keys are <b>not being backed up from this session</b>.": "Your keys are <b>not being backed up from this session</b>.",
     "Back up your keys before signing out to avoid losing them.": "Back up your keys before signing out to avoid losing them.",
+    "When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.": "When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.",
     "well formed": "well formed",
     "unexpected type": "unexpected type",
     "Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Recovery Key.": "Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Recovery Key.",


### PR DESCRIPTION
Added details to the logout key backup warning dialog, why access to encrypted messages will be lost.
Closes https://github.com/vector-im/element-web/issues/15565

Signed-off by: notramo <notramo@protonmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Clarify logout key backup warning dialog ([\#5363](https://github.com/matrix-org/matrix-react-sdk/pull/5363)). Fixes vector-im/element-web#15565. Contributed by @notramo.<!-- CHANGELOG_PREVIEW_END -->