### PR TITLE
Nest other layers inside on automation

### DIFF
--- a/scripts/ci/app-tests.sh
+++ b/scripts/ci/app-tests.sh
@@ -7,6 +7,6 @@
 set -ev
 
 scripts/ci/layered.sh
-cd ../element-web
+cd element-web
 yarn build:genfiles # so the tests can run. Faster version of `build`
 yarn test

--- a/scripts/ci/end-to-end-tests.sh
+++ b/scripts/ci/end-to-end-tests.sh
@@ -15,10 +15,10 @@ trap 'handle_error' ERR
 
 echo "--- Building Element"
 scripts/ci/layered.sh
-cd ../element-web
+cd element-web
 element_web_dir=`pwd`
 CI_PACKAGE=true yarn build
-cd ../matrix-react-sdk
+cd ..
 # run end to end tests
 pushd test/end-to-end-tests
 ln -s $element_web_dir element/element-web

--- a/scripts/ci/layered.sh
+++ b/scripts/ci/layered.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 
-# Creates an environment similar to one that element-web would expect for
-# development. This means going one directory up (and assuming we're in
-# a directory like /workdir/matrix-react-sdk) and putting element-web and
-# the js-sdk there.
+# Creates a layered environment with the full repo for the app and SDKs cloned
+# and linked.
 
-cd ../  # Assume we're at something like /workdir/matrix-react-sdk
+# Note that this style is different from the recommended developer setup: this
+# file nests js-sdk and element-web inside react-sdk, while the local
+# development setup places them all at the same level. We are nesting them here
+# because some CI systems do not allow moving to a directory above the checkout
+# for the primary repo (react-sdk in this case).
 
 # Set up the js-sdk first
-matrix-react-sdk/scripts/fetchdep.sh matrix-org matrix-js-sdk
+scripts/fetchdep.sh matrix-org matrix-js-sdk
 pushd matrix-js-sdk
 yarn link
 yarn install
 popd
 
 # Now set up the react-sdk
-pushd matrix-react-sdk
 yarn link matrix-js-sdk
 yarn link
 yarn install
-popd
 
 # Finally, set up element-web
-matrix-react-sdk/scripts/fetchdep.sh vector-im element-web
+scripts/fetchdep.sh vector-im element-web
 pushd element-web
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk


### PR DESCRIPTION
This changes the nesting style because some CI / CD systems do not allow moving
to a directory above the checkout for the primary repo (`react-sdk` in this
case).

This PR also has the first Netlify preview attached: look for `netlify/matrix-react-sdk/deploy-preview` in the checks and click "details" to go to the preview copy of Element.

Part of https://github.com/vector-im/element-web/issues/12624