### PR TITLE
Fix flair height after accent changes

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -74,7 +74,6 @@ $left-gutter: 64px;
     margin-left: 5px;
     display: inline-block;
     vertical-align: top;
-    height: 16px;
     overflow: hidden;
     user-select: none;
 


### PR DESCRIPTION
The accent changes in https://github.com/matrix-org/matrix-react-sdk/pull/5569
led to a regression in flair display where the bottom edge was clipped.

<img width="181" alt="image" src="https://user-images.githubusercontent.com/279572/106642390-312a3100-6580-11eb-914d-f809a2f10e26.png">

Fixes https://github.com/vector-im/element-web/issues/16350
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/5569