### PR TITLE
Fix drag drop file to upload for Safari

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1147,16 +1147,9 @@ export default class RoomView extends React.Component<IProps, IState> {
 
         ev.dataTransfer.dropEffect = 'none';
 
-        const items = [...ev.dataTransfer.items];
-        if (items.length >= 1) {
-            const isDraggingFiles = items.every(function(item) {
-                return item.kind == 'file';
-            });
-
-            if (isDraggingFiles) {
-                this.setState({ draggingFile: true });
-                ev.dataTransfer.dropEffect = 'copy';
-            }
+        if (ev.dataTransfer.types.includes("Files") || ev.dataTransfer.types.includes("application/x-moz-file")) {
+            this.setState({ draggingFile: true });
+            ev.dataTransfer.dropEffect = 'copy';
         }
     };
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/7420


What is happening is for Privacy Safari is saying 0 files are being dragged on dragOver event, other browsers say quantity and type here. https://stackoverflow.com/a/34866211 

WhatWG agrees https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface

> This version of the API does not expose the types of the files during the drag.


Instead we can check the `types` property.

Tested on Chrome, Firefox and Safari on macOS.