### PR TITLE
Fix MAU usage alerts

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -305,7 +305,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         }
     };
 
-    _onHideToast = () => {
+    private onUsageLimitDismissed = () => {
         this.setState({
             usageLimitDismissed: true,
         });
@@ -322,7 +322,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         if (usageLimitEventContent && this.state.usageLimitDismissed) {
             showServerLimitToast(
                 usageLimitEventContent.limit_type,
-                this._onHideToast,
+                this.onUsageLimitDismissed,
                 usageLimitEventContent.admin_contact,
                 error,
             );

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -108,6 +108,7 @@ interface IState {
         };
     };
     usageLimitEventContent?: IUsageLimit;
+    usageLimitEventTs?: number;
     useCompactLayout: boolean;
 }
 
@@ -339,9 +340,18 @@ class LoggedInView extends React.Component<IProps, IState> {
                 e.getContent()['server_notice_type'] === 'm.server_notice.usage_limit_reached'
             );
         });
+        if (this.state.usageLimitEventTs > usageLimitEvent.getTs()) {
+            // We've processed a newer event than this one, so ignore it.
+            return;
+        }
         const usageLimitEventContent = usageLimitEvent && usageLimitEvent.getContent();
         this._calculateServerLimitToast(this.state.syncErrorData, usageLimitEventContent);
-        this.setState({ usageLimitEventContent });
+        this.setState({
+            usageLimitEventContent,
+            usageLimitEventTs: usageLimitEvent.getTs(),
+            // This is a fresh toast, we can show toasts again
+            usageLimitDismissed: false,
+        });
     };
 
     _onPaste = (ev) => {

--- a/src/toasts/ServerLimitToast.tsx
+++ b/src/toasts/ServerLimitToast.tsx
@@ -40,7 +40,7 @@ export const showToast = (limitType: string, onHideToast: () => void, adminConta
             acceptLabel: _t("Ok"),
             onAccept: () => {
                 hideToast()
-                if (onHideToast) { onHideToast() }
+                if (onHideToast) onHideToast();
             },
         },
         component: GenericToast,

--- a/src/toasts/ServerLimitToast.tsx
+++ b/src/toasts/ServerLimitToast.tsx
@@ -40,7 +40,7 @@ export const showToast = (limitType: string, onHideToast: () => void, adminConta
             acceptLabel: _t("Ok"),
             onAccept: () => {
                 hideToast()
-                onHideToast()
+                if (onHideToast) { onHideToast() }
             },
         },
         component: GenericToast,

--- a/src/toasts/ServerLimitToast.tsx
+++ b/src/toasts/ServerLimitToast.tsx
@@ -23,7 +23,7 @@ import {messageForResourceLimitError} from "../utils/ErrorUtils";
 
 const TOAST_KEY = "serverlimit";
 
-export const showToast = (limitType: string, adminContact?: string, syncError?: boolean) => {
+export const showToast = (limitType: string, onHideToast: () => void, adminContact?: string, syncError?: boolean) => {
     const errorText = messageForResourceLimitError(limitType, adminContact, {
         'monthly_active_user': _td("Your homeserver has exceeded its user limit."),
         '': _td("Your homeserver has exceeded one of its resource limits."),
@@ -38,7 +38,10 @@ export const showToast = (limitType: string, adminContact?: string, syncError?: 
         props: {
             description: <React.Fragment>{errorText} {contactText}</React.Fragment>,
             acceptLabel: _t("Ok"),
-            onAccept: hideToast,
+            onAccept: () => {
+                hideToast()
+                onHideToast()
+            },
         },
         component: GenericToast,
         priority: 70,


### PR DESCRIPTION
This PR fixes two bugs for the toast alerts that popup when a host has reached it's MAU limit:

- If Synapse informs Element that the host has gone under the limit (by removing the pinned message), Element would process the pinned state event change twice. It's not clear *why* it would do this, but I've made it so that we check the timestamp of the event we're processing to ensure we don't race here.
- If the user dismisses the toast, it will show again next time the users syncs as we calculate this toast on each sync. I've added a state variable to track if a toast has been dismissed by the user.