### PR TITLE
Make user autocomplete query search beyond prefix

### DIFF
--- a/src/autocomplete/QueryMatcher.ts
+++ b/src/autocomplete/QueryMatcher.ts
@@ -23,7 +23,6 @@ interface IOptions<T extends {}> {
     keys: Array<string | keyof T>;
     funcs?: Array<(T) => string>;
     shouldMatchWordsOnly?: boolean;
-    shouldMatchPrefix?: boolean;
     // whether to apply unhomoglyph and strip diacritics to fuzz up the search. Defaults to true
     fuzzy?: boolean;
 }
@@ -55,12 +54,6 @@ export default class QueryMatcher<T extends Object> {
         // query and the value being queried before matching
         if (this._options.shouldMatchWordsOnly === undefined) {
             this._options.shouldMatchWordsOnly = true;
-        }
-
-        // By default, match anywhere in the string being searched. If enabled, only return
-        // matches that are prefixed with the query.
-        if (this._options.shouldMatchPrefix === undefined) {
-            this._options.shouldMatchPrefix = false;
         }
     }
 
@@ -112,7 +105,7 @@ export default class QueryMatcher<T extends Object> {
                 resultKey = resultKey.replace(/[^\w]/g, '');
             }
             const index = resultKey.indexOf(query);
-            if (index !== -1 && (!this._options.shouldMatchPrefix || index === 0)) {
+            if (index !== -1) {
                 matches.push(
                     ...candidates.map((candidate) => ({index, ...candidate})),
                 );

--- a/src/autocomplete/UserProvider.tsx
+++ b/src/autocomplete/UserProvider.tsx
@@ -56,7 +56,6 @@ export default class UserProvider extends AutocompleteProvider {
         this.matcher = new QueryMatcher([], {
             keys: ['name'],
             funcs: [obj => obj.userId.slice(1)], // index by user id minus the leading '@'
-            shouldMatchPrefix: false,
             shouldMatchWordsOnly: false,
         });
 

--- a/src/autocomplete/UserProvider.tsx
+++ b/src/autocomplete/UserProvider.tsx
@@ -56,7 +56,7 @@ export default class UserProvider extends AutocompleteProvider {
         this.matcher = new QueryMatcher([], {
             keys: ['name'],
             funcs: [obj => obj.userId.slice(1)], // index by user id minus the leading '@'
-            shouldMatchPrefix: true,
+            shouldMatchPrefix: false,
             shouldMatchWordsOnly: false,
         });
 

--- a/test/autocomplete/QueryMatcher-test.js
+++ b/test/autocomplete/QueryMatcher-test.js
@@ -183,18 +183,4 @@ describe('QueryMatcher', function() {
         expect(results.length).toBe(1);
         expect(results[0].name).toBe('bob');
     });
-
-    it('Matches only by prefix with shouldMatchPrefix on', function() {
-        const qm = new QueryMatcher([
-            {name: "Victoria"},
-            {name: "Tori"},
-        ], {
-            keys: ["name"],
-            shouldMatchPrefix: true,
-         });
-
-        const results = qm.match('tori');
-        expect(results.length).toBe(1);
-        expect(results[0].name).toBe('Tori');
-    });
 });


### PR DESCRIPTION
fixes vector-im/element-web#12237

The user autocomplete query matcher would not look beyond the prefix. This changes this behaviour to be able to look through the whole user name