### PR TITLE
Remove reliance on DOM API to generated message preview

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -130,11 +130,14 @@ export function sanitizedHtmlNode(insaneHtml: string) {
     return <div dangerouslySetInnerHTML={{ __html: saneHtml }} dir="auto" />;
 }
 
-export function sanitizedHtmlNodeInnerText(insaneHtml: string) {
-    const saneHtml = sanitizeHtml(insaneHtml, sanitizeHtmlParams);
-    const contentDiv = document.createElement("div");
-    contentDiv.innerHTML = saneHtml;
-    return contentDiv.innerText;
+export function getHtmlText(insaneHtml: string) {
+    return sanitizeHtml(insaneHtml, {
+        allowedTags: [],
+        allowedAttributes: {},
+        selfClosing: [],
+        allowedSchemes: [],
+        disallowedTagsMode: 'discard',
+    })
 }
 
 /**

--- a/src/stores/room-list/previews/MessageEventPreview.ts
+++ b/src/stores/room-list/previews/MessageEventPreview.ts
@@ -20,7 +20,7 @@ import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { _t } from "../../../languageHandler";
 import { getSenderName, isSelf, shouldPrefixMessagesIn } from "./utils";
 import ReplyThread from "../../../components/views/elements/ReplyThread";
-import { sanitizedHtmlNodeInnerText } from "../../../HtmlUtils";
+import { getHtmlText } from "../../../HtmlUtils";
 
 export class MessageEventPreview implements IPreview {
     public getTextFor(event: MatrixEvent, tagId?: TagID): string {
@@ -55,7 +55,7 @@ export class MessageEventPreview implements IPreview {
         }
 
         if (hasHtml) {
-            body = sanitizedHtmlNodeInnerText(body);
+            body = getHtmlText(body);
         }
 
         if (msgtype === 'm.emote') {


### PR DESCRIPTION
Improves vector-im/element-web#14750

When previews are enabled HTML messages rely on the DOM to extract the text from the event.
We can drop our reliance on the DOM and use `sanitizeHtml` only.

The important part is to allow no tags and keep `disallowedTagsMode: 'discard'`

> If you set disallowedTagsMode to discard (the default), disallowed tags are discarded. Any text content or subtags is still included, depending on whether the individual subtags are allowed.

This can take up to ~2.5ms per room tile rendered on screen from the benchmark I have seen and we perform a double HTML parsing.
1. The first one by `sanitizeHtml`
2. Switfly followed by an `.innerHtml` call
