### PR TITLE
Fix Jitsi widgets causing localized tile crashes

### DIFF
--- a/src/components/views/messages/MJitsiWidgetEvent.tsx
+++ b/src/components/views/messages/MJitsiWidgetEvent.tsx
@@ -37,11 +37,13 @@ export default class MJitsiWidgetEvent extends React.PureComponent<IProps> {
         const senderName = this.props.mxEvent.sender?.name || this.props.mxEvent.getSender();
         const room = MatrixClientPeg.get().getRoom(this.props.mxEvent.getRoomId());
         const widgetId = this.props.mxEvent.getStateKey();
-        const widget = WidgetStore.instance.getRoom(room.roomId).widgets.find(w => w.id === widgetId);
+        const widget = WidgetStore.instance.getRoom(room.roomId, true).widgets.find(w => w.id === widgetId);
 
         let joinCopy = _t('Join the conference at the top of this room');
         if (widget && WidgetLayoutStore.instance.isInContainer(room, widget, Container.Right)) {
             joinCopy = _t('Join the conference from the room information card on the right');
+        } else if (!widget) {
+            joinCopy = null;
         }
 
         if (!url) {

--- a/src/stores/WidgetStore.ts
+++ b/src/stores/WidgetStore.ts
@@ -154,7 +154,8 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
         this.emit(UPDATE_EVENT, roomId);
     };
 
-    public getRoom = (roomId: string) => {
+    public getRoom = (roomId: string, initIfNeeded = false) => {
+        if (initIfNeeded) this.initRoom(roomId); // internally handles "if needed"
         return this.roomMap.get(roomId);
     };
 


### PR DESCRIPTION
Seems to be that as part of the layout work the timing sequence for when `.getRoom().widgets` will work changed. We can get around this with `initIfNeeded` which will no-op in the worst case.

This also includes a copy change to make ended conferences stop lying about where to find the widget. This is work towards https://github.com/vector-im/element-web/issues/15739