### PR TITLE
Ensure PersistedElement are unmounted on application logout

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -586,7 +586,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 break;
             case 'logout':
                 dis.dispatch({action: "hangup_all"});
-                dis.dispatch({action: "logout"});
                 Lifecycle.logout();
                 break;
             case 'require_registration':

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -586,6 +586,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 break;
             case 'logout':
                 dis.dispatch({action: "hangup_all"});
+                dis.dispatch({action: "logout"});
                 Lifecycle.logout();
                 break;
             case 'require_registration':

--- a/src/components/views/elements/PersistedElement.js
+++ b/src/components/views/elements/PersistedElement.js
@@ -139,6 +139,8 @@ export default class PersistedElement extends React.Component {
     _onAction(payload) {
         if (payload.action === 'timeline_resize') {
             this._repositionChild();
+        } else if (payload.action === 'logout') {
+            PersistedElement.destroyElement(this.props.persistKey);
         }
     }
 


### PR DESCRIPTION
Fixes vector-im/element-web#16725

`PersistedElement` is a React component that lets us float any widget on top of the app. It comes at the cost that we are responsible for its rendering. Upon a logout the React tree is correctly unmounted but no signal was sent to this class to notify it to remove its persisted elements 