### PR TITLE
Remove status area UI defects when in-call

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -262,12 +262,6 @@ hr.mx_RoomView_myReadMarker {
     padding-top: 1px;
 }
 
-.mx_RoomView_inCall .mx_RoomView_statusAreaBox {
-    background-color: $accent-color;
-    color: $accent-fg-color;
-    position: relative;
-}
-
 .mx_RoomView_voipChevron {
     position: absolute;
     bottom: -11px;


### PR DESCRIPTION
Fixes vector-im/element-web#16830

It looks like some extra CSS was applied to the `StatusAreaBox` only when in call. Removing that extra bit of CSS makes it looks exactly the same no matter whether you are in call or not

The `position: relative` also explains the second isuse where two items are stacked. By removing it `StatusAreaBox` does not have a stacking context assigned and therefore the call toast will be displayed over that piece of UI