### PR TITLE
Disallow inline display maths

### DIFF
--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -61,9 +61,9 @@ export function htmlSerializeIfNeeded(model: EditorModel, {forceHTML = false} = 
                 // const inlinePattern = "(?:^|\\s)(?<!\\\\)\\$(?!\\s)(([^$]|\\\\\\$)+?)(?<!\\\\|\\s)\\$";
 
                 // conditions for display math detection $$...$$:
-                // - pattern starts at beginning of line or is not prefixed with backslash or dollar
+                // - pattern starts and ends on a new line
                 // - left delimiter ($$) is not escaped by backslash
-                "display": "(^|[^\\\\$])\\$\\$(([^$]|\\\\\\$)+?)\\$\\$",
+                "display": "(^)\\$\\$(([^$]|\\\\\\$)+?)\\$\\$$",
 
                 // conditions for inline math detection $...$:
                 // - pattern starts at beginning of line, follows whitespace character or punctuation
@@ -78,9 +78,9 @@ export function htmlSerializeIfNeeded(model: EditorModel, {forceHTML = false} = 
                 // detect math with latex delimiters, inline: \(...\), display \[...\]
 
                 // conditions for display math detection \[...\]:
-                // - pattern starts at beginning of line or is not prefixed with backslash
+                // - pattern starts and ends on a new line
                 // - pattern is not empty
-                "display": "(^|[^\\\\])\\\\\\[(?!\\\\\\])(.*?)\\\\\\]",
+                "display": "(^)\\\\\\[(?!\\\\\\])(.*?)\\\\\\]$",
 
                 // conditions for inline math detection \(...\):
                 // - pattern starts at beginning of line or is not prefixed with backslash


### PR DESCRIPTION
This fixes https://github.com/vector-im/element-web/issues/17095 by changing the default regex for display maths to only parse display maths when it starts and ends on a new line.

I believe this is acceptable since display maths will be rendered using the full page width anyway.

The default behavior in `config.json` can now be reproduced as follows:

```json
    "latex_maths_delims": {
        "inline": {
            "left": "\\(",
            "right": "\\)",
            "pattern": {
                "latex": "(^|[^\\\\])\\\\\\((?!\\\\\\))(.*?)\\\\\\)",
                "tex": "(^|\\s|[.,!?:;])(?!\\\\)\\$(?!\\s)(([^$\\n]|\\\\\\$)*([^\\\\\\s\\$]|\\\\\\$)(?:\\\\\\$)?)\\$"
            }
        },
        "display": {
            "left": "\\[",
            "right": "\\]",
            "pattern": {
                "latex": "(^)\\\\\\[(?!\\\\\\])(.*?)\\\\\\]$",
                "tex": "(^)\\$\\$(([^$]|\\\\\\$)+?)\\$\\$$"
            }
        }
    },
```