### PR TITLE
Add a confirmation modal before account deactivation

### DIFF
--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -40,6 +40,7 @@ import Spinner from "../../../elements/Spinner";
 import {SettingLevel} from "../../../../../settings/SettingLevel";
 import {UIFeature} from "../../../../../settings/UIFeature";
 import {replaceableComponent} from "../../../../../utils/replaceableComponent";
+import QuestionDialog from '../../../dialogs/QuestionDialog';
 
 @replaceableComponent("views.settings.tabs.user.GeneralUserSettingsTab")
 export default class GeneralUserSettingsTab extends React.Component {
@@ -236,7 +237,21 @@ export default class GeneralUserSettingsTab extends React.Component {
         });
     };
 
-    _onDeactivateClicked = () => {
+    _onDeactivateClicked = async () => {
+        const { finished } = Modal.createTrackedDialog("Warning", "", QuestionDialog, {
+            title: _t("Warning"),
+            description: <div>
+                <p>
+                    { _t(`Please note that this is a permanent action. Once you deactivate your account, your
+                     account cannot be reactivated, and you won't be able to sign up again with the same user ID.`) }
+                </p>
+            </div>,
+            danger: true,
+            button: _t('I understand the risks and wish to continue'),
+        });
+        const [proceed] = await finished;
+        if (!proceed) return;
+
         Modal.createTrackedDialog('Deactivate Account', '', DeactivateAccountDialog, {
             onFinished: (success) => {
                 if (success) this.props.closeSettingsFn();

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1229,6 +1229,8 @@
     "Failed to change password. Is your password correct?": "Failed to change password. Is your password correct?",
     "Success": "Success",
     "Your password was successfully changed. You will not receive push notifications on other sessions until you log back in to them": "Your password was successfully changed. You will not receive push notifications on other sessions until you log back in to them",
+    "Please note that this is a permanent action. Once you deactivate your account, your\n                     account cannot be reactivated, and you won't be able to sign up again with the same user ID.": "Please note that this is a permanent action. Once you deactivate your account, your\n                     account cannot be reactivated, and you won't be able to sign up again with the same user ID.",
+    "I understand the risks and wish to continue": "I understand the risks and wish to continue",
     "Email addresses": "Email addresses",
     "Phone numbers": "Phone numbers",
     "Set a new account password...": "Set a new account password...",


### PR DESCRIPTION
Closes vector-im/element-web#17422

![image](https://user-images.githubusercontent.com/65661241/119778780-8ac6ba80-bee5-11eb-9969-eb0ca07b4b56.png)

Signed-off-by: Jaiwanth jaiwanth2011@gmail.com