### PR TITLE
Avoid being stuck in a space

### DIFF
--- a/src/stores/SpaceStore.tsx
+++ b/src/stores/SpaceStore.tsx
@@ -514,7 +514,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
                 const room = this.matrixClient?.getRoom(payload.room_id);
 
                 // persist last viewed room from a space
-                if (room) {
+                if (room && !room.isSpaceRoom()) {
                     window.localStorage.setItem(getLastViewedRoomsStorageKey(this.activeSpace), payload.room_id);
                 }
 

--- a/src/stores/SpaceStore.tsx
+++ b/src/stores/SpaceStore.tsx
@@ -514,6 +514,12 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
                 const room = this.matrixClient?.getRoom(payload.room_id);
 
                 // persist last viewed room from a space
+
+                // Don't save if the room is a space room. This would cause a problem:
+                // When switching to a space home, we first view that room and
+                // only after that we switch to that space. This causes us to
+                // save the space home to be the last viewed room in the home
+                // space.
                 if (room && !room.isSpaceRoom()) {
                     window.localStorage.setItem(getLastViewedRoomsStorageKey(this.activeSpace), payload.room_id);
                 }


### PR DESCRIPTION
Fixes [#17017](https://github.com/vector-im/element-web/issues/17017)

This problem is caused by the fact that when switching to a space home, we first view that room and only after that we switch to that space. This causes us to save the space home to be the last viewed room in the home space. Which causes the bug.

Originally, this would also happen at startup but that seems to have been fixed