### PR TITLE
Fix border radius when the panel is collapsed

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -197,6 +197,9 @@ limitations under the License.
 
         .mx_RoomSublist_resizerHandles {
             flex: 0 0 4px;
+            display: flex;
+            justify-content: center;
+            width: 100%;
         }
 
         // Class name comes from the ResizableBox component
@@ -207,17 +210,12 @@ limitations under the License.
             border-radius: 3px;
 
             // Override styles from library
-            width: unset !important;
+            max-width: 64px;
             height: 4px !important; // Update RESIZE_HANDLE_HEIGHT if this changes
 
             // This is positioned directly below the 'show more' button.
-            position: absolute;
+            position: relative !important;
             bottom: 0 !important; // override from library
-
-            // Together, these make the bar 64px wide
-            // These are also overridden from the library
-            left: calc(50% - 32px) !important;
-            right: calc(50% - 32px) !important;
         }
 
         &:hover, &.mx_RoomSublist_hasMenuOpen {


### PR DESCRIPTION
Fixes [#16443](https://github.com/vector-im/element-web/issues/16443)

![Screenshot_20210213_085549](https://user-images.githubusercontent.com/25768714/107845095-51a48780-6dd9-11eb-934e-7a56bb91f193.png)
![Screenshot_20210213_085601](https://user-images.githubusercontent.com/25768714/107845097-52d5b480-6dd9-11eb-97e3-183b80437c1a.png)
