### PR TITLE
Support MSC3086 asserted identity

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -87,7 +87,6 @@ import VoipUserMapper from './VoipUserMapper';
 import { addManagedHybridWidget, isManagedHybridWidgetEnabled } from './widgets/ManagedHybrid';
 import { randomUppercaseString, randomLowercaseString } from "matrix-js-sdk/src/randomstring";
 import SdkConfig from './SdkConfig';
-import DMRoomMap from './utils/DMRoomMap';
 import { ensureDMExists, findDMForUser } from './createRoom';
 
 export const PROTOCOL_PSTN = 'm.protocol.pstn';

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -168,7 +168,7 @@ export default class CallHandler {
     private invitedRoomsAreVirtual = new Map<string, boolean>();
     private invitedRoomCheckInProgress = false;
 
-    // Map of the asserted identiy users after we've looked them up using the API.
+    // Map of the asserted identity users after we've looked them up using the API.
     // We need to be be able to determine the mapped room synchronously, so we
     // do the async lookup when we get new information and then store these mappings here
     private assertedIdentityNativeUsers = new Map<string, string>();

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -188,7 +188,9 @@ export default class CallHandler {
     public roomIdForCall(call: MatrixCall): string {
         if (!call) return null;
 
-        if (SdkConfig.get()['voipObeyAssertedIdentity']) {
+        const voipConfig = SdkConfig.get()['voip'];
+
+        if (voipConfig && voipConfig.obeyAssertedIdentity) {
             const nativeUser = this.assertedIdentityNativeUsers[call.callId];
             if (nativeUser) {
                 const room = findDMForUser(MatrixClientPeg.get(), nativeUser);

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -532,6 +532,11 @@ export default class CallHandler {
             if (newNativeAssertedIdentity) {
                 this.assertedIdentityNativeUsers[call.callId] = newNativeAssertedIdentity;
 
+                // If we don't already have a room with this user, make one. This will be slightly odd
+                // if they called us because we'll be inviting them, but there's not much we can do about
+                // this if we want the actual, native room to exist (which we do). This is why it's
+                // important to only obey asserted identity in trusted environments, since anyone you're
+                // on a call with can cause you to send a room invite to someone.
                 await ensureDMExists(MatrixClientPeg.get(), newNativeAssertedIdentity);
 
                 const newMappedRoomId = CallHandler.sharedInstance().roomIdForCall(call);

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -59,7 +59,6 @@ import {MatrixClientPeg} from './MatrixClientPeg';
 import PlatformPeg from './PlatformPeg';
 import Modal from './Modal';
 import { _t } from './languageHandler';
-import { createNewMatrixCall } from 'matrix-js-sdk/src/webrtc/call';
 import dis from './dispatcher/dispatcher';
 import WidgetUtils from './utils/WidgetUtils';
 import WidgetEchoStore from './stores/WidgetEchoStore';
@@ -395,7 +394,7 @@ export default class CallHandler {
         // We don't allow placing more than one call per room, but that doesn't mean there
         // can't be more than one, eg. in a glare situation. This checks that the given call
         // is the call we consider 'the' call for its room.
-        const mappedRoomId = CallHandler.sharedInstance().roomIdForCall(call);
+        const mappedRoomId = this.roomIdForCall(call);
 
         const callForThisRoom = this.getCallForRoom(mappedRoomId);
         return callForThisRoom && call.callId === callForThisRoom.callId;
@@ -539,7 +538,7 @@ export default class CallHandler {
                 // on a call with can cause you to send a room invite to someone.
                 await ensureDMExists(MatrixClientPeg.get(), newNativeAssertedIdentity);
 
-                const newMappedRoomId = CallHandler.sharedInstance().roomIdForCall(call);
+                const newMappedRoomId = this.roomIdForCall(call);
                 console.log(`Old room ID: ${mappedRoomId}, new room ID: ${newMappedRoomId}`);
                 if (newMappedRoomId !== mappedRoomId) {
                     this.removeCallForRoom(mappedRoomId);
@@ -691,7 +690,7 @@ export default class CallHandler {
 
         const timeUntilTurnCresExpire = MatrixClientPeg.get().getTurnServersExpiry() - Date.now();
         console.log("Current turn creds expire in " + timeUntilTurnCresExpire + " ms");
-        const call = createNewMatrixCall(MatrixClientPeg.get(), mappedRoomId);
+        const call = MatrixClientPeg.get().createCall(mappedRoomId);
 
         this.calls.set(roomId, call);
         if (transferee) {

--- a/src/VoipUserMapper.ts
+++ b/src/VoipUserMapper.ts
@@ -57,7 +57,11 @@ export default class VoipUserMapper {
         if (!virtualRoom) return null;
         const virtualRoomEvent = virtualRoom.getAccountData(VIRTUAL_ROOM_EVENT_TYPE);
         if (!virtualRoomEvent || !virtualRoomEvent.getContent()) return null;
-        return virtualRoomEvent.getContent()['native_room'] || null;
+        const nativeRoomID = virtualRoomEvent.getContent()['native_room'];
+        const nativeRoom = MatrixClientPeg.get().getRoom(nativeRoomID);
+        if (!nativeRoom || nativeRoom.getMyMembership() !== 'join') return null;
+
+        return nativeRoomID;
     }
 
     public isVirtualRoom(room: Room): boolean {

--- a/src/components/views/voip/CallPreview.tsx
+++ b/src/components/views/voip/CallPreview.tsx
@@ -27,6 +27,7 @@ import SettingsStore from "../../../settings/SettingsStore";
 import { CallEvent, CallState, MatrixCall } from 'matrix-js-sdk/src/webrtc/call';
 import { MatrixClientPeg } from '../../../MatrixClientPeg';
 import {replaceableComponent} from "../../../utils/replaceableComponent";
+import { Action } from '../../../dispatcher/actions';
 
 const SHOW_CALL_IN_STATES = [
     CallState.Connected,
@@ -142,6 +143,7 @@ export default class CallPreview extends React.Component<IProps, IState> {
         switch (payload.action) {
             // listen for call state changes to prod the render method, which
             // may hide the global CallView if the call it is tracking is dead
+            case Action.CallChangeRoom:
             case 'call_state': {
                 const [primaryCall, secondaryCalls] = getPrimarySecondaryCalls(
                     CallHandler.sharedInstance().getAllActiveCallsNotInRoom(this.state.roomId),

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -208,7 +208,7 @@ export default class CallView extends React.Component<IProps, IState> {
     };
 
     private onExpandClick = () => {
-        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
+        const userFacingRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.call);
         dis.dispatch({
             action: 'view_room',
             room_id: userFacingRoomId,
@@ -337,7 +337,7 @@ export default class CallView extends React.Component<IProps, IState> {
     };
 
     private onRoomAvatarClick = () => {
-        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
+        const userFacingRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.call);
         dis.dispatch({
             action: 'view_room',
             room_id: userFacingRoomId,
@@ -345,7 +345,7 @@ export default class CallView extends React.Component<IProps, IState> {
     }
 
     private onSecondaryRoomAvatarClick = () => {
-        const userFacingRoomId = CallHandler.roomIdForCall(this.props.secondaryCall);
+        const userFacingRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.secondaryCall);
 
         dis.dispatch({
             action: 'view_room',
@@ -354,7 +354,7 @@ export default class CallView extends React.Component<IProps, IState> {
     }
 
     private onCallResumeClick = () => {
-        const userFacingRoomId = CallHandler.roomIdForCall(this.props.call);
+        const userFacingRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.call);
         CallHandler.sharedInstance().setActiveCallRoomId(userFacingRoomId);
     }
 
@@ -365,8 +365,8 @@ export default class CallView extends React.Component<IProps, IState> {
 
     public render() {
         const client = MatrixClientPeg.get();
-        const callRoomId = CallHandler.roomIdForCall(this.props.call);
-        const secondaryCallRoomId = CallHandler.roomIdForCall(this.props.secondaryCall);
+        const callRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.call);
+        const secondaryCallRoomId = CallHandler.sharedInstance().roomIdForCall(this.props.secondaryCall);
         const callRoom = client.getRoom(callRoomId);
         const secCallRoom = this.props.secondaryCall ? client.getRoom(secondaryCallRoomId) : null;
 
@@ -482,11 +482,13 @@ export default class CallView extends React.Component<IProps, IState> {
         const isOnHold = this.state.isLocalOnHold || this.state.isRemoteOnHold;
         let holdTransferContent;
         if (transfereeCall) {
-            const transferTargetRoom = MatrixClientPeg.get().getRoom(CallHandler.roomIdForCall(this.props.call));
+            const transferTargetRoom = MatrixClientPeg.get().getRoom(
+                CallHandler.sharedInstance().roomIdForCall(this.props.call),
+            );
             const transferTargetName = transferTargetRoom ? transferTargetRoom.name : _t("unknown person");
 
             const transfereeRoom = MatrixClientPeg.get().getRoom(
-                CallHandler.roomIdForCall(transfereeCall),
+                CallHandler.sharedInstance().roomIdForCall(transfereeCall),
             );
             const transfereeName = transfereeRoom ? transfereeRoom.name : _t("unknown person");
 

--- a/src/components/views/voip/CallViewForRoom.tsx
+++ b/src/components/views/voip/CallViewForRoom.tsx
@@ -22,6 +22,7 @@ import dis from '../../../dispatcher/dispatcher';
 import {Resizable} from "re-resizable";
 import ResizeNotifier from "../../../utils/ResizeNotifier";
 import {replaceableComponent} from "../../../utils/replaceableComponent";
+import { Action } from '../../../dispatcher/actions';
 
 interface IProps {
     // What room we should display the call for
@@ -62,6 +63,7 @@ export default class CallViewForRoom extends React.Component<IProps, IState> {
 
     private onAction = (payload) => {
         switch (payload.action) {
+            case Action.CallChangeRoom:
             case 'call_state': {
                 const newCall = this.getCall();
                 if (newCall !== this.state.call) {

--- a/src/components/views/voip/IncomingCallBox.tsx
+++ b/src/components/views/voip/IncomingCallBox.tsx
@@ -72,7 +72,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
         e.stopPropagation();
         dis.dispatch({
             action: 'answer',
-            room_id: CallHandler.roomIdForCall(this.state.incomingCall),
+            room_id: CallHandler.sharedInstance().roomIdForCall(this.state.incomingCall),
         });
     };
 
@@ -80,7 +80,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
         e.stopPropagation();
         dis.dispatch({
             action: 'reject',
-            room_id: CallHandler.roomIdForCall(this.state.incomingCall),
+            room_id: CallHandler.sharedInstance().roomIdForCall(this.state.incomingCall),
         });
     };
 
@@ -91,7 +91,7 @@ export default class IncomingCallBox extends React.Component<IProps, IState> {
 
         let room = null;
         if (this.state.incomingCall) {
-            room = MatrixClientPeg.get().getRoom(CallHandler.roomIdForCall(this.state.incomingCall));
+            room = MatrixClientPeg.get().getRoom(CallHandler.sharedInstance().roomIdForCall(this.state.incomingCall));
         }
 
         const caller = room ? room.name : _t("Unknown caller");

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -114,6 +114,9 @@ export enum Action {
      */
     VirtualRoomSupportUpdated = "virtual_room_support_updated",
 
+    // Probably would be better to have a VoIP states in a store and have the store emit changes
+    CallChangeRoom = "call_change_room",
+
     /**
      * Fired when an upload has started. Should be used with UploadStartedPayload.
      */

--- a/src/utils/DMRoomMap.ts
+++ b/src/utils/DMRoomMap.ts
@@ -56,6 +56,15 @@ export default class DMRoomMap {
     }
 
     /**
+     * Set the shared instance to the instance supplied
+     * Used by tests
+     * @param inst the new shared instance
+     */
+    public static setShared(inst: DMRoomMap) {
+        DMRoomMap.sharedInstance = inst;
+    }
+
+    /**
      * Returns a shared instance of the class
      * that uses the singleton matrix client
      * The shared instance must be started before use.

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2015-2021 The Matrix.org Foundation C.I.C.
+Copyright 2021 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -1,0 +1,214 @@
+/*
+Copyright 2015-2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import './skinned-sdk';
+
+import CallHandler, { PlaceCallType } from '../src/CallHandler';
+import { stubClient, mkStubRoom } from './test-utils';
+import { MatrixClientPeg } from '../src/MatrixClientPeg';
+import dis from '../src/dispatcher/dispatcher';
+import { CallEvent, CallState } from 'matrix-js-sdk/src/webrtc/call';
+import DMRoomMap from '../src/utils/DMRoomMap';
+import EventEmitter from 'events';
+import { Action } from '../src/dispatcher/actions';
+import SdkConfig from '../src/SdkConfig';
+
+const REAL_ROOM_ID = '$room1:example.org';
+const MAPPED_ROOM_ID = '$room2:example.org';
+const MAPPED_ROOM_ID_2 = '$room3:example.org';
+
+function mkStubDM(roomId, userId) {
+    const room = mkStubRoom(roomId);
+    room.getJoinedMembers = jest.fn().mockReturnValue([
+        {
+            userId: '@me:example.org',
+            name: 'Member',
+            rawDisplayName: 'Member',
+            roomId: roomId,
+            membership: 'join',
+            getAvatarUrl: () => 'mxc://avatar.url/image.png',
+            getMxcAvatarUrl: () => 'mxc://avatar.url/image.png',
+        },
+        {
+            userId: userId,
+            name: 'Member',
+            rawDisplayName: 'Member',
+            roomId: roomId,
+            membership: 'join',
+            getAvatarUrl: () => 'mxc://avatar.url/image.png',
+            getMxcAvatarUrl: () => 'mxc://avatar.url/image.png',
+        },
+    ]);
+    room.currentState.getMembers = room.getJoinedMembers;
+
+    return room;
+}
+
+class FakeCall extends EventEmitter {
+    roomId: string;
+    callId = "fake call id";
+
+    constructor(roomId) {
+        super();
+
+        this.roomId = roomId;
+    }
+
+    setRemoteOnHold() {}
+    setRemoteAudioElement() {}
+
+    placeVoiceCall() {
+        this.emit(CallEvent.State, CallState.Connected, null);
+    }
+}
+
+describe('CallHandler', () => {
+    let dmRoomMap;
+    let callHandler;
+    let audioElement;
+    let fakeCall;
+
+    beforeEach(() => {
+        stubClient();
+        MatrixClientPeg.get().createCall = roomId => {
+            if (fakeCall && fakeCall.roomId !== roomId) {
+                throw new Error("Only one call is supported!");
+            }
+            fakeCall = new FakeCall(roomId);
+            return fakeCall;
+        };
+
+        callHandler = new CallHandler();
+        callHandler.start();
+
+        dmRoomMap = {
+            getUserIdForRoomId: roomId => {
+                if (roomId === REAL_ROOM_ID) {
+                    return '@user1:example.org';
+                } else if (roomId === MAPPED_ROOM_ID) {
+                    return '@user2:example.org';
+                } else if (roomId === MAPPED_ROOM_ID_2) {
+                    return '@user3:example.org';
+                } else {
+                    return null;
+                }
+            },
+            getDMRoomsForUserId: userId => {
+                if (userId === '@user2:example.org') {
+                    return [MAPPED_ROOM_ID];
+                } else if (userId === '@user3:example.org') {
+                    return [MAPPED_ROOM_ID_2];
+                } else {
+                    return [];
+                }
+            },
+        };
+        DMRoomMap.setShared(dmRoomMap);
+
+        audioElement = document.createElement('audio');
+        audioElement.id = "remoteAudio";
+        document.body.appendChild(audioElement);
+    });
+
+    afterEach(() => {
+        callHandler.stop();
+        DMRoomMap.setShared(null);
+        // @ts-ignore
+        window.mxCallHandler = null;
+        MatrixClientPeg.unset();
+
+        document.body.removeChild(audioElement);
+        SdkConfig.unset();
+    });
+
+    it('should move calls between rooms when remote asserted identity changes', async () => {
+        const realRoom = mkStubDM(REAL_ROOM_ID, '@user1:example.org');
+        const mappedRoom = mkStubDM(MAPPED_ROOM_ID, '@user2:example.org');
+        const mappedRoom2 = mkStubDM(MAPPED_ROOM_ID_2, '@user3:example.org');
+
+        MatrixClientPeg.get().getRoom = roomId => {
+            switch (roomId) {
+                case REAL_ROOM_ID:
+                    return realRoom;
+                case MAPPED_ROOM_ID:
+                    return mappedRoom;
+                case MAPPED_ROOM_ID_2:
+                    return mappedRoom2;
+            }
+        };
+
+        dis.dispatch({
+            action: 'place_call',
+            type: PlaceCallType.Voice,
+            room_id: REAL_ROOM_ID,
+        }, true);
+
+        let dispatchHandle;
+        // wait for the call to be set up
+        await new Promise<void>(resolve => {
+            dispatchHandle = dis.register(payload => {
+                if (payload.action === 'call_state') {
+                    resolve();
+                }
+            });
+        });
+        dis.unregister(dispatchHandle);
+
+        // should start off in the actual room ID it's in at the protocol level
+        expect(callHandler.getCallForRoom(REAL_ROOM_ID)).toBe(fakeCall);
+
+        let callRoomChangeEventCount = 0;
+        const roomChangePromise = new Promise<void>(resolve => {
+            dispatchHandle = dis.register(payload => {
+                if (payload.action === Action.CallChangeRoom) {
+                    ++callRoomChangeEventCount;
+                    resolve();
+                }
+            });
+        });
+
+        // Now emit an asserted identity for user2: this should be ignored
+        // because we haven't set the config option to obey asserted identity
+        fakeCall.getRemoteAssertedIdentity = jest.fn().mockReturnValue({
+            id: "@user2:example.org",
+        });
+        fakeCall.emit(CallEvent.AssertedIdentityChanged);
+
+        // Now set the config option
+        SdkConfig.put({
+            voipObeyAssertedIdentity: true,
+        });
+
+        // ...and send another asserted identity event for a different user
+        fakeCall.getRemoteAssertedIdentity = jest.fn().mockReturnValue({
+            id: "@user3:example.org",
+        });
+        fakeCall.emit(CallEvent.AssertedIdentityChanged);
+
+        await roomChangePromise;
+        dis.unregister(dispatchHandle);
+
+        // If everything's gone well, we should have seen only one room change
+        // event and the call should now be in user 3's room.
+        // If it's not obeying any, the call will still be in REAL_ROOM_ID.
+        // If it incorrectly obeyed both asserted identity changes, either it will
+        // have just processed one and the call will be in the wrong room, or we'll
+        // have seen two room change dispatches.
+        expect(callRoomChangeEventCount).toEqual(1);
+        expect(callHandler.getCallForRoom(REAL_ROOM_ID)).toBeNull();
+        expect(callHandler.getCallForRoom(MAPPED_ROOM_ID_2)).toBe(fakeCall);
+    });
+});

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -189,7 +189,9 @@ describe('CallHandler', () => {
 
         // Now set the config option
         SdkConfig.put({
-            voipObeyAssertedIdentity: true,
+            voip: {
+                obeyAssertedIdentity: true,
+            },
         });
 
         // ...and send another asserted identity event for a different user

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -64,6 +64,11 @@ export function createTestClient() {
         getRoomIdForAlias: jest.fn().mockResolvedValue(undefined),
         getRoomDirectoryVisibility: jest.fn().mockResolvedValue(undefined),
         getProfileInfo: jest.fn().mockResolvedValue({}),
+        getThirdpartyProtocols: jest.fn().mockResolvedValue({}),
+        getClientWellKnown: jest.fn().mockReturnValue(null),
+        supportsVoip: jest.fn().mockReturnValue(true),
+        getTurnServersExpiry: jest.fn().mockReturnValue(2^32),
+        getThirdpartyUser: jest.fn().mockResolvedValue([]),
         getAccountData: (type) => {
             return mkEvent({
                 type,


### PR DESCRIPTION
Add support for switching calls between rooms based on MSC3086 asserted identity events. Requires config option documented in https://github.com/vector-im/element-web/pull/17008.

Also includes our first tests for CallHandler which introduces a bit more stuff for testing. Updates to the new method to create call objects, then stubs this method out in the tests.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/1674