### PR TITLE
Replace bind by arrow functions (PasswordLogin.js)

### DIFF
--- a/src/components/views/auth/PasswordLogin.js
+++ b/src/components/views/auth/PasswordLogin.js
@@ -79,26 +79,15 @@ export default class PasswordLogin extends React.Component {
             phoneNumber: this.props.initialPhoneNumber,
             loginType: PasswordLogin.LOGIN_FIELD_MXID,
         };
-
-        this.onForgotPasswordClick = this.onForgotPasswordClick.bind(this);
-        this.onSubmitForm = this.onSubmitForm.bind(this);
-        this.onUsernameChanged = this.onUsernameChanged.bind(this);
-        this.onUsernameBlur = this.onUsernameBlur.bind(this);
-        this.onLoginTypeChange = this.onLoginTypeChange.bind(this);
-        this.onPhoneCountryChanged = this.onPhoneCountryChanged.bind(this);
-        this.onPhoneNumberChanged = this.onPhoneNumberChanged.bind(this);
-        this.onPhoneNumberBlur = this.onPhoneNumberBlur.bind(this);
-        this.onPasswordChanged = this.onPasswordChanged.bind(this);
-        this.isLoginEmpty = this.isLoginEmpty.bind(this);
     }
 
-    onForgotPasswordClick(ev) {
+    onForgotPasswordClick = (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
         this.props.onForgotPasswordClick();
     }
 
-    onSubmitForm(ev) {
+    onSubmitForm = (ev) => {
         ev.preventDefault();
 
         let username = ''; // XXX: Synapse breaks if you send null here:
@@ -146,12 +135,12 @@ export default class PasswordLogin extends React.Component {
         );
     }
 
-    onUsernameChanged(ev) {
+    onUsernameChanged = (ev) => {
         this.setState({username: ev.target.value});
         this.props.onUsernameChanged(ev.target.value);
     }
 
-    onUsernameFocus() {
+    onUsernameFocus = () => {
         if (this.state.loginType === PasswordLogin.LOGIN_FIELD_MXID) {
             CountlyAnalytics.instance.track("onboarding_login_mxid_focus");
         } else {
@@ -159,7 +148,7 @@ export default class PasswordLogin extends React.Component {
         }
     }
 
-    onUsernameBlur(ev) {
+    onUsernameBlur = (ev) => {
         if (this.state.loginType === PasswordLogin.LOGIN_FIELD_MXID) {
             CountlyAnalytics.instance.track("onboarding_login_mxid_blur");
         } else {
@@ -168,7 +157,7 @@ export default class PasswordLogin extends React.Component {
         this.props.onUsernameBlur(ev.target.value);
     }
 
-    onLoginTypeChange(ev) {
+    onLoginTypeChange = (ev) => {
         const loginType = ev.target.value;
         this.props.onError(null); // send a null error to clear any error messages
         this.setState({
@@ -178,7 +167,7 @@ export default class PasswordLogin extends React.Component {
         CountlyAnalytics.instance.track("onboarding_login_type_changed", { loginType });
     }
 
-    onPhoneCountryChanged(country) {
+    onPhoneCountryChanged = (country) =>{
         this.setState({
             phoneCountry: country.iso2,
             phonePrefix: country.prefix,
@@ -186,21 +175,21 @@ export default class PasswordLogin extends React.Component {
         this.props.onPhoneCountryChanged(country.iso2);
     }
 
-    onPhoneNumberChanged(ev) {
+    onPhoneNumberChanged = (ev) => {
         this.setState({phoneNumber: ev.target.value});
         this.props.onPhoneNumberChanged(ev.target.value);
     }
 
-    onPhoneNumberFocus() {
+    onPhoneNumberFocus = () => {
         CountlyAnalytics.instance.track("onboarding_login_phone_number_focus");
     }
 
-    onPhoneNumberBlur(ev) {
+    onPhoneNumberBlur = (ev) => {
         this.props.onPhoneNumberBlur(ev.target.value);
         CountlyAnalytics.instance.track("onboarding_login_phone_number_blur");
     }
 
-    onPasswordChanged(ev) {
+    onPasswordChanged = (ev) => {
         this.setState({password: ev.target.value});
         this.props.onPasswordChanged(ev.target.value);
     }
@@ -271,7 +260,7 @@ export default class PasswordLogin extends React.Component {
         }
     }
 
-    isLoginEmpty() {
+    isLoginEmpty = () => {
         switch (this.state.loginType) {
             case PasswordLogin.LOGIN_FIELD_EMAIL:
             case PasswordLogin.LOGIN_FIELD_MXID:

--- a/src/components/views/auth/PasswordLogin.tsx
+++ b/src/components/views/auth/PasswordLogin.tsx
@@ -26,10 +26,41 @@ import {ValidatedServerConfig} from "../../../utils/AutoDiscoveryUtils";
 import AccessibleButton from "../elements/AccessibleButton";
 import CountlyAnalytics from "../../../CountlyAnalytics";
 
+interface IProps {
+    onError: (error: string) => void;
+    onEditServerDetailsClick: () => void | null,
+    onUsernameChanged: (username: string) => void;
+    onUsernameBlur: (blur: string) => void;
+    onPasswordChanged: (password: string) => void;
+    onPhoneCountryChanged: (country: any) => void;
+    onPhoneNumberChanged: (number: string) => void;
+    onPhoneNumberBlur: (blur: string) => void;
+    onForgotPasswordClick: () => void;
+    onSubmit: (username: string, phoneCountry: string, phoneNumber: string, password: string) => void;
+
+    initialUsername: string;
+    initialPassword: string;
+    initialPhoneCountry: string;
+    initialPhoneNumber: string;
+    loginIncorrect: boolean;
+    disableSubmit: boolean;
+    busy?: boolean;
+    serverConfig?: any;
+}
+
+interface IState {
+    username: string;
+    password: string;
+    phoneCountry: string;
+    phoneNumber: string;
+    phonePrefix?: string;
+    loginType: string;
+}
+
 /**
  * A pure UI component which displays a username/password form.
  */
-export default class PasswordLogin extends React.Component {
+export default class PasswordLogin extends React.Component<IProps, IState> {
     static propTypes = {
         onSubmit: PropTypes.func.isRequired, // fn(username, password)
         onError: PropTypes.func,
@@ -93,7 +124,7 @@ export default class PasswordLogin extends React.Component {
         let username = ''; // XXX: Synapse breaks if you send null here:
         let phoneCountry = null;
         let phoneNumber = null;
-        let error;
+        let error: string;
 
         switch (this.state.loginType) {
             case PasswordLogin.LOGIN_FIELD_EMAIL:
@@ -135,7 +166,7 @@ export default class PasswordLogin extends React.Component {
         );
     }
 
-    onUsernameChanged = (ev) => {
+    onUsernameChanged = (ev: any) => {
         this.setState({username: ev.target.value});
         this.props.onUsernameChanged(ev.target.value);
     }
@@ -148,7 +179,7 @@ export default class PasswordLogin extends React.Component {
         }
     }
 
-    onUsernameBlur = (ev) => {
+    onUsernameBlur = (ev: any) => {
         if (this.state.loginType === PasswordLogin.LOGIN_FIELD_MXID) {
             CountlyAnalytics.instance.track("onboarding_login_mxid_blur");
         } else {
@@ -167,7 +198,7 @@ export default class PasswordLogin extends React.Component {
         CountlyAnalytics.instance.track("onboarding_login_type_changed", { loginType });
     }
 
-    onPhoneCountryChanged = (country) =>{
+    onPhoneCountryChanged = (country: {iso2: string, name: string, prefix: string}) =>{
         this.setState({
             phoneCountry: country.iso2,
             phonePrefix: country.prefix,
@@ -197,7 +228,7 @@ export default class PasswordLogin extends React.Component {
     renderLoginField(loginType, autoFocus) {
         const Field = sdk.getComponent('elements.Field');
 
-        const classes = {};
+        const classes: { error?: boolean } = {};
 
         switch (loginType) {
             case PasswordLogin.LOGIN_FIELD_EMAIL:

--- a/src/components/views/auth/PasswordLogin.tsx
+++ b/src/components/views/auth/PasswordLogin.tsx
@@ -283,7 +283,7 @@ export default class PasswordLogin extends React.Component<IProps, IState> {
     }
 
     render() {
-        let forgotPasswordJsx;
+        let forgotPasswordJsx: JSX.Element | undefined;
 
         if (this.props.onForgotPasswordClick) {
             forgotPasswordJsx = <span>
@@ -311,7 +311,7 @@ export default class PasswordLogin extends React.Component<IProps, IState> {
         const autoFocusPassword = !this.isLoginEmpty();
         const loginField = this.renderLoginField(this.state.loginType, !autoFocusPassword);
 
-        let loginType;
+        let loginType: JSX.Element | undefined;
         if (!SdkConfig.get().disable_3pid_login) {
             loginType = (
                 <div className="mx_Login_type_container">


### PR DESCRIPTION
The member functions `onUsernameFocus` was not bound which caused
uncaught exceptions. Use arrow functions instead to make it unnecessary
to bind member functions.

Signed-off-by: Clemens Zeidler <clemens.zeidler@gmail.com>