### PR TITLE
IRC Layout fix layout spacing in replies

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -159,6 +159,7 @@ $left-gutter: 64px;
 .mx_EventTile.focus-visible:focus-within > div > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile_last > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile:hover > a > .mx_MessageTimestamp,
+.mx_IRCLayout .mx_ReplyThread .mx_EventTile > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile.mx_EventTile_actionBarFocused > a > .mx_MessageTimestamp,
 .mx_IRCLayout .mx_EventTile.focus-visible:focus-within > a > .mx_MessageTimestamp {
     visibility: visible;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -136,27 +136,6 @@ $irc-line-height: $font-18px;
         }
     }
 
-    .mx_ReplyThread {
-        .mx_EventTile_emote {
-            > .mx_EventTile_avatar {
-                margin-left: initial;
-            }
-        }
-
-        .mx_MessageTimestamp {
-            width: initial;
-        }
-
-        /**
-         * adding the icon back in the document flow
-         * if it's not present, there's no unwanted wasted space
-         */
-        .mx_EventTile_e2eIcon {
-            position: relative;
-            order: -1;
-        }
-    }
-
     blockquote {
         margin: 0;
     }
@@ -236,6 +215,25 @@ $irc-line-height: $font-18px;
                     min-width: inherit;
                 }
             }
+        }
+
+        .mx_EventTile_emote {
+            > .mx_EventTile_avatar {
+                margin-left: initial;
+            }
+        }
+
+        .mx_MessageTimestamp {
+            width: initial;
+        }
+
+        /**
+         * adding the icon back in the document flow
+         * if it's not present, there's no unwanted wasted space
+         */
+        .mx_EventTile_e2eIcon {
+            position: relative;
+            order: -1;
         }
     }
 

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -137,6 +137,12 @@ $irc-line-height: $font-18px;
     }
 
     .mx_ReplyThread {
+        .mx_EventTile_emote {
+            > .mx_EventTile_avatar {
+                margin-left: initial;
+            }
+        }
+
         .mx_MessageTimestamp {
             width: initial;
         }

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -136,6 +136,21 @@ $irc-line-height: $font-18px;
         }
     }
 
+    .mx_ReplyThread {
+        .mx_MessageTimestamp {
+            width: initial;
+        }
+
+        /**
+         * adding the icon back in the document flow
+         * if it's not present, there's no unwanted wasted space
+         */
+        .mx_EventTile_e2eIcon {
+            position: relative;
+            order: -1;
+        }
+    }
+
     blockquote {
         margin: 0;
     }


### PR DESCRIPTION
Fixes vector-im/element-web#13723

The spacing was caused by the shield icon and the timestamp. The layout is quite fixed so that everything looks aligned when in the normal flow of the timeline but when in replies that creates unwanted spacing.

My solution is to put the shield icon back in the flow of the page, and display the timestamp at all times (not only on hover as it used to be). A reply can now take the following forms

![Screen Shot 2021-04-13 at 11 26 28](https://user-images.githubusercontent.com/769871/114538300-24dee600-9c4b-11eb-8c5f-c128e776b3ba.png)
![Screen Shot 2021-04-13 at 11 26 38](https://user-images.githubusercontent.com/769871/114538302-25777c80-9c4b-11eb-889d-e5ec76b5436e.png)

It is important to keep the timestamp as it is the only way for a user to jump back to when the message was sent in the timeline

PS: As a bonus, this PR also fixes vector-im/element-web#13771 ✨ 
