### PR TITLE
Fix inverted settings default value

### DIFF
--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -42,7 +42,7 @@ for (const key of Object.keys(SETTINGS)) {
     if (SETTINGS[key].invertedSettingName) {
         // Invert now so that the rest of the system will invert it back
         // to what was intended.
-        invertedDefaultSettings[key] = !SETTINGS[key].default;
+        invertedDefaultSettings[SETTINGS[key].invertedSettingName] = !SETTINGS[key].default;
     }
 }
 


### PR DESCRIPTION
Currently it doesn't matter what's set in the default property once the invertedSettingName property exists

Signed-off-by: Quirin Götz <qg@supercable.onl>