### PR TITLE
Add missing space on beta feedback dialog

### DIFF
--- a/src/components/views/dialogs/BetaFeedbackDialog.tsx
+++ b/src/components/views/dialogs/BetaFeedbackDialog.tsx
@@ -63,7 +63,7 @@ const BetaFeedbackDialog: React.FC<IProps> = ({featureId, onFinished}) => {
         description={<React.Fragment>
             <div className="mx_BetaFeedbackDialog_subheading">
                 { _t(info.feedbackSubheading) }
-
+                &nbsp;
                 { _t("Your platform and username will be noted to help us use your feedback as much as we can.")}
 
                 <AccessibleButton kind="link" onClick={() => {


### PR DESCRIPTION
<img width="766" alt="image" src="https://user-images.githubusercontent.com/279572/117968531-308efc80-b31e-11eb-958b-fa670a70a1d8.png">