### PR TITLE
Implement sticky headers using CSS

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -30,7 +30,7 @@ limitations under the License.
         position: sticky;
         top: 0;
         z-index: 9;
-        background: rgb(245,245,245);
+        background: rgb(245, 245, 245);
 
         // Allow the container to collapse on itself if its children
         // are not in the normal document flow

--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -27,51 +27,15 @@ limitations under the License.
         display: flex;
         align-items: center;
 
-        // ***************************
-        // Sticky Headers Start
+        position: sticky;
+        top: 0;
+        z-index: 9;
+        background: rgb(245,245,245);
 
-        // Ideally we'd be able to use `position: sticky; top: 0; bottom: 0;` on the
-        // headerContainer, however due to our layout concerns we actually have to
-        // calculate it manually so we can sticky things in the right places. We also
-        // target the headerText instead of the container to reduce jumps when scrolling,
-        // and to help hide the badges/other buttons that could appear on hover. This
-        // all works by ensuring the header text has a fixed height when sticky so the
-        // fixed height of the container can maintain the scroll position.
-
-        // The combined height must be set in the LeftPanel component for sticky headers
-        // to work correctly.
-        padding-bottom: 8px;
         // Allow the container to collapse on itself if its children
         // are not in the normal document flow
         max-height: 24px;
         color: $roomlist-header-color;
