### PR TITLE
Fix mx_MemberList icons

### DIFF
--- a/res/css/views/rooms/_MemberList.scss
+++ b/res/css/views/rooms/_MemberList.scss
@@ -112,10 +112,10 @@ limitations under the License.
     }
 }
 
-.mx_MemberList_inviteCommunity span {
-    background-image: url('$(res)/img/icon-invite-people.svg');
+.mx_MemberList_inviteCommunity span::before {
+    mask-image: url('$(res)/img/icon-invite-people.svg');
 }
 
-.mx_MemberList_addRoomToCommunity span {
-    background-image: url('$(res)/img/icons-room-add.svg');
+.mx_MemberList_addRoomToCommunity span::before {
+    mask-image: url('$(res)/img/icons-room-add.svg');
 }


### PR DESCRIPTION
Invalid stylesheets:
![image](https://user-images.githubusercontent.com/7534274/102205158-17973200-3ecb-11eb-9ddf-09dfa97edbef.png)
![image](https://user-images.githubusercontent.com/7534274/102205173-1c5be600-3ecb-11eb-9647-98c93b5d5075.png)

Apparently icon changed from `background-image` to `mask-image` and this has been forgotten.

After change:
![image](https://user-images.githubusercontent.com/7534274/102205391-6c3aad00-3ecb-11eb-8f64-fc364d86c225.png)
![image](https://user-images.githubusercontent.com/7534274/102205380-6775f900-3ecb-11eb-8a0f-0819daf86450.png)
