### PR TITLE
Tweak code block icon positions

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -531,14 +531,14 @@ $left-gutter: 64px;
     display: inline-block;
     visibility: hidden;
     cursor: pointer;
-    top: 6px;
-    right: 12px;
+    top: 8px;
+    right: 8px;
     width: 19px;
     height: 19px;
     background-color: $message-action-bar-fg-color;
 }
 .mx_EventTile_buttonBottom {
-    top: 31px;
+    top: 33px;
 }
 .mx_EventTile_copyButton {
     mask-image: url($copy-button-url);


### PR DESCRIPTION
This tweaks the icon positions to look a bit better. Especially with a scrollbar on the side.

![Screenshot_20210213_153018](https://user-images.githubusercontent.com/25768714/107852315-68b29c00-6e10-11eb-9fe0-f6284d109c62.png)
![Screenshot_20210213_153029](https://user-images.githubusercontent.com/25768714/107852317-6a7c5f80-6e10-11eb-9882-5f9e5061f632.png)

Note: I already attempted this in a previous commit but it didn't look very well, therefore this PR