### PR TITLE
Only show confetti if the current room is receiving an appropriate event

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -801,6 +801,7 @@ export default class RoomView extends React.Component<IProps, IState> {
 
     private handleEffects = (ev) => {
         if (!this.state.room || !this.state.matrixClientIsReady) return; // not ready at all
+        if (ev.getRoomId() !== this.state.room.roomId) return; // not for us
 
         const notifState = RoomNotificationStateStore.instance.getRoomState(this.state.room);
         if (!notifState.isUnread) return;


### PR DESCRIPTION
We weren't checking the event to see if it was in the current room, which meant that if your current room was unread and a 🎉 was sent elsewhere it would cause confetti.