### PR TITLE
Fix CIDER formatting buttons on Safari

### DIFF
--- a/docs/ciderEditor.md
+++ b/docs/ciderEditor.md
@@ -21,14 +21,14 @@ caret nodes (more on that later).
 For these reasons it doesn't use `innerText`, `textContent` or anything similar.
 The model addresses any content in the editor within as an offset within this string.
 The caret position is thus also converted from a position in the DOM tree
-to an offset in the content string. This happens in `getCaretOffsetAndText` in `dom.js`.
+to an offset in the content string. This happens in `getCaretOffsetAndText` in `dom.ts`.
 
 Once the content string and caret offset is calculated, it is passed to the `update()`
 method of the model. The model first calculates the same content string of its current parts,
 basically just concatenating their text. It then looks for differences between
 the current and the new content string. The diffing algorithm is very basic,
 and assumes there is only one change around the caret offset,
-so this should be very inexpensive. See `diff.js` for details.
+so this should be very inexpensive. See `diff.ts` for details.
 
 The result of the diffing is the strings that were added and/or removed from
 the current content. These differences are then applied to the parts,
@@ -51,7 +51,7 @@ which relate poorly to text input or changes, and don't need the `beforeinput` e
 which isn't broadly supported yet.
 
 Once the parts of the model are updated, the DOM of the editor is then reconciled
-with the new model state, see `renderModel` in `render.js` for this.
+with the new model state, see `renderModel` in `render.ts` for this.
 If the model didn't reject the input and didn't make any additional changes,
 this won't make any changes to the DOM at all, and should thus be fairly efficient.
 

--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -60,6 +60,8 @@ limitations under the License.
         width: 27px;
         height: 24px;
         box-sizing: border-box;
+        background: none;
+        vertical-align: middle;
     }
 
     .mx_MessageComposerFormatBar_button::after {

--- a/src/components/views/rooms/MessageComposerFormatBar.js
+++ b/src/components/views/rooms/MessageComposerFormatBar.js
@@ -85,8 +85,8 @@ class FormatButton extends React.PureComponent {
 
         return (
             <AccessibleTooltipButton
-                as="span"
-                role="button"
+                element="button"
+                type="button"
                 onClick={this.props.onClick}
                 title={this.props.label}
                 tooltip={tooltip}


### PR DESCRIPTION
Hi folks 👋 ,

This PR fixes vector-im/element-web#15710

The issue stemmed from the fact that `document.getSelection()` would be empty when called inside `BasicMessageComposer.tsx#onFormatAction`.
After a bit of digging around it appears that Safari resets the selection if a user clicks on something different than a `<button type="button">` (which is odd given that passing the `role="button"` attribute down should help)

My fix is to essentially use the more semantic HTML tag. I had a bit of CSS tweaking as `button` inherit a background colour and have a different inline type compared to `div`.
There are references to an `as` prop on the `AccessibleButton` component but could not see it anywhere in the proptypes, I have assumed that `element` was the appropriate prop to use here

PS: I have updated docs where names have gone stale after migrating from JS to TS