### PR TITLE
Fix crash on opening notification panel

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -473,7 +473,7 @@ export default class MessagePanel extends React.Component {
     }
 
     get _roomHasPendingEdit() {
-        return localStorage.getItem(`mx_edit_room_${this.props.room.roomId}`);
+        return this.props.room && localStorage.getItem(`mx_edit_room_${this.props.room.roomId}`);
     }
 
     _getEventTiles() {


### PR DESCRIPTION
The check for pending edits (introduced in #6001) needed a null guard, since the notification panel uses MessagePanel but is not associated with a specific room.