### PR TITLE
Prevent DecoratedRoomAvatar to update its state for the same value

### DIFF
--- a/src/components/views/avatars/DecoratedRoomAvatar.tsx
+++ b/src/components/views/avatars/DecoratedRoomAvatar.tsx
@@ -119,7 +119,10 @@ export default class DecoratedRoomAvatar extends React.PureComponent<IProps, ISt
         if (this.props.room.roomId !== room.roomId) return;
 
         if (ev.getType() === 'm.room.join_rules' || ev.getType() === 'm.room.member') {
-            this.setState({icon: this.calculateIcon()});
+            const newIcon = this.calculateIcon();
+            if (newIcon !== this.state.icon) {
+                this.setState({icon: newIcon});
+            }
         }
     };
 


### PR DESCRIPTION
Without this line, it's not rare to see a call stack like the following when scrolling up in the timeline 

![Screen Shot 2021-05-25 at 17 02 37](https://user-images.githubusercontent.com/769871/119530572-0b1cdc80-bd7b-11eb-95a2-ad5852a1b47b.png)
