### PR TITLE
Increase default visible tiles for room sublists

### DIFF
--- a/src/stores/room-list/ListLayout.ts
+++ b/src/stores/room-list/ListLayout.ts
@@ -82,7 +82,7 @@ export class ListLayout {
 
     public get defaultVisibleTiles(): number {
         // This number is what "feels right", and mostly subject to design's opinion.
-        return 5;
+        return 8;
     }
 
     public tilesWithPadding(n: number, paddingPx: number): number {


### PR DESCRIPTION
Fixes vector-im/element-web#15756

This has been discussed with @jryans and @nadonomy and increasing felt like the most pragmatic decision to make in this scenario

Another approach that we discussed what to never collapse anything for new users so that they won't face this issue. This however requires us to define what defines a new user on Element and for the behaviour to change unexpectedly 