### PR TITLE
Add a WheelEvent normalization function

### DIFF
--- a/src/components/views/elements/ImageView.tsx
+++ b/src/components/views/elements/ImageView.tsx
@@ -32,13 +32,14 @@ import dis from '../../../dispatcher/dispatcher';
 import {replaceableComponent} from "../../../utils/replaceableComponent";
 import {RoomPermalinkCreator} from "../../../utils/permalinks/Permalinks"
 import {MatrixEvent} from "matrix-js-sdk/src/models/event";
+import {normalizeWheelEvent} from "../../../utils/Mouse";
 
 const MIN_ZOOM = 100;
 const MAX_ZOOM = 300;
 // This is used for the buttons
 const ZOOM_STEP = 10;
 // This is used for mouse wheel events
-const ZOOM_COEFFICIENT = 7.5;
+const ZOOM_COEFFICIENT = 0.5;
 // If we have moved only this much we can zoom
 const ZOOM_DISTANCE = 10;
 
@@ -115,7 +116,9 @@ export default class ImageView extends React.Component<IProps, IState> {
     private onWheel = (ev: WheelEvent) => {
         ev.stopPropagation();
         ev.preventDefault();
-        const newZoom = this.state.zoom - (ev.deltaY * ZOOM_COEFFICIENT);
+
+        const {deltaY} = normalizeWheelEvent(ev);
+        const newZoom = this.state.zoom - (deltaY * ZOOM_COEFFICIENT);
 
         if (newZoom <= MIN_ZOOM) {
             this.setState({

--- a/src/utils/Mouse.ts
+++ b/src/utils/Mouse.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 Šimon Brandner <simon.bra.ag@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Different browsers use different deltaModes. This causes different behaviour.
+ * To avoid that we use this function to convert any event to pixels.
+ * @param {WheelEvent} event to normalize
+ * @returns {WheelEvent} normalized event event
+ */
+export function normalizeWheelEvent(event: WheelEvent): WheelEvent {
+    const LINE_HEIGHT = 18;
+
+    let deltaX;
+    let deltaY;
+    let deltaZ;
+
+    if (event.deltaMode === 1) { // Units are lines
+        deltaX = (event.deltaX * LINE_HEIGHT);
+        deltaY = (event.deltaY * LINE_HEIGHT);
+        deltaZ = (event.deltaZ * LINE_HEIGHT);
+    } else {
+        deltaX = event.deltaX;
+        deltaY = event.deltaY;
+        deltaZ = event.deltaZ;
+    }
+
+    return new WheelEvent(
+        "syntheticWheel",
+        {
+            deltaMode: 0,
+            deltaY: deltaY,
+            deltaX: deltaX,
+            deltaZ: deltaZ,
+            ...event,
+        },
+    );
+}


### PR DESCRIPTION
Fixes [#17037](https://github.com/vector-im/element-web/issues/17037)

Different browsers use different `deltaMode`s. This causes different behaviour. To avoid that I've added a `normalizeWheelEvent()` function to convert any event to pixels.