### PR TITLE
Skip generatePreview if event is not part of the live timeline

### DIFF
--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -176,7 +176,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
 
         if (payload.action === 'MatrixActions.Room.timeline' || payload.action === 'MatrixActions.Event.decrypted') {
             const event = payload.event; // TODO: Type out the dispatcher
-            if (!this.previews.has(event.getRoomId())) return; // not important
+            if (!this.previews.has(event.getRoomId()) || !event.isLiveEvent) return; // not important
             await this.generatePreview(this.matrixClient.getRoom(event.getRoomId()), TAG_ANY);
         }
     }


### PR DESCRIPTION
`generatePreview` is called all the time when loading a new set of messages in the timeline. We can safely skip that operation if the event is not part of the live timeline as by definiton the message preview will only be required for newer events

This actions takes up to ~40ms depending on the type of preview to generate