### PR TITLE
Remove unused middlePanelResized event listener

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -54,6 +54,7 @@ import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { getUnsentMessages } from "../../structures/RoomStatusBar";
 import { StaticNotificationState } from "../../../stores/notifications/StaticNotificationState";
 import { ResizeNotifier } from "../../../utils/ResizeNotifier";
+import { checkObjectHasNoAdditionalKeys } from "matrix-js-sdk/src/utils";
 
 interface IProps {
     room: Room;
@@ -106,9 +107,6 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
 
         this.notificationState = RoomNotificationStateStore.instance.getRoomState(this.props.room);
         this.roomProps = EchoChamber.forRoom(this.props.room);
-        if (this.props.resizeNotifier) {
-            this.props.resizeNotifier.on("middlePanelResized", this.onResize);
-        }
     }
 
     private countUnsentEvents(): number {
@@ -121,12 +119,6 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
 
     private onNotificationUpdate = () => {
         this.forceUpdate(); // notification state changed - update
-    };
-
-    private onResize = () => {
-        if (this.showMessagePreview && !this.state.messagePreview) {
-            this.generatePreview();
-        }
     };
 
     private onLocalEchoUpdated = (ev: MatrixEvent, room: Room) => {
@@ -148,7 +140,9 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
     }
 
     public componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
-        if (prevProps.showMessagePreview !== this.props.showMessagePreview && this.showMessagePreview) {
+        const showMessageChanged = prevProps.showMessagePreview !== this.props.showMessagePreview;
+        const minimizedChanged = prevProps.isMinimized !== this.props.isMinimized;
+        if (showMessageChanged || minimizedChanged) {
             this.generatePreview();
         }
         if (prevProps.room?.roomId !== this.props.room?.roomId) {
@@ -207,9 +201,6 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
                 this.onCommunityUpdate,
             );
             this.props.room.off("Room.name", this.onRoomNameUpdate);
-        }
-        if (this.props.resizeNotifier) {
-            this.props.resizeNotifier.off("middlePanelResized", this.onResize);
         }
         ActiveRoomObserver.removeListener(this.props.room.roomId, this.onActiveRoomUpdate);
         defaultDispatcher.unregister(this.dispatcherRef);


### PR DESCRIPTION
This gets rid of a nasty warning saying that we have too many event listeners for `EventTile`.

It appears that this was probably needed when the preview was being truncated on the JavaScript side. Nowadays this happens on the CSS side using `text-ellipsis`.