### PR TITLE
Add missing favo(u)rite i18n for US English

### DIFF
--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -99,6 +99,7 @@
     "Failure to create room": "Failure to create room",
     "Favourite": "Favorite",
     "Favourites": "Favorites",
+    "Favourited": "Favorited",
     "Fill screen": "Fill screen",
     "Filter room members": "Filter room members",
     "Forget room": "Forget room",


### PR DESCRIPTION
A small PR to get my feet wet with Matrix/Element.

This should close https://github.com/vector-im/element-web/issues/16901. I've run it locally under US English and it fixes the issue.