### PR TITLE
Fix spaces filtering sometimes lagging behind or behaving oddly

### DIFF
--- a/src/stores/SpaceStore.tsx
+++ b/src/stores/SpaceStore.tsx
@@ -446,11 +446,11 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
         }
     };
 
-    private onRoomAccountData = (ev: MatrixEvent, room: Room, lastEvent: MatrixEvent) => {
+    private onRoomAccountData = (ev: MatrixEvent, room: Room, lastEvent?: MatrixEvent) => {
         if (ev.getType() === EventType.Tag && !room.isSpaceRoom()) {
             // If the room was in favourites and now isn't or the opposite then update its position in the trees
-            const oldTags = lastEvent.getContent()?.tags;
-            const newTags = ev.getContent()?.tags;
+            const oldTags = lastEvent?.getContent()?.tags || {};
+            const newTags = ev.getContent()?.tags || {};
             if (!!oldTags[DefaultTagID.Favourite] !== !!newTags[DefaultTagID.Favourite]) {
                 this.onRoomUpdate(room);
             }

--- a/src/stores/room-list/filters/SpaceFilterCondition.ts
+++ b/src/stores/room-list/filters/SpaceFilterCondition.ts
@@ -42,10 +42,16 @@ export class SpaceFilterCondition extends EventEmitter implements IFilterConditi
 
     private onStoreUpdate = async (): Promise<void> => {
         const beforeRoomIds = this.roomIds;
-        this.roomIds = SpaceStore.instance.getSpaceFilteredRoomIds(this.space);
+        // clone the set as it may be mutated by the space store internally
+        this.roomIds = new Set(SpaceStore.instance.getSpaceFilteredRoomIds(this.space));
 
         if (setHasDiff(beforeRoomIds, this.roomIds)) {
             this.emit(FILTER_CHANGED);
+            // XXX: Room List Store has a bug where updates to the pre-filter during a local echo of a
+            // tags transition seem to be ignored, so refire in the next tick to work around it
+            setImmediate(() => {
+                this.emit(FILTER_CHANGED);
+            });
         }
     };
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16978

This was a mutable reference issue, but also unearthed another issue where a room gained its first tag and there was no lastEvent.

Unfortunately also uncovered another edge case behaviour in the RLS with local echoes, temporary workaround had to be brought back (removed in https://github.com/matrix-org/matrix-react-sdk/pull/5825#discussion_r605388017)