### PR TITLE
Remove forgotten rooms from the room list once forgotten

### DIFF
--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -655,6 +655,18 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
         if (!algorithmTags) return [DefaultTagID.Untagged];
         return algorithmTags;
     }
+
+    /**
+     * Manually update a room with a given cause. This should only be used if the
+     * room list store would otherwise be incapable of doing the update itself. Note
+     * that this may race with the room list's regular operation.
+     * @param {Room} room The room to update.
+     * @param {RoomUpdateCause} cause The cause to update for.
+     */
+    public async manualRoomUpdate(room: Room, cause: RoomUpdateCause) {
+        await this.handleRoomUpdate(room, cause);
+        this.updateFn.trigger();
+    }
 }
 
 export default class RoomListStore {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15559

This isn't exactly perfect as an implementation: if the user refreshes immediately after forgetting then there is a good chance the room re-appears because of the sync accumulator. At the very least this change makes it so in *most* cases the room goes away, which is probably good enough until https://github.com/vector-im/element-web/issues/14038 can be implemented properly.