### PR TITLE
Make inline emojis bigger

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -212,6 +212,11 @@ $left-gutter: 64px;
         overflow-y: hidden;
     }
 
+    .mx_EventTile_Emoji {
+        font-size: 1.8rem;
+        vertical-align: bottom;
+    }
+
     &.mx_EventTile_selected .mx_EventTile_line,
     &:hover .mx_EventTile_line {
         border-top-left-radius: 4px;

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -395,6 +395,46 @@ export interface IOptsReturnString extends IOpts {
     returnString: true;
 }
 
+/**
+ * Wraps emojis in <span> to style them separately from the rest of message. Consecutive emojis (and modifiers) are wrapped
+ * in the same <span>.
+ * @param {string} message the text to format
+ * @param {boolean} isHtmlMessage whether the message contains HTML
+ * @returns if isHtmlMessage is true, returns an array of strings, otherwise return an array of React Elements for emojis
+ * and plain text for everything else
+ */
+function formatEmojis(message: string, isHtmlMessage: boolean): (JSX.Element | string)[] {
+    const emojiToSpan = isHtmlMessage ? (emoji: string) => `<span class='mx_EventTile_Emoji'>${emoji}</span>` :
+        (emoji: string, key: number) => <span key={key} className='mx_EventTile_Emoji'>{ emoji }</span>;
+    const result: (JSX.Element | string)[] = [];
+    let text = '';
+    let emojis = '';
+    let key = 0;
+    for (const char of message) {
+        if (mightContainEmoji(char) || ZWJ_REGEX.test(char) || char === '\ufe0f') {
+            if (text) {
+                result.push(text);
+                text = '';
+            }
+            emojis += char;
+        } else {
+            if (emojis) {
+                result.push(emojiToSpan(emojis, key));
+                key++;
+                emojis = '';
+            }
+            text += char;
+        }
+    }
+    if (text) {
+        result.push(text);
+    }
+    if (emojis) {
+        result.push(emojiToSpan(emojis, key));
+    }
+    return result;
+}
+
 /* turn a matrix event body into html
  *
  * content: 'content' of the MatrixEvent
@@ -477,6 +517,9 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
                 });
                 safeBody = phtml.html();
             }
+            if (bodyHasEmoji) {
+                safeBody = formatEmojis(safeBody, true).join('');
+            }
         }
     } finally {
         delete sanitizeParams.textFilter;
@@ -519,6 +562,11 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
         'markdown-body': isHtmlMessage && !emojiBody,
     });
 
+    let emojiBodyElements: JSX.Element[];
+    if (!isDisplayedWithHtml && bodyHasEmoji && !emojiBody) {
+        emojiBodyElements = formatEmojis(strippedBody, false) as JSX.Element[];
+    }
+
     return isDisplayedWithHtml ?
         <span
             key="body"
@@ -526,7 +574,9 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
             className={className}
             dangerouslySetInnerHTML={{ __html: safeBody }}
             dir="auto"
-        /> : <span key="body" ref={opts.ref} className={className} dir="auto">{ strippedBody }</span>;
+        /> : <span key="body" ref={opts.ref} className={className} dir="auto">
+            { emojiBodyElements || strippedBody }
+        </span>;
 }
 
 /**


### PR DESCRIPTION
Fixes vector-im/element-web#2890
[Previous attempt](https://github.com/vector-im/element-web/pull/3642) is outdated because emojis don't use images now and thus can't be easily styled.

The regular inline emojis are too small by default and it's hard to recognize them. The only way to make them look good is to post only emojis as a single message, then they become much bigger. This pull request makes regular emojis much more readable like in other mainstream messengers.
Before:
![2020-11-07_15-33-46](https://user-images.githubusercontent.com/184066/98441382-ec246900-210e-11eb-8ed2-ad92e2372fa1.png)
![2020-11-07_15-38-11](https://user-images.githubusercontent.com/184066/98441429-43c2d480-210f-11eb-8902-c1d78fdad19e.png)

After:
![2020-11-07_15-36-23](https://user-images.githubusercontent.com/184066/98441392-02322980-210f-11eb-9d72-52f6e2ad5915.png)
![2020-11-07_15-36-49](https://user-images.githubusercontent.com/184066/98441406-1413cc80-210f-11eb-94bc-41df962f4888.png)

Signed-off-by: Sergey Shpikin <rkfg@rkfg.me>




<!-- Replace -->
Preview: https://618158226af8110aa94c88f8--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
