### PR TITLE
Increase hover feedback on room sub list buttons

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -114,11 +114,10 @@ limitations under the License.
             }
         }
 
-    .mx_RoomSublist_auxButton:hover,
-    .mx_RoomSublist_menuButton:hover {
+        .mx_RoomSublist_auxButton:hover,
+        .mx_RoomSublist_menuButton:hover {
             background:$roomlist-button-bg-color;
         }
-
 
         // Hide the menu button by default
         .mx_RoomSublist_menuButton {

--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -116,7 +116,7 @@ limitations under the License.
 
         .mx_RoomSublist_auxButton:hover,
         .mx_RoomSublist_menuButton:hover {
-            background:$roomlist-button-bg-color;
+            background: $roomlist-button-bg-color;
         }
 
         // Hide the menu button by default
@@ -133,7 +133,6 @@ limitations under the License.
         .mx_RoomSublist_menuButton::before {
             mask-image: url('$(res)/img/element-icons/context-menu.svg');
         }
-
 
         .mx_RoomSublist_headerText {
             flex: 1;

--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -98,7 +98,7 @@ limitations under the License.
             position: relative;
             width: 24px;
             height: 24px;
-            border-radius: 32px;
+            border-radius: 8px;
 
             &::before {
                 content: '';
@@ -114,6 +114,12 @@ limitations under the License.
             }
         }
 
+    .mx_RoomSublist_auxButton:hover,
+    .mx_RoomSublist_menuButton:hover {
+            background:$roomlist-button-bg-color;
+        }
+
+
         // Hide the menu button by default
         .mx_RoomSublist_menuButton {
             visibility: hidden;
@@ -128,6 +134,7 @@ limitations under the License.
         .mx_RoomSublist_menuButton::before {
             mask-image: url('$(res)/img/element-icons/context-menu.svg');
         }
+
 
         .mx_RoomSublist_headerText {
             flex: 1;


### PR DESCRIPTION
Alter border-radius of RoomSublist buttons to reflect the shape of other buttons in the room list, like the explore button.

Add background color on hover to RoomSublist buttons to provide more visual feedback.

Before:
![roomsublist-icon-button-dark-old](https://user-images.githubusercontent.com/1587166/118244255-407e1c00-b497-11eb-9cd3-e67625a1a76c.gif)


After:
![roomsublist-icon-button-dark](https://user-images.githubusercontent.com/1587166/118243971-f5fc9f80-b496-11eb-94dd-8fe2216c2dc5.gif)
![roomsublist-icon-button-light](https://user-images.githubusercontent.com/1587166/118244137-1cbad600-b497-11eb-9239-87c1bb7744e4.gif)



__

I did try to also change the mask-image color on hover but I couldn't work out how to do it.