### PR TITLE
Labs: Add quick/cheap "do not disturb" flag

### DIFF
--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -117,6 +117,32 @@ limitations under the License.
         .mx_UserMenu_headerButtons {
             // No special styles: the rest of the layout happens to make it work.
         }
+
+        .mx_UserMenu_dnd {
+            width: 24px;
+            height: 24px;
+            margin-right: 8px;
+            position: relative;
+
+            &::before {
+                content: '';
+                position: absolute;
+                width: 24px;
+                height: 24px;
+                mask-position: center;
+                mask-size: contain;
+                mask-repeat: no-repeat;
+                background: $muted-fg-color;
+            }
+
+            &.mx_UserMenu_dnd_noisy::before {
+                mask-image: url('$(res)/img/element-icons/notifications.svg');
+            }
+
+            &.mx_UserMenu_dnd_muted::before {
+                mask-image: url('$(res)/img/element-icons/roomlist/notifications-off.svg');
+            }
+        }
     }
 
     &.mx_UserMenu_minimized {

--- a/src/Notifier.ts
+++ b/src/Notifier.ts
@@ -383,6 +383,10 @@ export const Notifier = {
                 // don't bother notifying as user was recently active in this room
                 return;
             }
+            if (SettingsStore.getValue("doNotDisturb")) {
+                // Don't bother the user if they didn't ask to be bothered
+                return;
+            }
 
             if (this.isEnabled()) {
                 this._displayPopupNotification(ev, room);

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -786,6 +786,7 @@
     "%(senderName)s: %(stickerName)s": "%(senderName)s: %(stickerName)s",
     "Change notification settings": "Change notification settings",
     "Spaces prototype. Incompatible with Communities, Communities v2 and Custom Tags. Requires compatible homeserver for some features.": "Spaces prototype. Incompatible with Communities, Communities v2 and Custom Tags. Requires compatible homeserver for some features.",
+    "Show options to enable 'Do not disturb' mode": "Show options to enable 'Do not disturb' mode",
     "Send and receive voice messages (in development)": "Send and receive voice messages (in development)",
     "Render LaTeX maths in messages": "Render LaTeX maths in messages",
     "Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution.": "Communities v2 prototypes. Requires compatible homeserver. Highly experimental - use with caution.",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -128,6 +128,12 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: false,
         controller: new ReloadOnChangeController(),
     },
+    "feature_dnd": {
+        isFeature: true,
+        displayName: _td("Show options to enable 'Do not disturb' mode"),
+        supportedLevels: LEVELS_FEATURE,
+        default: false,
+    },
     "feature_voice_messages": {
         isFeature: true,
         displayName: _td("Send and receive voice messages (in development)"),
@@ -224,6 +230,10 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         // TODO: Remove flag before launch: https://github.com/vector-im/element-web/issues/14231
         displayName: _td("Enable advanced debugging for the room list"),
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        default: false,
+    },
+    "doNotDisturb": {
+        supportedLevels: [SettingLevel.DEVICE],
         default: false,
     },
     "mjolnirRooms": {


### PR DESCRIPTION
This just disables audio notifications and the popup, which is the easiest way to do "do not disturb" for a device. This needs spec changes to be done properly, as it's a shame that mobile devices for the user will still go off.

Disabling all of push doesn't sound ideal as it would potentially mean missing highlights for when leaving DND mode.

**Paired with https://github.com/vector-im/element-web/pull/16962**

----

**Reviewer**: This is without design/product review, hence labs flag. It's largely expected to just fall into the bucket of ancient labs flags for now.

----

Context for this PR: New personal workflow could do with some quiet time.

![image](https://user-images.githubusercontent.com/1190097/114826260-822a8280-9d84-11eb-96b4-33473daac18d.png)
![image](https://user-images.githubusercontent.com/1190097/114826278-89519080-9d84-11eb-93b6-b7be7bc15ccf.png)
