### PR TITLE
Fix being unable to pin widgets

### DIFF
--- a/src/stores/WidgetStore.ts
+++ b/src/stores/WidgetStore.ts
@@ -134,6 +134,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
         // first clean out old widgets from the map which originate from this room
         // otherwise we are out of sync with the rest of the app with stale widget events during removal
         Array.from(this.widgetMap.values()).forEach(app => {
+            if (app.roomId !== room.roomId) return; // skip - wrong room
             this.widgetMap.delete(widgetUid(app));
         });
 
@@ -233,7 +234,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
 
         // Clean up the pinned record
         Object.keys(roomInfo).forEach(wId => {
-            if (!roomInfo.widgets.some(w => w.id === wId)) {
+            if (!roomInfo.widgets.some(w => w.id === wId) || !roomInfo.pinned[wId]) {
                 delete roomInfo.pinned[wId];
             }
         });


### PR DESCRIPTION
Turns out that we were obliterating the entire store of widgets each time we loaded a widget, which is less than helpful. This commit fixes that.

This commit also improves the cleanup of the pinned event object to remove unpinned widgets, reducing accumulation over time.

Fixes https://github.com/vector-im/element-web/issues/15948

Note: the last widget to be detected would work, but none of the others.