### PR TITLE
Remove redundant lockOrigin parameter from usercontent

### DIFF
--- a/src/components/views/messages/MFileBody.js
+++ b/src/components/views/messages/MFileBody.js
@@ -288,7 +288,7 @@ export default class MFileBody extends React.Component {
                             <a ref={this._dummyLink} />
                         </div>
                         <iframe
-                            src={`${url}?origin=${encodeURIComponent(window.location.origin)}`}
+                            src={url}
                             onLoad={onIframeLoad}
                             ref={this._iframe}
                             sandbox="allow-scripts allow-downloads allow-downloads-without-user-activation" />

--- a/src/usercontent/index.js
+++ b/src/usercontent/index.js
@@ -1,10 +1,3 @@
-const params = window.location.search.substring(1).split('&');
-let lockOrigin;
-for (let i = 0; i < params.length; ++i) {
-    const parts = params[i].split('=');
-    if (parts[0] === 'origin') lockOrigin = decodeURIComponent(parts[1]);
-}
-
 function remoteRender(event) {
     const data = event.data;
 
@@ -45,7 +38,7 @@ function remoteSetTint(event) {
 }
 
 window.onmessage = function(e) {
-    if (e.origin === lockOrigin) {
+    if (e.origin === window.location.origin) {
         if (e.data.blob) remoteRender(e);
         else remoteSetTint(e);
     }


### PR DESCRIPTION
now that each Element has its own, and not usercontent.riot.im, it only has to permit its own origin