### PR TITLE
Fix js-sdk import in SlashCommands

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -20,7 +20,7 @@ limitations under the License.
 
 import * as React from 'react';
 
-import { ContentHelpers } from 'matrix-js-sdk';
+import { ContentHelpers } from 'matrix-js-sdk/src/content-helpers';
 import {MatrixClientPeg} from './MatrixClientPeg';
 import dis from './dispatcher/dispatcher';
 import * as sdk from './index';

--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -20,7 +20,7 @@ limitations under the License.
 
 import * as React from 'react';
 
-import { ContentHelpers } from 'matrix-js-sdk/src/content-helpers';
+import * as ContentHelpers from 'matrix-js-sdk/src/content-helpers';
 import {MatrixClientPeg} from './MatrixClientPeg';
 import dis from './dispatcher/dispatcher';
 import * as sdk from './index';


### PR DESCRIPTION
This is important because the `matrix-js-sdk` types are mismatched in some builds of Element