### PR TITLE
Don't render single character Messages as Markdown.

### DIFF
--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -48,6 +48,11 @@ export function mdSerialize(model: EditorModel) {
 export function htmlSerializeIfNeeded(model: EditorModel, {forceHTML = false} = {}) {
     let md = mdSerialize(model);
 
+    // if it is only a single character,
+    // do not treat it as markdown
+    // https://github.com/matrix-org/matrix-react-sdk/pull/5779
+    if (md.trim().length <= 1) return md
+
     if (SettingsStore.getValue("feature_latex_maths")) {
         const displayPattern = (SdkConfig.get()['latex_maths_delims'] || {})['display_pattern'] ||
             "\\$\\$(([^$]|\\\\\\$)*)\\$\\$";


### PR DESCRIPTION
In my circles during video conferences it is quite common to respond non-verbally to spoken content with following messages
- `+`  _"I support"_
- `-` _"I oppose"_
- `*` _"I want to say something"_

unfortunately all of these 3 messages get rendered by markdown to a list with a single empty entry. like:

-

Because I can't imagine any single character message, where it could be somehow useful to have it rendered as markdown, I think we could just avoid the rendering for such short messages.