### PR TITLE
Improve styling of the message action bar

### DIFF
--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -80,7 +80,7 @@ limitations under the License.
     background-color: $secondary-fg-color;
 }
 
-.mx_MessageActionBar_maskButton:hover:after {
+.mx_MessageActionBar_maskButton:hover::after {
     background-color: $primary-fg-color;
 }
 

--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -20,12 +20,12 @@ limitations under the License.
     visibility: hidden;
     cursor: pointer;
     display: flex;
-    height: 28px;
+    height: 32px;
     line-height: $font-24px;
     border-radius: 8px;
     background: $primary-bg-color;
     border: 1px solid $input-border-color;
-    top: -28px;
+    top: -32px;
     right: 8px;
     user-select: none;
     // Ensure the action bar appears above over things, like the read marker.
@@ -63,8 +63,8 @@ limitations under the License.
 }
 
 .mx_MessageActionBar_maskButton {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
 }
 
 .mx_MessageActionBar_maskButton::after {

--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -20,11 +20,12 @@ limitations under the License.
     visibility: hidden;
     cursor: pointer;
     display: flex;
-    height: 24px;
+    height: 28px;
     line-height: $font-24px;
-    border-radius: 4px;
-    background: $message-action-bar-bg-color;
-    top: -26px;
+    border-radius: 8px;
+    background: $primary-bg-color;
+    border: 1px solid $input-border-color;
+    top: -28px;
     right: 8px;
     user-select: none;
     // Ensure the action bar appears above over things, like the read marker.
@@ -51,31 +52,19 @@ limitations under the License.
         white-space: nowrap;
         display: inline-block;
         position: relative;
-        border: 1px solid $message-action-bar-border-color;
-        margin-left: -1px;
+        margin: 2px;
 
         &:hover {
-            border-color: $message-action-bar-hover-border-color;
+            background: $roomlist-button-bg-color;
+            border-radius: 6px;
             z-index: 1;
-        }
-
-        &:first-child {
-            border-radius: 3px 0 0 3px;
-        }
-
-        &:last-child {
-            border-radius: 0 3px 3px 0;
-        }
-
-        &:only-child {
-            border-radius: 3px;
         }
     }
 }
 
-
 .mx_MessageActionBar_maskButton {
-    width: 27px;
+    width: 24px;
+    height: 24px;
 }
 
 .mx_MessageActionBar_maskButton::after {
@@ -88,7 +77,11 @@ limitations under the License.
     mask-size: 18px;
     mask-repeat: no-repeat;
     mask-position: center;
-    background-color: $message-action-bar-fg-color;
+    background-color: $secondary-fg-color;
+}
+
+.mx_MessageActionBar_maskButton:hover:after {
+    background-color: $primary-fg-color;
 }
 
 .mx_MessageActionBar_reactButton::after {


### PR DESCRIPTION
**Refine UI of the message action bar to increase usability, focus on bar content, UI consistency.**

Before:

![control](https://user-images.githubusercontent.com/1587166/118796623-b0274900-b893-11eb-87d1-49895c18290f.gif)

After:

![style-04](https://user-images.githubusercontent.com/1587166/118796716-c46b4600-b893-11eb-9342-298302234a91.gif)


- **Increase focus on menu content** by a) removing borders that were brighter than contents, making it slightly harder to see the icons and decide next steps; b) increasing size of buttons; c) changing background to not blend into the event tile hover

- **Increase UI consistency** by a) reflecting other (recently made) lists of icons that don't use borders to separate iconography, see room header and composer options; b) using colour used for other icons

- **Increase usability** by increasing the size of buttons and providing more feedback

________


**Further notes**


I took the opportunity to look at the action bar in Slack and Discord for reference.

![slack-01](https://user-images.githubusercontent.com/1587166/118797871-eb764780-b894-11eb-88c3-e49856a68841.gif)

![discord-01](https://user-images.githubusercontent.com/1587166/118798134-3728f100-b895-11eb-9c44-2cce6f3a02b2.gif)

This helped guide me to boost the size of the buttons, and use contrasting tones.

I did consider other options, like keeping the same button size, but the above examples made me want to propose a larger button.

![style-03](https://user-images.githubusercontent.com/1587166/118798324-6c354380-b895-11eb-81f5-425d2b45ee3f.gif)

My hope is to iterate this after trying it in the product for a week and when confident, use the styling to alter the message composer actions

![image](https://user-images.githubusercontent.com/1587166/118798560-b1f20c00-b895-11eb-94b4-daf1c21d1257.png)

