### PR TITLE
Only show the ask anyway modal for explicit user lookup failures

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -886,19 +886,21 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
     };
 
     _toggleMember = (member: Member) => {
-        let filterText = this.state.filterText;
-        const targets = this.state.targets.map(t => t); // cheap clone for mutation
-        const idx = targets.indexOf(member);
-        if (idx >= 0) {
-            targets.splice(idx, 1);
-        } else {
-            targets.push(member);
-            filterText = ""; // clear the filter when the user accepts a suggestion
-        }
-        this.setState({targets, filterText});
+        if (!this.state.busy) {
+            let filterText = this.state.filterText;
+            const targets = this.state.targets.map(t => t); // cheap clone for mutation
+            const idx = targets.indexOf(member);
+            if (idx >= 0) {
+                targets.splice(idx, 1);
+            } else {
+                targets.push(member);
+                filterText = ""; // clear the filter when the user accepts a suggestion
+            }
+            this.setState({targets, filterText});
 
-        if (this._editorRef && this._editorRef.current) {
-            this._editorRef.current.focus();
+            if (this._editorRef && this._editorRef.current) {
+                this._editorRef.current.focus();
+            }
         }
     };
 

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -673,7 +673,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
             console.error(err);
             this.setState({
                 busy: false,
-                errorText: _t("We couldn't create your DM. Please check the users you want to invite and try again."),
+                errorText: _t("We couldn't create your DM."),
             });
         });
     };

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2184,7 +2184,7 @@
     "Click the button below to confirm your identity.": "Click the button below to confirm your identity.",
     "Invite by email": "Invite by email",
     "Failed to invite the following users to chat: %(csvUsers)s": "Failed to invite the following users to chat: %(csvUsers)s",
-    "We couldn't create your DM. Please check the users you want to invite and try again.": "We couldn't create your DM. Please check the users you want to invite and try again.",
+    "We couldn't create your DM.": "We couldn't create your DM.",
     "Something went wrong trying to invite the users.": "Something went wrong trying to invite the users.",
     "We couldn't invite those users. Please check the users you want to invite and try again.": "We couldn't invite those users. Please check the users you want to invite and try again.",
     "A call can only be transferred to a single user.": "A call can only be transferred to a single user.",

--- a/src/utils/MultiInviter.js
+++ b/src/utils/MultiInviter.js
@@ -164,7 +164,7 @@ export default class MultiInviter {
                         this._doInvite(address, ignoreProfile).then(resolve, reject);
                     }, 5000);
                     return;
-                } else if (['M_NOT_FOUND', 'M_USER_NOT_FOUND', 'RIOT.USER_NOT_FOUND'].includes(err.errcode)) {
+                } else if (['M_NOT_FOUND', 'M_USER_NOT_FOUND'].includes(err.errcode)) {
                     errorText = _t("User %(user_id)s does not exist", {user_id: address});
                 } else if (err.errcode === 'M_PROFILE_UNDISCLOSED') {
                     errorText = _t("User %(user_id)s may or may not exist", {user_id: address});
@@ -205,7 +205,7 @@ export default class MultiInviter {
             if (Object.keys(this.errors).length > 0 && !this.groupId) {
                 // There were problems inviting some people - see if we can invite them
                 // without caring if they exist or not.
-                const unknownProfileErrors = ['M_NOT_FOUND', 'M_USER_NOT_FOUND', 'M_PROFILE_UNDISCLOSED', 'M_PROFILE_NOT_FOUND', 'RIOT.USER_NOT_FOUND'];
+                const unknownProfileErrors = ['M_NOT_FOUND', 'M_USER_NOT_FOUND', 'M_PROFILE_UNDISCLOSED', 'M_PROFILE_NOT_FOUND'];
                 const unknownProfileUsers = Object.keys(this.errors).filter(a => unknownProfileErrors.includes(this.errors[a].errcode));
 
                 if (unknownProfileUsers.length > 0) {

--- a/src/utils/MultiInviter.js
+++ b/src/utils/MultiInviter.js
@@ -111,17 +111,10 @@ export default class MultiInviter {
             }
 
             if (!ignoreProfile && SettingsStore.getValue("promptBeforeInviteUnknownUsers", this.roomId)) {
-                try {
-                    const profile = await MatrixClientPeg.get().getProfileInfo(addr);
-                    if (!profile) {
-                        // noinspection ExceptionCaughtLocallyJS
-                        throw new Error("User has no profile");
-                    }
-                } catch (e) {
-                    throw {
-                        errcode: "RIOT.USER_NOT_FOUND",
-                        error: "User does not have a profile or does not exist."
-                    };
+                const profile = await MatrixClientPeg.get().getProfileInfo(addr);
+                if (!profile) {
+                    // noinspection ExceptionCaughtLocallyJS
+                    throw new Error("User has no profile");
                 }
             }
 

--- a/src/utils/MultiInviter.js
+++ b/src/utils/MultiInviter.js
@@ -221,7 +221,7 @@ export default class MultiInviter {
 
                     const AskInviteAnywayDialog = sdk.getComponent("dialogs.AskInviteAnywayDialog");
                     console.log("Showing failed to invite dialog...");
-                    Modal.createTrackedDialog('Failed to invite the following users to the room', '', AskInviteAnywayDialog, {
+                    Modal.createTrackedDialog('Failed to invite', '', AskInviteAnywayDialog, {
                         unknownProfileUsers: unknownProfileUsers.map(u => {return {userId: u, errorText: this.errors[u].errorText};}),
                         onInviteAnyways: () => inviteUnknowns(),
                         onGiveUp: () => {


### PR DESCRIPTION
This PR fixes vector-im/element-web#16168 

Two main issues were identified
- The "ask anyway" modal was shown a bit too often
- In the direct message invite flow, it is possible to toggle an other in whilst a request is performed

Many other quirks and improvements to the invite flow were uncovered too but would require significant update from @nadonomy & the team, so this PR focuses on the two issue above

### Copy in the "_invite to a room_" flow when a request has failed
> Failed to invite the following users to chat: @johndoe:example.com


### Copy in the "_invite to DM_" flow when a request has failed
> We couldn't create your DM. Please check the users you want to invite and try again.