### PR TITLE
Revert "Use another login"

### DIFF
--- a/src/components/structures/auth/CompleteSecurity.js
+++ b/src/components/structures/auth/CompleteSecurity.js
@@ -65,7 +65,7 @@ export default class CompleteSecurity extends React.Component {
             return null;
         } else if (phase === PHASE_INTRO) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
-            title = _t("Verify this login");
+            title = _t("Verify this session");
         } else if (phase === PHASE_DONE) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_verified" />;
             title = _t("Session verified");
@@ -74,7 +74,7 @@ export default class CompleteSecurity extends React.Component {
             title = _t("Are you sure?");
         } else if (phase === PHASE_BUSY) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
-            title = _t("Verify this login");
+            title = _t("Verify this session");
         } else {
             throw new Error(`Unknown phase ${phase}`);
         }

--- a/src/components/structures/auth/SetupEncryptionBody.js
+++ b/src/components/structures/auth/SetupEncryptionBody.js
@@ -155,7 +155,7 @@ export default class SetupEncryptionBody extends React.Component {
             let verifyButton;
             if (store.hasDevicesToVerifyAgainst) {
                 verifyButton = <AccessibleButton kind="primary" onClick={this._onVerifyClick}>
-                    { _t("Use another login") }
+                    { _t("Use another session to verify") }
                 </AccessibleButton>;
             }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2710,7 +2710,6 @@
     "Could not load user profile": "Could not load user profile",
     "Decrypted event source": "Decrypted event source",
     "Original event source": "Original event source",
-    "Verify this login": "Verify this login",
     "Session verified": "Session verified",
     "Failed to send email": "Failed to send email",
     "The email address linked to your account must be entered.": "The email address linked to your account must be entered.",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2767,7 +2767,7 @@
     "Decide where your account is hosted": "Decide where your account is hosted",
     "Use Security Key or Phrase": "Use Security Key or Phrase",
     "Use Security Key": "Use Security Key",
-    "Use another login": "Use another login",
+    "Use another session to verify": "Use another session to verify",
     "Verify your identity to access encrypted messages and prove your identity to others.": "Verify your identity to access encrypted messages and prove your identity to others.",
     "Your new session is now verified. It has access to your encrypted messages, and other users will see it as trusted.": "Your new session is now verified. It has access to your encrypted messages, and other users will see it as trusted.",
     "Your new session is now verified. Other users will see it as trusted.": "Your new session is now verified. Other users will see it as trusted.",


### PR DESCRIPTION
### Description

As mentioned [here](https://github.com/vector-im/element-meta/issues/361), _Use another login_ and _Verify this login_ are regressions in many people's opinion. In the Czech translation, this resulted in something more like _Use another username_ which is not what the option is at all...

![Screenshot_20210504_210433](https://user-images.githubusercontent.com/25768714/117056215-56177700-ad1c-11eb-9ce5-612bd104a0b2.png)

### Notes

This currently does the change _only_ in this dialog, but I think we should globally stick to it. _Session_ is already used in most places, so I don't really see the reason to use _login_ which is actually probably more confusing, imo. 

Personally, I feel like _device_ is the best but that isn't ideal either because you can have multiple logged-in sessions on one physical device.

One thing I am almost sure about is that _login_ isn't good as it sounds more like a _username_ or something along those lines. These seem to support this: ["login" (dictionary.com)](https://www.dictionary.com/browse/login), ["login" (techterms.com)](https://techterms.com/definition/login), ["login" (wikipedia.org)](https://en.wikipedia.org/wiki/Login), ["login" (dictionary.cambridge.org)](https://dictionary.cambridge.org/dictionary/english/login)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Use another login" ([\#5967](https://github.com/matrix-org/matrix-react-sdk/pull/5967)).<!-- CHANGELOG_PREVIEW_END -->