### PR TITLE
Fix codeblock scrollbar color for non-Firefox

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -259,6 +259,11 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
 .mx_EventTile_content .markdown-body pre:hover {
     border-color: #808080 !important; // inverted due to rules below
     scrollbar-color: rgba(0, 0, 0, 0.2) transparent; // copied from light theme due to inversion below
+    // the code above works only in Firefox, this is for other browsers
+    // see https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
+    &::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.2); // copied from light theme due to inversion below
+    }
 }
 .mx_EventTile_content .markdown-body {
     pre, code {


### PR DESCRIPTION
[#5630](https://github.com/matrix-org/matrix-react-sdk/pull/5630) works only in Firefox. This is necessary for other browsers.

![Screenshot_20210213_130125](https://user-images.githubusercontent.com/25768714/107849507-f041e000-6dfb-11eb-9153-2c08cbd96e51.png)
