### PR TITLE
Fix password change popup message

### DIFF
--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -206,10 +206,10 @@ export default class GeneralUserSettingsTab extends React.Component {
 
     _onPasswordChangeError = (err) => {
         // TODO: Figure out a design that doesn't involve replacing the current dialog
-        let errMsg = err.error || "";
+        let errMsg = err.error || err.message || "";
         if (err.httpStatus === 403) {
             errMsg = _t("Failed to change password. Is your password correct?");
-        } else if (err.httpStatus) {
+        } else if (!errMsg) {
             errMsg += ` (HTTP status ${err.httpStatus})`;
         }
         const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");


### PR DESCRIPTION
Fixed bad error message when providing bad old password during password change.

Broken behaviour:
When providing an incorrect old password in password change form in user settings, element gets a response from synapse with error message inside "message" field. It expects it in "error" field so the popup message shows "HTTP status 401"

Expected behaviour after change:
The popup says whatever comes from synapse. "Wrong password" in this example.

This looks like https://github.com/vector-im/element-web/issues/4365 but this PR doesn't address showing the same popup twice as described in the issue. It was not observed on most current synapse-element combo.