### PR TITLE
Update isUserOnDarkTheme to take use_system_theme in account

### DIFF
--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -103,11 +103,15 @@ export default class UserMenu extends React.Component<IProps, IState> {
     };
 
     private isUserOnDarkTheme(): boolean {
-        const theme = SettingsStore.getValue("theme");
-        if (theme.startsWith("custom-")) {
-            return getCustomTheme(theme.substring("custom-".length)).is_dark;
+        if (SettingsStore.getValue("use_system_theme")) {
+            return window.matchMedia("(prefers-color-scheme: dark)").matches;
+        } else {
+            const theme = SettingsStore.getValue("theme");
+            if (theme.startsWith("custom-")) {
+                return getCustomTheme(theme.substring("custom-".length)).is_dark;
+            }
+            return theme === "dark";
         }
-        return theme === "dark";
     }
 
     private onProfileUpdate = async () => {


### PR DESCRIPTION
This PR attempts to fix vector-im/element-web#16502

I can see that the `isUserOnDarkTheme` function is trying to determine the selected theme by looking at the `SettingsStore` property `theme`. However that value is incorrect when `use_system_theme` is set to `true`.

In that scenario I believe a reasonable approach is to using [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) to figure out whether the user is using the US UI dark theme or not.

Let me know your thoughts, I appreciate that `SettingsStore.getValue("theme")` can be out of sync when `use_system_theme` is set to `true` but I decided to go with that approach as it is the one with the smallest footprint. Happy to update it if anyone has a better idea

