### PR TITLE
Add view source button on error boundary for messages

### DIFF
--- a/src/components/views/messages/TileErrorBoundary.js
+++ b/src/components/views/messages/TileErrorBoundary.js
@@ -17,7 +17,6 @@ limitations under the License.
 import React from 'react';
 import classNames from 'classnames';
 import { _t } from '../../../languageHandler';
-import * as sdk from '../../../index';
 import Modal from '../../../Modal';
 import SdkConfig from "../../../SdkConfig";
 import {replaceableComponent} from "../../../utils/replaceableComponent";

--- a/src/components/views/messages/TileErrorBoundary.js
+++ b/src/components/views/messages/TileErrorBoundary.js
@@ -83,7 +83,7 @@ export default class TileErrorBoundary extends React.Component {
                             {_t("Can't load this message")}
                             {mxEvent && ` (${mxEvent.getType()})`}
                             {submitLogsButton}
-                            {viewSourceButton}
+                            {mxEvent && viewSourceButton}
                         </span>
                     </div>
                 </div>

--- a/src/components/views/messages/TileErrorBoundary.js
+++ b/src/components/views/messages/TileErrorBoundary.js
@@ -48,6 +48,13 @@ export default class TileErrorBoundary extends React.Component {
         });
     };
 
+    onViewSourceClick = () => {
+        const ViewSource = sdk.getComponent('structures.ViewSource');
+        Modal.createTrackedDialog('View Event Source', '', ViewSource, {
+            mxEvent: this.props.mxEvent,
+        }, 'mx_Dialog_viewsource');
+    };
+
     render() {
         if (this.state.error) {
             const { mxEvent } = this.props;
@@ -65,15 +72,22 @@ export default class TileErrorBoundary extends React.Component {
                 </a>;
             }
 
-            return (<div className={classNames(classes)}>
-                <div className="mx_EventTile_line">
-                    <span>
-                        {_t("Can't load this message")}
-                        { mxEvent && ` (${mxEvent.getType()})` }
-                        { submitLogsButton }
-                    </span>
+            const viewSourceButton = <a onClick={this.onViewSourceClick} href="#">
+                {_t("View Source")}
+            </a>;
+
+            return (
+                <div className={classNames(classes)}>
+                    <div className="mx_EventTile_line">
+                        <span>
+                            {_t("Can't load this message")}
+                            {mxEvent && ` (${mxEvent.getType()})`}
+                            {submitLogsButton}
+                            {viewSourceButton}
+                        </span>
+                    </div>
                 </div>
-            </div>);
+            );
         }
 
         return this.props.children;

--- a/src/components/views/messages/TileErrorBoundary.js
+++ b/src/components/views/messages/TileErrorBoundary.js
@@ -21,6 +21,8 @@ import * as sdk from '../../../index';
 import Modal from '../../../Modal';
 import SdkConfig from "../../../SdkConfig";
 import {replaceableComponent} from "../../../utils/replaceableComponent";
+import ViewSource from '../../structures/ViewSource';
+import BugReportDialog from '../dialogs/BugReportDialog';
 
 @replaceableComponent("views.messages.TileErrorBoundary")
 export default class TileErrorBoundary extends React.Component {
@@ -39,17 +41,12 @@ export default class TileErrorBoundary extends React.Component {
     }
 
     _onBugReport = () => {
-        const BugReportDialog = sdk.getComponent("dialogs.BugReportDialog");
-        if (!BugReportDialog) {
-            return;
-        }
         Modal.createTrackedDialog('Bug Report Dialog', '', BugReportDialog, {
             label: 'react-soft-crash-tile',
         });
     };
 
     onViewSourceClick = () => {
-        const ViewSource = sdk.getComponent('structures.ViewSource');
         Modal.createTrackedDialog('View Event Source', '', ViewSource, {
             mxEvent: this.props.mxEvent,
         }, 'mx_Dialog_viewsource');


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15409

We could not want this, though, because I suppose errors will not happen at all, and you can use the console or the logs to debug the error.

I added a second link here. We could also do it with a context menu like on normal messages.
![image](https://user-images.githubusercontent.com/27917356/112497913-b666e080-8d8e-11eb-9882-c3583659fd74.png)

Signed-off-by: Panagiotis Chalimourdas <panagiotis4531@gmail.com>