### PR TITLE
Performance monitoring measurements

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -42,6 +42,7 @@ import {SpaceStoreClass} from "../stores/SpaceStore";
 import TypingStore from "../stores/TypingStore";
 import { EventIndexPeg } from "../indexing/EventIndexPeg";
 import {VoiceRecordingStore} from "../stores/VoiceRecordingStore";
+import PerformanceMonitor, { PerformanceEntryNames } from "../performance";
 
 declare global {
     interface Window {
@@ -79,6 +80,8 @@ declare global {
         mxVoiceRecordingStore: VoiceRecordingStore;
         mxTypingStore: TypingStore;
         mxEventIndexPeg: EventIndexPeg;
+        mxPerformanceMonitor: PerformanceMonitor;
+        mxPerformanceEntryNames: PerformanceEntryNames;
     }
 
     interface Document {

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -486,14 +486,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     startPageChangeTimer() {
-        PerformanceMonitor.start(PerformanceEntryNames.SWITCH_ROOM);
+        PerformanceMonitor.start(PerformanceEntryNames.PAGE_CHANGE);
     }
 
     stopPageChangeTimer() {
-        PerformanceMonitor.stop(PerformanceEntryNames.SWITCH_ROOM);
+        PerformanceMonitor.stop(PerformanceEntryNames.PAGE_CHANGE);
 
         const entries = PerformanceMonitor.getEntries({
-            name: PerformanceEntryNames.SWITCH_ROOM,
+            name: PerformanceEntryNames.PAGE_CHANGE,
         });
         const measurement = entries.pop();
 
@@ -1612,13 +1612,13 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 action: 'start_registration',
                 params: params,
             });
-            Performance.start(PerformanceEntryNames.REGISTER);
+            PerformanceMonitor.start(PerformanceEntryNames.REGISTER);
         } else if (screen === 'login') {
             dis.dispatch({
                 action: 'start_login',
                 params: params,
             });
-            Performance.start(PerformanceEntryNames.LOGIN);
+            PerformanceMonitor.start(PerformanceEntryNames.LOGIN);
         } else if (screen === 'forgot_password') {
             dis.dispatch({
                 action: 'start_password_recovery',
@@ -1858,7 +1858,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
     // returns a promise which resolves to the new MatrixClient
     onRegistered(credentials: IMatrixClientCreds) {
-        Performance.stop(PerformanceEntryNames.REGISTER);
+        PerformanceMonitor.stop(PerformanceEntryNames.REGISTER);
         return Lifecycle.setLoggedIn(credentials);
     }
 
@@ -1948,7 +1948,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         // Create and start the client
         await Lifecycle.setLoggedIn(credentials);
         await this.postLoginSetup();
-        Performance.stop(PerformanceEntryNames.LOGIN);
+        PerformanceMonitor.stop(PerformanceEntryNames.LOGIN);
     };
 
     // complete security / e2e setup has finished

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1858,7 +1858,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
     // returns a promise which resolves to the new MatrixClient
     onRegistered(credentials: IMatrixClientCreds) {
-        PerformanceMonitor.stop(PerformanceEntryNames.REGISTER);
         return Lifecycle.setLoggedIn(credentials);
     }
 
@@ -1949,6 +1948,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         await Lifecycle.setLoggedIn(credentials);
         await this.postLoginSetup();
         PerformanceMonitor.stop(PerformanceEntryNames.LOGIN);
+        PerformanceMonitor.stop(PerformanceEntryNames.REGISTER);
     };
 
     // complete security / e2e setup has finished

--- a/src/performance/entry-names.ts
+++ b/src/performance/entry-names.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export enum PerformanceEntryNames {
+
+    /**
+     * Application wide
+     */
+
+    APP_STARTUP = "mx_AppStartup",
+    PAGE_CHANGE = "mx_PageChange",
+
+    /**
+     * Events
+     */
+
+    RESEND_EVENT = "mx_ResendEvent",
+    SEND_E2EE_EVENT = "mx_SendE2EEEvent",
+    SEND_ATTACHMENT = "mx_SendAttachment",
+
+    /**
+     * Rooms
+     */
+
+    SWITCH_ROOM = "mx_SwithRoom",
+    JUMP_TO_ROOM = "mx_JumpToRoom",
+    JOIN_ROOM = "mx_JoinRoom",
+    CREATE_DM = "mx_CreateDM",
+    PEEK_ROOM = "mx_PeekRoom",
+
+    /**
+     * User
+     */
+
+    VERIFY_E2EE_USER = "mx_VerifyE2EEUser",
+    LOGIN = "mx_Login",
+    REGISTER = "mx_Register",
+
+    /**
+     * VoIP
+     */
+
+    SETUP_VOIP_CALL = "mx_SetupVoIPCall",
+}

--- a/src/performance/index.ts
+++ b/src/performance/index.ts
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { string } from "prop-types";
+import { PerformanceEntryNames } from "./entry-names";
+
+const START_PREFIX = "start:";
+const STOP_PREFIX = "stop:";
+
+export {
+    PerformanceEntryNames,
+}
+
+interface GetEntriesOptions {
+    name?: string,
+    type?: string,
+}
+
+export default class PerformanceMonitor {
+    /**
+     * Starts a performance recording
+     * @param name Name of the recording
+     * @param id Specify an identifier appended to the measurement name
+     * @returns {void}
+     */
+    static start(name: string, id?: string): void {
+        if (!supportsPerformanceApi()) {
+            return;
+        }
+        const key = buildKey(name, id);
+
+        if (!performance.getEntriesByName(key).length) {
+            console.warn(`Recording already started for: ${name}`);
+            return;
+        }
+
+        performance.mark(START_PREFIX + key);
+    }
+
+    /**
+     * Stops a performance recording and stores delta duration
+     * with the start marker
+     * @param name Name of the recording
+     * @param id Specify an identifier appended to the measurement name
+     * @returns {void}
+     */
+    static stop(name: string, id?: string): void {
+        if (!supportsPerformanceApi()) {
+            return;
+        }
+        const key = buildKey(name, id);
+        if (!performance.getEntriesByName(START_PREFIX + key).length) {
+            console.warn(`No recording started for: ${name}`);
+            return;
+        }
+
+        performance.mark(STOP_PREFIX + key);
+        performance.measure(
+            key,
+            START_PREFIX + key,
+            STOP_PREFIX + key,
+        );
+
+        this.clear(name, id);
+    }
+
+    static clear(name: string, id?: string): void {
+        if (!supportsPerformanceApi()) {
+            return;
+        }
+        const key = buildKey(name, id);
+        performance.clearMarks(START_PREFIX + key);
+        performance.clearMarks(STOP_PREFIX + key);
+    }
+
+    static getEntries({ name, type }: GetEntriesOptions = {}): PerformanceEntry[] {
+        if (!supportsPerformanceApi()) {
+            return;
+        }
+
+        if (!name && !type) {
+            return performance.getEntries();
+        } else if (!name) {
+            return performance.getEntriesByType(type);
+        } else {
+            return performance.getEntriesByName(name, type);
+        }
+    }
+}
+
+/**
+ * Tor browser does not support the Performance API
+ * @returns {boolean} true if the Performance API is supported
+ */
+function supportsPerformanceApi(): boolean {
+    return performance !== undefined && performance.mark !== undefined;
+}
+
+/**
+ * Internal utility to ensure consistent name for the recording
+ * @param name Name of the recording
+ * @param id Specify an identifier appended to the measurement name
+ * @returns {string} a compound of the name and identifier if present
+ */
+function buildKey(name: string, id?: string): string {
+    return `${name}${id ? `:${id}` : ''}`;
+}

--- a/test/end-to-end-tests/.gitignore
+++ b/test/end-to-end-tests/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.png
 element/env
+performance-entries.json

--- a/test/end-to-end-tests/src/session.js
+++ b/test/end-to-end-tests/src/session.js
@@ -208,7 +208,7 @@ module.exports = class ElementSession {
         this.log.done();
     }
 
-    close() {
+    async close() {
         return this.browser.close();
     }
 


### PR DESCRIPTION
I am going to focus on performance improvements for the rest of the quarter. And one of the most important thing is to be able to measure how we progress. That will help us to set targets and guard us against regression that build frustrations for users over time

This pull request creates a `PerfomanceMonitor` class that will be used throughout the codebase to mark code flows and measure the time it takes to complete a certain action.

It is then possible to listen to those performance measurements, and this is exactly what our end to end test suite does. Right before finishing its duties, it will collect all the performance entries and write them to disk so that we can draw a graph of how common operations perform in Element or to see whether a given PR made that feature significantly slower

This PR definitely calls for tests, I am currently working on them but I am seeking early feedback

So far, three events are tracked in code:
- `PAGE_CHANGE`
- `LOGIN`
- `REGISTER`

More to come once we have all agreed on an approach