### PR TITLE
Close current modal when session is logged out

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1378,14 +1378,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 Lifecycle.softLogout();
                 return;
             }
-            
+
             Modal.closeCurrentModal("User has been logged out.");
 
             Modal.createTrackedDialog('Signed out', '', ErrorDialog, {
                 title: _t('Signed Out'),
                 description: _t('For security, this session has been signed out. Please sign in again.'),
             });
-            
+
             dis.dispatch({
                 action: 'logout',
             });

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1378,11 +1378,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 Lifecycle.softLogout();
                 return;
             }
+            
+            Modal.closeCurrentModal("User has been logged out.");
 
             Modal.createTrackedDialog('Signed out', '', ErrorDialog, {
                 title: _t('Signed Out'),
                 description: _t('For security, this session has been signed out. Please sign in again.'),
             });
+            
             dis.dispatch({
                 action: 'logout',
             });

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1373,13 +1373,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         cli.on('Session.logged_out', function(errObj) {
             if (Lifecycle.isLoggingOut()) return;
 
+            // A modal might have been open when we were logged out by the server
+            Modal.closeCurrentModal('Session.logged_out');
+
             if (errObj.httpStatus === 401 && errObj.data && errObj.data['soft_logout']) {
                 console.warn("Soft logout issued by server - avoiding data deletion");
                 Lifecycle.softLogout();
                 return;
             }
-
-            Modal.closeCurrentModal("User has been logged out.");
 
             Modal.createTrackedDialog('Signed out', '', ErrorDialog, {
                 title: _t('Signed Out'),


### PR DESCRIPTION
Fixes vector-im/element-web#16346

This fix closes the current modal (if there is one displayed) when the client session ends.