### PR TITLE
Spaces visual fixes

### DIFF
--- a/res/css/structures/_SpaceRoomView.scss
+++ b/res/css/structures/_SpaceRoomView.scss
@@ -214,12 +214,11 @@ $SpaceRoomViewInnerWidth: 428px;
 
             .mx_SpaceRoomView_info {
                 display: inline-block;
-                margin: 0;
+                margin: 0 auto 0 0;
             }
 
             .mx_FacePile {
                 display: inline-block;
-                margin-left: auto;
                 margin-right: 12px;
 
                 .mx_FacePile_faces {

--- a/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
+++ b/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
@@ -157,12 +157,6 @@ limitations under the License.
             .mx_Checkbox {
                 align-items: center;
             }
-
-            .mx_FormButton {
-                min-width: 92px;
-                font-weight: normal;
-                box-sizing: border-box;
-            }
         }
     }
 
@@ -199,9 +193,5 @@ limitations under the License.
         .mx_AccessibleButton_kind_link {
             padding: 0;
         }
-    }
-
-    .mx_FormButton {
-        padding: 8px 22px;
     }
 }

--- a/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
+++ b/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
@@ -148,6 +148,10 @@ limitations under the License.
                 font-size: $font-15px;
                 line-height: 30px;
                 flex-grow: 1;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                margin-right: 12px;
             }
 
             .mx_FormButton {

--- a/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
+++ b/res/css/views/dialogs/_AddExistingToSpaceDialog.scss
@@ -154,6 +154,10 @@ limitations under the License.
                 margin-right: 12px;
             }
 
+            .mx_Checkbox {
+                align-items: center;
+            }
+
             .mx_FormButton {
                 min-width: 92px;
                 font-weight: normal;


### PR DESCRIPTION
Cut off long room names and align checkboxes in the add existing rooms dialog, and fix the invite button margin.

Before:

![Screenshot_2021-04-22 Element Matrix(1)](https://user-images.githubusercontent.com/48614497/115745254-40d83b00-a361-11eb-8a58-1408828dfb0b.png)
![Screenshot_2021-04-22 Element Toaq(2)](https://user-images.githubusercontent.com/48614497/115745364-5a798280-a361-11eb-969c-ceba55783498.png)

After:

![Screenshot_2021-04-22 Element Matrix](https://user-images.githubusercontent.com/48614497/115745284-4897df80-a361-11eb-9139-f9486399968f.png)
![Screenshot_2021-04-22 Element Toaq(1)](https://user-images.githubusercontent.com/48614497/115745390-6107fa00-a361-11eb-860e-1184a97e8942.png)