### PR TITLE
 Exporting Room Names

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -382,6 +382,15 @@ limitations under the License.
     .mx_RadioButton, .mx_Checkbox {
         margin-top: 8px;
     }
+    .mx_AccessibleButton_kind_secondary {
+        color: $button-primary-fg-color;
+        font-size: $font-14px;
+    }
+    .mx_AccessibleButton_kind_secondary:hover {
+        color: $button-primary-fg-color;
+        background-color: rgba(141, 151, 165, 0.2);
+        font-size: $font-14px;
+    }
 }
 
 .mx_RoomSublist_addRoomTooltip {

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -418,7 +418,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         this.forceUpdate(); // because the layout doesn't trigger a re-render
     };
     private getRoomNames = () => {
-        let expor={}
+        const expor={}
         this.state.rooms.forEach(room =>{expor[room.name]=room.roomId })
         console.log(expor)
         navigator.clipboard.writeText(JSON.stringify(expor))
@@ -589,12 +589,11 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                             <hr />
                             <div className='mx_RoomSublist_contextMenu_title'>{"Export/Import"}</div> {/* Needs a translation object for sure */}
                             <AccessibleButton onClick={this.getRoomNames}
-                            kind="secondary"
-                            >   
+                                kind="secondary"
+                            >
                                 {"Copy Room Names"}            {/* Needs a translation object for sure */}
                             </AccessibleButton>
 
-                            
 
                         </div>
 

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -417,7 +417,12 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         this.layout.showPreviews = !this.layout.showPreviews;
         this.forceUpdate(); // because the layout doesn't trigger a re-render
     };
-
+    private getRoomNames = () => {
+        let expor={}
+        this.state.rooms.forEach(room =>{expor[room.name]=room.roomId })
+        console.log(expor)
+        navigator.clipboard.writeText(JSON.stringify(expor))
+    }
     private onBadgeClick = (ev: React.MouseEvent) => {
         ev.preventDefault();
         ev.stopPropagation();
@@ -581,7 +586,18 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                             >
                                 {_t("Show previews of messages")}
                             </StyledMenuItemCheckbox>
+                            <hr />
+                            <div className='mx_RoomSublist_contextMenu_title'>{"Export/Import"}</div> {/* Needs a translation object for sure */}
+                            <AccessibleButton onClick={this.getRoomNames}
+                            kind="secondary"
+                            >   
+                                {"Copy Room Names"}            {/* Needs a translation object for sure */}
+                            </AccessibleButton>
+
+                            
+
                         </div>
+
                     </React.Fragment>
                 );
             }

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -421,7 +421,8 @@ export default class RoomSublist extends React.Component<IProps, IState> {
         const expor={}
         this.state.rooms.forEach(room =>{expor[room.name]=room.roomId })
         console.log(expor)
-        navigator.clipboard.writeText(JSON.stringify(expor))
+        navigator.clipboard.writeText(JSON.stringify(expor));
+        this.setState({contextMenuPosition: null});
     }
     private onBadgeClick = (ev: React.MouseEvent) => {
         ev.preventDefault();
@@ -587,7 +588,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                                 {_t("Show previews of messages")}
                             </StyledMenuItemCheckbox>
                             <hr />
-                            <div className='mx_RoomSublist_contextMenu_title'>{"Export/Import"}</div> {/* Needs a translation object for sure */}
+                            <div className='mx_RoomSublist_contextMenu_title'>{"Export / Import Rooms"}</div> {/* Needs a translation object for sure */}
                             <AccessibleButton onClick={this.getRoomNames}
                                 kind="secondary"
                             >


### PR DESCRIPTION
Aims to implement the export room names in vector-im/element-meta#769

Currently added a method to copy the Room names and RoomIds from `ContextMenu` for `RoomSublists` 

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/43457420/117535629-4e095100-b014-11eb-912a-7f330107be7d.gif)

Goals:
- [x] Base Design for exporting
- [x] Add a better design for the Option in the Context Menu
- [ ] Allow downloading as a format? 

Signed-off-by : Ayush Pratap Singh <ayushpratap16@gmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 *  Exporting Room Names ([\#5997](https://github.com/matrix-org/matrix-react-sdk/pull/5997)). Contributed by @DantrazTrev.<!-- CHANGELOG_PREVIEW_END -->