### PR TITLE
Changes in the UI for Dev Tools

### DIFF
--- a/src/components/views/dialogs/DevtoolsDialog.js
+++ b/src/components/views/dialogs/DevtoolsDialog.js
@@ -160,7 +160,7 @@ export class SendCustomEvent extends GenericEditor {
             <div className="mx_Dialog_buttons">
                 <button onClick={this.onBack}>{ _t('Back') }</button>
                 { !this.state.message && <button onClick={this._send}>{ _t('Send') }</button> }
-                { showTglFlip && <div style={{float: "right"}}>
+                { showTglFlip && <div style={{float: "left"}}>
                     <input id="isStateEvent" className="mx_DevTools_tgl mx_DevTools_tgl-flip" type="checkbox" onChange={this._onChange} checked={this.state.isStateEvent} />
                     <label className="mx_DevTools_tgl-btn" data-tg-off="Event" data-tg-on="State Event" htmlFor="isStateEvent" />
                 </div> }
@@ -244,7 +244,7 @@ class SendAccountData extends GenericEditor {
             <div className="mx_Dialog_buttons">
                 <button onClick={this.onBack}>{ _t('Back') }</button>
                 { !this.state.message && <button onClick={this._send}>{ _t('Send') }</button> }
-                { !this.state.message && <div style={{float: "right"}}>
+                { !this.state.message && <div style={{float: "left"}}>
                     <input id="isRoomAccountData" className="mx_DevTools_tgl mx_DevTools_tgl-flip" type="checkbox" onChange={this._onChange} checked={this.state.isRoomAccountData} disabled={this.props.forceMode} />
                     <label className="mx_DevTools_tgl-btn" data-tg-off="Account Data" data-tg-on="Room Data" htmlFor="isRoomAccountData" />
                 </div> }
@@ -572,7 +572,7 @@ class AccountDataExplorer extends React.PureComponent {
             </div>
             <div className="mx_Dialog_buttons">
                 <button onClick={this.onBack}>{ _t('Back') }</button>
-                { !this.state.message && <div style={{float: "right"}}>
+                { !this.state.message && <div style={{float: "left"}}>
                     <input id="isRoomAccountData" className="mx_DevTools_tgl mx_DevTools_tgl-flip" type="checkbox" onChange={this._onChange} checked={this.state.isRoomAccountData} />
                     <label className="mx_DevTools_tgl-btn" data-tg-off="Account Data" data-tg-on="Room Data" htmlFor="isRoomAccountData" />
                 </div> }


### PR DESCRIPTION
Aims to fix vector-im/element-web/issues/9583
and add changing headings to the specified dialog boxes

The toggle could be placed on the left to prevent someone from considering it the main action button
![image](https://user-images.githubusercontent.com/43457420/116784214-ac807d80-aab0-11eb-8b28-f1eade0f0df3.png)

Also not really sure if the `Send account Data` has something to do with `roomId`. So that could be dropped in it

![image](https://user-images.githubusercontent.com/43457420/116784748-89a39880-aab3-11eb-854a-7166a76eeff5.png)

As it could mark as a distinction from the toggled `Room Data` Dialog along with the label
![image](https://user-images.githubusercontent.com/43457420/116784959-a7253200-aab4-11eb-9831-e7b6befb157c.png)

This could be done by passing the whole Room ID down to the child dialogs. 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Changes in the UI for Dev Tools ([\#5941](https://github.com/matrix-org/matrix-react-sdk/pull/5941)). Contributed by @DantrazTrev.<!-- CHANGELOG_PREVIEW_END -->