### PR TITLE
Fix colours used for the back button in space create menu

### DIFF
--- a/res/css/views/spaces/_SpaceCreateMenu.scss
+++ b/res/css/views/spaces/_SpaceCreateMenu.scss
@@ -67,7 +67,7 @@ $spacePanelWidth: 71px;
             width: 28px;
             height: 28px;
             position: relative;
-            background-color: $theme-button-bg-color;
+            background-color: $roomlist-button-bg-color;
             border-radius: 14px;
             margin-bottom: 12px;
 
@@ -78,7 +78,7 @@ $spacePanelWidth: 71px;
                 width: 28px;
                 top: 0;
                 left: 0;
-                background-color: $muted-fg-color;
+                background-color: $tertiary-fg-color;
                 transform: rotate(90deg);
                 mask-repeat: no-repeat;
                 mask-position: 2px 3px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17255

![image](https://user-images.githubusercontent.com/2403652/117954967-742e3a00-b30f-11eb-85cc-15d92790d763.png)
![image](https://user-images.githubusercontent.com/2403652/117954988-785a5780-b30f-11eb-9b23-64db6bc4f651.png)
