### PR TITLE
Fix saving room pill part to history

### DIFF
--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -158,7 +158,7 @@ export default class EditorModel {
         }
     }
 
-    reset(serializedParts: SerializedPart[], caret: Caret, inputType: string) {
+    reset(serializedParts: SerializedPart[], caret?: Caret, inputType?: string) {
         this._parts = serializedParts.map(p => this._partCreator.deserializePart(p));
         if (!caret) {
             caret = this.getPositionAtEnd();

--- a/src/editor/parts.ts
+++ b/src/editor/parts.ts
@@ -287,6 +287,14 @@ abstract class PillPart extends BasePart implements IPillPart {
         }
     }
 
+    serialize(): ISerializedPillPart {
+        return {
+            type: this.type,
+            text: this.text,
+            resourceId: this.resourceId,
+        };
+    }
+
     get canEdit() {
         return false;
     }
@@ -394,14 +402,6 @@ class UserPillPart extends PillPart {
     get className() {
         return "mx_UserPill mx_Pill";
     }
-
-    serialize(): ISerializedPillPart {
-        return {
-            type: this.type,
-            text: this.text,
-            resourceId: this.resourceId,
-        };
-    }
 }
 
 class PillCandidatePart extends PlainBasePart implements IPillCandidatePart {
@@ -495,7 +495,7 @@ export class PartCreator {
             case Type.PillCandidate:
                 return this.pillCandidate(part.text);
             case Type.RoomPill:
-                return this.roomPill(part.text);
+                return this.roomPill(part.resourceId);
             case Type.UserPill:
                 return this.userPill(part.text, part.resourceId);
         }

--- a/src/editor/parts.ts
+++ b/src/editor/parts.ts
@@ -34,7 +34,7 @@ interface ISerializedPart {
 interface ISerializedPillPart {
     type: Type.AtRoomPill | Type.RoomPill | Type.UserPill;
     text: string;
-    resourceId: string;
+    resourceId?: string;
 }
 
 export type SerializedPart = ISerializedPart | ISerializedPillPart;
@@ -373,6 +373,13 @@ class AtRoomPillPart extends RoomPillPart {
 
     get type(): IPillPart["type"] {
         return Type.AtRoomPill;
+    }
+
+    serialize(): ISerializedPillPart {
+        return {
+            type: this.type,
+            text: this.text,
+        };
     }
 }
 

--- a/test/editor/deserialize-test.js
+++ b/test/editor/deserialize-test.js
@@ -178,7 +178,7 @@ describe('editor/deserialize', function() {
             const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
             expect(parts.length).toBe(3);
             expect(parts[0]).toStrictEqual({type: "plain", text: "Try "});
-            expect(parts[1]).toStrictEqual({type: "room-pill", text: "#room:hs.tld"});
+            expect(parts[1]).toStrictEqual({type: "room-pill", text: "#room:hs.tld", resourceId: "#room:hs.tld"});
             expect(parts[2]).toStrictEqual({type: "plain", text: "?"});
         });
         it('@room pill', function() {


### PR DESCRIPTION
Fixes [#17115](https://github.com/vector-im/element-web/issues/17115) and makes some params of `EditorModel::reset()` optional because they should be. 