### PR TITLE
Don't use name width in reply thread for IRC layout

### DIFF
--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -207,6 +207,17 @@ $irc-line-height: $font-18px;
             width: unset;
             max-width: var(--name-width);
         }
+
+        .mx_SenderProfile_hover {
+            background: transparent;
+
+            > span {
+                > .mx_SenderProfile_name,
+                > .mx_SenderProfile_aux {
+                    min-width: inherit;
+                }
+            }
+        }
     }
 
     .mx_ProfileResizer {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/24576130/102796070-fd1ef600-43ad-11eb-9616-ae31270fae72.png)

After:

![image](https://user-images.githubusercontent.com/24576130/102796135-19229780-43ae-11eb-9bfd-5fa9da8157a1.png)

In addition to that, don't use the background color override so that hovered messages don't look odd.