### PR TITLE
Add highlight colour for context/popup menus

### DIFF
--- a/res/css/views/context_menus/_MessageContextMenu.scss
+++ b/res/css/views/context_menus/_MessageContextMenu.scss
@@ -23,6 +23,10 @@ limitations under the License.
     padding: 3px 6px 3px 6px;
     cursor: pointer;
     white-space: nowrap;
+
+    &:hover {
+        background-color: $menu-selected-color;
+    }
 }
 
 .mx_MessageContextMenu_field.mx_MessageContextMenu_fieldSet {

--- a/res/css/views/elements/_StyledRadioButton.scss
+++ b/res/css/views/elements/_StyledRadioButton.scss
@@ -25,7 +25,7 @@ limitations under the License.
     position: relative;
 
     display: flex;
-    align-items: baseline;
+    align-items: center;
     flex-grow: 1;
 
     > .mx_RadioButton_content {

--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -376,7 +376,11 @@ limitations under the License.
     }
 
     .mx_RadioButton, .mx_Checkbox {
-        margin-top: 8px;
+        padding: 4px;
+
+        &:hover {
+            background-color: $menu-selected-color;
+        }
     }
 }
 


### PR DESCRIPTION
I used the same colour as for the current highlighted items like in the "click your name" menu.  
In addition to that I changed the radio alignment type.

Here are the results:

**before**

| message | room list | radio |
| --- | --- | --- |
| ![before_message_context](https://user-images.githubusercontent.com/6216686/104838670-d2489480-58bc-11eb-81ad-d2a99fd5790d.png) | ![before_room_list](https://user-images.githubusercontent.com/6216686/104838676-d379c180-58bc-11eb-8d0f-5df35b6c0303.png) | ![before_radio_alignment](https://user-images.githubusercontent.com/6216686/104838674-d2e12b00-58bc-11eb-8b61-bb0f4fa3e585.png) |

**after**

| message | room list | radio |
| --- | --- | --- |
| ![after_message_context](https://user-images.githubusercontent.com/6216686/104838725-18055d00-58bd-11eb-975f-bd7dce29ae97.png) | ![after_room_list](https://user-images.githubusercontent.com/6216686/104838731-1fc50180-58bd-11eb-8863-473f3c533b6b.png) | ![after_radio_alignment](https://user-images.githubusercontent.com/6216686/104838749-366b5880-58bd-11eb-8965-30d6f822600e.png) |
| ![after_message_context_dark](https://user-images.githubusercontent.com/6216686/104838754-3d926680-58bd-11eb-9c5e-1a7222f871af.png) | ![after_room_list_dark](https://user-images.githubusercontent.com/6216686/104838756-42571a80-58bd-11eb-8883-6afd44cec2a2.png) | |

Closes vector-im/element-web#16178