### PR TITLE
Add look of dissaproval command

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -207,6 +207,19 @@ export const Commands = [
         category: CommandCategories.messages,
     }),
     new Command({
+        command: 'disapproval',
+        args: '<message>',
+        description: _td('Prepends ಠ_ಠ to a plain-text message'),
+        runFn: function(roomId, args) {
+            let message = 'ಠ_ಠ';
+            if (args) {
+                message = message + ' ' + args;
+            }
+            return success(MatrixClientPeg.get().sendTextMessage(roomId, message));
+        },
+        category: CommandCategories.messages,
+    }),
+    new Command({
         command: 'plain',
         args: '<message>',
         description: _td('Sends a message as plain text, without interpreting it as markdown'),


### PR DESCRIPTION
Adds the look of dissaproval ಠ_ಠ.

Signed-off-by: Mark Featherston <mark@embeddedarm.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add look of dissaproval command ([\#5726](https://github.com/matrix-org/matrix-react-sdk/pull/5726)). Contributed by @markfeathers.<!-- CHANGELOG_PREVIEW_END -->