### PR TITLE
Hangup all calls on logout

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -788,6 +788,11 @@ export default class CallHandler {
                 // don't remove the call yet: let the hangup event handler do it (otherwise it will throw
                 // the hangup event away)
                 break;
+            case 'hangup_all':
+                for (const call of this.calls.values()) {
+                    call.hangup(CallErrorCode.UserHangup, false);
+                }
+                break;
             case 'answer': {
                 if (!this.calls.has(payload.room_id)) {
                     return; // no call to answer

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -582,6 +582,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 }
                 break;
             case 'logout':
+                dis.dispatch({action: "hangup_all"});
                 Lifecycle.logout();
                 break;
             case 'require_registration':


### PR DESCRIPTION
Fixes [#16362](https://github.com/vector-im/element-web/issues/16362).

This isn't an ideal solution since the `m.call.hangup` event doesn't get sent before log out. That means that the call doesn't end for the other side, and it tries to reconnect. But this solves the privacy problems (the users can't hear/see each other), and the call will eventually fail on the other side.