### PR TITLE
View Source: make Event ID go below Event ID

### DIFF
--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -14,14 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_ViewSource_label_left {
-    float: left;
-}
-
-.mx_ViewSource_label_right {
-    float: right;
-}
-
 .mx_ViewSource_separator {
     clear: both;
     border-bottom: 1px solid #e5e5e5;

--- a/src/components/structures/ViewSource.js
+++ b/src/components/structures/ViewSource.js
@@ -176,8 +176,8 @@ export default class ViewSource extends React.Component {
         return (
             <BaseDialog className="mx_ViewSource" onFinished={this.props.onFinished} title={_t("View Source")}>
                 <div>
-                    <div className="mx_ViewSource_label_left">Room ID: {roomId}</div>
-                    <div className="mx_ViewSource_label_left">Event ID: {eventId}</div>
+                    <div>Room ID: {roomId}</div>
+                    <div>Event ID: {eventId}</div>
                     <div className="mx_ViewSource_separator" />
                     {isEditing ? this.editSourceContent() : this.viewSourceContent()}
                 </div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16653

Before (when the width was large enough):
![image](https://user-images.githubusercontent.com/27917356/112495956-0a70c580-8d8d-11eb-8268-4d26b87dec75.png)
After:
![image](https://user-images.githubusercontent.com/27917356/112496149-2d9b7500-8d8d-11eb-9747-935d474df403.png)

Signed-off-by: Panagiotis Chalimourdas <panagiotis4531@gmail.com>