### PR TITLE
Recognise `*.element.io` links as Element permalinks

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -163,7 +163,7 @@ const transformTags: IExtendedSanitizeOptions["transformTags"] = { // custom to 
             attribs.target = '_blank'; // by default
 
             const transformed = tryTransformPermalinkToLocalHref(attribs.href);
-            if (transformed !== attribs.href || attribs.href.match(linkifyMatrix.VECTOR_URL_PATTERN)) {
+            if (transformed !== attribs.href || attribs.href.match(linkifyMatrix.ELEMENT_URL_PATTERN)) {
                 attribs.href = transformed;
                 delete attribs.target;
             }

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -188,7 +188,8 @@ const escapeRegExp = function(string) {
 matrixLinkify.ELEMENT_URL_PATTERN =
     "^(?:https?://)?(?:" +
         escapeRegExp(window.location.host + window.location.pathname) + "|" +
-        "(?:www\\.)?(?:riot|vector)\\.im/(?:app|beta|staging|develop)/" +
+        "(?:www\\.)?(?:riot|vector)\\.im/(?:app|beta|staging|develop)/|" +
+        "(?:app|beta|staging|develop)\\.element\\.io/" +
     ")(#.*)";
 
 matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?://)?(?:www\\.)?matrix\\.to/#/(([#@!+]).*)";

--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -183,12 +183,13 @@ const escapeRegExp = function(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 };
 
-// Recognise URLs from both our local vector and official vector as vector.
-// anyone else really should be using matrix.to.
-matrixLinkify.VECTOR_URL_PATTERN = "^(?:https?://)?(?:"
-    + escapeRegExp(window.location.host + window.location.pathname) + "|"
-    + "(?:www\\.)?(?:riot|vector)\\.im/(?:app|beta|staging|develop)/"
-    + ")(#.*)";
+// Recognise URLs from both our local and official Element deployments.
+// Anyone else really should be using matrix.to.
+matrixLinkify.ELEMENT_URL_PATTERN =
+    "^(?:https?://)?(?:" +
+        escapeRegExp(window.location.host + window.location.pathname) + "|" +
+        "(?:www\\.)?(?:riot|vector)\\.im/(?:app|beta|staging|develop)/" +
+    ")(#.*)";
 
 matrixLinkify.MATRIXTO_URL_PATTERN = "^(?:https?://)?(?:www\\.)?matrix\\.to/#/(([#@!+]).*)";
 matrixLinkify.MATRIXTO_MD_LINK_PATTERN =
@@ -253,7 +254,7 @@ matrixLinkify.options = {
     target: function(href, type) {
         if (type === 'url') {
             const transformed = tryTransformPermalinkToLocalHref(href);
-            if (transformed !== href || href.match(matrixLinkify.VECTOR_URL_PATTERN)) {
+            if (transformed !== href || href.match(matrixLinkify.ELEMENT_URL_PATTERN)) {
                 return null;
             } else {
                 return '_blank';

--- a/src/utils/permalinks/Permalinks.js
+++ b/src/utils/permalinks/Permalinks.js
@@ -331,7 +331,7 @@ export function tryTransformPermalinkToLocalHref(permalink: string): string {
         return permalink;
     }
 
-    const m = permalink.match(matrixLinkify.VECTOR_URL_PATTERN);
+    const m = permalink.match(matrixLinkify.ELEMENT_URL_PATTERN);
     if (m) {
         return m[1];
     }
@@ -365,7 +365,7 @@ export function getPrimaryPermalinkEntity(permalink: string): string {
 
         // If not a permalink, try the vector patterns.
         if (!permalinkParts) {
-            const m = permalink.match(matrixLinkify.VECTOR_URL_PATTERN);
+            const m = permalink.match(matrixLinkify.ELEMENT_URL_PATTERN);
             if (m) {
                 // A bit of a hack, but it gets the job done
                 const handler = new ElementPermalinkConstructor("http://localhost");


### PR DESCRIPTION
This ensures all Elements detect permalinks to official deployments as Element
and handle them internally.

Fixes https://github.com/vector-im/element-web/issues/16005
