### PR TITLE
Restrict size of image and video thumbnails

### DIFF
--- a/res/css/views/messages/_MVideoBody.scss
+++ b/res/css/views/messages/_MVideoBody.scss
@@ -17,7 +17,7 @@ limitations under the License.
 span.mx_MVideoBody {
     video.mx_MVideoBody {
         max-width: 100%;
-        height: auto;
+        max-height: 300px;
         border-radius: 4px;
     }
 }

--- a/src/components/views/messages/MImageBody.js
+++ b/src/components/views/messages/MImageBody.js
@@ -362,7 +362,7 @@ export default class MImageBody extends React.Component {
         }
 
         // The maximum height of the thumbnail as it is rendered as an <img>
-        const maxHeight = Math.min(this.props.maxImageHeight || 600, infoHeight);
+        const maxHeight = Math.min(this.props.maxImageHeight || 240, infoHeight);
         // The maximum width of the thumbnail, as dictated by its natural
         // maximum height.
         const maxWidth = infoWidth * maxHeight / infoHeight;


### PR DESCRIPTION
While my previous PR included changes to the URL preview widget that didn't go over well, community response seemed overwhelmingly positive for the changes that made the image and video thumbnails smaller. This PR is just those two changes.

[Original community discussion about the changes, for reference](https://github.com/vector-im/element-web/issues/16479)
+ "However the smaller image previews are a godsend. Surprisingly significant improvement to my user experience."
+ "While I agree with the feedback regarding URL previews, it also limits the size of image files sent in the timeline, which I like because it makes the room timeline much more readable."
+ "I agree that the smaller image previews are amazing."

However, it seems like this might still be up for conversation from the design team due to [Matthew's response](https://github.com/vector-im/element-web/issues/16479#issuecomment-781490806).

Signed-off-by William Kray github@williamkray.com