### PR TITLE
Remove custom LoggedInView::shouldComponentUpdate logic

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -27,7 +27,7 @@ import CallMediaHandler from '../../CallMediaHandler';
 import { fixupColorFonts } from '../../utils/FontManager';
 import * as sdk from '../../index';
 import dis from '../../dispatcher/dispatcher';
-import {MatrixClientPeg, IMatrixClientCreds} from '../../MatrixClientPeg';
+import { IMatrixClientCreds } from '../../MatrixClientPeg';
 import SettingsStore from "../../settings/SettingsStore";
 
 import TagOrderActions from '../../actions/TagOrderActions';

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -219,16 +219,6 @@ class LoggedInView extends React.Component<IProps, IState> {
         });
     };
 
-    // Child components assume that the client peg will not be null, so give them some
-    // sort of assurance here by only allowing a re-render if the client is truthy.
-    //
-    // This is required because `LoggedInView` maintains its own state and if this state
-    // updates after the client peg has been made null (during logout), then it will
-    // attempt to re-render and the children will throw errors.
-    shouldComponentUpdate() {
-        return Boolean(MatrixClientPeg.get());
-    }
-
     canResetTimelineInRoom = (roomId) => {
         if (!this._roomView.current) {
             return true;


### PR DESCRIPTION
This pull request reduces the work that needs to be done on every sync by approximately half. It scraps the second part of the call stack 

![Screen Shot 2021-05-17 at 14 34 21](https://user-images.githubusercontent.com/769871/118499654-0e7eeb00-b71f-11eb-9051-d044b139bfbf.png)

`LoggedInView::shouldComponentUpdate`, would ALWAYS return `true`. And you can find the following code on the `onSync` callback

```
this.setState({
    syncErrorData: null,
});
```

The comment regarding why `shouldComponentUpdate` was written this way is also now irrelevant as whenever a logout occurs an action is dispatched and the `LoggedInView` is unmounted