### PR TITLE
Update MemberList to reflect changes for invite permission change

### DIFF
--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -133,16 +133,21 @@ export default class MemberList extends React.Component {
         }
     }
 
+    get canInvite() {
+        const cli = MatrixClientPeg.get();
+        const room = cli.getRoom(this.props.roomId);
+        return room && room.canInvite(cli.getUserId());
+    }
+
     _getMembersState(members) {
         // set the state after determining _showPresence to make sure it's
         // taken into account while rerendering
-        const cli = MatrixClientPeg.get();
         return {
             loading: false,
             members: members,
             filteredJoinedMembers: this._filterMembers(members, 'join'),
             filteredInvitedMembers: this._filterMembers(members, 'invite'),
-            canInvite: cli.getRoom(this.props.roomId).canInvite(cli.getUserId()),
+            canInvite: this.canInvite,
 
             // ideally we'd size this to the page height, but
             // in practice I find that a little constraining
@@ -199,9 +204,7 @@ export default class MemberList extends React.Component {
             this._updateList();
         }
 
-        const cli = MatrixClientPeg.get();
-        const canInvite = cli.getRoom(this.props.roomId).canInvite(cli.getUserId());
-        if (canInvite !== this.state.canInvite) this.setState({canInvite});
+        if (this.canInvite !== this.state.canInvite) this.setState({ canInvite: this.canInvite });
     };
 
     _updateList = rate_limited_func(() => {

--- a/src/components/views/rooms/MemberList.js
+++ b/src/components/views/rooms/MemberList.js
@@ -196,6 +196,9 @@ export default class MemberList extends React.Component {
             event.getType() === "m.room.third_party_invite") {
             this._updateList();
         }
+        if (event.getContent().invite !== event.getPrevContent().invite) {
+            this.forceUpdate();
+        }
     };
 
     _updateList = rate_limited_func(() => {

--- a/test/components/views/rooms/MemberList-test.js
+++ b/test/components/views/rooms/MemberList-test.js
@@ -88,6 +88,7 @@ describe('MemberList', () => {
         };
         memberListRoom.currentState = {
             members: {},
+            getMember: jest.fn(),
             getStateEvents: (eventType, stateKey) => stateKey === undefined ? [] : null, // ignore 3pid invites
         };
         for (const member of [...adminUsers, ...moderatorUsers, ...defaultUsers]) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -245,6 +245,7 @@ export function mkStubRoom(roomId = null) {
         maySendMessage: jest.fn().mockReturnValue(true),
         currentState: {
             getStateEvents: jest.fn(),
+            getMember: jest.fn(),
             mayClientSendStateEvent: jest.fn().mockReturnValue(true),
             maySendStateEvent: jest.fn().mockReturnValue(true),
             maySendEvent: jest.fn().mockReturnValue(true),


### PR DESCRIPTION
The invite button doesn't reflect any changes when the invite permission is changed for the user viewing the member list. This PR fixes that.

Signed-off-by: Jaiwanth <jaiwanth2011@gmail.com>