### PR TITLE
Allow stickerpickers the legacy "visibility" capability

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -71,6 +71,10 @@ export class StopGapWidgetDriver extends WidgetDriver {
             const stickerSendingCap = WidgetEventCapability.forRoomEvent(EventDirection.Send, EventType.Sticker).raw;
             this.allowedCapabilities.add(MatrixCapabilities.StickerSending); // legacy as far as MSC2762 is concerned
             this.allowedCapabilities.add(stickerSendingCap);
+
+            // Auto-approve the legacy visibility capability. We send it regardless of capability.
+            // Widgets don't technically need to request this capability, but Scalar still does.
+            this.allowedCapabilities.add("visibility");
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16237