### PR TITLE
Fix minimized left panel avatar alignment

### DIFF
--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -180,6 +180,11 @@ $groupFilterPanelWidth: 56px; // only applies in this file, used for calculation
         .mx_LeftPanel_roomListContainer {
             width: 68px;
 
+            .mx_LeftPanel_userHeader {
+                flex-direction: row;
+                justify-content: center;
+            }
+
             .mx_LeftPanel_filterContainer {
                 // Organize the flexbox into a centered column layout
                 flex-direction: column;

--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -119,14 +119,10 @@ limitations under the License.
     }
 
     &.mx_UserMenu_minimized {
-        .mx_UserMenu_userHeader {
-            .mx_UserMenu_row {
-                justify-content: center;
-            }
+        padding-right: 0px;
 
-            .mx_UserMenu_userAvatarContainer {
-                margin-right: 0;
-            }
+        .mx_UserMenu_userAvatarContainer {
+            margin-right: 0px;
         }
     }
 }


### PR DESCRIPTION
I've fixed the alignment of the avatar icon in the left panel while it's minimized.


Before:

![Screenshot_20201215_144046](https://user-images.githubusercontent.com/25768714/102223748-63ef6b80-3ee5-11eb-8427-240bb876421b.png)

After:

![Screenshot_20201215_144025](https://user-images.githubusercontent.com/25768714/102223741-618d1180-3ee5-11eb-9ec4-c0a4ef5b295a.png)

