### PR TITLE
Remove weird margin from the file panel

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -22,7 +22,6 @@ limitations under the License.
 }
 
 .mx_FilePanel .mx_RoomView_messageListWrapper {
-    margin-right: 20px;
     flex-direction: row;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
As far as I can tell, there is no reason for this to exist

Before:
![Screenshot_20210420_082326](https://user-images.githubusercontent.com/25768714/115347442-b00f2d00-a1b1-11eb-932d-dc554b59d1e7.png)

After:
![Screenshot_20210420_082350](https://user-images.githubusercontent.com/25768714/115347490-bef5df80-a1b1-11eb-80d8-82e608fd5e10.png)
