### PR TITLE
Stabilise starting a DM with multiple people flow

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -656,6 +656,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
 
         // Check if it's a traditional DM and create the room if required.
         // TODO: [Canonical DMs] Remove this check and instead just create the multi-person DM
+        let abort = false;
         try {
             const isSelf = targetIds.length === 1 && targetIds[0] === client.getUserId();
             if (targetIds.length === 1 && !isSelf) {
@@ -673,9 +674,10 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                 await client.peekInRoom(roomId);
                 const invitesState = await inviteMultipleToRoom(roomId, targetIds);
 
-                if (!this._shouldAbortAfterInviteError(invitesState)) {
-                    this.props.onFinished();
-                }
+                abort = this._shouldAbortAfterInviteError(invitesState);
+            }
+            if (!abort) {
+                this.props.onFinished();
             }
         } catch (err) {
             console.error(err);

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -666,14 +666,15 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
             if (targetIds.length > 1) {
                 createRoomOptions.createOpts = targetIds.reduce(
                     (roomOptions, address) => {
-                        if (getAddressType(address) === 'email') {
+                        const type = getAddressType(address);
+                        if (type === 'email') {
                             const invite: IInvite3PID = {
                                 id_server: client.getIdentityServerUrl(true),
                                 medium: 'email',
                                 address,
                             };
                             roomOptions.invite_3pid.push(invite);
-                        } else {
+                        } else if (type === 'mx-user-id') {
                             roomOptions.invite.push(address);
                         }
                         return roomOptions;

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -90,6 +90,12 @@ export interface IOpts {
     parentSpace?: Room;
 }
 
+export interface IInvite3PID {
+    id_server: string,
+    medium: 'email',
+    address: string,
+}
+
 /**
  * Create a new room, and switch to it.
  *


### PR DESCRIPTION
Fixes vector-im/element-web#16924

This PR encompasses two changes
* ✨ Cosmetic refactor of the asynchronous flow in `_startDm`, (view [`8d95c01`](https://github.com/matrix-org/matrix-react-sdk/commit/8d95c012ef7bba98795322742756f80da81bd9bf))
* ⚙️ Logic change to stabilise the invite flow (view [`f89bbea`](https://github.com/matrix-org/matrix-react-sdk/commit/f89bbea3f1678754f2ef9b6e1eb2f8f178350f04))

Digging through this problem I uncovered two issues
1. A rate-limiting one, that has been raised on matrix-org/synapse#9804 (out of scope for this issue)
2. The room not being found when calling `MatrixClientPeg.get().getRoom(roomId)`

```
const roomId = await createRoom(createRoomOptions);
```

The above will create a room on the server side but the room is not accessible in the user account until the `SyncAPI#_processSyncResponse` has been executed. It is the code responsible to store the room in memory and make it accessible for any part of the application

This means that if the users are invited before the sync callback has been processed there is potential race condition. Using `peekInRoom` ensure that the room is accessible for anywhere in the account and the invite flow will definitely be able to access the data model  
