### PR TITLE
Upgrade showChatEffects to room-level setting exposure

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -730,7 +730,7 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: Layout.Group,
     },
     "showChatEffects": {
-        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        supportedLevels: LEVELS_ROOM_SETTINGS_WITH_ROOM,
         displayName: _td("Show chat effects (animations when receiving e.g. confetti)"),
         default: true,
         controller: new ReducedMotionController(),


### PR DESCRIPTION
There's no reason to keep this locked to the account. No UI exposure needed.