### PR TITLE
Shrink new room intro top margin to half for encryption bubble tile

### DIFF
--- a/res/css/views/rooms/_NewRoomIntro.scss
+++ b/res/css/views/rooms/_NewRoomIntro.scss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .mx_NewRoomIntro {
-    margin: 80px 0 48px 64px;
+    margin: 40px 0 48px 64px;
 
     .mx_MiniAvatarUploader_hasAvatar:not(.mx_MiniAvatarUploader_busy):not(:hover) {
         &::before, &::after {


### PR DESCRIPTION
Partial fix for https://github.com/vector-im/element-web/issues/15707 - leaving open as needs further improvement but is enough to clear the release-blocker

approved by design oob

![image](https://user-images.githubusercontent.com/2403652/99534521-71c1d780-299f-11eb-9b12-d24ff09d1964.png)
