### PR TITLE
fix: make room directory correct when using a homeserver with explicit port

### DIFF
--- a/src/MatrixClientPeg.ts
+++ b/src/MatrixClientPeg.ts
@@ -261,7 +261,7 @@ class _MatrixClientPeg implements IMatrixClientPeg {
     }
 
     public getHomeserverName(): string {
-        const matches = /^@.+:(.+)$/.exec(this.matrixClient.credentials.userId);
+        const matches = /^@[^:]+:(.+)$/.exec(this.matrixClient.credentials.userId);
         if (matches === null || matches.length < 1) {
             throw new Error("Failed to derive homeserver name from user ID!");
         }


### PR DESCRIPTION
Server names are allowed to contain ':' to specify a port, see https://matrix.org/docs/spec/appendices#server-name
User ids on the other hand are not allowed to contain ':', even
historical user ids, see https://matrix.org/docs/spec/appendices#historical-user-ids

Therefore we can use change the regex to make sure the localpart is not
allowed to contain ':'.

Signed-off-by: Timo Kösters timo@koesters.xyz