### PR TITLE
Prevent Re-request encryption keys from appearing under redacted messages

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -936,7 +936,7 @@ export default class EventTile extends React.Component {
             );
 
         const TooltipButton = sdk.getComponent('elements.TooltipButton');
-        const keyRequestInfo = isEncryptionFailure ?
+        const keyRequestInfo = isEncryptionFailure && !isRedacted ?
             <div className="mx_EventTile_keyRequestInfo">
                 <span className="mx_EventTile_keyRequestInfo_text">
                     { keyRequestInfoContent }


### PR DESCRIPTION
Couldn't find an issue for this but I find it annoying when the Re-request encryption keys prompt appears below redacted messages. Since the message was redacted clicking that surely isn't going to do anything to make the message more visible to me so it shouldn't be displayed at all.

Before:
<img width="434" alt="before screenshot" src="https://user-images.githubusercontent.com/5855073/112783933-0c00ee80-9016-11eb-9f60-dd76d89c3878.png">

After: 
<img width="226" alt="after screenshot" src="https://user-images.githubusercontent.com/5855073/112784016-3652ac00-9016-11eb-8537-efc59fc46940.png">
