### PR TITLE
Show device ID in UserInfo when there is no device name

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -187,9 +187,15 @@ function DeviceItem({userId, device}: {userId: string, device: IDevice}) {
         verifyDevice(cli.getUser(userId), device);
     };
 
-    const deviceName = device.ambiguous ?
-        (device.getDisplayName() ? device.getDisplayName() : "") + " (" + device.deviceId + ")" :
-        device.getDisplayName();
+    let deviceName;
+    if (device.getDisplayName() === null || device.getDisplayName().trim() === "") {
+        deviceName = device.deviceId;
+    } else {
+        deviceName = device.ambiguous ?
+            device.getDisplayName() + " (" + device.deviceId + ")" :
+            device.getDisplayName();
+    }
+
     let trustedLabel = null;
     if (userTrust.isVerified()) trustedLabel = isVerified ? _t("Trusted") : _t("Not trusted");
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/6166

Before:
<img width="322" src="https://user-images.githubusercontent.com/5855073/117383314-2005fe80-aea6-11eb-8e2c-5dbffad11832.png">

After:
<img width="328" src="https://user-images.githubusercontent.com/5855073/117383273-095fa780-aea6-11eb-80c9-88e1eed73dad.png">
