### PR TITLE
Support room-defined widget layouts

### DIFF
--- a/docs/widget-layouts.md
+++ b/docs/widget-layouts.md
@@ -27,7 +27,7 @@ and interpret the other options differently.
 
 This is the "App Drawer" or any pinned widgets in a room. This is by far the most versatile container
 though does introduce potential usability issues upon members of the room (widgets take up space and
-therefore less messages can be shown).
+therefore fewer messages can be shown).
 
 The `index` for a widget determines which order the widgets show up in from left to right. Widgets
 without an `index` will show up as the rightmost widgets. Tiebreaks (same `index` or multiple defined
@@ -58,4 +58,3 @@ container will be put in this container instead. Putting a widget in the right c
 automatically show it - it only mentions that widgets should not be in another container.
 
 The behaviour of this container may change in the future.
-

--- a/docs/widget-layouts.md
+++ b/docs/widget-layouts.md
@@ -1,0 +1,61 @@
+# Widget layout support
+
+Rooms can have a default widget layout to auto-pin certain widgets, make the container different
+sizes, etc. These are defined through the `io.element.widgets.layout` state event (empty state key).
+
+Full example content:
+```json5
+{
+  "widgets": {
+    "first-widget-id": {
+      "container": "top",
+      "index": 0,
+      "width": 60,
+      "height": 40
+    },
+    "second-widget-id": {
+      "container": "right"
+    }
+  }
+}
+```
+
+As shown, there are two containers possible for widgets. These containers have different behaviour
+and interpret the other options differently. 
+
+## `top` container
+
+This is the "App Drawer" or any pinned widgets in a room. This is by far the most versatile container
+though does introduce potential usability issues upon members of the room (widgets take up space and
+therefore less messages can be shown).
+
+The `index` for a widget determines which order the widgets show up in from left to right. Widgets
+without an `index` will show up as the rightmost widgets. Tiebreaks (same `index` or multiple defined
+without an `index`) are resolved by comparing widget IDs. A maximum of 3 widgets can be in the top
+container - any which exceed this will be ignored. Smaller numbers represent leftmost widgets.
+
+The `width` is relative width within the container in percentage points. This will be clamped to a
+range of 0-100 (inclusive). The rightmost widget will have its percentage adjusted to fill the 
+container appropriately, shrinking and growing if required. For example, if three widgets are in the
+top container at 40% width each then the 3rd widget will be shrunk to 20% because 120% > 100%.
+Similarly, if all three widgets were set to 10% width each then the 3rd widget would grow to be 80%.
+
+Note that the client may impose minimum widths on the widgets, such as a 10% minimum to avoid pinning
+hidden widgets. In general, widgets defined in the 30-70% range each will be free of these restrictions.
+
+The `height` is not in fact applied per-widget but is recorded per-widget for potential future 
+capabilities in future containers. The top container will take the tallest `height` and use that for
+the height of the whole container, and thus all widgets in that container. The `height` is relative
+to the container, like with `width`, meaning that 100% will consume as much space as the client is
+willing to sacrifice to the widget container. Like with `width`, the client may impose minimums to avoid
+the container being uselessly small. Heights in the 30-100% range are generally acceptable. The height
+is also clamped to be within 0-100, inclusive.
+
+## `right` container
+
+This is the default container and has no special configuration. Widgets which overflow from the top
+container will be put in this container instead. Putting a widget in the right container does not
+automatically show it - it only mentions that widgets should not be in another container.
+
+The behaviour of this container may change in the future.
+

--- a/docs/widget-layouts.md
+++ b/docs/widget-layouts.md
@@ -32,13 +32,13 @@ therefore fewer messages can be shown).
 The `index` for a widget determines which order the widgets show up in from left to right. Widgets
 without an `index` will show up as the rightmost widgets. Tiebreaks (same `index` or multiple defined
 without an `index`) are resolved by comparing widget IDs. A maximum of 3 widgets can be in the top
-container - any which exceed this will be ignored. Smaller numbers represent leftmost widgets.
+container - any which exceed this will be ignored (placed into the `right` container). Smaller numbers 
+represent leftmost widgets.
 
 The `width` is relative width within the container in percentage points. This will be clamped to a
-range of 0-100 (inclusive). The rightmost widget will have its percentage adjusted to fill the 
-container appropriately, shrinking and growing if required. For example, if three widgets are in the
-top container at 40% width each then the 3rd widget will be shrunk to 20% because 120% > 100%.
-Similarly, if all three widgets were set to 10% width each then the 3rd widget would grow to be 80%.
+range of 0-100 (inclusive). The widgets will attempt to scale to relative proportions when more than
+100% space is allocated. For example, if 3 widgets are defined at 40% width each then the client will
+attempt to show them at 33% width each.
 
 Note that the client may impose minimum widths on the widgets, such as a 10% minimum to avoid pinning
 hidden widgets. In general, widgets defined in the 30-70% range each will be free of these restrictions.

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -36,6 +36,7 @@ import {Analytics} from "../Analytics";
 import CountlyAnalytics from "../CountlyAnalytics";
 import UserActivity from "../UserActivity";
 import {ModalWidgetStore} from "../stores/ModalWidgetStore";
