### PR TITLE
Improve error reporting when EventIndex fails on a supported environment

### DIFF
--- a/src/components/views/settings/EventIndexPanel.js
+++ b/src/components/views/settings/EventIndexPanel.js
@@ -190,7 +190,7 @@ export default class EventIndexPanel extends React.Component {
                     }
                 </div>
             );
-        } else {
+        } else if (!EventIndexPeg.platformHasSupport()) {
             eventIndexingSettings = (
                 <div className='mx_SettingsTab_subsectionText'>
                     {
@@ -206,6 +206,23 @@ export default class EventIndexPanel extends React.Component {
                             },
                         )
                     }
+                </div>
+            );
+        } else {
+            eventIndexingSettings = (
+                <div className='mx_SettingsTab_subsectionText'>
+                    <p>
+                        {_t("Message search initilisation failed")}
+                    </p>
+                    {EventIndexPeg.error && (
+                    <details>
+                        <summary>{_t("Advanced")}</summary>
+                        <code>
+                            {EventIndexPeg.error.message}
+                        </code>
+                    </details>
+                    )}
+
                 </div>
             );
         }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1081,6 +1081,7 @@
     "Securely cache encrypted messages locally for them to appear in search results.": "Securely cache encrypted messages locally for them to appear in search results.",
     "%(brand)s is missing some components required for securely caching encrypted messages locally. If you'd like to experiment with this feature, build a custom %(brand)s Desktop with <nativeLink>search components added</nativeLink>.": "%(brand)s is missing some components required for securely caching encrypted messages locally. If you'd like to experiment with this feature, build a custom %(brand)s Desktop with <nativeLink>search components added</nativeLink>.",
     "%(brand)s can't securely cache encrypted messages locally while running in a web browser. Use <desktopLink>%(brand)s Desktop</desktopLink> for encrypted messages to appear in search results.": "%(brand)s can't securely cache encrypted messages locally while running in a web browser. Use <desktopLink>%(brand)s Desktop</desktopLink> for encrypted messages to appear in search results.",
+    "Message search initilisation failed": "Message search initilisation failed",
     "Connecting to integration manager...": "Connecting to integration manager...",
     "Cannot connect to integration manager": "Cannot connect to integration manager",
     "The integration manager is offline or it cannot reach your homeserver.": "The integration manager is offline or it cannot reach your homeserver.",

--- a/src/indexing/EventIndexPeg.js
+++ b/src/indexing/EventIndexPeg.js
@@ -31,6 +31,7 @@ class EventIndexPeg {
     constructor() {
         this.index = null;
         this._supportIsInstalled = false;
+        this.error = null;
     }
 
     /**
@@ -96,6 +97,7 @@ class EventIndexPeg {
             await index.init();
         } catch (e) {
             console.log("EventIndex: Error initializing the event index", e);
+            this.error = e;
             return false;
         }
 


### PR DESCRIPTION
Fixes vector-im/element-web#15168

The message search feature would sometimes fail to initialise for a [variety of reasons](https://github.com/matrix-org/seshat/blob/master/src/error.rs#L22)

The UI component would behave as if message search is not supported because the initilisation failed. We are now adding an extra condition to not incorrectly suggest that message search is not available.
Given the quite technical nature of the failures we added an `advanced` summary to surface the exception and help receive more accurate bug report

I will work on ways for a user to try and recover from those issues (see vector-im/element-web#14229)

And because a picture is worth a thousand words
![Screen Shot 2021-03-24 at 11 40 16](https://user-images.githubusercontent.com/769871/112305931-2a25c200-8c97-11eb-8920-afb233fdd09b.png)
