### PR TITLE
Fix Bottom border of state counters is white on the dark theme

### DIFF
--- a/res/css/views/rooms/_AuxPanel.scss
+++ b/res/css/views/rooms/_AuxPanel.scss
@@ -17,7 +17,7 @@ limitations under the License.
 .m_RoomView_auxPanel_stateViews {
     padding: 5px;
     padding-left: 19px;
-    border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid $primary-hairline-color;
 }
 
 .m_RoomView_auxPanel_stateViews_span a {


### PR DESCRIPTION
Fix [https://github.com/vector-im/element-web/issues/9091](https://github.com/vector-im/element-web/issues/9091)

Signed-off-by: Ayush Kumar 2580ayush2580@gmail.com