### PR TITLE
Inhibit sending RR when context switching to a room

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -190,6 +190,9 @@ export interface IState {
     rejectError?: Error;
     hasPinnedWidgets?: boolean;
     dragCounter: number;
+    // whether or not a spaces context switch brought us here,
+    // if it did we don't want the room to be marked as read as soon as it is loaded.
+    wasContextSwitch?: boolean;
 }
 
 @replaceableComponent("structures.RoomView")
@@ -326,6 +329,7 @@ export default class RoomView extends React.Component<IProps, IState> {
             shouldPeek: this.state.matrixClientIsReady && RoomViewStore.shouldPeek(),
             showingPinned: SettingsStore.getValue("PinnedEvents.isOpen", roomId),
             showReadReceipts: SettingsStore.getValue("showReadReceipts", roomId),
+            wasContextSwitch: RoomViewStore.getWasContextSwitch(),
         };
 
         if (!initial && this.state.shouldPeek && !newState.shouldPeek) {
@@ -2014,6 +2018,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                 timelineSet={this.state.room.getUnfilteredTimelineSet()}
                 showReadReceipts={this.state.showReadReceipts}
                 manageReadReceipts={!this.state.isPeeking}
+                sendReadReceiptOnLoad={!this.state.wasContextSwitch}
                 manageReadMarkers={!this.state.isPeeking}
                 hidden={hideMessagePanel}
                 highlightedEventId={highlightedEventId}

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -68,6 +68,7 @@ class TimelinePanel extends React.Component {
         showReadReceipts: PropTypes.bool,
         // Enable managing RRs and RMs. These require the timelineSet to have a room.
         manageReadReceipts: PropTypes.bool,
+        sendReadReceiptOnLoad: PropTypes.bool,
         manageReadMarkers: PropTypes.bool,
 
         // true to give the component a 'display: none' style.
@@ -126,6 +127,7 @@ class TimelinePanel extends React.Component {
         // event tile heights. (See _unpaginateEvents)
         timelineCap: Number.MAX_VALUE,
         className: 'mx_RoomView_messagePanel',
+        sendReadReceiptOnLoad: true,
     };
 
     constructor(props) {
@@ -1049,7 +1051,9 @@ class TimelinePanel extends React.Component {
                     this._messagePanel.current.scrollToBottom();
                 }
 
-                this.sendReadReceipt();
+                if (this.props.sendReadReceiptOnLoad) {
+                    this.sendReadReceipt();
+                }
             });
         };
 

--- a/src/stores/RoomViewStore.tsx
+++ b/src/stores/RoomViewStore.tsx
@@ -62,6 +62,8 @@ const INITIAL_STATE = {
     shouldPeek: false,
 
     viaServers: [],
+
+    wasContextSwitch: false,
 };
 
 /**
@@ -116,6 +118,7 @@ class RoomViewStore extends Store<ActionPayload> {
                     roomId: null,
                     roomAlias: null,
                     viaServers: [],
+                    wasContextSwitch: false,
                 });
                 break;
             case 'view_room_error':
@@ -195,6 +198,7 @@ class RoomViewStore extends Store<ActionPayload> {
                 // pull the user out of Room Settings
                 isEditingSettings: false,
                 viaServers: payload.via_servers,
+                wasContextSwitch: payload.context_switch,
             };
 
             // Allow being given an event to be replied to when switching rooms but sanity check its for this room
@@ -231,6 +235,7 @@ class RoomViewStore extends Store<ActionPayload> {
                     roomLoading: true,
                     roomLoadError: null,
                     viaServers: payload.via_servers,
+                    wasContextSwitch: payload.context_switch,
                 });
                 try {
                     const result = await MatrixClientPeg.get().getRoomIdForAlias(payload.room_alias);
@@ -256,6 +261,8 @@ class RoomViewStore extends Store<ActionPayload> {
                 room_alias: payload.room_alias,
                 auto_join: payload.auto_join,
                 oob_data: payload.oob_data,
+                viaServers: payload.via_servers,
+                wasContextSwitch: payload.context_switch,
             });
         }
     }
@@ -266,7 +273,6 @@ class RoomViewStore extends Store<ActionPayload> {
             roomAlias: payload.room_alias,
             roomLoading: false,
             roomLoadError: payload.err,
-            viaServers: [],
         });
     }
 
@@ -425,6 +431,10 @@ class RoomViewStore extends Store<ActionPayload> {
 
     public shouldPeek() {
         return this.state.shouldPeek;
+    }
+
+    public getWasContextSwitch() {
+        return this.state.wasContextSwitch;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17043

Tweaks a small bug with the viaServer state in the RVS too, which I noticed as the variable's lifecycle is nearly identical to the newly added one.

@matrix-org/design does this mark as read behaviour seem sane?