### PR TITLE
Add .tmp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 /src/component-index.js
 
 .DS_Store
+*.tmp


### PR DESCRIPTION
My git client is convinced that `src/component-index.js.tmp` needs to be checked in, which is nice of it but also wrong.