### PR TITLE
Don't mark a room as unread when redacted event is present

### DIFF
--- a/src/Unread.js
+++ b/src/Unread.js
@@ -40,6 +40,8 @@ export function eventTriggersUnreadCount(ev) {
         return false;
     } else if (ev.getType() == 'm.room.server_acl') {
         return false;
+    } else if (ev.isRedacted()) {
+        return false;
     }
     return haveTileForEvent(ev);
 }


### PR DESCRIPTION
Currently if "Show a placeholder for removed messages" is turned on, when a message is redacted the room is marked as unread. This PR prevents that from happening.