### PR TITLE
Ensure HostSignupDialog border colour matches light theme

### DIFF
--- a/res/css/views/dialogs/_HostSignupDialog.scss
+++ b/res/css/views/dialogs/_HostSignupDialog.scss
@@ -19,6 +19,11 @@ limitations under the License.
     max-width: 580px;
     height: 80vh;
     max-height: 600px;
+    // Ensure dialog borders are always white as the HostSignupDialog
+    // does not yet support dark mode or theming in general.
+    // In the future we might want to pass the theme to the called
+    // iframe, should some hosting provider have that need.
+    background-color: #ffffff;
 
     .mx_HostSignupDialog_info {
         text-align: center;


### PR DESCRIPTION
Ensure dialog borders are always white as the HostSignupDialog
does not yet support dark mode or theming in general.
In the future we might want to pass the theme to the called
iframe, should some hosting provider have that need.

When on dark theme, fixes this:

![Selection_999(108)](https://user-images.githubusercontent.com/1174866/109939561-dc421d80-7cd9-11eb-8d13-ff58be900a2a.png)

To be this:

![Selection_999(109)](https://user-images.githubusercontent.com/1174866/109939612-e82ddf80-7cd9-11eb-9670-722cc08007d4.png)

