### PR TITLE
Code link is text is coloured

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -18,7 +18,7 @@ $room-highlight-color: #343a46;
 $primary-fg-color: $text-primary-color;
 $primary-bg-color: $bg-color;
 $muted-fg-color: $header-panel-text-primary-color;
-
+$link-fg-color: #238CF5;
 // additional text colors
 $secondary-fg-color: #A9B2BC;
 $tertiary-fg-color: #8E99A4;
@@ -287,8 +287,7 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
         filter: invert(1);
     }
     a code{
-        color:#238CF5;
-
+        color: $link-fg-color;
     }
 
     pre code {


### PR DESCRIPTION
Fixes vector-im/element-web/issues/17099 for the Dark theme

The code link follows the same design as the code link
![image](https://user-images.githubusercontent.com/43457420/117615184-fe976200-b186-11eb-834b-353e7f5c816e.png)



Signed-off-by : Ayush Pratap Singh <ayushpratap16@gmail.com>