### PR TITLE
Failed reactions Design

### DIFF
--- a/res/css/views/messages/_ReactionsRowButton.scss
+++ b/res/css/views/messages/_ReactionsRowButton.scss
@@ -33,6 +33,10 @@ limitations under the License.
         background-color: $reaction-row-button-selected-bg-color;
         border-color: $reaction-row-button-selected-border-color;
     }
+    &.mx_ReactionsRowButton_failed {
+        background-color: rgba(140, 12, 12, 0.748);
+        border-color: rgba(68, 0, 0, 0.748);
+    }
 
     .mx_ReactionsRowButton_content {
         max-width: 100px;
@@ -40,5 +44,6 @@ limitations under the License.
         white-space: nowrap;
         text-overflow: ellipsis;
         padding-right: 4px;
-    }
+    }   
 }
+

--- a/src/components/views/messages/ReactionsRowButton.js
+++ b/src/components/views/messages/ReactionsRowButton.js
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
+import {EventStatus} from 'matrix-js-sdk/src/models/event';
 import {MatrixClientPeg} from '../../../MatrixClientPeg';
 import * as sdk from '../../../index';
 import { _t } from '../../../languageHandler';
@@ -86,9 +86,11 @@ export default class ReactionsRowButton extends React.PureComponent {
         const ReactionsRowButtonTooltip =
             sdk.getComponent('messages.ReactionsRowButtonTooltip');
         const { mxEvent, content, count, reactionEvents, myReactionEvent } = this.props;
-
+        const failed =Boolean(mxEvent.staus === EventStatus.NOT_SENT)
+        
         const classes = classNames({
             mx_ReactionsRowButton: true,
+            mx_ReactionsRowButton_failed:failed,
             mx_ReactionsRowButton_selected: !!myReactionEvent,
         });
 


### PR DESCRIPTION
Possibly Fixes vector-im/element-web/issues/17034 (Needs a bit design)

Added the `EventStatus.NOT_SENT`  the one used in `Resend Reactions` to determine the reactions to resend to the `ReactionRowsButton` for the logic of Failed to sent responses

        const failed =Boolean(mxEvent.staus === EventStatus.NOT_SENT)

Added `mx_ReactionsRowButton_failed` class to render a failed event . Although it needs a bit more design (The image shows a failed to send reaction)
 
![image](https://user-images.githubusercontent.com/43457420/116873265-04e08800-ac35-11eb-8568-b6f2ce3b7f60.png)
