### PR TITLE
Fix broken "Go to Home View" shortcut on macOS

### DIFF
--- a/src/KeyBindingsDefaults.ts
+++ b/src/KeyBindingsDefaults.ts
@@ -360,11 +360,11 @@ const navigationBindings = (): KeyBinding<NavigationAction>[] => {
             action: NavigationAction.GoToHome,
             keyCombo: {
                 key: Key.H,
-                ctrlOrCmd: true,
-                altKey: true,
+                ctrlKey: true,
+                altKey: !isMac,
+                shiftKey: isMac,
             },
         },
-
         {
             action: NavigationAction.SelectPrevRoom,
             keyCombo: {

--- a/src/accessibility/KeyboardShortcuts.tsx
+++ b/src/accessibility/KeyboardShortcuts.tsx
@@ -265,7 +265,7 @@ const shortcuts: Record<Categories, IShortcut[]> = {
             description: _td("Toggle this dialog"),
         }, {
             keybinds: [{
-                modifiers: [CMD_OR_CTRL, Modifiers.ALT],
+                modifiers: [Modifiers.CONTROL, isMac ? Modifiers.SHIFT : Modifiers.ALT],
                 key: Key.H,
             }],
             description: _td("Go to Home View"),


### PR DESCRIPTION
The previous shortcut CMD+OPT+H is already bound by the system (hide other windows) and cannot be overridden. This commit changes the shortcut to CTRL+SHIFT+H on macOS while keeping CTRL+ALT+H on other platforms.

Note that both CTRL+OPT+H (hide cursor) and CTRL+H (delete previous character) are bound by the system as well and wouldn't have worked as a replacement.

Fixes: vector-im/element-web#16692

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>