### PR TITLE
Fix some ineffective placeholders in a couple log lines

### DIFF
--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -99,9 +99,9 @@ class Presence {
 
         try {
             await MatrixClientPeg.get().setPresence(this.state);
-            console.info("Presence: %s", newState);
+            console.info("Presence:", newState);
         } catch (err) {
-            console.error("Failed to set presence: %s", err);
+            console.error("Failed to set presence:", err);
             this.state = oldState;
         }
     }


### PR DESCRIPTION
Was producing `Presence: %s unavailable` in the logs.

There may be a better log system we want to use here other than `console.log`, but this fixes the immediate issue.