+import { WidgetLayoutStore } from "../stores/widgets/WidgetLayoutStore";
 
 declare global {
     interface Window {
@@ -59,6 +60,7 @@ declare global {
         mxNotifier: typeof Notifier;
         mxRightPanelStore: RightPanelStore;
         mxWidgetStore: WidgetStore;
+        mxWidgetLayoutStore: WidgetLayoutStore;
         mxCallHandler: CallHandler;
         mxAnalytics: Analytics;
         mxCountlyAnalytics: typeof CountlyAnalytics;

--- a/src/TextForEvent.js
+++ b/src/TextForEvent.js
@@ -19,6 +19,7 @@ import * as Roles from './Roles';
 import {isValid3pidInvite} from "./RoomInvite";
 import SettingsStore from "./settings/SettingsStore";
 import {ALL_RULE_TYPES, ROOM_RULE_TYPES, SERVER_RULE_TYPES, USER_RULE_TYPES} from "./mjolnir/BanList";
+import {WIDGET_LAYOUT_EVENT_TYPE} from "./stores/widgets/WidgetLayoutStore";
 
 function textForMemberEvent(ev) {
     // XXX: SYJS-16 "sender is sometimes null for join messages"
@@ -477,6 +478,11 @@ function textForWidgetEvent(event) {
     }
 }
 
+function textForWidgetLayoutEvent(event) {
+    const senderName = event.sender?.name || event.getSender();
+    return _t("%(senderName)s has updated the widget layout", {senderName});
+}
+
 function textForMjolnirEvent(event) {
     const senderName = event.getSender();
     const {entity: prevEntity} = event.getPrevContent();
@@ -583,6 +589,7 @@ const stateHandlers = {
 
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
     'im.vector.modular.widgets': textForWidgetEvent,
+    [WIDGET_LAYOUT_EVENT_TYPE]: textForWidgetLayoutEvent,
 };
 
 // Add all the Mjolnir stuff to the renderer

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -78,6 +78,7 @@ import {UPDATE_EVENT} from "../../stores/AsyncStore";
 import Notifier from "../../Notifier";
 import {showToast as showNotificationsToast} from "../../toasts/DesktopNotificationsToast";
 import { RoomNotificationStateStore } from "../../stores/notifications/RoomNotificationStateStore";
+import { Container, WidgetLayoutStore } from "../../stores/widgets/WidgetLayoutStore";
 
 const DEBUG = false;
 let debuglog = function(msg: string) {};
@@ -280,8 +281,8 @@ export default class RoomView extends React.Component<IProps, IState> {
 
     private checkWidgets = (room) => {
         this.setState({
-            hasPinnedWidgets: WidgetStore.instance.getPinnedApps(room.roomId).length > 0,
-        })
+            hasPinnedWidgets: WidgetLayoutStore.instance.getContainerWidgets(room, Container.Top).length > 0,
+        });
     };
 
     private onReadReceiptsChange = () => {

--- a/src/components/views/context_menus/WidgetContextMenu.tsx
+++ b/src/components/views/context_menus/WidgetContextMenu.tsx
@@ -20,7 +20,7 @@ import {MatrixCapabilities} from "matrix-widget-api";
 import IconizedContextMenu, {IconizedContextMenuOption, IconizedContextMenuOptionList} from "./IconizedContextMenu";
 import {ChevronFace} from "../../structures/ContextMenu";
 import {_t} from "../../../languageHandler";
-import WidgetStore, {IApp} from "../../../stores/WidgetStore";
+import {IApp} from "../../../stores/WidgetStore";
 import WidgetUtils from "../../../utils/WidgetUtils";
 import {WidgetMessagingStore} from "../../../stores/widgets/WidgetMessagingStore";
 import RoomContext from "../../../contexts/RoomContext";
@@ -30,6 +30,7 @@ import Modal from "../../../Modal";
 import QuestionDialog from "../dialogs/QuestionDialog";
 import {WidgetType} from "../../../widgets/WidgetType";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import { Container, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 
 interface IProps extends React.ComponentProps<typeof IconizedContextMenu> {
     app: IApp;
@@ -56,7 +57,7 @@ const WidgetContextMenu: React.FC<IProps> = ({
     let unpinButton;
     if (showUnpin) {
         const onUnpinClick = () => {
-            WidgetStore.instance.unpinWidget(room.roomId, app.id);
+            WidgetLayoutStore.instance.moveToContainer(room, app, Container.Right);
             onFinished();
         };
 
@@ -137,13 +138,13 @@ const WidgetContextMenu: React.FC<IProps> = ({
         revokeButton = <IconizedContextMenuOption onClick={onRevokeClick} label={_t("Revoke permissions")} />;
     }
 
-    const pinnedWidgets = WidgetStore.instance.getPinnedApps(roomId);
+    const pinnedWidgets = WidgetLayoutStore.instance.getContainerWidgets(room, Container.Top);
     const widgetIndex = pinnedWidgets.findIndex(widget => widget.id === app.id);
 
     let moveLeftButton;
     if (showUnpin && widgetIndex > 0) {
         const onClick = () => {
-            WidgetStore.instance.movePinnedWidget(roomId, app.id, -1);
+            WidgetLayoutStore.instance.moveWithinContainer(room, Container.Top, app, -1);
             onFinished();
         };
 
@@ -153,7 +154,7 @@ const WidgetContextMenu: React.FC<IProps> = ({
     let moveRightButton;
     if (showUnpin && widgetIndex < pinnedWidgets.length - 1) {
         const onClick = () => {
-            WidgetStore.instance.movePinnedWidget(roomId, app.id, 1);
+            WidgetLayoutStore.instance.moveWithinContainer(room, Container.Top, app, 1);
             onFinished();
         };
 

--- a/src/components/views/messages/MJitsiWidgetEvent.tsx
+++ b/src/components/views/messages/MJitsiWidgetEvent.tsx
@@ -19,6 +19,8 @@ import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { _t } from "../../../languageHandler";
 import WidgetStore from "../../../stores/WidgetStore";
 import EventTileBubble from "./EventTileBubble";
+import { MatrixClientPeg } from "../../../MatrixClientPeg";
+import { Container, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -33,9 +35,12 @@ export default class MJitsiWidgetEvent extends React.PureComponent<IProps> {
         const url = this.props.mxEvent.getContent()['url'];
         const prevUrl = this.props.mxEvent.getPrevContent()['url'];
         const senderName = this.props.mxEvent.sender?.name || this.props.mxEvent.getSender();
+        const room = MatrixClientPeg.get().getRoom(this.props.mxEvent.getRoomId());
+        const widgetId = this.props.mxEvent.getStateKey();
+        const widget = WidgetStore.instance.getRoom(room.roomId).widgets.find(w => w.id === widgetId);
 
         let joinCopy = _t('Join the conference at the top of this room');
-        if (!WidgetStore.instance.isPinned(this.props.mxEvent.getRoomId(), this.props.mxEvent.getStateKey())) {
+        if (widget && WidgetLayoutStore.instance.isInContainer(room, widget, Container.Right)) {
             joinCopy = _t('Join the conference from the room information card on the right');
         }
 

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -186,9 +186,18 @@ const AppsSection: React.FC<IAppsSectionProps> = ({ room }) => {
         }
     };
 
+    let copyLayoutBtn = null;
+    if (apps.length > 0 && WidgetLayoutStore.instance.canCopyLayoutToRoom(room)) {
+        copyLayoutBtn = (
+            <AccessibleButton kind="link" onClick={() => WidgetLayoutStore.instance.copyLayoutToRoom(room)}>
+                { _t("Set my room layout for everyone") }
+            </AccessibleButton>
+        );
+    }
+
     return <Group className="mx_RoomSummaryCard_appsGroup" title={_t("Widgets")}>
         { apps.map(app => <AppRow key={app.id} app={app} room={room} />) }
-
+        { copyLayoutBtn }
         <AccessibleButton kind="link" onClick={onManageIntegrations}>
             { apps.length > 0 ? _t("Edit widgets, bridges & bots") : _t("Add widgets, bridges & bots") }
         </AccessibleButton>

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -37,13 +37,14 @@ import SettingsStore from "../../../settings/SettingsStore";
 import TextWithTooltip from "../elements/TextWithTooltip";
 import WidgetAvatar from "../avatars/WidgetAvatar";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
-import WidgetStore, {IApp, MAX_PINNED} from "../../../stores/WidgetStore";
+import WidgetStore, {IApp} from "../../../stores/WidgetStore";
 import { E2EStatus } from "../../../utils/ShieldUtils";
 import RoomContext from "../../../contexts/RoomContext";
 import {UIFeature} from "../../../settings/UIFeature";
 import {ChevronFace, ContextMenuTooltipButton, useContextMenu} from "../../structures/ContextMenu";
 import WidgetContextMenu from "../context_menus/WidgetContextMenu";
 import {useRoomMemberCount} from "../../../hooks/useRoomMembers";
+import { Container, MAX_PINNED, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 
 interface IProps {
     room: Room;
@@ -78,6 +79,7 @@ export const useWidgets = (room: Room) => {
 
     useEffect(updateApps, [room]);
     useEventEmitter(WidgetStore.instance, room.roomId, updateApps);
+    useEventEmitter(WidgetLayoutStore.instance, WidgetLayoutStore.emissionForRoom(room), updateApps);
 
     return apps;
 };
@@ -102,10 +104,10 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
         });
     };
 
-    const isPinned = WidgetStore.instance.isPinned(room.roomId, app.id);
+    const isPinned = WidgetLayoutStore.instance.isInContainer(room, app, Container.Top);
     const togglePin = isPinned
-        ? () => { WidgetStore.instance.unpinWidget(room.roomId, app.id); }
-        : () => { WidgetStore.instance.pinWidget(room.roomId, app.id); };
+        ? () => { WidgetLayoutStore.instance.moveToContainer(room, app, Container.Right); }
+        : () => { WidgetLayoutStore.instance.moveToContainer(room, app, Container.Top); };
 
     const [menuDisplayed, handle, openMenu, closeMenu] = useContextMenu<HTMLDivElement>();
     let contextMenu;
@@ -120,7 +122,7 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
         />;
     }
 
-    const cannotPin = !isPinned && !WidgetStore.instance.canPin(room.roomId, app.id);
+    const cannotPin = !isPinned && !WidgetLayoutStore.instance.canAddToContainer(room, Container.Top);
 
     let pinTitle: string;
     if (cannotPin) {

--- a/src/components/views/right_panel/WidgetCard.tsx
+++ b/src/components/views/right_panel/WidgetCard.tsx
@@ -14,22 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, {useContext, useEffect} from "react";
-import {Room} from "matrix-js-sdk/src/models/room";
+import React, { useContext, useEffect } from "react";
+import { Room } from "matrix-js-sdk/src/models/room";
 
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import BaseCard from "./BaseCard";
 import WidgetUtils from "../../../utils/WidgetUtils";
 import AppTile from "../elements/AppTile";
-import {_t} from "../../../languageHandler";
-import {useWidgets} from "./RoomSummaryCard";
-import {RightPanelPhases} from "../../../stores/RightPanelStorePhases";
+import { _t } from "../../../languageHandler";
+import { useWidgets } from "./RoomSummaryCard";
+import { RightPanelPhases } from "../../../stores/RightPanelStorePhases";
 import defaultDispatcher from "../../../dispatcher/dispatcher";
-import {SetRightPanelPhasePayload} from "../../../dispatcher/payloads/SetRightPanelPhasePayload";
-import {Action} from "../../../dispatcher/actions";
-import WidgetStore from "../../../stores/WidgetStore";
-import {ChevronFace, ContextMenuButton, useContextMenu} from "../../structures/ContextMenu";
+import { SetRightPanelPhasePayload } from "../../../dispatcher/payloads/SetRightPanelPhasePayload";
+import { Action } from "../../../dispatcher/actions";
+import { ChevronFace, ContextMenuButton, useContextMenu } from "../../structures/ContextMenu";
 import WidgetContextMenu from "../context_menus/WidgetContextMenu";
+import { Container, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 
 interface IProps {
     room: Room;
@@ -42,7 +42,7 @@ const WidgetCard: React.FC<IProps> = ({ room, widgetId, onClose }) => {
 
     const apps = useWidgets(room);
     const app = apps.find(a => a.id === widgetId);
-    const isPinned = app && WidgetStore.instance.isPinned(room.roomId, app.id);
+    const isPinned = app && WidgetLayoutStore.instance.isInContainer(room, app, Container.Top);
 
     const [menuDisplayed, handle, openMenu, closeMenu] = useContextMenu();
 

--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -287,7 +287,7 @@ const PersistentVResizer = ({
 
     const [height, setHeight] = useStateCallback(defaultHeight, newHeight => {
         newHeight = percentageOf(newHeight, minHeight, maxHeight) * 100;
-        WidgetLayoutStore.instance.setContainerHeight(room, Container.Top, newHeight)
+        WidgetLayoutStore.instance.setContainerHeight(room, Container.Top, newHeight);
     });
 
     return <Resizable

--- a/src/components/views/rooms/AppsDrawer.js
+++ b/src/components/views/rooms/AppsDrawer.js
@@ -30,10 +30,10 @@ import {IntegrationManagers} from "../../../integrations/IntegrationManagers";
 import SettingsStore from "../../../settings/SettingsStore";
 import {useLocalStorageState} from "../../../hooks/useLocalStorageState";
 import ResizeNotifier from "../../../utils/ResizeNotifier";
-import WidgetStore from "../../../stores/WidgetStore";
 import ResizeHandle from "../elements/ResizeHandle";
 import Resizer from "../../../resizer/resizer";
 import PercentageDistributor from "../../../resizer/distributors/percentage";
+import {Container, WidgetLayoutStore} from "../../../stores/widgets/WidgetLayoutStore";
 
 export default class AppsDrawer extends React.Component {
     static propTypes = {
@@ -62,13 +62,13 @@ export default class AppsDrawer extends React.Component {
 
     componentDidMount() {
         ScalarMessaging.startListening();
-        WidgetStore.instance.on(this.props.room.roomId, this._updateApps);
+        WidgetLayoutStore.instance.on(WidgetLayoutStore.emissionForRoom(this.props.room), this._updateApps);
         this.dispatcherRef = dis.register(this.onAction);
     }
 
     componentWillUnmount() {
         ScalarMessaging.stopListening();
-        WidgetStore.instance.off(this.props.room.roomId, this._updateApps);
+        WidgetLayoutStore.instance.off(WidgetLayoutStore.emissionForRoom(this.props.room), this._updateApps);
         if (this.dispatcherRef) dis.unregister(this.dispatcherRef);
         if (this._resizeContainer) {
             this.resizer.detach();
@@ -190,7 +190,7 @@ export default class AppsDrawer extends React.Component {
         }
     };
 
-    _getApps = () => WidgetStore.instance.getPinnedApps(this.props.room.roomId);
+    _getApps = () => WidgetLayoutStore.instance.getContainerWidgets(this.props.room, Container.Top);
 
     _updateApps = () => {
         this.setState({

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -37,6 +37,7 @@ import {E2E_STATE} from "./E2EIcon";
 import {toRem} from "../../../utils/units";
 import {WidgetType} from "../../../widgets/WidgetType";
 import RoomAvatar from "../avatars/RoomAvatar";
+import {WIDGET_LAYOUT_EVENT_TYPE} from "../../../stores/widgets/WidgetLayoutStore";
 
 const eventTileTypes = {
     'm.room.message': 'messages.MessageEvent',
@@ -65,6 +66,7 @@ const stateEventTileTypes = {
     'm.room.server_acl': 'messages.TextualEvent',
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
     'im.vector.modular.widgets': 'messages.TextualEvent',
+    [WIDGET_LAYOUT_EVENT_TYPE]: 'messages.TextualEvent',
     'm.room.tombstone': 'messages.TextualEvent',
     'm.room.join_rules': 'messages.TextualEvent',
     'm.room.guest_access': 'messages.TextualEvent',

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -18,12 +18,12 @@ import {useEffect, useState} from "react";
 import SettingsStore from '../settings/SettingsStore';
 
 // Hook to fetch the value of a setting and dynamically update when it changes
-export const useSettingValue = (settingName: string, roomId: string = null, excludeDefault = false) => {
-    const [value, setValue] = useState(SettingsStore.getValue(settingName, roomId, excludeDefault));
+export const useSettingValue = <T>(settingName: string, roomId: string = null, excludeDefault = false) => {
+    const [value, setValue] = useState(SettingsStore.getValue<T>(settingName, roomId, excludeDefault));
 
     useEffect(() => {
         const ref = SettingsStore.watchSetting(settingName, roomId, () => {
-            setValue(SettingsStore.getValue(settingName, roomId, excludeDefault));
+            setValue(SettingsStore.getValue<T>(settingName, roomId, excludeDefault));
         });
         // clean-up
         return () => {

--- a/src/hooks/useStateCallback.ts
+++ b/src/hooks/useStateCallback.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {Dispatch, SetStateAction, useState} from "react";
+
+// Hook to simplify interactions with a store-backed state values
+// Returns value and method to change the state value
+export const useStateCallback = <T>(initialValue: T, callback: (v: T) => void): [T, Dispatch<SetStateAction<T>>] => {
+    const [value, setValue] = useState(initialValue);
+    const interceptSetValue = (newVal: T) => {
+        setValue(newVal);
+        callback(newVal);
+    };
+    return [value, interceptSetValue];
+};

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -548,6 +548,7 @@
     "%(widgetName)s widget modified by %(senderName)s": "%(widgetName)s widget modified by %(senderName)s",
     "%(widgetName)s widget added by %(senderName)s": "%(widgetName)s widget added by %(senderName)s",
     "%(widgetName)s widget removed by %(senderName)s": "%(widgetName)s widget removed by %(senderName)s",
+    "%(senderName)s has updated the widget layout": "%(senderName)s has updated the widget layout",
     "%(senderName)s removed the rule banning users matching %(glob)s": "%(senderName)s removed the rule banning users matching %(glob)s",
     "%(senderName)s removed the rule banning rooms matching %(glob)s": "%(senderName)s removed the rule banning rooms matching %(glob)s",
     "%(senderName)s removed the rule banning servers matching %(glob)s": "%(senderName)s removed the rule banning servers matching %(glob)s",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1636,6 +1636,7 @@
     "Unpin": "Unpin",
     "Unpin a widget to view it in this panel": "Unpin a widget to view it in this panel",
     "Options": "Options",
+    "Set my room layout for everyone": "Set my room layout for everyone",
     "Widgets": "Widgets",
     "Edit widgets, bridges & bots": "Edit widgets, bridges & bots",
     "Add widgets, bridges & bots": "Add widgets, bridges & bots",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -633,7 +633,11 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         displayName: _td("Show chat effects"),
         default: true,
     },
-    "Widgets.pinned": {
+    "Widgets.pinned": { // deprecated
+        supportedLevels: LEVELS_ROOM_OR_ACCOUNT,
+        default: {},
+    },
+    "Widgets.layout": {
         supportedLevels: LEVELS_ROOM_OR_ACCOUNT,
         default: {},
     },

--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -276,7 +276,7 @@ export default class SettingsStore {
      * @param {boolean} excludeDefault True to disable using the default value.
      * @return {*} The value, or null if not found
      */
-    public static getValue(settingName: string, roomId: string = null, excludeDefault = false): any {
+    public static getValue<T = any>(settingName: string, roomId: string = null, excludeDefault = false): T {
         // Verify that the setting is actually a setting
         if (!SETTINGS[settingName]) {
             throw new Error("Setting '" + settingName + "' does not appear to be a setting.");

--- a/src/stores/AsyncStoreWithClient.ts
+++ b/src/stores/AsyncStoreWithClient.ts
@@ -21,13 +21,13 @@ import { Dispatcher } from "flux";
 import { ReadyWatchingStore } from "./ReadyWatchingStore";
 
 export abstract class AsyncStoreWithClient<T extends Object> extends AsyncStore<T> {
-    private readyStore: ReadyWatchingStore;
+    protected readyStore: ReadyWatchingStore;
 
     protected constructor(dispatcher: Dispatcher<ActionPayload>, initialState: T = <T>{}) {
         super(dispatcher, initialState);
 
         // Create an anonymous class to avoid code duplication
-        const asyncStore = this;
+        const asyncStore = this; // eslint-disable-line @typescript-eslint/no-this-alias
         this.readyStore = new (class extends ReadyWatchingStore {
             public get mxClient(): MatrixClient {
                 return this.matrixClient;

--- a/src/stores/AsyncStoreWithClient.ts
+++ b/src/stores/AsyncStoreWithClient.ts
@@ -18,22 +18,33 @@ import { MatrixClient } from "matrix-js-sdk/src/client";
 import { AsyncStore } from "./AsyncStore";
 import { ActionPayload } from "../dispatcher/payloads";
 import { Dispatcher } from "flux";
-import { MatrixClientPeg } from "../MatrixClientPeg";
+import { ReadyWatchingStore } from "./ReadyWatchingStore";
 
 export abstract class AsyncStoreWithClient<T extends Object> extends AsyncStore<T> {
-    protected matrixClient: MatrixClient;
-
-    protected abstract async onAction(payload: ActionPayload);
+    private readyStore: ReadyWatchingStore;
 
     protected constructor(dispatcher: Dispatcher<ActionPayload>, initialState: T = <T>{}) {
         super(dispatcher, initialState);
 
-        if (MatrixClientPeg.get()) {
-            this.matrixClient = MatrixClientPeg.get();
+        // Create an anonymous class to avoid code duplication
+        const asyncStore = this;
+        this.readyStore = new (class extends ReadyWatchingStore {
+            public get mxClient(): MatrixClient {
+                return this.matrixClient;
+            }
 
-            // noinspection JSIgnoredPromiseFromCall
-            this.onReady();
-        }
+            protected async onReady(): Promise<any> {
+                return asyncStore.onReady();
+            }
+
+            protected async onNotReady(): Promise<any> {
+                return asyncStore.onNotReady();
+            }
+        })(dispatcher);
+    }
+
+    protected get matrixClient(): MatrixClient {
+        return this.readyStore.mxClient;
     }
 
     protected async onReady() {
@@ -44,30 +55,9 @@ export abstract class AsyncStoreWithClient<T extends Object> extends AsyncStore<
         // Default implementation is to do nothing.
     }
 
+    protected abstract async onAction(payload: ActionPayload);
+
     protected async onDispatch(payload: ActionPayload) {
         await this.onAction(payload);
-
-        if (payload.action === 'MatrixActions.sync') {
-            // Only set the client on the transition into the PREPARED state.
-            // Everything after this is unnecessary (we only need to know once we have a client)
-            // and we intentionally don't set the client before this point to avoid stores
-            // updating for every event emitted during the cached sync.
-            if (!(payload.prevState === 'PREPARED' && payload.state !== 'PREPARED')) {
-                return;
-            }
-
-            if (this.matrixClient !== payload.matrixClient) {
-                if (this.matrixClient) {
-                    await this.onNotReady();
-                }
-                this.matrixClient = payload.matrixClient;
-                await this.onReady();
-            }
-        } else if (payload.action === 'on_client_not_viable' || payload.action === 'on_logged_out') {
-            if (this.matrixClient) {
-                await this.onNotReady();
-                this.matrixClient = null;
-            }
-        }
     }
 }

--- a/src/stores/ReadyWatchingStore.ts
+++ b/src/stores/ReadyWatchingStore.ts
@@ -42,6 +42,10 @@ export abstract class ReadyWatchingStore extends EventEmitter implements IDestro
         return this.matrixClient; // for external readonly access
     }
 
+    public useUnitTestClient(cli: MatrixClient) {
+        this.matrixClient = cli;
+    }
+
     public destroy() {
         this.dispatcher.unregister(this.dispatcherRef);
     }

--- a/src/stores/ReadyWatchingStore.ts
+++ b/src/stores/ReadyWatchingStore.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MatrixClient } from "matrix-js-sdk/src/client";
+import { MatrixClientPeg } from "../MatrixClientPeg";
+import { ActionPayload } from "../dispatcher/payloads";
+import { Dispatcher } from "flux";
+import { IDestroyable } from "../utils/IDestroyable";
+import { EventEmitter } from "events";
+
+export abstract class ReadyWatchingStore extends EventEmitter implements IDestroyable {
+    protected matrixClient: MatrixClient;
+    private readonly dispatcherRef: string;
+
+    constructor(protected readonly dispatcher: Dispatcher<ActionPayload>) {
+        super();
+
+        this.dispatcherRef = this.dispatcher.register(this.onAction);
+
+        if (MatrixClientPeg.get()) {
+            this.matrixClient = MatrixClientPeg.get();
+
+            // noinspection JSIgnoredPromiseFromCall
+            this.onReady();
+        }
+    }
+
+    public get mxClient(): MatrixClient {
+        return this.matrixClient; // for external readonly access
+    }
+
+    public destroy() {
+        this.dispatcher.unregister(this.dispatcherRef);
+    }
+
+    protected async onReady() {
+        // Default implementation is to do nothing.
+    }
+
+    protected async onNotReady() {
+        // Default implementation is to do nothing.
+    }
+
+    private onAction = async (payload: ActionPayload) => {
+        if (payload.action === 'MatrixActions.sync') {
+            // Only set the client on the transition into the PREPARED state.
+            // Everything after this is unnecessary (we only need to know once we have a client)
+            // and we intentionally don't set the client before this point to avoid stores
+            // updating for every event emitted during the cached sync.
+            if (!(payload.prevState === 'PREPARED' && payload.state !== 'PREPARED')) {
+                return;
+            }
+
+            if (this.matrixClient !== payload.matrixClient) {
+                if (this.matrixClient) {
+                    await this.onNotReady();
+                }
+                this.matrixClient = payload.matrixClient;
+                await this.onReady();
+            }
+        } else if (payload.action === 'on_client_not_viable' || payload.action === 'on_logged_out') {
+            if (this.matrixClient) {
+                await this.onNotReady();
+                this.matrixClient = null;
+            }
+        }
+    };
+}

--- a/src/stores/WidgetStore.ts
+++ b/src/stores/WidgetStore.ts
@@ -21,16 +21,12 @@ import { IWidget } from "matrix-widget-api";
 import { ActionPayload } from "../dispatcher/payloads";
 import { AsyncStoreWithClient } from "./AsyncStoreWithClient";
 import defaultDispatcher from "../dispatcher/dispatcher";
-import SettingsStore from "../settings/SettingsStore";
 import WidgetEchoStore from "../stores/WidgetEchoStore";
-import RoomViewStore from "../stores/RoomViewStore";
 import ActiveWidgetStore from "../stores/ActiveWidgetStore";
 import WidgetUtils from "../utils/WidgetUtils";
-import {SettingLevel} from "../settings/SettingLevel";
 import {WidgetType} from "../widgets/WidgetType";
 import {UPDATE_EVENT} from "./AsyncStore";
 import { MatrixClientPeg } from "../MatrixClientPeg";
-import { arrayDiff, arrayHasDiff, arrayUnion } from "../utils/arrays";
 
 interface IState {}
 
@@ -41,14 +37,9 @@ export interface IApp extends IWidget {
     avatar_url: string; // MSC2765 https://github.com/matrix-org/matrix-doc/pull/2765
 }
 
-type PinnedWidgets = Record<string, boolean>;
-
 interface IRoomWidgets {
     widgets: IApp[];
-    pinned: PinnedWidgets;
 }
-
-export const MAX_PINNED = 3;
 
 function widgetUid(app: IApp): string {
     return `${app.roomId ?? MatrixClientPeg.get().getUserId()}::${app.id}`;
@@ -65,7 +56,6 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
     private constructor() {
         super(defaultDispatcher, {});
 
-        SettingsStore.watchSetting("Widgets.pinned", null, this.onPinnedWidgetsChange);
         WidgetEchoStore.on("update", this.onWidgetEchoStoreUpdate);
     }
 
@@ -76,7 +66,6 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
     private initRoom(roomId: string) {
         if (!this.roomMap.has(roomId)) {
             this.roomMap.set(roomId, {
-                pinned: {}, // ordered
                 widgets: [],
             });
         }
@@ -85,16 +74,6 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
     protected async onReady(): Promise<any> {
         this.matrixClient.on("RoomState.events", this.onRoomStateEvents);
         this.matrixClient.getRooms().forEach((room: Room) => {
-            const pinned = SettingsStore.getValue("Widgets.pinned", room.roomId);
-
-            if (pinned || WidgetUtils.getRoomWidgets(room).length) {
-                this.initRoom(room.roomId);
-            }
-
-            if (pinned) {
-                this.getRoom(room.roomId).pinned = pinned;
-            }
-
             this.loadRoomWidgets(room);
         });
         this.emit(UPDATE_EVENT);
@@ -128,7 +107,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
 
     private loadRoomWidgets(room: Room) {
         if (!room) return;
-        const roomInfo = this.roomMap.get(room.roomId);
+        const roomInfo = this.roomMap.get(room.roomId) || <IRoomWidgets>{};
         roomInfo.widgets = [];
 
         // first clean out old widgets from the map which originate from this room
@@ -138,6 +117,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
             this.widgetMap.delete(widgetUid(app));
         });
 
+        let edited = false;
         this.generateApps(room).forEach(app => {
             // Sanity check for https://github.com/vector-im/element-web/issues/15705
             const existingApp = this.widgetMap.get(widgetUid(app));
@@ -150,12 +130,16 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
 
             this.widgetMap.set(widgetUid(app), app);
             roomInfo.widgets.push(app);
+            edited = true;
         });
+        if (edited && !this.roomMap.has(room.roomId)) {
+            this.roomMap.set(room.roomId, roomInfo);
+        }
         this.emit(room.roomId);
     }
 
     private onRoomStateEvents = (ev: MatrixEvent) => {
-        if (ev.getType() !== "im.vector.modular.widgets") return;
+        if (ev.getType() !== "im.vector.modular.widgets") return; // TODO: Support m.widget too
         const roomId = ev.getRoomId();
         this.initRoom(roomId);
         this.loadRoomWidgets(this.matrixClient.getRoom(roomId));
@@ -165,156 +149,6 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
     public getRoom = (roomId: string) => {
         return this.roomMap.get(roomId);
     };
-
-    private onPinnedWidgetsChange = (settingName: string, roomId: string) => {
-        this.initRoom(roomId);
-
-        const pinned: PinnedWidgets = SettingsStore.getValue(settingName, roomId);
-
-        // Sanity check for https://github.com/vector-im/element-web/issues/15705
-        const roomInfo = this.getRoom(roomId);
-        const remappedPinned: PinnedWidgets = {};
-        for (const widgetId of Object.keys(pinned)) {
-            const isPinned = pinned[widgetId];
-            if (!roomInfo.widgets?.some(w => w.id === widgetId)) {
-                console.warn(`Skipping pinned widget update for ${widgetId} in ${roomId} -- wrong room`);
-            } else {
-                remappedPinned[widgetId] = isPinned;
-            }
-        }
-        roomInfo.pinned = remappedPinned;
-
-        this.emit(roomId);
-        this.emit(UPDATE_EVENT);
-    };
-
-    public isPinned(roomId: string, widgetId: string) {
-        return !!this.getPinnedApps(roomId).find(w => w.id === widgetId);
-    }
-
-    // dev note: we don't need the widgetId on this function, but the contract makes more sense
-    // when we require it.
-    public canPin(roomId: string, widgetId: string) {
-        return this.getPinnedApps(roomId).length < MAX_PINNED;
-    }
-
-    public pinWidget(roomId: string, widgetId: string) {
-        const roomInfo = this.getRoom(roomId);
-        if (!roomInfo) return;
-
-        // When pinning, first confirm all the widgets (Jitsi) which were autopinned so that the order is correct
-        const autoPinned = this.getPinnedApps(roomId).filter(app => !roomInfo.pinned[app.id]);
-        autoPinned.forEach(app => {
-            this.setPinned(roomId, app.id, true);
-        });
-
-        this.setPinned(roomId, widgetId, true);
-
-        // Show the apps drawer upon the user pinning a widget
-        if (RoomViewStore.getRoomId() === roomId) {
-            defaultDispatcher.dispatch({
-                action: "appsDrawer",
-                show: true,
-            });
-        }
-    }
-
-    public unpinWidget(roomId: string, widgetId: string) {
-        this.setPinned(roomId, widgetId, false);
-    }
-
-    private setPinned(roomId: string, widgetId: string, value: boolean) {
-        const roomInfo = this.getRoom(roomId);
-        if (!roomInfo) return;
-        if (roomInfo.pinned[widgetId] === false && value) {
-            // delete this before write to maintain the correct object insertion order
-            delete roomInfo.pinned[widgetId];
-        }
-        roomInfo.pinned[widgetId] = value;
-
-        // Clean up the pinned record
-        Object.keys(roomInfo).forEach(wId => {
-            if (!roomInfo.widgets.some(w => w.id === wId) || !roomInfo.pinned[wId]) {
-                delete roomInfo.pinned[wId];
-            }
-        });
-
-        SettingsStore.setValue("Widgets.pinned", roomId, SettingLevel.ROOM_ACCOUNT, roomInfo.pinned);
-        this.emit(roomId);
-        this.emit(UPDATE_EVENT);
-    }
-
-    public movePinnedWidget(roomId: string, widgetId: string, delta: 1 | -1) {
-        // TODO simplify this by changing the storage medium of pinned to an array once the Jitsi default-on goes away
-        const roomInfo = this.getRoom(roomId);
-        if (!roomInfo || roomInfo.pinned[widgetId] === false) return;
-
-        const pinnedApps = this.getPinnedApps(roomId).map(app => app.id);
-        const i = pinnedApps.findIndex(id => id === widgetId);
-
-        if (delta > 0) {
-            pinnedApps.splice(i, 2, pinnedApps[i + 1], pinnedApps[i]);
-        } else {
-            pinnedApps.splice(i - 1, 2, pinnedApps[i], pinnedApps[i - 1]);
-        }
-
-        const reorderedPinned: IRoomWidgets["pinned"] = {};
-        pinnedApps.forEach(id => {
-            reorderedPinned[id] = true;
-        });
-        Object.keys(roomInfo.pinned).forEach(id => {
-            if (reorderedPinned[id] === undefined) {
-                reorderedPinned[id] = roomInfo.pinned[id];
-            }
-        });
-        roomInfo.pinned = reorderedPinned;
-
-        SettingsStore.setValue("Widgets.pinned", roomId, SettingLevel.ROOM_ACCOUNT, roomInfo.pinned);
-        this.emit(roomId);
-        this.emit(UPDATE_EVENT);
-    }
-
-    public getPinnedApps(roomId: string): IApp[] {
-        // returns the apps in the order they were pinned with, up to the maximum
-        const roomInfo = this.getRoom(roomId);
-        if (!roomInfo) return [];
-
-        // Show Jitsi widgets even if the user already had the maximum pinned, instead of their latest pinned,
-        // except if the user already explicitly unpinned the Jitsi widget
-        const priorityWidget = roomInfo.widgets.find(widget => {
-            return roomInfo.pinned[widget.id] === undefined && WidgetType.JITSI.matches(widget.type);
-        });
-
-        const order = Object.keys(roomInfo.pinned).filter(k => roomInfo.pinned[k]);
-        const apps = order
-            .map(wId => Array.from(this.widgetMap.values())
-                .find(w2 => w2.roomId === roomId && w2.id === wId))
-            .filter(Boolean)
-            .slice(0, priorityWidget ? MAX_PINNED - 1 : MAX_PINNED);
-        if (priorityWidget) {
-            apps.push(priorityWidget);
-        }
-
-        // Sanity check for https://github.com/vector-im/element-web/issues/15705
-        // We union the app IDs the above generated with the roomInfo's known widgets to
-        // get a list of IDs which both exist. We then diff that against the generated app
-        // IDs above to ensure that all of the app IDs are captured by the union with the
-        // room - if we grabbed a widget that wasn't part of the roomInfo's list, it wouldn't
-        // be in the union and thus result in a diff.
-        const appIds = apps.map(a => widgetUid(a));
-        const roomAppIds = roomInfo.widgets.map(a => widgetUid(a));
-        const roomAppIdsUnion = arrayUnion(appIds, roomAppIds);
-        const missingSomeApps = arrayHasDiff(roomAppIdsUnion, appIds);
-        if (missingSomeApps) {
-            const diff = arrayDiff(roomAppIdsUnion, appIds);
-            console.warn(
-                `${roomId} appears to have a conflict for which widgets belong to it. ` +
-                `Widget UIDs are: `, [...diff.added, ...diff.removed],
-            );
-        }
-
-        return apps;
-    }
 
     public getApps(roomId: string): IApp[] {
         const roomInfo = this.getRoom(roomId);

--- a/src/stores/WidgetStore.ts
+++ b/src/stores/WidgetStore.ts
@@ -76,7 +76,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
         this.matrixClient.getRooms().forEach((room: Room) => {
             this.loadRoomWidgets(room);
         });
-        this.emit(UPDATE_EVENT);
+        this.emit(UPDATE_EVENT, null); // emit for all rooms
     }
 
     protected async onNotReady(): Promise<any> {
@@ -94,7 +94,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
     private onWidgetEchoStoreUpdate = (roomId: string, widgetId: string) => {
         this.initRoom(roomId);
         this.loadRoomWidgets(this.matrixClient.getRoom(roomId));
-        this.emit(UPDATE_EVENT);
+        this.emit(UPDATE_EVENT, roomId);
     };
 
     private generateApps(room: Room): IApp[] {
@@ -143,7 +143,7 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
         const roomId = ev.getRoomId();
         this.initRoom(roomId);
         this.loadRoomWidgets(this.matrixClient.getRoom(roomId));
-        this.emit(UPDATE_EVENT);
+        this.emit(UPDATE_EVENT, roomId);
     };
 
     public getRoom = (roomId: string) => {

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -114,7 +114,7 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     // Public for test usage. Do not call this.
     public async makeReady(forcedClient?: MatrixClient) {
         if (forcedClient) {
-            super.readyStore.matrixClient = forcedClient;
+            super.readyStore.useUnitTestClient(forcedClient);
         }
 
         this.checkLoggingEnabled();

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -114,7 +114,7 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     // Public for test usage. Do not call this.
     public async makeReady(forcedClient?: MatrixClient) {
         if (forcedClient) {
-            super.matrixClient = forcedClient;
+            super.readyStore.matrixClient = forcedClient;
         }
 
         this.checkLoggingEnabled();

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -114,7 +114,7 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     // Public for test usage. Do not call this.
     public async makeReady(forcedClient?: MatrixClient) {
         if (forcedClient) {
-            super.readyStore.useUnitTestClient(forcedClient);
+            this.readyStore.useUnitTestClient(forcedClient);
         }
 
         this.checkLoggingEnabled();

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SettingsStore from "../../settings/SettingsStore";
+import { Room } from "matrix-js-sdk/src/models/room";
+import WidgetStore, { IApp } from "../WidgetStore";
+import { WidgetType } from "../../widgets/WidgetType";
+import { clamp, defaultNumber } from "../../utils/numbers";
+import { EventEmitter } from "events";
+import { AsyncStoreWithClient } from "../AsyncStoreWithClient";
+import defaultDispatcher from "../../dispatcher/dispatcher";
+import { ReadyWatchingStore } from "../ReadyWatchingStore";
+import { MatrixEvent } from "matrix-js-sdk/src/models/event";
+
+export const WIDGET_LAYOUT_EVENT_TYPE = "io.element.widgets.layout";
+
+export enum Container {
+    // "Top" is the app drawer, and currently the only sensible value.
+    Top = "top",
+
+    // "Right" is the right panel, and the default for widgets. Setting
+    // this as a container on a widget is essentially like saying "no
+    // changes needed", though this may change in the future.
+    Right = "right",
+
+    // ... more as needed. Note that most of this code assumes that there
+    // are only two containers, and that only the top container is special.
+}
+
+interface IStoredLayout {
+    // Where to store the widget. Required.
+    container: Container;
+
+    // The index (order) to position the widgets in. Only applies for
+    // ordered containers (like the top container). Smaller numbers first,
+    // and conflicts resolved by comparing widget IDs.
+    index?: number;
+
+    // Percentage (integer) for relative width of the container to consume.
+    // Clamped to 0-100 and may have minimums imposed upon it. Only applies
+    // to containers which support inner resizing (currently only the top
+    // container).
+    width?: number;
+
+    // Percentage (integer) for relative height of the container. Note that
+    // this only applies to the top container currently, and that container
+    // will take the highest value among widgets in the container. Clamped
+    // to 0-100 and may have minimums imposed on it.
+    height?: number;
+
+    // TODO: [Deferred] Maximizing (fullscreen) widgets by default.
+}
+
+interface ILayoutStateEvent {
+    // TODO: [Deferred] Forced layout (fixed with no changes)
+
+    // The widget layouts.
+    widgets: {
+        [widgetId: string]: IStoredLayout;
+    };
+}
+
+interface ILayoutSettings extends ILayoutStateEvent {
+    overrides?: string; // event ID for layout state event, if present
+}
+
+// Dev note: "Pinned" widgets are ones in the top container.
+const MAX_PINNED = 3;
+
+const MIN_WIDGET_WIDTH_PCT = 10; // Don't make anything smaller than 10% width
+const MIN_WIDGET_HEIGHT_PCT = 20;
+
+export class WidgetLayoutStore extends ReadyWatchingStore {
+    private static internalInstance: WidgetLayoutStore;
+
+    private byRoom: {
+        [roomId: string]: {
+            // @ts-ignore - TS wants a string key, but we know better
+            [container: Container]: {
+                ordered: IApp[];
+                height?: number;
+                distributions?: number[];
+            };
+        };
+    } = {};
+
+    private constructor() {
+        super(defaultDispatcher);
+    }
+
+    public static get instance(): WidgetLayoutStore {
+        if (!WidgetLayoutStore.internalInstance) {
+            WidgetLayoutStore.internalInstance = new WidgetLayoutStore();
+        }
+        return WidgetLayoutStore.internalInstance;
+    }
+
+    public static emissionForRoom(room: Room): string {
+        return `update_${room.roomId}`;
+    }
+
+    private emitFor(room: Room) {
+        this.emit(WidgetLayoutStore.emissionForRoom(room));
+    }
+
+    protected async onReady(): Promise<any> {
+        this.byRoom = {};
+        for (const room of this.matrixClient.getVisibleRooms()) {
+            this.recalculateRoom(room);
+        }
+
+        this.matrixClient.on("RoomState.events", this.updateRoomFromState);
+        // TODO: Register settings listeners
+        // TODO: Register WidgetStore listener
+    }
+
+    protected async onNotReady(): Promise<any> {
+        this.byRoom = {};
+    }
+
+    private updateRoomFromState = (ev: MatrixEvent) => {
+        if (ev.getType() !== WIDGET_LAYOUT_EVENT_TYPE) return;
+        const room = this.matrixClient.getRoom(ev.getRoomId());
+        this.recalculateRoom(room);
+    };
+
+    private recalculateRoom(room: Room) {
+        const widgets = WidgetStore.instance.getApps(room.roomId);
+        if (!widgets?.length) {
+            this.byRoom[room.roomId] = {};
+            this.emitFor(room);
+            return;
+        }
+
+        const layoutEv = room.currentState.getStateEvents(WIDGET_LAYOUT_EVENT_TYPE, "");
+        const legacyPinned = SettingsStore.getValue("Widgets.pinned", room.roomId);
+        let userLayout = SettingsStore.getValue<ILayoutSettings>("Widgets.layout", room.roomId);
+
+        if (layoutEv && userLayout && userLayout.overrides !== layoutEv.getId()) {
+            // For some other layout that we don't really care about. The user can reset this
+            // by updating their personal layout.
+            userLayout = null;
+        }
+
+        const roomLayout: ILayoutStateEvent = layoutEv ? layoutEv.getContent() : null;
+
+        // We essentially just need to find the top container's widgets because we
+        // only have two containers. Anything not in the top widget by the end of this
+        // function will go into the right container.
+        const topWidgets: IApp[] = [];
+        const rightWidgets: IApp[] = [];
+        for (const widget of widgets) {
+            if (WidgetType.JITSI.matches(widget.type)) {
+                topWidgets.push(widget);
+                continue;
+            }
+
+            const stateContainer = roomLayout?.widgets?.[widget.id]?.container;
+            const manualContainer = userLayout?.widgets?.[widget.id]?.container;
+            const isLegacyPinned = !!legacyPinned?.[widget.id];
+            const defaultContainer = WidgetType.JITSI.matches(widget.type) ? Container.Top : Container.Right;
+
+            if (manualContainer === Container.Right) {
+                rightWidgets.push(widget);
+            } else if (manualContainer === Container.Top || stateContainer === Container.Top) {
+                topWidgets.push(widget);
+            } else if (isLegacyPinned && !stateContainer) {
+                topWidgets.push(widget);
+            } else {
+                (defaultContainer === Container.Top ? topWidgets : rightWidgets).push(widget);
+            }
+        }
+
+        // Trim to MAX_PINNED
+        const runoff = topWidgets.slice(MAX_PINNED);
+        rightWidgets.push(...runoff);
+
+        // Order the widgets in the top container, putting autopinned Jitsi widgets first
+        // unless they have a specific order in mind
+        topWidgets.sort((a, b) => {
+            const layoutA = roomLayout?.widgets?.[a.id];
+            const layoutB = roomLayout?.widgets?.[b.id];
+
+            const userLayoutA = userLayout?.widgets?.[a.id];
+            const userLayoutB = userLayout?.widgets?.[b.id];
+
+            // Jitsi widgets are defaulted to be the leftmost widget whereas other widgets
+            // default to the right side.
+            const defaultA = WidgetType.JITSI.matches(a.type) ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+            const defaultB = WidgetType.JITSI.matches(b.type) ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+
+            const orderA = defaultNumber(userLayoutA, defaultNumber(layoutA?.index, defaultA));
+            const orderB = defaultNumber(userLayoutB, defaultNumber(layoutB?.index, defaultB));
+
+            if (orderA === orderB) {
+                // We just need a tiebreak
+                return a.id.localeCompare(b.id);
+            }
+
+            return orderA - orderB;
+        });
+
+        // Determine width distribution and height of the top container now (the only relevant one)
+        const widths: number[] = [];
+        let maxHeight = 0;
+        let doAutobalance = true;
+        for (let i = 0; i < topWidgets.length; i++) {
+            const widget = topWidgets[i];
+            const widgetLayout = roomLayout?.widgets?.[widget.id];
+            const userWidgetLayout = userLayout?.widgets?.[widget.id];
+
+            if (Number.isFinite(userWidgetLayout?.width) || Number.isFinite(widgetLayout?.width)) {
+                const val = userWidgetLayout?.width || widgetLayout?.width;
+                const normalized = clamp(val, MIN_WIDGET_WIDTH_PCT, 100);
+                widths.push(normalized);
+                doAutobalance = false; // a manual width was specified
+            } else {
+                widths.push(100); // we'll figure this out later
+            }
+
+            const defRoomHeight = defaultNumber(widgetLayout?.height, MIN_WIDGET_HEIGHT_PCT);
+            const h = defaultNumber(userWidgetLayout?.height, defRoomHeight);
+            maxHeight = Math.max(maxHeight, clamp(h, MIN_WIDGET_HEIGHT_PCT, 100));
+        }
+        let remainingWidth = 100;
+        for (const width of widths) {
+            remainingWidth -= width;
+        }
+        if (topWidgets.length > 1 && remainingWidth < MIN_WIDGET_WIDTH_PCT) {
+            const toReclaim = MIN_WIDGET_WIDTH_PCT - remainingWidth;
+            for (let i = 0; i < widths.length - 1; i++) {
+                widths[i] = widths[i] - (toReclaim / (widths.length - 1));
+            }
+            widths[widths.length - 1] = MIN_WIDGET_WIDTH_PCT;
+        }
+        if (doAutobalance) {
+            for (let i = 0; i < widths.length; i++) {
+                widths[i] = 100 / widths.length;
+            }
+        }
+
+        // Finally, fill in our cache and update
+        this.byRoom[room.roomId] = {
+            [Container.Top]: {
+                ordered: topWidgets,
+                distributions: widths,
+                height: maxHeight,
+            },
+            [Container.Right]: {
+                ordered: rightWidgets,
+            },
+        };
+        this.emitFor(room);
+    }
+
+    public getContainerWidgets(room: Room, container: Container): IApp[] {
+        return this.byRoom[room.roomId]?.[container]?.ordered || [];
+    }
+}
+
+window.mxWidgetLayoutStore = WidgetLayoutStore.instance;

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -103,6 +103,9 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         };
     } = {};
 
+    private pinnedRef: string;
+    private layoutRef: string;
+
     private constructor() {
         super(defaultDispatcher);
     }
@@ -126,13 +129,17 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         this.updateAllRooms();
 
         this.matrixClient.on("RoomState.events", this.updateRoomFromState);
-        SettingsStore.watchSetting("Widgets.pinned", null, this.updateFromSettings);
-        SettingsStore.watchSetting("Widgets.layout", null, this.updateFromSettings);
+        this.pinnedRef = SettingsStore.watchSetting("Widgets.pinned", null, this.updateFromSettings);
+        this.layoutRef = SettingsStore.watchSetting("Widgets.layout", null, this.updateFromSettings);
         WidgetStore.instance.on(UPDATE_EVENT, this.updateAllRooms);
     }
 
     protected async onNotReady(): Promise<any> {
         this.byRoom = {};
+
+        SettingsStore.unwatchSetting(this.pinnedRef);
+        SettingsStore.unwatchSetting(this.layoutRef);
+        WidgetStore.instance.off(UPDATE_EVENT, this.updateAllRooms);
     }
 
     private updateAllRooms = () => {

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -444,7 +444,8 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         SettingsStore.setValue("Widgets.layout", room.roomId, SettingLevel.ROOM_ACCOUNT, {
             overrides: layoutEv?.getId(),
             widgets: newLayout,
-        });
+        }).catch(() => this.recalculateRoom(room));
+        this.recalculateRoom(room); // call to try local echo on changes (the catch above undoes any errors)
     }
 }
 

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -155,7 +155,7 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         if (room) this.recalculateRoom(room);
     };
 
-    private updateFromSettings = (settingName: string, roomId: string, /* and other stuff */) => {
+    private updateFromSettings = (settingName: string, roomId: string /* and other stuff */) => {
         if (roomId) {
             const room = this.matrixClient.getRoom(roomId);
             if (room) this.recalculateRoom(room);
@@ -265,10 +265,6 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
                 const h = defaultNumber(userWidgetLayout?.height, defRoomHeight);
                 maxHeight = Math.max(maxHeight, clamp(h, MIN_WIDGET_HEIGHT_PCT, 100));
             }
-        }
-        let remainingWidth = 100;
-        for (const width of widths) {
-            remainingWidth -= width;
         }
         if (doAutobalance) {
             for (let i = 0; i < widths.length; i++) {
@@ -406,7 +402,9 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
     public moveToContainer(room: Room, widget: IApp, toContainer: Container) {
         const allWidgets = this.getAllWidgets(room);
         if (!allWidgets.some(([w])=> w.id === widget.id)) return; // invalid
-        this.updateUserLayout(room, {[widget.id]:{container: toContainer}});
+        this.updateUserLayout(room, {
+            [widget.id]: {container: toContainer},
+        });
     }
 
     public canCopyLayoutToRoom(room: Room): boolean {

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -131,7 +131,7 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         this.matrixClient.on("RoomState.events", this.updateRoomFromState);
         this.pinnedRef = SettingsStore.watchSetting("Widgets.pinned", null, this.updateFromSettings);
         this.layoutRef = SettingsStore.watchSetting("Widgets.layout", null, this.updateFromSettings);
-        WidgetStore.instance.on(UPDATE_EVENT, this.updateAllRooms);
+        WidgetStore.instance.on(UPDATE_EVENT, this.updateFromWidgetStore);
     }
 
     protected async onNotReady(): Promise<any> {
@@ -139,13 +139,22 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
 
         SettingsStore.unwatchSetting(this.pinnedRef);
         SettingsStore.unwatchSetting(this.layoutRef);
-        WidgetStore.instance.off(UPDATE_EVENT, this.updateAllRooms);
+        WidgetStore.instance.off(UPDATE_EVENT, this.updateFromWidgetStore);
     }
 
     private updateAllRooms = () => {
         this.byRoom = {};
         for (const room of this.matrixClient.getVisibleRooms()) {
             this.recalculateRoom(room);
+        }
+    };
+
+    private updateFromWidgetStore = (roomId?:string) => {
+        if (roomId) {
+            const room = this.matrixClient.getRoom(roomId);
+            if (room) this.recalculateRoom(room);
+        } else {
+            this.updateAllRooms();
         }
     };
 

--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -149,7 +149,7 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         }
     };
 
-    private updateFromWidgetStore = (roomId?:string) => {
+    private updateFromWidgetStore = (roomId?: string) => {
         if (roomId) {
             const room = this.matrixClient.getRoom(roomId);
             if (room) this.recalculateRoom(room);

--- a/src/utils/WidgetUtils.ts
+++ b/src/utils/WidgetUtils.ts
@@ -28,7 +28,7 @@ import {WidgetType} from "../widgets/WidgetType";
 import {objectClone} from "./objects";
 import {_t} from "../languageHandler";
 import {Capability, IWidgetData, MatrixCapabilities} from "matrix-widget-api";
-import {IApp} from "../stores/WidgetStore"; // TODO @@
+import {IApp} from "../stores/WidgetStore";
 
 // How long we wait for the state event echo to come back from the server
 // before waitFor[Room/User]Widget rejects its promise

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -28,3 +28,7 @@ export function defaultNumber(i: unknown, def: number): number {
 export function clamp(i: number, min: number, max: number): number {
     return Math.min(Math.max(i, min), max);
 }
+
+export function sum(...i: number[]): number {
+    return [...i].reduce((p, c) => c + p, 0);
+}

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -38,5 +38,5 @@ export function percentageWithin(pct: number, min: number, max: number): number 
 }
 
 export function percentageOf(val: number, min: number, max: number): number {
-    return (val - min) / max;
+    return (val - min) / (max - min);
 }

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -32,3 +32,11 @@ export function clamp(i: number, min: number, max: number): number {
 export function sum(...i: number[]): number {
     return [...i].reduce((p, c) => c + p, 0);
 }
+
+export function percentageWithin(pct: number, min: number, max: number): number {
+    return (pct * (max - min)) + min;
+}
+
+export function percentageOf(val: number, min: number, max: number): number {
+    return (val - min) / max;
+}

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Returns the default number if the given value, i, is not a number. Otherwise
+ * returns the given value.
+ * @param {*} i The value to check.
+ * @param {number} def The default value.
+ * @returns {number} Either the value or the default value, whichever is a number.
+ */
+export function defaultNumber(i: unknown, def: number): number {
+    return Number.isFinite(i) ? Number(i) : def;
+}
+
+export function clamp(i: number, min: number, max: number): number {
+    return Math.min(Math.max(i, min), max);
+}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15267

*This is required for FOSDEM.*

**Note to reviewer:** It may be easier to review this commit by commit. The rough history is I wrote all the layout parsing code first then wired up the individual parts, so the layout code got bug fixes in later commits.

This has already passed through design/product review. Further iterations are planned, but this is good enough for now.

There are built-in docs to this PR, but the idea is that by sending a state event into the room then room operators can set a layout that all users see. This notably does not include other requirements of this line of sponsored work such as automatically maximizing widgets (not a concept we have, yet) and locking the layout. These are deferred until later availability.

We aren't totally sold on the placement/behaviour of the copy-my-layout button, but we are hoping to dogfood it and see how it goes.

Relevant screenshots (everything else is an under-the-hood change):
![image](https://user-images.githubusercontent.com/1190097/104985547-6ce4c880-59ce-11eb-8714-7b57f3f71f88.png)
![image](https://user-images.githubusercontent.com/1190097/104985554-74a46d00-59ce-11eb-97ef-ac649d717f10.png)
