### PR TITLE
Add ability to hide post-login encryption setup with customisation point

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -80,10 +80,10 @@ import DialPadModal from "../views/voip/DialPadModal";
 import { showToast as showMobileGuideToast } from '../../toasts/MobileGuideToast';
 import { shouldUseLoginForWelcome } from "../../utils/pages";
 import SpaceStore from "../../stores/SpaceStore";
-import SpaceRoomDirectory from "./SpaceRoomDirectory";
 import {replaceableComponent} from "../../utils/replaceableComponent";
 import RoomListStore from "../../stores/room-list/RoomListStore";
 import {RoomUpdateCause} from "../../stores/room-list/models";
+import defaultDispatcher from "../../dispatcher/dispatcher";
 import SecurityCustomisations from "../../customisations/Security";
 
 /** constants for MatrixChat.state.view */
@@ -203,7 +203,6 @@ interface IState {
     ready: boolean;
     threepidInvite?: IThreepidInvite,
     roomOobData?: object;
-    viaServers?: string[];
     pendingInitialSync?: boolean;
     justRegistered?: boolean;
     roomJustCreatedOpts?: IOpts;
@@ -696,10 +695,10 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             }
             case Action.ViewRoomDirectory: {
                 if (SpaceStore.instance.activeSpace) {
-                    Modal.createTrackedDialog("Space room directory", "", SpaceRoomDirectory, {
-                        space: SpaceStore.instance.activeSpace,
-                        initialText: payload.initialText,
-                    }, "mx_SpaceRoomDirectory_dialogWrapper", false, true);
+                    defaultDispatcher.dispatch({
+                        action: "view_room",
+                        room_id: SpaceStore.instance.activeSpace.roomId,
+                    });
                 } else {
                     const RoomDirectory = sdk.getComponent("structures.RoomDirectory");
                     Modal.createTrackedDialog('Room directory', '', RoomDirectory, {
@@ -934,7 +933,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 page_type: PageTypes.RoomView,
                 threepidInvite: roomInfo.threepid_invite,
                 roomOobData: roomInfo.oob_data,
-                viaServers: roomInfo.via_servers,
                 ready: true,
                 roomJustCreatedOpts: roomInfo.justCreatedOpts,
             }, () => {

--- a/src/components/structures/auth/CompleteSecurity.js
+++ b/src/components/structures/auth/CompleteSecurity.js
@@ -28,7 +28,6 @@ import {
 } from '../../../stores/SetupEncryptionStore';
 import SetupEncryptionBody from "./SetupEncryptionBody";
 import {replaceableComponent} from "../../../utils/replaceableComponent";
-import SecurityCustomisations from "../../../customisations/Security";
 
 @replaceableComponent("structures.auth.CompleteSecurity")
 export default class CompleteSecurity extends React.Component {
@@ -46,13 +45,6 @@ export default class CompleteSecurity extends React.Component {
 
     _onStoreUpdate = () => {
         const store = SetupEncryptionStore.sharedInstance();
-
-        // Skip "you're done" phase if the UI isn't shown
-        if (store.phase === PHASE_DONE && SecurityCustomisations.SHOW_ENCRYPTION_SETUP_UI === false) {
-            this.props.onFinished(true);
-            return;
-        }
-
         this.setState({phase: store.phase});
     };
 
@@ -69,9 +61,7 @@ export default class CompleteSecurity extends React.Component {
         let icon;
         let title;
 
-        // If the encryption UI is hidden then we can simply return nothing - the UI doesn't
-        // need to be running in order to set up encryption with the SecurityCustomisations.
-        if (phase === PHASE_LOADING || SecurityCustomisations.SHOW_ENCRYPTION_SETUP_UI === false) {
+        if (phase === PHASE_LOADING) {
             return null;
         } else if (phase === PHASE_INTRO) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;

--- a/src/components/structures/auth/CompleteSecurity.js
+++ b/src/components/structures/auth/CompleteSecurity.js
@@ -28,6 +28,7 @@ import {
 } from '../../../stores/SetupEncryptionStore';
 import SetupEncryptionBody from "./SetupEncryptionBody";
 import {replaceableComponent} from "../../../utils/replaceableComponent";
+import SecurityCustomisations from "../../../customisations/Security";
 
 @replaceableComponent("structures.auth.CompleteSecurity")
 export default class CompleteSecurity extends React.Component {
@@ -45,6 +46,13 @@ export default class CompleteSecurity extends React.Component {
 
     _onStoreUpdate = () => {
         const store = SetupEncryptionStore.sharedInstance();
+
+        // Skip "you're done" phase if the UI isn't shown
+        if (store.phase === PHASE_DONE && SecurityCustomisations.SHOW_ENCRYPTION_SETUP_UI === false) {
+            this.props.onFinished(true);
+            return;
+        }
+
         this.setState({phase: store.phase});
     };
 
@@ -61,7 +69,9 @@ export default class CompleteSecurity extends React.Component {
         let icon;
         let title;
 
-        if (phase === PHASE_LOADING) {
+        // If the encryption UI is hidden then we can simply return nothing - the UI doesn't
+        // need to be running in order to set up encryption with the SecurityCustomisations.
+        if (phase === PHASE_LOADING || SecurityCustomisations.SHOW_ENCRYPTION_SETUP_UI === false) {
             return null;
         } else if (phase === PHASE_INTRO) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;

--- a/src/customisations/Security.ts
+++ b/src/customisations/Security.ts
@@ -74,8 +74,20 @@ export interface ISecurityCustomisations {
     catchAccessSecretStorageError?: typeof catchAccessSecretStorageError,
     setupEncryptionNeeded?: typeof setupEncryptionNeeded,
     getDehydrationKey?: typeof getDehydrationKey,
+
+    /**
+     * When false, disables the post-login UI from showing. If there's
+     * an error during setup, that will be shown to the user.
+     *
+     * Note: when this is set to false then the app will assume the user's
+     * encryption is set up some other way which would circumvent the default
+     * UI, such as by presenting alternative UI.
+     */
+    SHOW_ENCRYPTION_SETUP_UI?: boolean, // default true
 }
 
 // A real customisation module will define and export one or more of the
 // customisation points that make up `ISecurityCustomisations`.
-export default {} as ISecurityCustomisations;
+export default {
+    SHOW_ENCRYPTION_SETUP_UI: true,
+} as ISecurityCustomisations;


### PR DESCRIPTION
This is primarily intended for alternative setup UI or where the customisations end up configuring encryption some other way. If used without respecting the warnings in the docs, the user could end up at a blank page - use with caution, and only as directed.

**Reviewer**: If you need an example of this, please ping me somewhere.