### PR TITLE
Improve addEventsToTimeline performance scoping WhoIsTypingTile::setState

### DIFF
--- a/src/components/views/rooms/WhoIsTypingTile.js
+++ b/src/components/views/rooms/WhoIsTypingTile.js
@@ -87,7 +87,9 @@ export default class WhoIsTypingTile extends React.Component {
             const userId = event.getSender();
             // remove user from usersTyping
             const usersTyping = this.state.usersTyping.filter((m) => m.userId !== userId);
-            this.setState({usersTyping});
+            if (usersTyping.length !== this.state.usersTyping.length) {
+                this.setState({usersTyping});
+            }
             // abort timer if any
             this._abortUserTimer(userId);
         }


### PR DESCRIPTION
That `setState` call was a bit too eagerly called resulting in `addEventsToTimeline` taking approximately 50ms versus 3ms afterwards

![Screen Shot 2021-05-25 at 12 40 07](https://user-images.githubusercontent.com/769871/119492672-40173800-bd57-11eb-867f-600ee66a867f.png)
![Screen Shot 2021-05-25 at 12 43 38](https://user-images.githubusercontent.com/769871/119492676-41486500-bd57-11eb-96db-85f24c9584ab.png)
