### PR TITLE
Enable sharing historical keys on invite

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -712,8 +712,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                 this.props.onFinished();
             }
 
-            if (cli.isRoomEncrypted(this.props.roomId) &&
-                SettingsStore.getValue("feature_room_history_key_sharing")) {
+            if (cli.isRoomEncrypted(this.props.roomId)) {
                 const visibilityEvent = room.currentState.getStateEvents(
                     "m.room.history_visibility", "",
                 );
@@ -1344,8 +1343,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
             buttonText = _t("Invite");
             goButtonFn = this._inviteUsers;
 
-            if (SettingsStore.getValue("feature_room_history_key_sharing") &&
-                cli.isRoomEncrypted(this.props.roomId)) {
+            if (cli.isRoomEncrypted(this.props.roomId)) {
                 const room = cli.getRoom(this.props.roomId);
                 const visibilityEvent = room.currentState.getStateEvents(
                     "m.room.history_visibility", "",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -800,7 +800,6 @@
     "Show message previews for reactions in DMs": "Show message previews for reactions in DMs",
     "Show message previews for reactions in all rooms": "Show message previews for reactions in all rooms",
     "Offline encrypted messaging using dehydrated devices": "Offline encrypted messaging using dehydrated devices",
-    "Share decryption keys for room history when inviting users": "Share decryption keys for room history when inviting users",
     "Enable advanced debugging for the room list": "Enable advanced debugging for the room list",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
     "Font size": "Font size",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -220,12 +220,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
-    "feature_room_history_key_sharing": {
-        isFeature: true,
-        displayName: _td("Share decryption keys for room history when inviting users"),
-        supportedLevels: LEVELS_FEATURE,
-        default: true,
-    },
     "advancedRoomListLogging": {
         // TODO: Remove flag before launch: https://github.com/vector-im/element-web/issues/14231
         displayName: _td("Enable advanced debugging for the room list"),

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -224,7 +224,7 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         isFeature: true,
         displayName: _td("Share decryption keys for room history when inviting users"),
         supportedLevels: LEVELS_FEATURE,
-        default: false,
+        default: true,
     },
     "advancedRoomListLogging": {
         // TODO: Remove flag before launch: https://github.com/vector-im/element-web/issues/14231


### PR DESCRIPTION
After discussion with Product, we're ready to enable this key sharing work from https://github.com/matrix-org/matrix-react-sdk/pull/5763 (based on https://github.com/matrix-org/matrix-doc/pull/3061).