### PR TITLE
Fix edge case with space panel alignment with subspaces on ff

### DIFF
--- a/res/css/structures/_SpacePanel.scss
+++ b/res/css/structures/_SpacePanel.scss
@@ -79,6 +79,7 @@ $activeBorderColor: $secondary-fg-color;
     .mx_SpaceItem {
         display: inline-flex;
         flex-flow: wrap;
+        align-self: baseline;
     }
 
     .mx_SpaceItem.collapsed {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2403652/116998187-bf27cc00-acd5-11eb-9ce0-6751fe7e7a1e.png)

Before 
![image](https://user-images.githubusercontent.com/2403652/116998206-c6e77080-acd5-11eb-91aa-19cb90fc172a.png)
After
![image](https://user-images.githubusercontent.com/2403652/116998233-cfd84200-acd5-11eb-9ad1-f95a272764ea.png)

Chrome had both already looking the same as After.