### PR TITLE
Change read receipt drift to be non-fractional

### DIFF
--- a/src/components/views/rooms/ReadReceiptMarker.js
+++ b/src/components/views/rooms/ReadReceiptMarker.js
@@ -156,14 +156,14 @@ export default class ReadReceiptMarker extends React.PureComponent {
         // then shift to the rightmost column,
         // and then it will drop down to its resting position
         //
-        // XXX: We use a fractional left value to trick velocity-animate into actually animating.
+        // XXX: We use a small left value to trick velocity-animate into actually animating.
         // This is a very annoying bug where if it thinks there's no change to `left` then it'll
         // skip applying it, thus making our read receipt at +14px instead of +0px like it
         // should be. This does cause a tiny amount of drift for read receipts, however with a
         // value so small it's not perceived by a user.
         // Note: Any smaller values (or trying to interchange units) might cause read receipts to
         // fail to fall down or cause gaps.
-        startStyles.push({ top: startTopOffset+'px', left: '0.001px' });
+        startStyles.push({ top: startTopOffset+'px', left: '1px' });
         enterTransitionOpts.push({
             duration: bounce ? Math.min(Math.log(Math.abs(startTopOffset)) * 200, 3000) : 300,
             easing: bounce ? 'easeOutBounce' : 'easeOutCubic',


### PR DESCRIPTION
I suspect this is what is causing issues in Firefox for read receipts not falling down.