### PR TITLE
Disable e2e config

### DIFF
--- a/src/components/views/dialogs/CreateRoomDialog.tsx
+++ b/src/components/views/dialogs/CreateRoomDialog.tsx
@@ -235,7 +235,7 @@ export default class CreateRoomDialog extends React.Component<IProps, IState> {
         }
 
         let e2eeSection;
-        if (!this.state.isPublic) {
+        if (!this.state.isPublic && MatrixClientPeg.get().isCryptoEnabled()) {
             let microcopy;
             if (privateShouldBeEncrypted()) {
                 if (this.state.canChangeEncryption) {

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -368,7 +368,7 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
         const room = client.getRoom(this.props.roomId);
         const isEncrypted = this.state.encrypted;
         const hasEncryptionPermission = room.currentState.mayClientSendStateEvent("m.room.encryption", client);
-        const canEnableEncryption = !isEncrypted && hasEncryptionPermission;
+        const canEnableEncryption = !isEncrypted && hasEncryptionPermission && MatrixClientPeg.get().isCryptoEnabled();
 
         let encryptionSettings = null;
         if (isEncrypted && SettingsStore.isEnabled("blacklistUnverifiedDevices")) {

--- a/src/stores/RightPanelStore.ts
+++ b/src/stores/RightPanelStore.ts
@@ -22,6 +22,7 @@ import {RightPanelPhases, RIGHT_PANEL_PHASES_NO_ARGS} from "./RightPanelStorePha
 import {ActionPayload} from "../dispatcher/payloads";
 import {Action} from '../dispatcher/actions';
 import { SettingLevel } from "../settings/SettingLevel";
+import {MatrixClientPeg} from "../MatrixClientPeg";
 
 interface RightPanelStoreState {
     // Whether or not to show the right panel at all. We split out rooms and groups
@@ -162,7 +163,11 @@ export default class RightPanelStore extends Store<ActionPayload> {
                 let targetPhase = payload.phase;
                 let refireParams = payload.refireParams;
                 // redirect to EncryptionPanel if there is an ongoing verification request
-                if (targetPhase === RightPanelPhases.RoomMemberInfo && payload.refireParams) {
+                if (
+                    targetPhase === RightPanelPhases.RoomMemberInfo &&
+                    payload.refireParams &&
+                    MatrixClientPeg.get().isCryptoEnabled()
+                ) {
                     const {member} = payload.refireParams;
                     const pendingRequest = pendingVerificationRequestForUser(member);
                     if (pendingRequest) {

--- a/src/utils/createMatrixClient.js
+++ b/src/utils/createMatrixClient.js
@@ -18,6 +18,8 @@ import {createClient} from "matrix-js-sdk/src/matrix";
 import {IndexedDBCryptoStore} from "matrix-js-sdk/src/crypto/store/indexeddb-crypto-store";
 import {WebStorageSessionStore} from "matrix-js-sdk/src/store/session/webstorage";
 import {IndexedDBStore} from "matrix-js-sdk/src/store/indexeddb";
+import * as Matrix from 'matrix-js-sdk';
+import SdkConfig from "../SdkConfig";
 
 const localStorage = window.localStorage;
 
@@ -55,14 +57,19 @@ export default function createMatrixClient(opts) {
         });
     }
 
+    const disableEncryption = SdkConfig.get()['disableEncryption'] === true;
     if (localStorage) {
         storeOpts.sessionStore = new WebStorageSessionStore(localStorage);
     }
 
-    if (indexedDB) {
+    if (indexedDB && !disableEncryption) {
         storeOpts.cryptoStore = new IndexedDBCryptoStore(
             indexedDB, "matrix-js-sdk:crypto",
         );
+    }
+
+    if (disableEncryption) {
+        Matrix.setCryptoStoreFactory(() => null);
     }
 
     opts = Object.assign(storeOpts, opts);


### PR DESCRIPTION
This pr adds a new config option `disableEncryption `.

It disables the creation of the crypto store, which leads to element not showing e2e encryption options.
Mainly it disables all encryption screens when logging into element web.

Fixes vector-im/element-meta#292

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Disable e2e config ([\#5652](https://github.com/matrix-org/matrix-react-sdk/pull/5652)). Fixes vector-im/element-meta#292. Contributed by @djschilling.<!-- CHANGELOG_PREVIEW_END -->