### PR TITLE
Wrap decodeURIComponent in try-catch to protect against malformed URIs

### DIFF
--- a/src/linkify-matrix.js
+++ b/src/linkify-matrix.js
@@ -254,11 +254,15 @@ matrixLinkify.options = {
 
     target: function(href, type) {
         if (type === 'url') {
-            const transformed = tryTransformPermalinkToLocalHref(href);
-            if (transformed !== href || decodeURIComponent(href).match(matrixLinkify.ELEMENT_URL_PATTERN)) {
-                return null;
-            } else {
-                return '_blank';
+            try {
+                const transformed = tryTransformPermalinkToLocalHref(href);
+                if (transformed !== href || decodeURIComponent(href).match(matrixLinkify.ELEMENT_URL_PATTERN)) {
+                    return null;
+                } else {
+                    return '_blank';
+                }
+            } catch (e) {
+                // malformed URI
             }
         }
         return null;

--- a/src/utils/permalinks/Permalinks.ts
+++ b/src/utils/permalinks/Permalinks.ts
@@ -346,9 +346,14 @@ export function tryTransformPermalinkToLocalHref(permalink: string): string {
         return permalink;
     }
 
-    const m = decodeURIComponent(permalink).match(matrixLinkify.ELEMENT_URL_PATTERN);
-    if (m) {
-        return m[1];
+    try {
+        const m = decodeURIComponent(permalink).match(matrixLinkify.ELEMENT_URL_PATTERN);
+        if (m) {
+            return m[1];
+        }
+    } catch (e) {
+        // Not a valid URI
+        return permalink;
     }
 
     // A bit of a hack to convert permalinks of unknown origin to Element links


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17281

![image](https://user-images.githubusercontent.com/2403652/118105881-e3ba2d00-b3d4-11eb-9597-357eddb624a5.png)
