### PR TITLE
Label unlabeled avatar button in event panel

### DIFF
--- a/src/components/views/avatars/BaseAvatar.tsx
+++ b/src/components/views/avatars/BaseAvatar.tsx
@@ -26,6 +26,7 @@ import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import {useEventEmitter} from "../../../hooks/useEventEmitter";
 import {toPx} from "../../../utils/units";
 import {ResizeMethod} from "../../../Avatar";
+import { _t } from '../../../languageHandler';
 
 interface IProps {
     name: string; // The name (first initial used as default)
@@ -140,6 +141,7 @@ const BaseAvatar = (props: IProps) => {
         if (onClick) {
             return (
                 <AccessibleButton
+                    aria-label={_t("Avatar")}
                     {...otherProps}
                     element="span"
                     className={classNames("mx_BaseAvatar", className)}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2430,6 +2430,7 @@
     "Revoke permissions": "Revoke permissions",
     "Move left": "Move left",
     "Move right": "Move right",
+    "Avatar": "Avatar",
     "This room is public": "This room is public",
     "Away": "Away",
     "User Status": "User Status",


### PR DESCRIPTION
As of now, this button is unlabeled, and I'm not quite sure what it does. It appears to bring up the actions toolbar for a message, but not always. In any case, I labeled it "Avatar" so it at least has some context. Then, if someone says to click on the message avatar to view the available actions, screen reader users know what they're doing.