### PR TITLE
Log candidates for calls

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -396,6 +396,7 @@ export default class CallHandler {
                     }
 
                     this.logCallStats(call, mappedRoomId);
+                    break;
                 }
             }
         });

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -426,15 +426,17 @@ export default class CallHandler {
         );
         logger.debug("Local candidates:");
         for (const cand of stats.filter(item => item.type === 'local-candidate')) {
+            const address = cand.address || cand.ip; // firefox uses 'address', chrome uses 'ip'
             logger.debug(
-                `${cand.id} - type: ${cand.candidateType}, ip: ${cand.ip}, port: ${cand.port}, ` +
+                `${cand.id} - type: ${cand.candidateType}, address: ${address}, port: ${cand.port}, ` +
                 `protocol: ${cand.protocol}, relay protocol: ${cand.relayProtocol}, network type: ${cand.networkType}`,
             );
         }
         logger.debug("Remote candidates:");
         for (const cand of stats.filter(item => item.type === 'remote-candidate')) {
+            const address = cand.address || cand.ip; // firefox uses 'address', chrome uses 'ip'
             logger.debug(
-                `${cand.id} - type: ${cand.candidateType}, ip: ${cand.ip}, port: ${cand.port}, ` +
+                `${cand.id} - type: ${cand.candidateType}, address: ${address}, port: ${cand.port}, ` +
                 `protocol: ${cand.protocol}`,
             );
         }

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -356,6 +356,7 @@ export default class CallHandler {
                     this.play(AudioID.Ringback);
                     break;
                 case CallState.Ended:
+                {
                     Analytics.trackEvent('voip', 'callEnded', 'hangupReason', call.hangupReason);
                     this.removeCallForRoom(mappedRoomId);
                     if (oldState === CallState.InviteSent && (
@@ -393,6 +394,9 @@ export default class CallHandler {
                         // don't play the end-call sound for calls that never got off the ground
                         this.play(AudioID.CallEnd);
                     }
+
+                    this.logCallStats(call, mappedRoomId);
+                }
             }
         });
         call.on(CallEvent.Replaced, (newCall: MatrixCall) => {
@@ -410,6 +414,40 @@ export default class CallHandler {
             this.setCallListeners(newCall);
             this.setCallState(newCall, newCall.state);
         });
+    }
+
+    private async logCallStats(call: MatrixCall, mappedRoomId: string) {
+        const stats = await call.getCurrentCallStats();
+        logger.debug(
+            `Call completed. Call ID: ${call.callId}, virtual room ID: ${call.roomId}, ` +
+            `user-facing room ID: ${mappedRoomId}, direction: ${call.direction}, ` +
+            `our Party ID: ${call.ourPartyId}, hangup party: ${call.hangupParty}, ` +
+            `hangup reason: ${call.hangupReason}`,
+        );
+        logger.debug("Local candidates:");
+        for (const cand of stats.filter(item => item.type === 'local-candidate')) {
+            logger.debug(
+                `${cand.id} - type: ${cand.candidateType}, ip: ${cand.ip}, port: ${cand.port}, ` +
+                `protocol: ${cand.protocol}, relay protocol: ${cand.relayProtocol}, network type: ${cand.networkType}`,
+            );
+        }
+        logger.debug("Remote candidates:");
+        for (const cand of stats.filter(item => item.type === 'remote-candidate')) {
+            logger.debug(
+                `${cand.id} - type: ${cand.candidateType}, ip: ${cand.ip}, port: ${cand.port}, ` +
+                `protocol: ${cand.protocol}`,
+            );
+        }
+        logger.debug("Candidate pairs:");
+        for (const pair of stats.filter(item => item.type === 'candidate-pair')) {
+            logger.debug(
+                `${pair.localCandidateId} / ${pair.remoteCandidateId} - state: ${pair.state}, ` +
+                `nominated: ${pair.nominated}, ` +
+                `requests sent ${pair.requestsSent}, requests received  ${pair.requestsReceived},  ` +
+                `responses received: ${pair.responsesReceived}, responses sent: ${pair.responsesSent}, ` +
+                `bytes received: ${pair.bytesReceived}, bytes sent: ${pair.bytesSent}, `,
+            );
+        }
     }
 
     private setCallAudioElement(call: MatrixCall) {


### PR DESCRIPTION
First attempt at this was sending everything from
RTCPeerConnection.getStats() as a separate item in the rageshake,
but the rageshake server doesn't handle that in a particularly sensible
way and it's probably better to pick & choose what data we want explicitly
from a privacy PoV. This summarises the candidates used for the calls into
the log that will be included in rageshakes so we can diagnose connectivity
issues from rageshakes.

Requires matrix-org/matrix-js-sdk#1584