### PR TITLE
Fix missing space in the beta feedback dialog

### DIFF
--- a/src/components/views/dialogs/BetaFeedbackDialog.tsx
+++ b/src/components/views/dialogs/BetaFeedbackDialog.tsx
@@ -63,7 +63,7 @@ const BetaFeedbackDialog: React.FC<IProps> = ({featureId, onFinished}) => {
         description={<React.Fragment>
             <div className="mx_BetaFeedbackDialog_subheading">
                 { _t(info.feedbackSubheading) }
-
+                { " " }
                 { _t("Your platform and username will be noted to help us use your feedback as much as we can.")}
 
                 <AccessibleButton kind="link" onClick={() => {


### PR DESCRIPTION
Before:
![Screenshot_20210512_100916](https://user-images.githubusercontent.com/25768714/117941208-27943000-b30a-11eb-88f8-ed6b9b63a9d2.png)

After:
![Screenshot_20210512_100858](https://user-images.githubusercontent.com/25768714/117941110-13e8c980-b30a-11eb-8955-b5668f8d1dc4.png)

Note: this is a bit ugly, but I am not sure there is a nice way to do this - I am open to suggestions