### PR TITLE
Rename "Delete sessions" to "Sign out" + UX improvements

### DIFF
--- a/res/css/views/settings/_DevicesPanel.scss
+++ b/res/css/views/settings/_DevicesPanel.scss
@@ -17,17 +17,12 @@ limitations under the License.
 .mx_DevicesPanel {
     display: table;
     table-layout: fixed;
-    width: 880px;
     border-spacing: 10px;
 }
 
 .mx_DevicesPanel_header {
     display: table-header-group;
     font-weight: bold;
-}
-
-.mx_DevicesPanel_header > .mx_DevicesPanel_deviceButtons {
-    height: 48px; // make this tall so the table doesn't move down when the delete button appears
 }
 
 .mx_DevicesPanel_header > div {
@@ -43,8 +38,12 @@ limitations under the License.
     width: 30%;
 }
 
-.mx_DevicesPanel_header .mx_DevicesPanel_deviceButtons {
-    width: 20%;
+.mx_DevicesPanel_deviceButtons {
+    margin: 1em 0;
+
+    :nth-child(n + 1) {
+        margin-inline-end: 10px;
+    }
 }
 
 .mx_DevicesPanel_device {
@@ -57,4 +56,8 @@ limitations under the License.
 
 .mx_DevicesPanel_myDevice {
     font-weight: bold;
+}
+
+.mx_DevicesPanel_signout_devices {
+    font-size: 0.9em;
 }

--- a/src/components/views/settings/DevicesPanelEntry.js
+++ b/src/components/views/settings/DevicesPanelEntry.js
@@ -73,17 +73,24 @@ export default class DevicesPanelEntry extends React.Component {
                     { device.device_id }
                 </div>
                 <div className="mx_DevicesPanel_deviceName">
-                    <EditableTextContainer initialValue={device.display_name}
-                        onSubmit={this._onDisplayNameChanged}
-                        placeholder={device.device_id}
-                    />
+                {
+                    this.props.editable ?
+                        <EditableTextContainer initialValue={device.display_name}
+                            onSubmit={this._onDisplayNameChanged}
+                            placeholder={device.device_id}
+                        />
+                        :
+                        device.display_name
+                }
                 </div>
                 <div className="mx_DevicesPanel_lastSeen">
                     { lastSeen }
                 </div>
-                <div className="mx_DevicesPanel_deviceButtons">
-                    <StyledCheckbox onChange={this.onDeviceToggled} checked={this.props.selected} />
-                </div>
+                {
+                    this.props.editable ? 
+                        <StyledCheckbox onChange={this.onDeviceToggled} checked={this.props.selected} />
+                    : null
+                }
             </div>
         );
     }

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.js
@@ -387,7 +387,8 @@ export default class SecurityUserSettingsTab extends React.Component {
                 {warning}
                 <div className="mx_SettingsTab_heading">{_t("Where you’re logged in")}</div>
                 <div className="mx_SettingsTab_section">
-                    <span>
+                    <div className='mx_SettingsTab_subsectionText'>
+                    <p>
                         {_t(
                             "Manage the names of and sign out of your sessions below or " +
                             "<a>verify them in your User Profile</a>.", {},
@@ -397,9 +398,10 @@ export default class SecurityUserSettingsTab extends React.Component {
                                 </AccessibleButton>,
                             },
                         )}
-                    </span>
-                    <div className='mx_SettingsTab_subsectionText'>
-                        {_t("A session's public name is visible to people you communicate with")}
+                    </p>
+                    <p>
+                        {_t("A session's public name is visible to people you communicate with.")}
+                        </p>
                         <DevicesPanel />
                     </div>
                 </div>


### PR DESCRIPTION
"Delete sessions" sounds very dangerous to me while "Sign out" sounds
more fitting (as it is called in Element Android).

Other UX changes:
1) The sign out button is now below the devices table in a button row
matching the style of all other buttons in the settings panel.
2) The sign out button is now always shown but disabled when no session
is selected. Hiding the button was a bit confusing since there was no
indication what could be done by selecting sessions. Furthermore, with
many active sessions the delete button was off-screen when selecting an
old session at the bottom of the table. This made it even more confusing
to use.
3) The sessions to be signed out are now listed in the dialog so that
users can verify they selected the correct sessions.