-
-        .mx_RoomSublist_stickable {
-            flex: 1;
-            max-width: 100%;
-
-            // Create a flexbox to make ordering easy
-            display: flex;
-            align-items: center;
-
-            // We use a generic sticky class for 2 reasons: to reduce style duplication and
-            // to identify when a header is sticky. If we didn't have a consistent sticky class,
-            // we'd have to do the "is sticky" checks again on click, as clicking the header
-            // when sticky scrolls instead of collapses the list.
-            &.mx_RoomSublist_headerContainer_sticky {
-                position: fixed;
-                height: 32px; // to match the header container
-                // width set by JS
-                width: calc(100% - 22px);
-            }
-
-            // We don't have a top style because the top is dependent on the room list header's
-            // height, and is therefore calculated in JS.
-            // The class, mx_RoomSublist_headerContainer_stickyTop, is applied though.
-        }
-
-        // Sticky Headers End
-        // ***************************
 
         .mx_RoomSublist_badgeContainer {
             // Create another flexbox row because it's super easy to position the badge this way.

--- a/res/themes/light/css/_mods.scss
+++ b/res/themes/light/css/_mods.scss
@@ -1,30 +1,3 @@
-// sidebar blurred avatar background
-//
-// if backdrop-filter is supported,
-// set the user avatar (if any) as a background so
-// it can be blurred by the tag panel and room list
-
-@supports (backdrop-filter: none) {
-    .mx_LeftPanel {
-        background-image: var(--avatar-url, unset);
-        background-repeat: no-repeat;
-        background-size: cover;
-        background-position: left top;
-    }
-
-    .mx_GroupFilterPanel {
-        backdrop-filter: blur($groupFilterPanel-background-blur-amount);
-    }
-
-    .mx_SpacePanel {
-        backdrop-filter: blur($groupFilterPanel-background-blur-amount);
-    }
-
-    .mx_LeftPanel .mx_LeftPanel_roomListContainer {
-        backdrop-filter: blur($roomlist-background-blur-amount);
-    }
-}
-
 .mx_RoomSublist_showNButton {
     background-color: transparent !important;
 }

--- a/src/components/structures/LeftPanel.tsx
+++ b/src/components/structures/LeftPanel.tsx
@@ -35,11 +35,9 @@ import SettingsStore from "../../settings/SettingsStore";
 import RoomListStore, { LISTS_UPDATE_EVENT } from "../../stores/room-list/RoomListStore";
 import IndicatorScrollbar from "../structures/IndicatorScrollbar";
 import AccessibleTooltipButton from "../views/elements/AccessibleTooltipButton";
-import { OwnProfileStore } from "../../stores/OwnProfileStore";
 import RoomListNumResults from "../views/rooms/RoomListNumResults";
 import LeftPanelWidget from "./LeftPanelWidget";
 import {replaceableComponent} from "../../utils/replaceableComponent";
-import {mediaFromMxc} from "../../customisations/Media";
 import SpaceStore, {UPDATE_SELECTED_SPACE} from "../../stores/SpaceStore";
 import { getKeyBindingsManager, RoomListAction } from "../../KeyBindingsManager";
 
@@ -82,10 +80,7 @@ export default class LeftPanel extends React.Component<IProps, IState> {
 
         BreadcrumbsStore.instance.on(UPDATE_EVENT, this.onBreadcrumbsUpdate);
         RoomListStore.instance.on(LISTS_UPDATE_EVENT, this.onBreadcrumbsUpdate);
-        OwnProfileStore.instance.on(UPDATE_EVENT, this.onBackgroundImageUpdate);
         SpaceStore.instance.on(UPDATE_SELECTED_SPACE, this.updateActiveSpace);
-        this.bgImageWatcherRef = SettingsStore.watchSetting(
-            "RoomList.backgroundImage", null, this.onBackgroundImageUpdate);
         this.groupFilterPanelWatcherRef = SettingsStore.watchSetting("TagPanel.enableTagPanel", null, () => {
             this.setState({showGroupFilterPanel: SettingsStore.getValue("TagPanel.enableTagPanel")});
         });
@@ -96,7 +91,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
         SettingsStore.unwatchSetting(this.bgImageWatcherRef);
         BreadcrumbsStore.instance.off(UPDATE_EVENT, this.onBreadcrumbsUpdate);
         RoomListStore.instance.off(LISTS_UPDATE_EVENT, this.onBreadcrumbsUpdate);
-        OwnProfileStore.instance.off(UPDATE_EVENT, this.onBackgroundImageUpdate);
         SpaceStore.instance.off(UPDATE_SELECTED_SPACE, this.updateActiveSpace);
     }
 
@@ -112,23 +106,6 @@ export default class LeftPanel extends React.Component<IProps, IState> {
         const newVal = BreadcrumbsStore.instance.visible;
         if (newVal !== this.state.showBreadcrumbs) {
             this.setState({showBreadcrumbs: newVal});
-        }
-    };
-
-    private onBackgroundImageUpdate = () => {
-        // Note: we do this in the LeftPanel as it uses this variable most prominently.
-        const avatarSize = 32; // arbitrary
-        let avatarUrl = OwnProfileStore.instance.getHttpAvatarUrl(avatarSize);
-        const settingBgMxc = SettingsStore.getValue("RoomList.backgroundImage");
-        if (settingBgMxc) {
-            avatarUrl = mediaFromMxc(settingBgMxc).getSquareThumbnailHttp(avatarSize);
-        }
-
-        const avatarUrlProp = `url(${avatarUrl})`;
-        if (!avatarUrl) {
-            document.body.style.removeProperty("--avatar-url");
-        } else if (document.body.style.getPropertyValue("--avatar-url") !== avatarUrlProp) {
-            document.body.style.setProperty("--avatar-url", avatarUrlProp);
         }
     };
 

--- a/src/components/structures/LeftPanelWidget.tsx
+++ b/src/components/structures/LeftPanelWidget.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, {useContext, useEffect, useMemo} from "react";
+import React, {useContext, useMemo} from "react";
 import {Resizable} from "re-resizable";
 import classNames from "classnames";
 
@@ -29,14 +29,13 @@ import AppTile from "../views/elements/AppTile";
 import {useSettingValue} from "../../hooks/useSettings";
 
 interface IProps {
-    onResize(): void;
 }
 
 const MIN_HEIGHT = 100;
 const MAX_HEIGHT = 500; // or 50% of the window height
 const INITIAL_HEIGHT = 280;
 
-const LeftPanelWidget: React.FC<IProps> = ({ onResize }) => {
+const LeftPanelWidget: React.FC<IProps> = (props) => {
     const cli = useContext(MatrixClientContext);
 
     const mWidgetsEvent = useAccountData<Record<string, IWidgetEvent>>(cli, "m.widgets");
@@ -56,8 +55,6 @@ const LeftPanelWidget: React.FC<IProps> = ({ onResize }) => {
 
     const [height, setHeight] = useLocalStorageState("left-panel-widget-height", INITIAL_HEIGHT);
     const [expanded, setExpanded] = useLocalStorageState("left-panel-widget-expanded", true);
-    useEffect(onResize, [expanded, onResize]);
-
     const [onFocus, isActive, ref] = useRovingTabIndex();
     const tabIndex = isActive ? 0 : -1;
 
@@ -69,7 +66,6 @@ const LeftPanelWidget: React.FC<IProps> = ({ onResize }) => {
             size={{height} as any}
             minHeight={MIN_HEIGHT}
             maxHeight={Math.min(window.innerHeight / 2, MAX_HEIGHT)}
-            onResize={onResize}
             onResizeStop={(e, dir, ref, d) => {
                 setHeight(height + d.height);
             }}

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -56,7 +56,7 @@ interface IProps {
     onKeyDown: (ev: React.KeyboardEvent) => void;
     onFocus: (ev: React.FocusEvent) => void;
     onBlur: (ev: React.FocusEvent) => void;
-    onResize: () => void;
+    onResize?: () => void;
     resizeNotifier: ResizeNotifier;
     isMinimized: boolean;
     activeSpace: Room;
@@ -406,7 +406,9 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
             const sublists = objectShallowClone(newSublists, (k, v) => arrayFastClone(v));
 
             this.setState({sublists, isNameFiltering}, () => {
-                this.props.onResize();
+                if (this.props.onResize) {
+                    this.props.onResize();
+                }
             });
         }
     };

--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -724,26 +724,25 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                             onFocus={onFocus}
                             aria-label={this.props.label}
                         >
-                            <div className="mx_RoomSublist_stickable">
-                                <Button
-                                    onFocus={onFocus}
-                                    inputRef={ref}
-                                    tabIndex={tabIndex}
-                                    className="mx_RoomSublist_headerText"
-                                    role="treeitem"
-                                    aria-expanded={this.state.isExpanded}
-                                    aria-level={1}
-                                    onClick={this.onHeaderClick}
-                                    onContextMenu={this.onContextMenu}
-                                    title={this.props.isMinimized ? this.props.label : undefined}
-                                >
-                                    <span className={collapseClasses} />
-                                    <span>{this.props.label}</span>
-                                </Button>
-                                {this.renderMenu()}
-                                {this.props.isMinimized ? null : badgeContainer}
-                                {this.props.isMinimized ? null : addRoomButton}
-                            </div>
+                            <Button
+                                onFocus={onFocus}
+                                inputRef={ref}
+                                tabIndex={tabIndex}
+                                className="mx_RoomSublist_headerText"
+                                role="treeitem"
+                                aria-expanded={this.state.isExpanded}
+                                aria-level={1}
+                                onClick={this.onHeaderClick}
+                                onContextMenu={this.onContextMenu}
+                                title={this.props.isMinimized ? this.props.label : undefined}
+                            >
+                                <span className={collapseClasses} />
+                                <span>{this.props.label}</span>
+                            </Button>
+                            {this.renderMenu()}
+                            {this.props.isMinimized ? null : badgeContainer}
+                            {this.props.isMinimized ? null : addRoomButton}
+
                             {this.props.isMinimized ? badgeContainer : null}
                             {this.props.isMinimized ? addRoomButton : null}
                         </div>


### PR DESCRIPTION
Fixes vector-im/element-web#14709
Fixes https://github.com/vector-im/element-web/issues/14665
Fixes https://github.com/vector-im/element-web/issues/14531
Fixes https://github.com/vector-im/element-web/issues/14493
Fixes https://github.com/vector-im/element-web/issues/17412
Fixes https://github.com/vector-im/element-web/issues/17283

Asking for a design review by @matrix-org/design as implementing this requires us to remove the blurred background image as we need to have a background color set on the sublist header for this CSS implementation to work.
As an alternative to a solid background we could have a horizontal linear gradient.

Tested on
- Chromium
- Firefox
- Safari

Overall the scrolling experience is way smoother. Looking at the recording it can seem that we are doing more work with the JavaScript implementation, but this is purely because now the browser is able to render at a higher frame rate

# Before 🐌 

![Screen Shot 2021-05-18 at 10 35 58](https://user-images.githubusercontent.com/769871/118630465-72102380-b7c6-11eb-9b20-4fcd1276f539.png)

# After 🐎 

![Screen Shot 2021-05-18 at 10 38 36](https://user-images.githubusercontent.com/769871/118630459-71778d00-b7c6-11eb-9705-92d7f001649b.png)




<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->