### PR TITLE
Fix voice message playback being squished up against send button

### DIFF
--- a/res/css/views/rooms/_VoiceRecordComposerTile.scss
+++ b/res/css/views/rooms/_VoiceRecordComposerTile.scss
@@ -46,11 +46,11 @@ limitations under the License.
     mask-image: url('$(res)/img/element-icons/trashcan.svg');
 }
 
-.mx_VoiceRecordComposerTile_recording.mx_VoiceMessagePrimaryContainer {
+.mx_MessageComposer_row .mx_VoiceMessagePrimaryContainer {
     // Note: remaining class properties are in the PlayerContainer CSS.
 
     margin: 6px; // force the composer area to put a gutter around us
-    margin-right: 12px; // isolate from stop button
+    margin-right: 12px; // isolate from stop/send button
 
     position: relative; // important for the live circle
 


### PR DESCRIPTION
In the style shuffle of https://github.com/matrix-org/matrix-react-sdk/pull/5970 the playback bar got squished up against the send button. This just fixes the selector to actually hit the composer-based recorder all the time, not just when recording.

![image](https://user-images.githubusercontent.com/1190097/117394699-dae8c900-aeb3-11eb-8417-d63946b60f10.png)
