### PR TITLE
Allow room publish setting if local alias is allowed

### DIFF
--- a/src/components/views/room_settings/AliasSettings.js
+++ b/src/components/views/room_settings/AliasSettings.js
@@ -358,7 +358,7 @@ export default class AliasSettings extends React.Component {
                 <p>{_t("Published addresses can be used by anyone on any server to join your room. " +
                     "To publish an address, it needs to be set as a local address first.")}</p>
                 {canonicalAliasSection}
-                <RoomPublishSetting roomId={this.props.roomId} canSetCanonicalAlias={this.props.canSetCanonicalAlias} />
+                <RoomPublishSetting roomId={this.props.roomId} canSetAliases={this.props.canSetAliases} />
                 <datalist id="mx_AliasSettings_altRecommendations">
                     {this._getLocalNonAltAliases().map(alias => {
                         return <option value={alias} key={alias} />;

--- a/src/components/views/room_settings/RoomPublishSetting.js
+++ b/src/components/views/room_settings/RoomPublishSetting.js
@@ -54,7 +54,7 @@ export default class RoomPublishSetting extends React.PureComponent {
 
         return (<LabelledToggleSwitch value={this.state.isRoomPublished}
             onChange={this.onRoomPublishChange}
-            disabled={!this.props.canSetCanonicalAlias}
+            disabled={!this.props.canSetAliases}
             label={_t("Publish this room to the public in %(domain)s's room directory?", {
               domain: client.getDomain(),
             })} />);


### PR DESCRIPTION
Hello,

Sorry, I don't know your code and I am not so happy with the proposed solution. So I may need help to improve this. Feel free to comment.

Allowing a user to publish on local room list, is a rules in the config option on the server side (room_list_publication_rules in synapse). I don't know the proper way to get this value here ...  

In the current implementation this is the flag canSetCanonicalAlias which is used. As I think it is related to the room setting, it does not allow normal user who have the good right on server side to publish the room.
https://github.com/matrix-org/matrix-react-sdk/blob/5f47077a3016882f0695ffc99c6fd71c1d4d7636/src/components/views/room_settings/RoomPublishSetting.js#L57

In this PR I switch to the flag canSetAliases which I think is related to local aliases on the server side (alias_creation_rules in synapse). I think this because it is already used to allow the edit of local aliases on those line:
https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/components/views/room_settings/AliasSettings.js#L339-L352

So I think it is better, as for now the the toggle switch is not usable if your are not admin of the room.

The server may not accept the request as it depend on config ( but most of time, I think config are the same for the two option)
I may add an error handling for it.

Or maybe a better way would be to create a new flag specific for this.
I have seen some call to room.currentState.maySendStateEvent. But I don't know if there is an event for this, and if yes, I don't know it's name.
Or maybe juste add a flag to true like here:
https://github.com/matrix-org/matrix-react-sdk/blob/5f47077a3016882f0695ffc99c6fd71c1d4d7636/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.js#L58


