### PR TITLE
Modified regex to account for an immediate new line after slash commands

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -1182,7 +1182,7 @@ export function parseCommandString(input: string) {
     input = input.replace(/\s+$/, '');
     if (input[0] !== '/') return {}; // not a command
 
-    const bits = input.match(/^(\S+?)(?: +((.|\n)*))?$/);
+    const bits = input.match(/^(\S+?)(?:[ \n]+((.|\n)*))?$/);
     let cmd;
     let args;
     if (bits) {


### PR DESCRIPTION
Fixes vector-im/element-web#16224

![ezgif com-gif-maker](https://user-images.githubusercontent.com/65661241/107945597-e06dfb80-6fb5-11eb-90a4-8616c5b89484.gif)

Signed-off-by: Jaiwanth <jaiwanth2011@gmail.com>