### PR TITLE
Fix new rooms being titled 'Empty Room'

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -155,8 +155,8 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
                 CommunityPrototypeStore.getUpdateEventName(this.props.room?.roomId),
                 this.onCommunityUpdate,
             );
-            prevProps.room.off("Room.name", this.onRoomNameUpdate);
-            this.props.room.on("Room.name", this.onRoomNameUpdate);
+            prevProps.room?.off("Room.name", this.onRoomNameUpdate);
+            this.props.room?.on("Room.name", this.onRoomNameUpdate);
         }
     }
 

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -110,6 +110,11 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
             CommunityPrototypeStore.getUpdateEventName(this.props.room.roomId),
             this.onCommunityUpdate,
         );
+        this.props.room.on("Room.name", this.onRoomNameUpdate);
+    }
+
+    private onRoomNameUpdate = (room) => {
+        this.forceUpdate();
     }
 
     private onNotificationUpdate = () => {
@@ -150,6 +155,8 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
                 CommunityPrototypeStore.getUpdateEventName(this.props.room?.roomId),
                 this.onCommunityUpdate,
             );
+            prevProps.room.off("Room.name", this.onRoomNameUpdate);
+            this.props.room.on("Room.name", this.onRoomNameUpdate);
         }
     }
 
@@ -171,6 +178,7 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
                 CommunityPrototypeStore.getUpdateEventName(this.props.room.roomId),
                 this.onCommunityUpdate,
             );
+            this.props.room.off("Room.name", this.onRoomNameUpdate);
         }
         defaultDispatcher.unregister(this.dispatcherRef);
         this.notificationState.off(NOTIFICATION_STATE_UPDATE, this.onNotificationUpdate);


### PR DESCRIPTION
The room name is not included in the original sync message received when the room is created so when the RoomTile instance is initially created the `calculateRoomName ` method on room.js returns "Empty Room".

On creation of the Room Tile I have added an event handler on the Room model to listen for "Room.name" events and redraw the tile when the event is received.

Fixes vector-im/element-web#16270