### PR TITLE
Expand upon voice message event & include overall waveform

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -138,7 +138,6 @@ declare global {
             outputs: Float32Array[][],
             parameters: Record<string, Float32Array>
         ): boolean;
-
     }
 
     // https://github.com/microsoft/TypeScript/issues/28308#issuecomment-650802278

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -129,4 +129,31 @@ declare global {
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber
         columnNumber?: number;
     }
+
+    // https://github.com/microsoft/TypeScript/issues/28308#issuecomment-650802278
+    interface AudioWorkletProcessor {
+        readonly port: MessagePort;
+        process(
+            inputs: Float32Array[][],
+            outputs: Float32Array[][],
+            parameters: Record<string, Float32Array>
+        ): boolean;
+
+    }
+
+    // https://github.com/microsoft/TypeScript/issues/28308#issuecomment-650802278
+    const AudioWorkletProcessor: {
+        prototype: AudioWorkletProcessor;
+        new (options?: AudioWorkletNodeOptions): AudioWorkletProcessor;
+    };
+
+    // https://github.com/microsoft/TypeScript/issues/28308#issuecomment-650802278
+    function registerProcessor(
+        name: string,
+        processorCtor: (new (
+            options?: AudioWorkletNodeOptions
+        ) => AudioWorkletProcessor) & {
+            parameterDescriptors?: AudioParamDescriptor[];
+        }
+    );
 }

