### PR TITLE
Fix RoomView re-mounting breaking peeking

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -267,12 +267,6 @@ export default class RoomView extends React.Component<IProps, IState> {
         this.layoutWatcherRef = SettingsStore.watchSetting("useIRCLayout", null, this.onLayoutChange);
     }
 
-    // TODO: [REACT-WARNING] Move into constructor
-    // eslint-disable-next-line camelcase
-    UNSAFE_componentWillMount() {
-        this.onRoomViewStoreUpdate(true);
-    }
-
     private onWidgetStoreUpdate = () => {
         if (this.state.room) {
             this.checkWidgets(this.state.room);
@@ -512,6 +506,8 @@ export default class RoomView extends React.Component<IProps, IState> {
     }
 
     componentDidMount() {
+        this.onRoomViewStoreUpdate(true);
+
         const call = this.getCallForRoom();
         const callState = call ? call.state : null;
         this.setState({


### PR DESCRIPTION
Because as of React 16 order of unmount & re-mount is undefined
this was causing the possibility of the willUnmount running after
the willMount of the replacement RoomView, upsetting the state
of the singleton inside the js-sdk.

Paired with https://github.com/matrix-org/matrix-js-sdk/pull/1587