### PR TITLE
Allow usage of m.always_on_screen capability by all widgets

### DIFF
--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -298,18 +298,18 @@ export class StopGapWidget extends EventEmitter {
             ActiveWidgetStore.setRoomId(this.mockWidget.id, this.appTileProps.room.roomId);
         }
 
-        if (WidgetType.JITSI.matches(this.mockWidget.type)) {
-            this.messaging.on("action:set_always_on_screen",
-                (ev: CustomEvent<IStickyActionRequest>) => {
-                    if (this.messaging.hasCapability(MatrixCapabilities.AlwaysOnScreen)) {
-                        CountlyAnalytics.instance.trackJoinCall(this.appTileProps.room.roomId, true, true);
-                        ActiveWidgetStore.setWidgetPersistence(this.mockWidget.id, ev.detail.data.value);
-                        ev.preventDefault();
-                        this.messaging.transport.reply(ev.detail, <IWidgetApiRequestEmptyData>{}); // ack
-                    }
-                },
-            );
-        } else if (WidgetType.STICKERPICKER.matches(this.mockWidget.type)) {
+        this.messaging.on("action:set_always_on_screen",
+            (ev: CustomEvent<IStickyActionRequest>) => {
+                if (this.messaging.hasCapability(MatrixCapabilities.AlwaysOnScreen)) {
+                    CountlyAnalytics.instance.trackJoinCall(this.appTileProps.room.roomId, true, true);
+                    ActiveWidgetStore.setWidgetPersistence(this.mockWidget.id, ev.detail.data.value);
+                    ev.preventDefault();
+                    this.messaging.transport.reply(ev.detail, <IWidgetApiRequestEmptyData>{}); // ack
+                }
+            },
+        );
+
+        if (WidgetType.STICKERPICKER.matches(this.mockWidget.type)) {
             this.messaging.on(`action:${ElementWidgetActions.OpenIntegrationManager}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {
                     // Acknowledge first

--- a/src/utils/WidgetUtils.ts
+++ b/src/utils/WidgetUtils.ts
@@ -445,14 +445,11 @@ export default class WidgetUtils {
     static getCapWhitelistForAppTypeInRoomId(appType: string, roomId: string): Capability[] {
         const enableScreenshots = SettingsStore.getValue("enableWidgetScreenshots", roomId);
 
-        const capWhitelist = enableScreenshots ? [MatrixCapabilities.Screenshots] : [];
+        const capWhitelist = [];
 
-        // Obviously anyone that can add a widget can claim it's a jitsi widget,
-        // so this doesn't really offer much over the set of domains we load
-        // widgets from at all, but it probably makes sense for sanity.
-        if (WidgetType.JITSI.matches(appType)) {
-            capWhitelist.push(MatrixCapabilities.AlwaysOnScreen);
-        }
+        if (enableScreenshots) capWhitelist.push(MatrixCapabilities.Screenshots)
+
+        capWhitelist.push(MatrixCapabilities.AlwaysOnScreen);
 
         return capWhitelist;
     }


### PR DESCRIPTION
like metioned in vector-im/element-web#15001 the `m.always_on_screen` capability currently only works only for jitsi widgets.
A reason is provided as a commit in the source code:
>  Obviously anyone that can add a widget can claim it's a jitsi widget, so this doesn't really offer much over the set of domains we load widgets from at all, but it probably makes sense for sanity.

I think this currently doesn't provide any additional security or sanity, but blocks people from developing other persistent widgets.

In this PR I removed this restriction.

### Open Challenge
merging it like it is now would lead to every single widget being wrapped in an `PersistedElement`.

:question:  **Anyone any idea how we can somehow retrieve at this place whether the `m.always_on_screen` capability got actually requested?**

https://github.com/matrix-org/matrix-react-sdk/blob/cbd568a1e8604601fc67b9735292ed8bf6a2779c/src/components/views/elements/AppTile.js#L378-L390

closes vector-im/element-web#15001

