### PR TITLE
Remove check that prevents Jitsi widgets from being unpinned

### DIFF
--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -201,11 +201,6 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
         const topWidgets: IApp[] = [];
         const rightWidgets: IApp[] = [];
         for (const widget of widgets) {
-            if (WidgetType.JITSI.matches(widget.type)) {
-                topWidgets.push(widget);
-                continue;
-            }
-
             const stateContainer = roomLayout?.widgets?.[widget.id]?.container;
             const manualContainer = userLayout?.widgets?.[widget.id]?.container;
             const isLegacyPinned = !!legacyPinned?.[widget.id];


### PR DESCRIPTION
Later in the code we do a conditional on the widget type to auto-pin the widget, so we don't need this one to force the widget higher.

Fixes https://github.com/vector-im/element-web/issues/16280