### PR TITLE
Add clipboard write permission for widgets

### DIFF
--- a/src/components/views/elements/AppTile.js
+++ b/src/components/views/elements/AppTile.js
@@ -325,7 +325,7 @@ export default class AppTile extends React.Component {
 
         // Additional iframe feature pemissions
         // (see - https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes and https://wicg.github.io/feature-policy/)
-        const iframeFeatures = "microphone; camera; encrypted-media; autoplay; display-capture;";
+        const iframeFeatures = "microphone; camera; encrypted-media; autoplay; display-capture; clipboard-write;";
 
         const appTileBodyClass = 'mx_AppTileBody' + (this.props.miniMode ? '_mini  ' : ' ');
 


### PR DESCRIPTION
I needed to copy elements inside of a widget.
For that I need clipboard permission but right now just for the write one.

For testing you can use:
/addwidget https://giphymatrix-git-addcopyonclick-helderfsferreira.vercel.app/m/test

With a click the GIF is copied.