### PR TITLE
fix issue 16226 to allow switching back to default HS.

### DIFF
--- a/src/components/views/dialogs/ServerPickerDialog.tsx
+++ b/src/components/views/dialogs/ServerPickerDialog.tsx
@@ -157,7 +157,7 @@ export default class ServerPickerDialog extends React.PureComponent<IProps, ISta
             return;
         }
 
-        this.props.onFinished(this.validatedConf);
+        this.props.onFinished(this.state.defaultChosen ? this.defaultServer : this.validatedConf);
     };
 
     public render() {


### PR DESCRIPTION
This PR fixes https://github.com/vector-im/element-web/issues/16226 where the default HS cannot be selected if another homeserver has previously been selected.

Signed-off-by: Dan Gwynne dangwynne1@gmail.com