### PR TITLE
Fix line numbers when missing trailing newline

### DIFF
--- a/src/components/views/messages/TextualBody.js
+++ b/src/components/views/messages/TextualBody.js
@@ -216,12 +216,12 @@ export default class TextualBody extends React.Component {
     }
 
     _addLineNumbers(pre) {
+        // Calculate number of lines in pre
+        const number = pre.innerHTML.replace(/\n(<\/code>)?$/, "").split(/\n/).length;
         pre.innerHTML = '<span class="mx_EventTile_lineNumbers"></span>' + pre.innerHTML + '<span></span>';
         const lineNumbers = pre.getElementsByClassName("mx_EventTile_lineNumbers")[0];
-        // Calculate number of lines in pre
-        const number = pre.innerHTML.split(/\n/).length;
         // Iterate through lines starting with 1 (number of the first line is 1)
-        for (let i = 1; i < number; i++) {
+        for (let i = 1; i <= number; i++) {
             lineNumbers.innerHTML += '<span class="mx_EventTile_lineNumber">' + i + '</span>';
         }
     }


### PR DESCRIPTION
`_addLineNumbers` expected code blocks to contain a trailing newline, but this is not always the case.

Before:

![Screenshot_2021-03-25 Element Test room(1)](https://user-images.githubusercontent.com/48614497/112548161-2b87e500-8d92-11eb-9cfe-55d7f45294ac.png)

After:

![Screenshot_2021-03-25 Element Test room(2)](https://user-images.githubusercontent.com/48614497/112548178-32aef300-8d92-11eb-8982-bb92ed63a43e.png)