### PR TITLE
Calculate the real waveform in the Playback class for voice messages

### DIFF
--- a/src/voice/Playback.ts
+++ b/src/voice/Playback.ts
@@ -93,6 +93,8 @@ export class Playback extends EventEmitter implements IDestroyable {
     public async prepare() {
         this.audioBuf = await this.context.decodeAudioData(this.buf);
 
+        // Update the waveform to the real waveform once we have channel data to use. We don't
+        // exactly trust the user-provided waveform to be accurate...
         const waveform = Array.from(this.audioBuf.getChannelData(0)).map(v => clamp(v, 0, 1));
         this.resampledWaveform = arrayFastResample(waveform, PLAYBACK_WAVEFORM_SAMPLES);
         this.waveformObservable.update(this.resampledWaveform);

--- a/src/voice/Playback.ts
+++ b/src/voice/Playback.ts
@@ -20,6 +20,7 @@ import {arrayFastResample, arraySeed} from "../utils/arrays";
 import {SimpleObservable} from "matrix-widget-api";
 import {IDestroyable} from "../utils/IDestroyable";
 import {PlaybackClock} from "./PlaybackClock";
+import {clamp} from "../utils/numbers";
 
 export enum PlaybackState {
     Decoding = "decoding",
@@ -52,8 +53,6 @@ export class Playback extends EventEmitter implements IDestroyable {
         this.resampledWaveform = arrayFastResample(seedWaveform, PLAYBACK_WAVEFORM_SAMPLES);
         this.waveformObservable.update(this.resampledWaveform);
         this.clock = new PlaybackClock(this.context);
-
-        // TODO: @@ TR: Calculate real waveform
     }
 
     public get waveform(): number[] {
@@ -93,6 +92,11 @@ export class Playback extends EventEmitter implements IDestroyable {
 
     public async prepare() {
         this.audioBuf = await this.context.decodeAudioData(this.buf);
+
+        const waveform = Array.from(this.audioBuf.getChannelData(0)).map(v => clamp(v, 0, 1));
+        this.resampledWaveform = arrayFastResample(waveform, PLAYBACK_WAVEFORM_SAMPLES);
+        this.waveformObservable.update(this.resampledWaveform);
+
         this.emit(PlaybackState.Stopped); // signal that we're not decoding anymore
         this.clock.durationSeconds = this.audioBuf.duration;
     }


### PR DESCRIPTION
This is to ensure that we always have some sort of waveform to show the user. In practice, the decoding happens quickly enough where the event-provided waveform is not super important, but can be useful as a placeholder if the media takes a while to download.