### PR TITLE
Add fake fallback thumbnail URL for encrypted videos

### DIFF
--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -132,7 +132,7 @@ export default class MVideoBody extends React.PureComponent<IProps, IState> {
                         // enable the play button. Firefox does not seem to care either
                         // way, so it's fine to do for all browsers.
                         decryptedUrl: `data:${content?.info?.mimetype},`,
-                        decryptedThumbnailUrl: thumbnailUrl,
+                        decryptedThumbnailUrl: thumbnailUrl || `data:${content?.info?.mimetype},`,
                         decryptedBlob: null,
                     });
                 }


### PR DESCRIPTION
Without this fix, encrypted videos without a thumbnail aren't playable at all, since the browser decides it's invalid and doesn't show the play button to load the full video.