### PR TITLE
Tweak security key error handling

### DIFF
--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -395,6 +395,8 @@ export async function accessSecretStorage(func = async () => { }, forceReset = f
     } catch (e) {
         SecurityCustomisations.catchAccessSecretStorageError?.(e);
         console.error(e);
+        // Re-throw so that higher level logic can abort as needed
+        throw e;
     } finally {
         // Clear secret storage key cache now that work is complete
         secretStorageBeingAccessed = false;

--- a/src/stores/SetupEncryptionStore.js
+++ b/src/stores/SetupEncryptionStore.js
@@ -121,21 +121,16 @@ export class SetupEncryptionStore extends EventEmitter {
             // on the first trust check, and the key backup restore will happen
             // in the background.
             await new Promise((resolve, reject) => {
-                try {
-                    accessSecretStorage(async () => {
-                        await cli.checkOwnCrossSigningTrust();
-                        resolve();
-                        if (backupInfo) {
-                            // A complete restore can take many minutes for large
-                            // accounts / slow servers, so we allow the dialog
-                            // to advance before this.
-                            await cli.restoreKeyBackupWithSecretStorage(backupInfo);
-                        }
-                    }).catch(reject);
-                } catch (e) {
-                    console.error(e);
-                    reject(e);
-                }
+                accessSecretStorage(async () => {
+                    await cli.checkOwnCrossSigningTrust();
+                    resolve();
+                    if (backupInfo) {
+                        // A complete restore can take many minutes for large
+                        // accounts / slow servers, so we allow the dialog
+                        // to advance before this.
+                        await cli.restoreKeyBackupWithSecretStorage(backupInfo);
+                    }
+                }).catch(reject);
             });
 
             if (cli.getCrossSigningId()) {


### PR DESCRIPTION
This reworks error handling of "use security key" so we stop the overall operation when cancelling access (instead of just the immediate prompt). In addition, flowing the error to outer catch block also handles resetting state to re-display the initial verification choices.

Fixes https://github.com/vector-im/element-web/issues/15584
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1653