### PR TITLE
Stop overscroll in Firefox Nightly for macOS

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -45,6 +45,8 @@ html {
        N.B. Breaks things when we have legitimate horizontal overscroll */
     height: 100%;
     overflow: hidden;
+    // Stop similar overscroll bounce in Firefox Nightly for macOS
+    overscroll-behavior: none;
 }
 
 body {


### PR DESCRIPTION
Firefox is working on an overscroll feature for macOS, similar to the one Safari has had for some time now. It doesn't really make sense in an application context, so this disables it.

An example of what this prevents:

![firefox-macos-overscroll](https://user-images.githubusercontent.com/279572/119483449-e3af1b00-bd4c-11eb-9b10-1068a5d5fd76.gif)