### PR TITLE
Add email only if the verification is complete

### DIFF
--- a/src/components/views/settings/account/EmailAddresses.js
+++ b/src/components/views/settings/account/EmailAddresses.js
@@ -179,6 +179,7 @@ export default class EmailAddresses extends React.Component {
 
         this.setState({continueDisabled: true});
         this.state.addTask.checkEmailLinkClicked().then(([finished]) => {
+            let newEmailAddress = this.state.newEmailAddress;
             if (finished) {
                 const email = this.state.newEmailAddress;
                 const emails = [
@@ -186,12 +187,13 @@ export default class EmailAddresses extends React.Component {
                     { address: email, medium: "email" },
                 ];
                 this.props.onEmailsChange(emails);
+                newEmailAddress = "";
             }
             this.setState({
                 addTask: null,
                 continueDisabled: false,
                 verifying: false,
-                newEmailAddress: "",
+                newEmailAddress,
             });
         }).catch((err) => {
             this.setState({continueDisabled: false});

--- a/src/components/views/settings/account/EmailAddresses.js
+++ b/src/components/views/settings/account/EmailAddresses.js
@@ -178,19 +178,21 @@ export default class EmailAddresses extends React.Component {
         e.preventDefault();
 
         this.setState({continueDisabled: true});
-        this.state.addTask.checkEmailLinkClicked().then(() => {
-            const email = this.state.newEmailAddress;
+        this.state.addTask.checkEmailLinkClicked().then(([finished]) => {
+            if (finished) {
+                const email = this.state.newEmailAddress;
+                const emails = [
+                    ...this.props.emails,
+                    { address: email, medium: "email" },
+                ];
+                this.props.onEmailsChange(emails);
+            }
             this.setState({
                 addTask: null,
                 continueDisabled: false,
                 verifying: false,
                 newEmailAddress: "",
             });
-            const emails = [
-                ...this.props.emails,
-                { address: email, medium: "email" },
-            ];
-            this.props.onEmailsChange(emails);
         }).catch((err) => {
             this.setState({continueDisabled: false});
             const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");

--- a/src/components/views/settings/account/PhoneNumbers.js
+++ b/src/components/views/settings/account/PhoneNumbers.js
@@ -177,21 +177,25 @@ export default class PhoneNumbers extends React.Component {
         this.setState({continueDisabled: true});
         const token = this.state.newPhoneNumberCode;
         const address = this.state.verifyMsisdn;
-        this.state.addTask.haveMsisdnToken(token).then(() => {
+        this.state.addTask.haveMsisdnToken(token).then(([finished]) => {
+            let newPhoneNumber = this.state.newPhoneNumber;
+            if (finished) {
+                const msisdns = [
+                    ...this.props.msisdns,
+                    { address, medium: "msisdn" },
+                ];
+                this.props.onMsisdnsChange(msisdns);
+                newPhoneNumber = "";
+            }
             this.setState({
                 addTask: null,
                 continueDisabled: false,
                 verifying: false,
                 verifyMsisdn: "",
                 verifyError: null,
-                newPhoneNumber: "",
+                newPhoneNumber,
                 newPhoneNumberCode: "",
             });
-            const msisdns = [
-                ...this.props.msisdns,
-                { address, medium: "msisdn" },
-            ];
-            this.props.onMsisdnsChange(msisdns);
         }).catch((err) => {
             this.setState({continueDisabled: false});
             if (err.errcode !== 'M_THREEPID_AUTH_FAILED') {


### PR DESCRIPTION
Fixes [element-web#16414](https://github.com/vector-im/element-web/issues/16414)
Signed-off-by: Punit Lodha punitlodha@pm.me

Should the input field be cleared when the dialog box is dismissed, or should it be left unchanged with the entered email?
Currently the input is being cleared, but i think we should leave the email, when the dialog is dismissed by the user itself