### PR TITLE
Change "Password" to "New Password"

### DIFF
--- a/src/components/structures/auth/ForgotPassword.js
+++ b/src/components/structures/auth/ForgotPassword.js
@@ -305,7 +305,7 @@ export default class ForgotPassword extends React.Component {
                     <Field
                         name="reset_password"
                         type="password"
-                        label={_t('Password')}
+                        label={_t('New Password')}
                         value={this.state.password}
                         onChange={this.onInputChanged.bind(this, "password")}
                     />


### PR DESCRIPTION
Doesn't solve most issues in the Forgot Password menu, but clears up the
UI a little. "New Password" makes more sense here, as "Password" may
suggest to the user that they have to enter the password they forgot.

Partially fixes one of the issues in https://github.com/vector-im/element-web/issues/2780

Signed-off-by: Resynth <resynth1943@tutanota.com>