### PR TITLE
Depile encrypted events to find the most suitable one for preview

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -123,9 +123,9 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
         this.forceUpdate(); // notification state changed - update
     };
 
-    private onResize = async () => {
+    private onResize = () => {
         if (this.showMessagePreview && !this.state.messagePreview) {
-            await this.generatePreview();
+            this.generatePreview();
         }
     };
 
@@ -236,9 +236,9 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
         this.forceUpdate(); // we don't have anything to actually update
     };
 
-    private onRoomPreviewChanged = async (room: Room) => {
+    private onRoomPreviewChanged = (room: Room) => {
         if (this.props.room && room.roomId === this.props.room.roomId) {
-            await this.generatePreview();
+            this.generatePreview();
         }
     };
 

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -100,8 +100,10 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
             hasUnsentEvents: this.countUnsentEvents() > 0,
 
             // generatePreview() will return nothing if the user has previews disabled
-            messagePreview: this.generatePreview(),
+            messagePreview: "",
         };
+        this.generatePreview();
+
         this.notificationState = RoomNotificationStateStore.instance.getRoomState(this.props.room);
         this.roomProps = EchoChamber.forRoom(this.props.room);
         if (this.props.resizeNotifier) {
@@ -121,9 +123,9 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
         this.forceUpdate(); // notification state changed - update
     };
 
-    private onResize = () => {
+    private onResize = async () => {
         if (this.showMessagePreview && !this.state.messagePreview) {
-            this.setState({messagePreview: this.generatePreview()});
+            await this.generatePreview();
         }
     };
 
@@ -147,7 +149,7 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
 
     public componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
         if (prevProps.showMessagePreview !== this.props.showMessagePreview && this.showMessagePreview) {
-            this.setState({messagePreview: this.generatePreview()});
+            this.generatePreview();
         }
         if (prevProps.room?.roomId !== this.props.room?.roomId) {
             MessagePreviewStore.instance.off(
@@ -234,19 +236,19 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
         this.forceUpdate(); // we don't have anything to actually update
     };
 
-    private onRoomPreviewChanged = (room: Room) => {
+    private onRoomPreviewChanged = async (room: Room) => {
         if (this.props.room && room.roomId === this.props.room.roomId) {
-            // generatePreview() will return nothing if the user has previews disabled
-            this.setState({messagePreview: this.generatePreview()});
+            await this.generatePreview();
         }
     };
 
-    private generatePreview(): string | null {
+    private async generatePreview() {
         if (!this.showMessagePreview) {
             return null;
         }
 
-        return MessagePreviewStore.instance.getPreviewForRoom(this.props.room, this.props.tag);
+        const messagePreview = await MessagePreviewStore.instance.getPreviewForRoom(this.props.room, this.props.tag);
+        this.setState({ messagePreview });
     }
 
     private scrollIntoView = () => {

--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -94,10 +94,10 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
      * @param inTagId The tag ID in which the room resides
      * @returns The preview, or null if none present.
      */
-    public getPreviewForRoom(room: Room, inTagId: TagID): string {
+    public async getPreviewForRoom(room: Room, inTagId: TagID): Promise<string> {
         if (!room) return null; // invalid room, just return nothing
 
-        if (!this.previews.has(room.roomId)) this.generatePreview(room, inTagId);
+        if (!this.previews.has(room.roomId)) await this.generatePreview(room, inTagId);
 
         const previews = this.previews.get(room.roomId);
         if (!previews) return null;
@@ -108,7 +108,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
         return previews.get(inTagId);
     }
 
-    private generatePreview(room: Room, tagId?: TagID) {
+    private async generatePreview(room: Room, tagId?: TagID) {
         const events = room.timeline;
         if (!events) return; // should only happen in tests
 
@@ -130,6 +130,11 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
             }
 
             const event = events[i];
+
+            if (event.shouldAttemptDecryption()) {
+                await this.matrixClient.decryptEvent(event);
+            }
+
             const previewDef = PREVIEWS[event.getType()];
             if (!previewDef) continue;
             if (previewDef.isState && isNullOrUndefined(event.getStateKey())) continue;
@@ -174,7 +179,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
         if (payload.action === 'MatrixActions.Room.timeline' || payload.action === 'MatrixActions.Event.decrypted') {
             const event = payload.event; // TODO: Type out the dispatcher
             if (!this.previews.has(event.getRoomId())) return; // not important
-            this.generatePreview(this.matrixClient.getRoom(event.getRoomId()), TAG_ANY);
+            await this.generatePreview(this.matrixClient.getRoom(event.getRoomId()), TAG_ANY);
         }
     }
 }

--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -131,9 +131,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
 
             const event = events[i];
 
-            if (event.shouldAttemptDecryption()) {
-                await this.matrixClient.decryptEvent(event);
-            }
+            await this.matrixClient.decryptEvent(event);
 
             const previewDef = PREVIEWS[event.getType()];
             if (!previewDef) continue;

--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -131,7 +131,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
 
             const event = events[i];
 
-            await this.matrixClient.decryptEvent(event);
+            await this.matrixClient.decryptEventIfNeeded(event);
 
             const previewDef = PREVIEWS[event.getType()];
             if (!previewDef) continue;


### PR DESCRIPTION
Regression introduced by matrix-org/matrix-js-sdk#1684
Blocked by matrix-org/matrix-js-sdk#1696 who introduces `MatrixClient::decryptEvent`