### PR TITLE
Run chat effects on events sent by widgets too

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -39,7 +39,7 @@ import WidgetCapabilitiesPromptDialog, {
 import { WidgetPermissionCustomisations } from "../../customisations/WidgetPermissions";
 import { OIDCState, WidgetPermissionStore } from "./WidgetPermissionStore";
 import { WidgetType } from "../../widgets/WidgetType";
-import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
+import { EventType } from "matrix-js-sdk/src/@types/event";
 import { CHAT_EFFECTS } from "../../effects";
 import { containsEmoji } from "../../effects/utils";
 import dis from "../../dispatcher/dispatcher";

--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -39,7 +39,10 @@ import WidgetCapabilitiesPromptDialog, {
 import { WidgetPermissionCustomisations } from "../../customisations/WidgetPermissions";
 import { OIDCState, WidgetPermissionStore } from "./WidgetPermissionStore";
 import { WidgetType } from "../../widgets/WidgetType";
-import { EventType } from "matrix-js-sdk/src/@types/event";
+import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
+import { CHAT_EFFECTS } from "../../effects";
+import { containsEmoji } from "../../effects/utils";
+import dis from "../../dispatcher/dispatcher";
 
 // TODO: Purge this from the universe
 
@@ -123,6 +126,14 @@ export class StopGapWidgetDriver extends WidgetDriver {
         } else {
             // message event
             r = await client.sendEvent(roomId, eventType, content);
+
+            if (eventType === EventType.RoomMessage) {
+                CHAT_EFFECTS.forEach((effect) => {
+                    if (containsEmoji(content, effect.emojis)) {
+                        dis.dispatch({action: `effects.${effect.command}`});
+                    }
+                });
+            }
         }
 
         return {roomId, eventId: r.event_id};


### PR DESCRIPTION
This appears to be a missed case more than anything else, likely because widget event sending was added during the review cycle for chat effects.