### PR TITLE
Add VoIP user mapper

### DIFF
--- a/src/VoipUserMapper.ts
+++ b/src/VoipUserMapper.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ensureDMExists, findDMForUser } from './createRoom';
+import { MatrixClientPeg } from "./MatrixClientPeg";
+import DMRoomMap from "./utils/DMRoomMap";
+import SdkConfig from "./SdkConfig";
+
+// Functions for mapping users & rooms for the voip_mxid_translate_pattern
+// config option
+
+export function voipUserMapperEnabled(): boolean {
+    return SdkConfig.get()['voip_mxid_translate_pattern'] !== undefined;
+}
+
+function userToVirtualUser(userId: string, templateString?: string): string {
+    if (templateString === undefined) templateString = SdkConfig.get()['voip_mxid_translate_pattern'];
+    if (!templateString) return null;
+    return templateString.replace('${mxid}', encodeURIComponent(userId).replace(/%/g, '=').toLowerCase());
+}
+
+function virtualUserToUser(userId: string, templateString?: string): string {
+    if (templateString === undefined) templateString = SdkConfig.get()['voip_mxid_translate_pattern'];
+    if (!templateString) return null;
+
+    const regexString = templateString.replace('${mxid}', '(.+)');
+
+    const match = userId.match('^' + regexString + '$');
+    if (!match) return null;
+
+    return decodeURIComponent(match[1].replace(/=/g, '%'));
+}
+
+async function getOrCreateVirtualRoomForUser(userId: string):Promise<string> {
+    const virtualUser = userToVirtualUser(userId);
+    if (!virtualUser) return null;
+
+    return await ensureDMExists(MatrixClientPeg.get(), virtualUser);
+}
+
+export async function getOrCreateVirtualRoomForRoom(roomId: string):Promise<string> {
+    const user = DMRoomMap.shared().getUserIdForRoomId(roomId);
+    if (!user) return null;
+    return getOrCreateVirtualRoomForUser(user);
+}
+
+export function roomForVirtualRoom(roomId: string):string {
+    const virtualUser = DMRoomMap.shared().getUserIdForRoomId(roomId);
+    if (!virtualUser) return null;
+    const realUser = virtualUserToUser(virtualUser);
+    const room = findDMForUser(MatrixClientPeg.get(), realUser);
+    if (room) {
+        return room.roomId;
+    } else {
+        return null;
+    }
+}
+
+export function isVirtualRoom(roomId: string):boolean {
+    const virtualUser = DMRoomMap.shared().getUserIdForRoomId(roomId);
+    if (!virtualUser) return null;
+    const realUser = virtualUserToUser(virtualUser);
+    return Boolean(realUser);
+}

--- a/src/VoipUserMapper.ts
+++ b/src/VoipUserMapper.ts
@@ -26,13 +26,15 @@ export function voipUserMapperEnabled(): boolean {
     return SdkConfig.get()['voip_mxid_translate_pattern'] !== undefined;
 }
 