--- a/src/components/views/rooms/VoiceRecordComposerTile.tsx
+++ b/src/components/views/rooms/VoiceRecordComposerTile.tsx
@@ -53,11 +53,11 @@ export default class VoiceRecordComposerTile extends React.PureComponent<IProps,
             await this.state.recorder.stop();
             const mxc = await this.state.recorder.upload();
             MatrixClientPeg.get().sendMessage(this.props.room.roomId, {
-                body: "Voice message",
-                msgtype: "org.matrix.msc2516.voice",
-                //msgtype: MsgType.Audio,
-                url: mxc,
-                info: {
+                "body": "Voice message",
+                "msgtype": "org.matrix.msc2516.voice",
+                //"msgtype": MsgType.Audio,
+                "url": mxc,
+                "info": {
                     duration: Math.round(this.state.recorder.durationSeconds * 1000),
                     mimetype: this.state.recorder.contentType,
                     size: this.state.recorder.contentLength,

--- a/src/components/views/rooms/VoiceRecordComposerTile.tsx
+++ b/src/components/views/rooms/VoiceRecordComposerTile.tsx
@@ -77,7 +77,13 @@ export default class VoiceRecordComposerTile extends React.PureComponent<IProps,
                 },
                 "org.matrix.experimental.msc2516.voice": { // MSC2516+MSC1767 experiment
                     duration: Math.round(this.state.recorder.durationSeconds * 1000),
-                    // TODO: @@ TravisR: Waveform.
+
+                    // Events can't have floats, so we try to maintain resolution by using 1024
+                    // as a maximum value. The waveform contains values between zero and 1, so this
+                    // should come out largely sane.
+                    //
+                    // We're expecting about one data point per second of audio.
+                    waveform: this.state.recorder.finalWaveform.map(v => Math.round(v * 1024)),
                 },
             });
             await VoiceRecordingStore.instance.disposeRecording();

--- a/src/components/views/rooms/VoiceRecordComposerTile.tsx
+++ b/src/components/views/rooms/VoiceRecordComposerTile.tsx
@@ -55,7 +55,30 @@ export default class VoiceRecordComposerTile extends React.PureComponent<IProps,
             MatrixClientPeg.get().sendMessage(this.props.room.roomId, {
                 body: "Voice message",
                 msgtype: "org.matrix.msc2516.voice",
+                //msgtype: MsgType.Audio,
                 url: mxc,
+                info: {
+                    duration: Math.round(this.state.recorder.durationSeconds * 1000),
+                    mimetype: this.state.recorder.contentType,
+                    size: this.state.recorder.contentLength,
+                },
+
+                // MSC1767 experiment
+                "org.matrix.msc1767.text": "Voice message",
+                "org.matrix.msc1767.file": {
+                    url: mxc,
+                    name: "Voice message.ogg",
+                    mimetype: this.state.recorder.contentType,
+                    size: this.state.recorder.contentLength,
+                },
+                "org.matrix.msc1767.audio": {
+                    duration: Math.round(this.state.recorder.durationSeconds * 1000),
+                    // TODO: @@ TravisR: Waveform? (MSC1767 decision)
+                },
+                "org.matrix.experimental.msc2516.voice": { // MSC2516+MSC1767 experiment
+                    duration: Math.round(this.state.recorder.durationSeconds * 1000),
+                    // TODO: @@ TravisR: Waveform.
+                },
             });
             await VoiceRecordingStore.instance.disposeRecording();
             this.setState({recorder: null});

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -54,7 +54,7 @@ export function arraySeed<T>(val: T, length: number): T[] {
  * @param a The array to clone. Must be defined.
  * @returns A copy of the array.
  */
-export function arrayFastClone(a: any[]): any[] {
+export function arrayFastClone<T>(a: T[]): T[] {
     return a.slice(0, a.length);
 }
 

--- a/src/voice/RecorderWorklet.ts
+++ b/src/voice/RecorderWorklet.ts
@@ -19,8 +19,8 @@ import {percentageOf} from "../utils/numbers";
 
 // from AudioWorkletGlobalScope: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletGlobalScope
 declare const currentTime: number;
-declare const currentFrame: number;
-declare const sampleRate: number;
+// declare const currentFrame: number;
+// declare const sampleRate: number;
 
 class MxVoiceWorklet extends AudioWorkletProcessor {
     private nextAmplitudeSecond = 0;

--- a/src/voice/RecorderWorklet.ts
+++ b/src/voice/RecorderWorklet.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {ITimingPayload, PayloadEvent, WORKLET_NAME} from "./consts";
+import {IAmplitudePayload, ITimingPayload, PayloadEvent, WORKLET_NAME} from "./consts";
+import {percentageOf} from "../utils/numbers";
 
 // from AudioWorkletGlobalScope: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletGlobalScope
 declare const currentTime: number;
@@ -22,12 +23,45 @@ declare const currentFrame: number;
 declare const sampleRate: number;
 
 class MxVoiceWorklet extends AudioWorkletProcessor {
+    private nextAmplitudeSecond = 0;
+
     constructor() {
         super();
     }
 
     process(inputs, outputs, parameters) {
+        // We only fire amplitude updates once a second to avoid flooding the recording instance
+        // with useless data. Much of the data would end up discarded, so we ratelimit ourselves
+        // here.
+        const currentSecond = Math.round(currentTime);
+        if (currentSecond === this.nextAmplitudeSecond) {
+            // We're expecting exactly one mono input source, so just grab the very first frame of
+            // samples for the analysis.
+            const monoChan = inputs[0][0];
+
+            // The amplitude of the frame's samples is effectively the loudness of the frame. This
+            // translates into a bar which can be rendered as part of the whole recording clip's
+            // waveform.
+            //
+            // We translate the amplitude down to 0-1 for sanity's sake.
+            const minVal = monoChan.reduce((m, v) => Math.min(m, v), Number.MAX_SAFE_INTEGER);
+            const maxVal = monoChan.reduce((m, v) => Math.max(m, v), Number.MIN_SAFE_INTEGER);
+            const amplitude = percentageOf(maxVal, -1, 1) - percentageOf(minVal, -1, 1);
+
+            this.port.postMessage(<IAmplitudePayload>{
+                ev: PayloadEvent.AmplitudeMark,
+                amplitude: amplitude,
+                forSecond: currentSecond,
+            });
+            this.nextAmplitudeSecond++;
+        }
+
+        // We mostly use this worklet to fire regular clock updates through to components
         this.port.postMessage(<ITimingPayload>{ev: PayloadEvent.Timekeep, timeSeconds: currentTime});
+
+        // We're supposed to return false when we're "done" with the audio clip, but seeing as
+        // we are acting as a passive processor we are never truly "done". The browser will clean
+        // us up when it is done with us.
         return true;
     }
 }

--- a/src/voice/RecorderWorklet.ts
+++ b/src/voice/RecorderWorklet.ts
@@ -25,10 +25,6 @@ declare const currentTime: number;
 class MxVoiceWorklet extends AudioWorkletProcessor {
     private nextAmplitudeSecond = 0;
 
-    constructor() {
-        super();
-    }
-
     process(inputs, outputs, parameters) {
         // We only fire amplitude updates once a second to avoid flooding the recording instance
         // with useless data. Much of the data would end up discarded, so we ratelimit ourselves

--- a/src/voice/RecorderWorklet.ts
+++ b/src/voice/RecorderWorklet.ts
@@ -44,8 +44,8 @@ class MxVoiceWorklet extends AudioWorkletProcessor {
             // waveform.
             //
             // We translate the amplitude down to 0-1 for sanity's sake.
-            const minVal = monoChan.reduce((m, v) => Math.min(m, v), Number.MAX_SAFE_INTEGER);
-            const maxVal = monoChan.reduce((m, v) => Math.max(m, v), Number.MIN_SAFE_INTEGER);
+            const minVal = Math.min(...monoChan);
+            const maxVal = Math.max(...monoChan);
             const amplitude = percentageOf(maxVal, -1, 1) - percentageOf(minVal, -1, 1);
 
             this.port.postMessage(<IAmplitudePayload>{

--- a/src/voice/RecorderWorklet.ts
+++ b/src/voice/RecorderWorklet.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {ITimingPayload, PayloadEvent, WORKLET_NAME} from "./consts";
+
+// from AudioWorkletGlobalScope: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletGlobalScope
+declare const currentTime: number;
+declare const currentFrame: number;
+declare const sampleRate: number;
+
+class MxVoiceWorklet extends AudioWorkletProcessor {
+    constructor() {
+        super();
+    }
+
+    process(inputs, outputs, parameters) {
+        this.port.postMessage(<ITimingPayload>{ev: PayloadEvent.Timekeep, timeSeconds: currentTime});
+        return true;
+    }
+}
+
+registerProcessor(WORKLET_NAME, MxVoiceWorklet);
+
+export default null; // to appease module loaders (we never use the export)

--- a/src/voice/VoiceRecording.ts
+++ b/src/voice/VoiceRecording.ts
@@ -59,6 +59,19 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
         super();
     }
 
+    public get contentType(): string {
+        return "audio/ogg";
+    }
+
+    public get contentLength(): number {
+        return this.buffer.length;
+    }
+
+    public get durationSeconds(): number {
+        if (!this.recorder) throw new Error("Duration not available without a recording");
+        return this.recorderContext.currentTime;
+    }
+
     private async makeRecorder() {
         this.recorderStream = await navigator.mediaDevices.getUserMedia({
             audio: {
@@ -240,7 +253,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
 
         this.emit(RecordingState.Uploading);
         this.mxc = await this.client.uploadContent(new Blob([this.buffer], {
-            type: "audio/ogg",
+            type: this.contentType,
         }), {
             onlyContentUri: false, // to stop the warnings in the console
         }).then(r => r['content_uri']);

--- a/src/voice/VoiceRecording.ts
+++ b/src/voice/VoiceRecording.ts
@@ -116,7 +116,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
 
         // Dev note: we can't use `addEventListener` for some reason. It just doesn't work.
         this.recorderWorklet.port.onmessage = (ev) => {
-            switch(ev.data['ev']) {
+            switch (ev.data['ev']) {
                 case PayloadEvent.Timekeep:
                     this.processAudioUpdate(ev.data['timeSeconds']);
                     break;

--- a/src/voice/consts.ts
+++ b/src/voice/consts.ts
@@ -18,6 +18,7 @@ export const WORKLET_NAME = "mx-voice-worklet";
 
 export enum PayloadEvent {
     Timekeep = "timekeep",
+    AmplitudeMark = "amplitude_mark",
 }
 
 export interface IPayload {
@@ -25,5 +26,12 @@ export interface IPayload {
 }
 
 export interface ITimingPayload extends IPayload {
+    ev: PayloadEvent.Timekeep;
     timeSeconds: number;
+}
+
+export interface IAmplitudePayload extends IPayload {
+    ev: PayloadEvent.AmplitudeMark;
+    forSecond: number;
+    amplitude: number;
 }

--- a/src/voice/consts.ts
+++ b/src/voice/consts.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export const WORKLET_NAME = "mx-voice-worklet";
+
+export enum PayloadEvent {
+    Timekeep = "timekeep",
+}
+
+export interface IPayload {
+    ev: PayloadEvent;
+}
+
+export interface ITimingPayload extends IPayload {
+    timeSeconds: number;
+}


### PR DESCRIPTION
This does two primary things: 
1. Gets rid of the deprecated processor usage, replacing things with a worklet.
2. Determines the final waveform of the recorded clip to include it in the event. This will later be used for timeline rendering.

There's no specification or MSC for what the `waveform` attribute would contain, so this assumes that "one sample per second" is suitable. This is highly likely to change as a 1 second clip is likely to need a few dozen more samples.

Note that this mixes in a couple MSCs to the event format. This is part of an experiment to see how it ends up working out.

----

**Requires https://github.com/vector-im/element-web/pull/17013**

----
