### PR TITLE
Enforce exact NewLine key combos

### DIFF
--- a/src/KeyBindingsDefaults.ts
+++ b/src/KeyBindingsDefaults.ts
@@ -131,6 +131,13 @@ const messageComposerBindings = (): KeyBinding<MessageComposerAction>[] => {
                 key: Key.ENTER,
             },
         });
+        bindings.push({
+            action: MessageComposerAction.NewLine,
+            keyCombo: {
+                key: Key.ENTER,
+                shiftKey: true,
+            },
+        });
     } else {
         bindings.push({
             action: MessageComposerAction.Send,

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -490,7 +490,8 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         // 1) It makes it possible to set the NewLine key binding to a key other than Enter without still triggering a
         // new line when pressing Enter.
         // 2) It stops key combos like shift + Enter or alt + Enter to generate NewLines.
-        // 3) It avoids a Chrome 'quirk' which sometimes results in a '\n\n' input on shift+Enter (#17215).
+        // 3) It avoids a Chrome 'quirk' which sometimes results in a '\n\n' input on shift+Enter
+        // (https://github.com/vector-im/element-web/issues/17215).
         if (event.key === Key.ENTER) {
             event.preventDefault();
             return;

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -489,7 +489,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         // Always prevent the default if key === Enter. There are multiple reasons for this:
         // 1) It makes it possible to set the NewLine key binding to a key other than Enter without still triggering a
         // new line when pressing Enter.
-        // 2) It stops key combos like shift + Enter or alt + Enter to generate NewLines.
+        // 2) It stops key combos like alt + Enter to generate NewLines.
         // 3) It avoids a Chrome 'quirk' which sometimes results in a '\n\n' input on shift+Enter
         // (https://github.com/vector-im/element-web/issues/17215).
         if (event.key === Key.ENTER) {

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -480,7 +480,12 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                 handled = true;
                 break;
         }
-        if (handled) {
+        // Always stop the event propagation if key === Enter. There are multiple reasons for this:
+        // 1) It makes it possible to set the NewLine key binding to a key other than Enter without still triggering a
+        // new line when pressing Enter.
+        // 2) It stops key combos like shift + Enter or alt + Enter to generate NewLines.
+        // 3) It avoids a Chrome 'quirk' which sometimes results in a '\n\n' input on shift+Enter (#17215).
+        if (handled || event.key === Key.ENTER) {
             event.preventDefault();
             event.stopPropagation();
             return;

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -480,14 +480,19 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                 handled = true;
                 break;
         }
-        // Always stop the event propagation if key === Enter. There are multiple reasons for this:
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+        // Always prevent the default if key === Enter. There are multiple reasons for this:
         // 1) It makes it possible to set the NewLine key binding to a key other than Enter without still triggering a
         // new line when pressing Enter.
         // 2) It stops key combos like shift + Enter or alt + Enter to generate NewLines.
         // 3) It avoids a Chrome 'quirk' which sometimes results in a '\n\n' input on shift+Enter (#17215).
-        if (handled || event.key === Key.ENTER) {
+        if (event.key === Key.ENTER) {
             event.preventDefault();
-            event.stopPropagation();
             return;
         }
 


### PR DESCRIPTION
The main motivation for this PR is to fix vector-im/element-web#17215.

Some background why I think key combos should be exact. Fuzzy key combos that allow combos like "`ctrl+Enter` OR `alt + Enter OR `Enter`" to trigger the same binding (e.g. new line), increase the probability that a user enters a fuzzy key combo accidentally. This can for example happen when the user is trying a different combo or is just clumsy. Applying a keybinding accidentally is certainly very frustrating (especially when sending a message too early, e.g. because the user thought alt+Enter instead of shift+Enter means new line). On the other hand, if a wrong/fuzzy key combo was entered on purpose and nothing happens the user simply has to re-enter the correct, exact combo. I argue that the exact matching is less frustrating to the user. Furthermore, it keeps things simple.

Signed-off-by: Clemens Zeidler <clemens.zeidler@gmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Enforce exact NewLine key combos ([\#6038](https://github.com/matrix-org/matrix-react-sdk/pull/6038)). Fixes vector-im/element-web#17215. Contributed by @czeidler.<!-- CHANGELOG_PREVIEW_END -->