### PR TITLE
Fix clicking on the avatar for opening member info requires pixel-perfect accuracy

### DIFF
--- a/res/css/views/rooms/_GroupLayout.scss
+++ b/res/css/views/rooms/_GroupLayout.scss
@@ -21,7 +21,7 @@ $left-gutter: 64px;
     .mx_EventTile {
         > .mx_SenderProfile {
             line-height: $font-20px;
-            padding-left: $left-gutter;
+            margin-left: $left-gutter;
         }
 
         > .mx_EventTile_line {


### PR DESCRIPTION
Fix [https://github.com/vector-im/element-web/issues/16584](https://github.com/vector-im/element-web/issues/16584)
