### PR TITLE
Remove old app test script path

### DIFF
--- a/scripts/ci/riot-unit-tests.sh
+++ b/scripts/ci/riot-unit-tests.sh
@@ -1,1 +1,0 @@
-app-tests.sh


### PR DESCRIPTION
Now that https://github.com/matrix-org/pipelines/pull/112 has merged, we no
longer need to support this old path for launching app-level tests.