### PR TITLE
Remember reply when switching rooms

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.js
+++ b/src/components/views/rooms/SendMessageComposer.js
@@ -472,12 +472,17 @@ export default class SendMessageComposer extends React.Component {
         }
     }
 
+    // should save state when editor has contents or reply is open
+    _shouldSaveStoredEditorState = () => {
+        return !this.model.isEmpty || this.props.replyToEvent;
+    }
+
     _saveStoredEditorState = () => {
-        if (this.model.isEmpty) {
-            this._clearStoredEditorState();
-        } else {
+        if (this._shouldSaveStoredEditorState()) {
             const item = SendHistoryManager.createItem(this.model, this.props.replyToEvent);
             localStorage.setItem(this._editorStateKey, JSON.stringify(item));
+        } else {
+            this._clearStoredEditorState();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16716 (with empty editor, and reply box open)
I didn't reproduce the problem when the editor had contents in it, as https://github.com/vector-im/element-web/issues/16767 reports. So, that problem could be unrelated.

Signed-off-by: Panagiotis Chalimourdas <panagiotis4531@gmail.com>