### PR TITLE
Add username colour override

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -35,6 +35,28 @@ export const useSettingValue = <T>(settingName: string, roomId: string = null, e
     return value;
 };
 
+// Hook to fetch the value of a setting and dynamically update when it changes
+// The setting should be a map and this returns the value for the given key in the map.
+export const useSettingSubValue = <T>(
+    settingName: string,
+    key: string, roomId: string = null,
+    excludeDefault = false,
+) => {
+    const [value, setValue] = useState((SettingsStore.getValue<T>(settingName, roomId, excludeDefault) || {})[key]);
+
+    useEffect(() => {
+        const ref = SettingsStore.watchSetting(settingName, roomId, () => {
+            setValue((SettingsStore.getValue<T>(settingName, roomId, excludeDefault) || {})[key]);
+        });
+        // clean-up
+        return () => {
+            SettingsStore.unwatchSetting(ref);
+        };
+    }, [settingName, key, roomId, excludeDefault]);
+
+    return value;
+};
+
 // Hook to fetch whether a feature is enabled and dynamically update when that changes
 export const useFeatureEnabled = (featureName: string, roomId: string = null): boolean => {
     const [enabled, setEnabled] = useState(SettingsStore.getValue<boolean>(featureName, roomId));

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2008,6 +2008,7 @@
     "%(count)s sessions|one": "%(count)s session",
     "Hide sessions": "Hide sessions",
     "Message": "Message",
+    "Override display name colour": "Override display name colour",
     "Jump to read receipt": "Jump to read receipt",
     "Mention": "Mention",
     "Share Link to User": "Share Link to User",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -883,6 +883,10 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_ROOM_OR_ACCOUNT,
         default: {},
     },
+    "override_colors": {
+        supportedLevels: [SettingLevel.ACCOUNT],
+        default: {},
+    },
     "Spaces.allRoomsInHome": {
         displayName: _td("Show all rooms in Home"),
         description: _td("All rooms you're in will appear in Home."),

--- a/src/settings/handlers/AccountSettingsHandler.ts
+++ b/src/settings/handlers/AccountSettingsHandler.ts
@@ -31,6 +31,7 @@ const RECENT_EMOJI_EVENT_TYPE = "io.element.recent_emoji";
 const INTEG_PROVISIONING_EVENT_TYPE = "im.vector.setting.integration_provisioning";
 const ANALYTICS_EVENT_TYPE = "im.vector.analytics";
 const DEFAULT_SETTINGS_EVENT_TYPE = "im.vector.web.settings";
+const OVERRIDE_COLORS_EVENT_TYPE = "im.vector.setting.override_colors";
 
 /**
  * Gets and sets settings at the "account" level for the current user.
@@ -76,6 +77,8 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         } else if (event.getType() === RECENT_EMOJI_EVENT_TYPE) {
             const val = event.getContent()['enabled'];
             this.watchers.notifyUpdate("recent_emoji", null, SettingLevel.ACCOUNT, val);
+        } else if (event.getType() === OVERRIDE_COLORS_EVENT_TYPE) {
+            this.watchers.notifyUpdate("override_colors", null, SettingLevel.ACCOUNT, event.getContent());
         }
     };
 
@@ -112,6 +115,11 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         if (settingName === "integrationProvisioning") {
             const content = this.getSettings(INTEG_PROVISIONING_EVENT_TYPE);
             return content ? content['enabled'] : null;
+        }
+
+        // Special case override colors
+        if (settingName === "override_colors") {
+            return this.getSettings(OVERRIDE_COLORS_EVENT_TYPE) || {};
         }
 
         if (settingName === "pseudonymousAnalyticsOptIn") {
@@ -204,6 +212,10 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
             // Special case analytics
             case "pseudonymousAnalyticsOptIn":
                 return this.setAccountData(ANALYTICS_EVENT_TYPE, "pseudonymousAnalyticsOptIn", newValue);
+
+            // Special case override colors
+            case "override_colors":
+                return (async () => { await this.client.setAccountData(OVERRIDE_COLORS_EVENT_TYPE, newValue); })();
 
             default:
                 return this.setAccountData(DEFAULT_SETTINGS_EVENT_TYPE, settingName, newValue);

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import { _t } from '../languageHandler';
+import SettingsStore from "../settings/SettingsStore";
 import { jsxJoin } from './ReactUtils';
 
 /**
@@ -89,8 +90,19 @@ export function hashCode(str: string): number {
 }
 
 export function getUserNameColorClass(userId: string): string {
-    const colorNumber = (hashCode(userId) % 8) + 1;
-    return `mx_Username_color${colorNumber}`;
+    const overrideColors = SettingsStore.getValue("override_colors") || {};
+    const overrideColor = overrideColors[userId];
+    const color = (((overrideColor && !overrideColor.startsWith("#")) ? +overrideColor : hashCode(userId)) % 8) + 1;
+    return `mx_Username_color${color}`;
+}
+
+export function getUserNameColorStyle(userId: string): object {
+    const overrideColors = SettingsStore.getValue("override_colors") || {};
+    const overrideColor = overrideColors[userId];
+    if (overrideColor && overrideColor.startsWith("#")) {
+        return { color: overrideColor };
+    }
+    return null;
 }
 
 /**


### PR DESCRIPTION
Implement part of issue [element-web#11816](https://github.com/vector-im/element-web/issues/11816)

- allow changing the nick color by clicking the "Override color" menu item in the room member detail page.

- the override-color can be specified as a hex string (#rrggbb) or as palette index (2)

- leaving the field blank reverts to the default hash-based nick color

- the setting is stored in account_data as im.vector.setting.override_colors, which is a map of userId -> colorSpec

The same feature is implemented in element-android in [PR#2614](https://github.com/vector-im/element-android/pull/2614)

future improvements / notes:

- replace the text-based color entry with a proper color picker dialog

Thanks to `Michaelt3chguy[m` for his help on irc

Signed-off-by: Péter Radics <mitchnull@gmail.com>

Screenshots:

Override color with color index from palette (same effect as-if the userId hash would be '4'):
![override-color-with-palette-color](https://user-images.githubusercontent.com/1486202/107690882-02f8cf80-6cab-11eb-9abc-ea842045ebd2.png)

Override color with rgb color, default palette is not used:
![override-color-with-rgb-color](https://user-images.githubusercontent.com/1486202/107690974-26bc1580-6cab-11eb-8e2f-5af3917495cc.png)

The new menu item is "Override color" under the avatar.
The color input dialog should be replaced with a proper color picker that allows picking a color from the palette or an arbitrary rgb color.  Using palette colors has the advantage that it presumably works well with all themes, yet it's still possible to change a frequent contact's color if it clashes with another one (or our own).


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->