### PR TITLE
Add slash command for custom status

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -355,6 +355,16 @@ export const Commands = [
         category: CommandCategories.actions,
     }),
     new Command({
+        command: 'status',
+        args: '[<message>]',
+        description: _td('Set or clear your custom status'),
+        isEnabled: () => SettingsStore.getValue("feature_custom_status"),
+        runFn: function(roomId, args) {
+            return success(MatrixClientPeg.get()._unstable_setStatusMessage(args));
+        },
+        category: CommandCategories.actions,
+    }),
+    new Command({
         command: 'roomavatar',
         args: '[<mxc_url>]',
         description: _td('Changes the avatar of the current room'),

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -433,6 +433,7 @@
     "Double check that your server supports the room version chosen and try again.": "Double check that your server supports the room version chosen and try again.",
     "Changes your display nickname": "Changes your display nickname",
     "Changes your display nickname in the current room only": "Changes your display nickname in the current room only",
+    "Set or clear your custom status": "Set or clear your custom status",
     "Changes the avatar of the current room": "Changes the avatar of the current room",
     "Changes your avatar in this current room only": "Changes your avatar in this current room only",
     "Changes your avatar in all rooms": "Changes your avatar in all rooms",


### PR DESCRIPTION
Fixes vector-im/element-web/issues/8354

It adds a slash command to set or clear a custom status.
Big thanks to @krkc, I could copy most of the work from his PR. I hope it's okay that I'm "stealing" this PR from you.

I also added translations for German and Portuguese.

Signed-off-by: Florian Schunk <florian.schunk@reaptr.de>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->