### PR TITLE
Fix object diffing when objects have different keys

### DIFF
--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -89,6 +89,7 @@ export function objectHasDiff<O extends {}>(a: O, b: O): boolean {
     if (a === b) return false;
     const aKeys = Object.keys(a);
     const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return true;
     const possibleChanges = arrayUnion(aKeys, bKeys);
     // if the amalgamation of both sets of keys has the a different length to the inputs then there must be a change
     if (possibleChanges.length !== aKeys.length) return true;


### PR DESCRIPTION
The object diff optimisation in 32cca0534c5ff7c7a86d854e6a00a4764652d20b is not correct for the case where `b` has some keys that are not in `a`.

By ensuring their key arrays are same length, we can preserve optimisation and be correct as well.

Fixes https://github.com/vector-im/element-web/issues/16514