### PR TITLE
Avoid leaving space behind the typing notification

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -742,12 +742,10 @@ export default class MessagePanel extends React.Component {
     _onTypingHidden = () => {
         const scrollPanel = this._scrollPanel.current;
         if (scrollPanel) {
-            // as hiding the typing notifications doesn't
-            // update the scrollPanel, we tell it to apply
-            // the shrinking prevention once the typing notifs are hidden
-            scrollPanel.updatePreventShrinking();
-            // order is important here as checkScroll will scroll down to
-            // reveal added padding to balance the notifs disappearing.
+            // we clear prevent shrinking so that no
+            // empty space is created below the messages
+            scrollPanel.clearPreventShrinking();
+            // order is important here
             scrollPanel.checkScroll();
         }
     };


### PR DESCRIPTION
### Description
This fixes [#8552](https://github.com/vector-im/element-web/issues/8552).

Currently, the typing notification leaves empty space:
![Peek 2021-02-11 19-04](https://user-images.githubusercontent.com/25768714/107678670-fb7dfa00-6c9b-11eb-9ebc-7f8554bf8d27.gif)
This PR removes that space and makes the timeline jump down

I am not sure if this PR aligns with what is expected so a product review is necessary. Feel free to close this if it doesn't match what is expected. From my perspective leaving empty space behind the typing notification is worse than the timeline moving when the typing notification disappears. 

I don't fully understand the `ScrollPanel` code... But as far as I am able to tell this has no side-effects, but it's quite possible I've missed something.

### Alternatives
[Move the typing notification below the composer](https://github.com/vector-im/element-web/issues/16304)