### PR TITLE
Log when turn creds expire

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -629,6 +629,8 @@ export default class CallHandler {
         const mappedRoomId = (await VoipUserMapper.sharedInstance().getOrCreateVirtualRoomForRoom(roomId)) || roomId;
         logger.debug("Mapped real room " + roomId + " to room ID " + mappedRoomId);
 
+        const timeUntilTurnCresExpire = MatrixClientPeg.get().getTurnServersExpiry() - Date.now();
+        console.log("Current turn creds expire in " + timeUntilTurnCresExpire + " seconds");
         const call = createNewMatrixCall(MatrixClientPeg.get(), mappedRoomId);
 
         this.calls.set(roomId, call);


### PR DESCRIPTION
Which, due to how special the js-sdk API is, needs to be done accross
two different projects.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/1620