### PR TITLE
Handle possible edge case with getting stuck in "unsent messages" bar

### DIFF
--- a/src/components/structures/RoomStatusBar.js
+++ b/src/components/structures/RoomStatusBar.js
@@ -128,7 +128,11 @@ export default class RoomStatusBar extends React.Component {
 
     _onRoomLocalEchoUpdated = (event, room, oldEventId, oldStatus) => {
         if (room.roomId !== this.props.room.roomId) return;
-        this.setState({unsentMessages: getUnsentMessages(this.props.room)});
+        const messages = getUnsentMessages(this.props.room);
+        this.setState({
+            unsentMessages: messages,
+            isResending: messages.length > 0 && this.state.isResending,
+        });
     };
 
     // Check whether current size is greater than 0, if yes call props.onVisible


### PR DESCRIPTION
Just in case we're not cleaning up the isResending state properly, here's a catch all.

Unrelated to https://github.com/vector-im/element-web/issues/17078 (this code doesn't affect the js-sdk error the author is seeing)