### PR TITLE
Changed text color of highlights

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -145,7 +145,7 @@ $event-sending-color: $text-secondary-color;
 $event-redacted-fg-color: #606060;
 $event-redacted-border-color: #000000;
 
-$event-highlight-fg-color: $warning-color;
+$event-highlight-fg-color: $primary-fg-color;
 $event-highlight-bg-color: #25271F;
 
 // event timestamp

--- a/res/themes/light-custom/css/_custom.scss
+++ b/res/themes/light-custom/css/_custom.scss
@@ -70,6 +70,7 @@ $roomlist-bg-color: var(--roomlist-background-color);
 // --timeline-text-color
 $message-action-bar-fg-color: var(--timeline-text-color);
 $primary-fg-color: var(--timeline-text-color);
+$event-highlight-fg-color: var(--timeline-text-color);
 $settings-profile-overlay-placeholder-fg-color: var(--timeline-text-color);
 $roomtopic-color: var(--timeline-text-color-50pct);
 $tab-label-fg-color: var(--timeline-text-color);
@@ -116,7 +117,6 @@ $input-focused-border-color: var(--primary-color);
 //
 // --warning-color
 $button-danger-bg-color: var(--warning-color);
-$event-highlight-fg-color: var(--warning-color);
 $input-invalid-border-color: var(--warning-color);
 $mention-user-pill-bg-color: var(--warning-color);
 $notice-primary-color: var(--warning-color);

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -224,7 +224,7 @@ $event-encrypting-color: #abddbc;
 $event-sending-color: #ddd;
 $event-notsent-color: #f44;
 
-$event-highlight-fg-color: $warning-color;
+$event-highlight-fg-color: $primary-fg-color;
 $event-highlight-bg-color: $yellow-background;
 
 // event redaction


### PR DESCRIPTION
This is a reintroduction of the changes from #2896.

Previously this change was rejected because in the absence of a pill, it would be impossible to tell if a message was highlighted or not. Since fc3c4fccc2a3b8d6f4d7a2d737fba6cb26df014b a yellow background has been added to highlighted messages making the red text redundant. I believe this also resolves the concerns discussed in in #2896.

This should address some issues with element (and probably a few more I'm missing):
vector-im/element-web/issues/9070
vector-im/element-web/issues/13963

Dark Theme:
Before: 
![element_before_c](https://user-images.githubusercontent.com/31573882/110228052-09562200-7ecc-11eb-9617-af390aa836f4.png)

After:
![element_after_c](https://user-images.githubusercontent.com/31573882/110228055-0f4c0300-7ecc-11eb-9bce-3a616fc9be6e.png)

Light Theme:
Before:
![element_before_light_c](https://user-images.githubusercontent.com/31573882/110228139-baf55300-7ecc-11eb-9431-46f117b1bbdd.png)

After:
![element_after_light_c](https://user-images.githubusercontent.com/31573882/110228143-c3e62480-7ecc-11eb-98fd-2667d118b8f5.png)

*Added 2021-04-01* Before and after demonstrating Replies, mentions, and keywords. (The disappearance of the shield icon is caused by an out-of-date fork)

Dark Theme:
Before:
![image](https://user-images.githubusercontent.com/31573882/113308323-0c2e1200-92d4-11eb-934c-87bdc6969ae4.png)

After:
![image](https://user-images.githubusercontent.com/31573882/113308358-16501080-92d4-11eb-9116-88e339b2d4bd.png)

Light Theme:
Before:
![image](https://user-images.githubusercontent.com/31573882/113307518-3501d780-92d3-11eb-9f79-7a4d6107440e.png)

After:
![image](https://user-images.githubusercontent.com/31573882/113307811-890cbc00-92d3-11eb-83fe-e0212b2b2985.png)

I wasn't able to generate a mention without a pill, although it should appear the same as the keyword message does in the examples above.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->