-function userToVirtualUser(userId: string, templateString?: string): string {
+// only exported for tests
+export function userToVirtualUser(userId: string, templateString?: string): string {
     if (templateString === undefined) templateString = SdkConfig.get()['voip_mxid_translate_pattern'];
     if (!templateString) return null;
     return templateString.replace('${mxid}', encodeURIComponent(userId).replace(/%/g, '=').toLowerCase());
 }
 
-function virtualUserToUser(userId: string, templateString?: string): string {
+// only exported for tests
+export function virtualUserToUser(userId: string, templateString?: string): string {
     if (templateString === undefined) templateString = SdkConfig.get()['voip_mxid_translate_pattern'];
     if (!templateString) return null;
 

--- a/src/components/views/rooms/MessageComposer.js
+++ b/src/components/views/rooms/MessageComposer.js
@@ -109,9 +109,12 @@ function HangupButton(props) {
 
         dis.dispatch({
             action,
-            // hangup the call for this room, which may not be the room in props
-            // (e.g. conferences which will hangup the 1:1 room instead)
-            room_id: call.roomId,
+            // hangup the call for this room. NB. We use the room in props as the room ID
+            // as call.roomId may be the 'virtual room', and the dispatch actions always
+            // use the user-facing room (there was a time when we deliberately used
+            // call.roomId and *not* props.roomId, but that was for the old
+            // style Freeswitch conference calls and those times are gone.)
+            room_id: props.roomId,
         });
     };
 

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -212,9 +212,10 @@ export default class CallView extends React.Component<IProps, IState> {
     };
 
     private onExpandClick = () => {
+        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
         dis.dispatch({
             action: 'view_room',
-            room_id: this.props.call.roomId,
+            room_id: userFacingRoomId,
         });
     };
 
@@ -340,27 +341,33 @@ export default class CallView extends React.Component<IProps, IState> {
     };
 
     private onRoomAvatarClick = () => {
+        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
         dis.dispatch({
             action: 'view_room',
-            room_id: this.props.call.roomId,
+            room_id: userFacingRoomId,
         });
     }
 
     private onSecondaryRoomAvatarClick = () => {
+        const userFacingRoomId = CallHandler.roomIdForCall(this.props.secondaryCall);
+
         dis.dispatch({
             action: 'view_room',
-            room_id: this.props.secondaryCall.roomId,
+            room_id: userFacingRoomId,
         });
     }
 
     private onCallResumeClick = () => {
-        CallHandler.sharedInstance().setActiveCallRoomId(this.props.call.roomId);
+        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
+        CallHandler.sharedInstance().setActiveCallRoomId(userFacingRoomId);
     }
 
     public render() {
         const client = MatrixClientPeg.get();
-        const callRoom = client.getRoom(this.props.call.roomId);
-        const secCallRoom = this.props.secondaryCall ? client.getRoom(this.props.secondaryCall.roomId) : null;
+        const callRoomId = CallHandler.roomIdForCall(this.props.call);
+        const secondaryCallRoomId = CallHandler.roomIdForCall(this.props.secondaryCall);
+        const callRoom = client.getRoom(callRoomId);
+        const secCallRoom = this.props.secondaryCall ? client.getRoom(secondaryCallRoomId) : null;
 
         let dialPad;
         let contextMenu;
@@ -456,7 +463,7 @@ export default class CallView extends React.Component<IProps, IState> {
                 onClick={() => {
                     dis.dispatch({
                         action: 'hangup',
-                        room_id: this.props.call.roomId,
+                        room_id: callRoomId,
                     });
                 }}
             />

--- a/src/components/views/voip/IncomingCallBox.tsx
+++ b/src/components/views/voip/IncomingCallBox.tsx
@@ -70,7 +70,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
         e.stopPropagation();
         dis.dispatch({
             action: 'answer',
-            room_id: this.state.incomingCall.roomId,
+            room_id: CallHandler.roomIdForCall(this.state.incomingCall),
         });
     };
 
@@ -78,7 +78,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
         e.stopPropagation();
         dis.dispatch({
             action: 'reject',
-            room_id: this.state.incomingCall.roomId,
+            room_id: CallHandler.roomIdForCall(this.state.incomingCall),
         });
     };
 
@@ -89,7 +89,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
 
         let room = null;
         if (this.state.incomingCall) {
-            room = MatrixClientPeg.get().getRoom(this.state.incomingCall.roomId);
+            room = MatrixClientPeg.get().getRoom(CallHandler.roomIdForCall(this.state.incomingCall));
         }
 
         const caller = room ? room.name : _t("Unknown caller");

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -398,6 +398,10 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
         default: null,
     },
+    "voip_mxid_translate_pattern": {
+        supportedLevels: LEVELS_UI_FEATURE, // not a UI feature, but same level (config only, maybe .well-known in future)
+        default: null,
+    },
     "language": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: "en",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -398,10 +398,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
         default: null,
     },
-    "voip_mxid_translate_pattern": {
-        supportedLevels: LEVELS_UI_FEATURE, // not a UI feature, but same level (config only, maybe .well-known in future)
-        default: null,
-    },
     "language": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: "en",

--- a/src/stores/room-list/filters/VisibilityProvider.ts
+++ b/src/stores/room-list/filters/VisibilityProvider.ts
@@ -16,6 +16,7 @@
 
 import {Room} from "matrix-js-sdk/src/models/room";
 import { RoomListCustomisations } from "../../../customisations/RoomList";
+import { isVirtualRoom, voipUserMapperEnabled } from "../../../VoipUserMapper";
 
 export class VisibilityProvider {
     private static internalInstance: VisibilityProvider;
@@ -31,18 +32,13 @@ export class VisibilityProvider {
     }
 
     public isRoomVisible(room: Room): boolean {
-        /* eslint-disable prefer-const */
         let isVisible = true; // Returned at the end of this function
         let forced = false; // When true, this function won't bother calling the customisation points
-        /* eslint-enable prefer-const */
 
-        // ------
-        // TODO: The `if` statements to control visibility of custom room types
-        // would go here. The remainder of this function assumes that the statements
-        // will be here.
-        //
-        // When removing this comment block, please remove the lint disable lines in the area.
-        // ------
+        if (voipUserMapperEnabled() && isVirtualRoom(room.roomId)) {
+            isVisible = false;
+            forced = true;
+        }
 
         const isVisibleFn = RoomListCustomisations.isRoomVisible;
         if (!forced && isVisibleFn) {

--- a/test/VoipUserMapper-test.ts
+++ b/test/VoipUserMapper-test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { userToVirtualUser, virtualUserToUser } from '../src/VoipUserMapper';
+
+const templateString = '@_greatappservice_${mxid}:frooble.example';
+const realUser = '@alice:boop.example';
+const virtualUser = "@_greatappservice_%40alice%3Aboop.example:frooble.example";
+
+describe('VoipUserMapper', function() {
+    it('translates users to virtual users', function() {
+        expect(userToVirtualUser(realUser, templateString)).toEqual(virtualUser);
+    });
+
+    it('translates users to virtual users', function() {
+        expect(virtualUserToUser(virtualUser, templateString)).toEqual(realUser);
+    });
+});

--- a/test/VoipUserMapper-test.ts
+++ b/test/VoipUserMapper-test.ts
@@ -18,7 +18,7 @@ import { userToVirtualUser, virtualUserToUser } from '../src/VoipUserMapper';
 
 const templateString = '@_greatappservice_${mxid}:frooble.example';
 const realUser = '@alice:boop.example';
-const virtualUser = "@_greatappservice_%40alice%3Aboop.example:frooble.example";
+const virtualUser = "@_greatappservice_=40alice=3aboop.example:frooble.example";
 
 describe('VoipUserMapper', function() {
     it('translates users to virtual users', function() {


### PR DESCRIPTION
The accompanying element-web PR with the config documentation should
explain what this is & why. Internally, this breaks the assumption
that call.roomId is the room that the call appears in for the user.
call.roomId may now be a 'virtual' room while the react SDK actually
displays it in a different room. React SDK always stores the calls
under the user-facing rooms, and provides a function to get the
user-facing room for a given call.