### PR TITLE
Fix context menu leaving visible area

### DIFF
--- a/src/components/structures/ContextMenu.tsx
+++ b/src/components/structures/ContextMenu.tsx
@@ -299,7 +299,7 @@ export class ContextMenu extends React.PureComponent<IProps, IState> {
             // such that it does not leave the (padded) window.
             if (contextMenuRect) {
                 const padding = 10;
-                adjusted = Math.min(position.top, document.body.clientHeight - contextMenuRect.height + padding);
+                adjusted = Math.min(position.top, document.body.clientHeight - contextMenuRect.height - padding);
             }
 
             position.top = adjusted;


### PR DESCRIPTION
I think the `+` should actually be a `-`. Before 10px have been added to top leading the menu being lower. If there should be a padding the pixels have to be subtracted.

Before (bottom of the screenshot = bottom of the browser window):
![before](https://user-images.githubusercontent.com/6216686/107884223-19459c00-6ef4-11eb-9b61-5c6c3ec699c5.png)

After:
![after](https://user-images.githubusercontent.com/6216686/107884226-1cd92300-6ef4-11eb-808e-9ef8cff90b08.png)

Relates to vector-im/element-web#3429