### PR TITLE
Use TypeScript source for development, swap to build during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "matrix-gen-i18n": "scripts/gen-i18n.js",
     "matrix-prune-i18n": "scripts/prune-i18n.js"
   },
-  "main": "./lib/index.js",
-  "typings": "./lib/index.d.ts",
+  "main": "./src/index.js",
   "matrix_src_main": "./src/index.js",
+  "matrix_lib_main": "./lib/index.js",
+  "matrix_lib_typings": "./lib/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build",
     "i18n": "matrix-gen-i18n",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "typings": "./lib/index.d.ts",
   "matrix_src_main": "./src/index.js",
   "scripts": {
-    "prepare": "yarn build",
+    "prepublishOnly": "yarn build",
     "i18n": "matrix-gen-i18n",
     "prunei18n": "matrix-prune-i18n",
     "diff-i18n": "cp src/i18n/strings/en_EN.json src/i18n/strings/en_EN_orig.json && ./scripts/gen-i18n.js && node scripts/compare-file.js src/i18n/strings/en_EN_orig.json src/i18n/strings/en_EN.json",

--- a/scripts/ci/install-deps.sh
+++ b/scripts/ci/install-deps.sh
@@ -7,7 +7,7 @@ scripts/fetchdep.sh matrix-org matrix-js-sdk
 pushd matrix-js-sdk
 yarn link
 yarn install $@
-yarn build
+yarn build:types
 popd
 
 yarn link matrix-js-sdk

--- a/scripts/ci/install-deps.sh
+++ b/scripts/ci/install-deps.sh
@@ -7,7 +7,6 @@ scripts/fetchdep.sh matrix-org matrix-js-sdk
 pushd matrix-js-sdk
 yarn link
 yarn install $@
-yarn build:types
 popd
 
 yarn link matrix-js-sdk

--- a/scripts/ci/layered.sh
+++ b/scripts/ci/layered.sh
@@ -20,6 +20,7 @@ popd
 yarn link matrix-js-sdk
 yarn link
 yarn install
+yarn reskindex
 
 # Finally, set up element-web
 scripts/fetchdep.sh vector-im element-web

--- a/scripts/ci/layered.sh
+++ b/scripts/ci/layered.sh
@@ -14,12 +14,14 @@ scripts/fetchdep.sh matrix-org matrix-js-sdk
 pushd matrix-js-sdk
 yarn link
 yarn install
+yarn build:types
 popd
 
 # Now set up the react-sdk
 yarn link matrix-js-sdk
 yarn link
 yarn install
+yarn build:types
 
 # Finally, set up element-web
 scripts/fetchdep.sh vector-im element-web

--- a/scripts/ci/layered.sh
+++ b/scripts/ci/layered.sh
@@ -14,14 +14,12 @@ scripts/fetchdep.sh matrix-org matrix-js-sdk
 pushd matrix-js-sdk
 yarn link
 yarn install
-yarn build:types
 popd
 
 # Now set up the react-sdk
 yarn link matrix-js-sdk
 yarn link
 yarn install
-yarn build:types
 
 # Finally, set up element-web
 scripts/fetchdep.sh vector-im element-web


### PR DESCRIPTION
This changes the JS SDK to point `main` to TypeScript source and remove any
indication of `typings`. For local development and CI workflows, it means many
steps can run without building first, which saves lots of time.

During release, we still build for Node and browsers as before. The release
script adjusts the `main` and `typings` fields before publishing and
distribution to point to the built output for those that use them.

Summary of improvements:

* `yarn install` no longer runs a build step
* Linting and (most) tests don't need a build step either
* CI runs are faster by several minutes as a result

Related to https://github.com/matrix-org/matrix-js-sdk/pull/1552
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1561
Part of https://github.com/vector-im/element-web/issues/15987