### PR TITLE
Display decrypted and encrypted event source on the same dialog

### DIFF
--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -43,3 +43,7 @@ limitations under the License.
     word-wrap: break-word;
     white-space: pre-wrap;
 }
+
+.mx_ViewSource_details {
+    margin-top: 0.8em;
+}

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -22,9 +22,18 @@ limitations under the License.
     float: right;
 }
 
-.mx_ViewSource_label_bottom {
+.mx_ViewSource_separator {
     clear: both;
     border-bottom: 1px solid #e5e5e5;
+    padding-top: 0.7em;
+    padding-bottom: 0.7em;
+}
+
+.mx_ViewSource_heading {
+    font-size: $font-17px;
+    font-weight: 400;
+    color: $primary-fg-color;
+    margin-top: 0.7em;
 }
 
 .mx_ViewSource pre {

--- a/src/components/structures/ViewSource.js
+++ b/src/components/structures/ViewSource.js
@@ -36,29 +36,42 @@ export default class ViewSource extends React.Component {
     render() {
         const BaseDialog = sdk.getComponent('views.dialogs.BaseDialog');
 
-        const DecryptedSection = <>
-            <div className="mx_ViewSource_separator" />
-            <div className="mx_ViewSource_heading">{_t("Decrypted event source")}</div>
-            <SyntaxHighlight className="json">
-                { JSON.stringify(this.props.decryptedContent, null, 2) }
-            </SyntaxHighlight>
-        </>;
-
-        const OriginalSection = <>
-            <div className="mx_ViewSource_separator" />
-            <div className="mx_ViewSource_heading">{_t("Original event source")}</div>
-            <SyntaxHighlight className="json">
-                { JSON.stringify(this.props.content, null, 2) }
-            </SyntaxHighlight>
-        </>;
+        let content;
+        if (this.props.isEncrypted) {
+            content = <>
+                <details open className="mx_ViewSource_details">
+                    <summary>
+                        <span className="mx_ViewSource_heading">{_t("Decrypted event source")}</span>
+                    </summary>
+                    <SyntaxHighlight className="json">
+                        { JSON.stringify(this.props.decryptedContent, null, 2) }
+                    </SyntaxHighlight>
+                </details>
+                <details className="mx_ViewSource_details">
+                    <summary>
+                        <span className="mx_ViewSource_heading">{_t("Original event source")}</span>
+                    </summary>
+                    <SyntaxHighlight className="json">
+                        { JSON.stringify(this.props.content, null, 2) }
+                    </SyntaxHighlight>
+                </details>
+            </>;
+        } else {
+            content = <>
+                <div className="mx_ViewSource_heading">{_t("Original event source")}</div>
+                <SyntaxHighlight className="json">
+                    { JSON.stringify(this.props.content, null, 2) }
+                </SyntaxHighlight>
+            </>;
+        }
 
         return (
             <BaseDialog className="mx_ViewSource" onFinished={this.props.onFinished} title={_t('View Source')}>
                 <div className="mx_Dialog_content">
                     <div className="mx_ViewSource_label_left">Room ID: { this.props.roomId }</div>
                     <div className="mx_ViewSource_label_left">Event ID: { this.props.eventId }</div>
-                    { this.props.isEncrypted && DecryptedSection }
-                    { OriginalSection }
+                    <div className="mx_ViewSource_separator" />
+                    { content }
                 </div>
             </BaseDialog>
         );

--- a/src/components/structures/ViewSource.js
+++ b/src/components/structures/ViewSource.js
@@ -19,7 +19,7 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import SyntaxHighlight from '../views/elements/SyntaxHighlight';
-import {_t} from "../../languageHandler";
+import {_t, _td} from "../../languageHandler";
 import * as sdk from "../../index";
 
 
@@ -29,20 +29,36 @@ export default class ViewSource extends React.Component {
         onFinished: PropTypes.func.isRequired,
         roomId: PropTypes.string.isRequired,
         eventId: PropTypes.string.isRequired,
+        isEncrypted: PropTypes.bool.isRequired,
+        decryptedContent: PropTypes.object,
     };
 
     render() {
         const BaseDialog = sdk.getComponent('views.dialogs.BaseDialog');
+
+        const DecryptedSection = <>
+            <div className="mx_ViewSource_separator" />
+            <div className="mx_ViewSource_heading">{_t("Decrypted event source")}</div>
+            <SyntaxHighlight className="json">
+                { JSON.stringify(this.props.decryptedContent, null, 2) }
+            </SyntaxHighlight>
+        </>;
+
+        const OriginalSection = <>
+            <div className="mx_ViewSource_separator" />
+            <div className="mx_ViewSource_heading">{_t("Original event source")}</div>
+            <SyntaxHighlight className="json">
+                { JSON.stringify(this.props.content, null, 2) }
+            </SyntaxHighlight>
+        </>;
+
         return (
             <BaseDialog className="mx_ViewSource" onFinished={this.props.onFinished} title={_t('View Source')}>
-                <div className="mx_ViewSource_label_left">Room ID: { this.props.roomId }</div>
-                <div className="mx_ViewSource_label_right">Event ID: { this.props.eventId }</div>
-                <div className="mx_ViewSource_label_bottom" />
-
                 <div className="mx_Dialog_content">
-                    <SyntaxHighlight className="json">
-                        { JSON.stringify(this.props.content, null, 2) }
-                    </SyntaxHighlight>
+                    <div className="mx_ViewSource_label_left">Room ID: { this.props.roomId }</div>
+                    <div className="mx_ViewSource_label_left">Event ID: { this.props.eventId }</div>
+                    { this.props.isEncrypted && DecryptedSection }
+                    { OriginalSection }
                 </div>
             </BaseDialog>
         );

--- a/src/components/structures/ViewSource.js
+++ b/src/components/structures/ViewSource.js
@@ -19,7 +19,7 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import SyntaxHighlight from '../views/elements/SyntaxHighlight';
-import {_t, _td} from "../../languageHandler";
+import {_t} from "../../languageHandler";
 import * as sdk from "../../index";
 
 

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -130,6 +130,8 @@ export default class MessageContextMenu extends React.Component {
             roomId: ev.getRoomId(),
             eventId: ev.getId(),
             content: ev.event,
+            isEncrypted: this.props.mxEvent.getType() !== this.props.mxEvent.getWireType(),
+            decryptedContent: ev._clearEvent,
         }, 'mx_Dialog_viewsource');
         this.closeMenu();
     };
@@ -309,7 +311,6 @@ export default class MessageContextMenu extends React.Component {
         let cancelButton;
         let forwardButton;
         let pinButton;
-        let viewClearSourceButton;
         let unhidePreviewButton;
         let externalURLButton;
         let quoteButton;
@@ -388,14 +389,6 @@ export default class MessageContextMenu extends React.Component {
                 { _t('View Source') }
             </MenuItem>
         );
-
-        if (mxEvent.getType() !== mxEvent.getWireType()) {
-            viewClearSourceButton = (
-                <MenuItem className="mx_MessageContextMenu_field" onClick={this.onViewClearSourceClick}>
-                    { _t('View Decrypted Source') }
-                </MenuItem>
-            );
-        }
 
         if (this.props.eventTileOps) {
             if (this.props.eventTileOps.isWidgetHidden()) {
@@ -481,7 +474,6 @@ export default class MessageContextMenu extends React.Component {
                 { forwardButton }
                 { pinButton }
                 { viewSourceButton }
-                { viewClearSourceButton }
                 { unhidePreviewButton }
                 { permalinkButton }
                 { quoteButton }

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -130,20 +130,9 @@ export default class MessageContextMenu extends React.Component {
             roomId: ev.getRoomId(),
             eventId: ev.getId(),
             content: ev.event,
-            isEncrypted: this.props.mxEvent.getType() !== this.props.mxEvent.getWireType(),
-            decryptedContent: ev._clearEvent,
-        }, 'mx_Dialog_viewsource');
-        this.closeMenu();
-    };
-
-    onViewClearSourceClick = () => {
-        const ev = this.props.mxEvent.replacingEvent() || this.props.mxEvent;
-        const ViewSource = sdk.getComponent('structures.ViewSource');
-        Modal.createTrackedDialog('View Clear Event Source', '', ViewSource, {
-            roomId: ev.getRoomId(),
-            eventId: ev.getId(),
+            isEncrypted: ev.isEncrypted(),
             // FIXME: _clearEvent is private
-            content: ev._clearEvent,
+            decryptedContent: ev._clearEvent,
         }, 'mx_Dialog_viewsource');
         this.closeMenu();
     };

--- a/src/components/views/dialogs/RoomSettingsDialog.js
+++ b/src/components/views/dialogs/RoomSettingsDialog.js
@@ -116,7 +116,7 @@ export default class RoomSettingsDialog extends React.Component {
         return (
             <BaseDialog className='mx_RoomSettingsDialog' hasCancel={true}
                         onFinished={this.props.onFinished} title={_t("Room Settings - %(roomName)s", {roomName})}>
-                <div className='ms_SettingsDialog_content'>
+                <div className='mx_SettingsDialog_content'>
                     <TabbedView tabs={this._getTabs()} />
                 </div>
             </BaseDialog>

--- a/src/components/views/dialogs/UserSettingsDialog.js
+++ b/src/components/views/dialogs/UserSettingsDialog.js
@@ -155,7 +155,7 @@ export default class UserSettingsDialog extends React.Component {
         return (
             <BaseDialog className='mx_UserSettingsDialog' hasCancel={true}
                         onFinished={this.props.onFinished} title={_t("Settings")}>
-                <div className='ms_SettingsDialog_content'>
+                <div className='mx_SettingsDialog_content'>
                     <TabbedView tabs={this._getTabs()} initialTabId={this.props.initialTabId} />
                 </div>
             </BaseDialog>

--- a/src/components/views/messages/EditHistoryMessage.js
+++ b/src/components/views/messages/EditHistoryMessage.js
@@ -77,6 +77,8 @@ export default class EditHistoryMessage extends React.PureComponent {
             roomId: this.props.mxEvent.getRoomId(),
             eventId: this.props.mxEvent.getId(),
             content: this.props.mxEvent.event,
+            isEncrypted: this.props.mxEvent.getType() !== this.props.mxEvent.getWireType(),
+            decryptedContent: this.props.mxEvent._clearEvent,
         }, 'mx_Dialog_viewsource');
     };
 

--- a/src/components/views/messages/EditHistoryMessage.js
+++ b/src/components/views/messages/EditHistoryMessage.js
@@ -77,7 +77,8 @@ export default class EditHistoryMessage extends React.PureComponent {
             roomId: this.props.mxEvent.getRoomId(),
             eventId: this.props.mxEvent.getId(),
             content: this.props.mxEvent.event,
-            isEncrypted: this.props.mxEvent.getType() !== this.props.mxEvent.getWireType(),
+            isEncrypted: this.props.mxEvent.isEncrypted(),
+            // FIXME: _clearEvent is private
             decryptedContent: this.props.mxEvent._clearEvent,
         }, 'mx_Dialog_viewsource');
     };

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2875,5 +2875,7 @@
     "Esc": "Esc",
     "Enter": "Enter",
     "Space": "Space",
-    "End": "End"
+    "End": "End",
+    "Decrypted event source": "Decrypted event source",
+    "Original event source": "Original event source"
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2396,7 +2396,6 @@
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",
     "Pin Message": "Pin Message",
-    "View Decrypted Source": "View Decrypted Source",
     "Unhide Preview": "Unhide Preview",
     "Share Permalink": "Share Permalink",
     "Share Message": "Share Message",
@@ -2652,6 +2651,8 @@
     "User menu": "User menu",
     "Community and user menu": "Community and user menu",
     "Could not load user profile": "Could not load user profile",
+    "Decrypted event source": "Decrypted event source",
+    "Original event source": "Original event source",
     "Verify this login": "Verify this login",
     "Session verified": "Session verified",
     "Failed to send email": "Failed to send email",
@@ -2875,7 +2876,5 @@
     "Esc": "Esc",
     "Enter": "Enter",
     "Space": "Space",
-    "End": "End",
-    "Decrypted event source": "Decrypted event source",
-    "Original event source": "Original event source"
+    "End": "End"
 }

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -650,7 +650,5 @@
     "Error upgrading room": "Error upgrading room",
     "Double check that your server supports the room version chosen and try again.": "Double check that your server supports the room version chosen and try again.",
     "Changes the avatar of the current room": "Changes the avatar of the current room",
-    "Changes your avatar in all rooms": "Changes your avatar in all rooms",
-    "Decrypted event source": "Decrypted event source",
-    "Original event source": "Original event source"
+    "Changes your avatar in all rooms": "Changes your avatar in all rooms"
 }

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -650,5 +650,7 @@
     "Error upgrading room": "Error upgrading room",
     "Double check that your server supports the room version chosen and try again.": "Double check that your server supports the room version chosen and try again.",
     "Changes the avatar of the current room": "Changes the avatar of the current room",
-    "Changes your avatar in all rooms": "Changes your avatar in all rooms"
+    "Changes your avatar in all rooms": "Changes your avatar in all rooms",
+    "Decrypted event source": "Decrypted event source",
+    "Original event source": "Original event source"
 }


### PR DESCRIPTION
display encrypted and decrypted event source on the same dialog
keep only one "View Source" action on event context menu

Context menu:
![image](https://user-images.githubusercontent.com/27917356/109873934-1d551600-7c77-11eb-8136-d3894f945ee2.png)
On encrypted rooms:
![image](https://user-images.githubusercontent.com/27917356/109873766-df57f200-7c76-11eb-94b6-be34feec558a.png)
On unencrypted rooms:
![image](https://user-images.githubusercontent.com/27917356/109873810-f3035880-7c76-11eb-8179-4f54c81578a6.png)


Fixes https://github.com/vector-im/element-web/issues/16002

Fixes https://github.com/vector-im/element-web/issues/11060

Will add an edit button in another PR