### PR TITLE
Prevent having duplicates in pending room state

### DIFF
--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -69,7 +69,7 @@ interface IState {
     contextMenuPosition: PartialDOMRect;
     isDarkTheme: boolean;
     selectedSpace?: Room;
-    pendingRoomJoin: Set<string>
+    pendingRoomJoin: Set<string>;
 }
 
 @replaceableComponent("structures.UserMenu")
@@ -182,8 +182,7 @@ export default class UserMenu extends React.Component<IProps, IState> {
     }
 
     private removePendingJoinRoom(roomId: string): void {
-        if (this.state.pendingRoomJoin.has(roomId)) {
-            this.state.pendingRoomJoin.delete(roomId);
+        if (this.state.pendingRoomJoin.delete(roomId)) {
             this.setState({
                 pendingRoomJoin: new Set<string>(this.state.pendingRoomJoin),
             })

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -106,6 +106,7 @@ export default class UserMenu extends React.Component<IProps, IState> {
         this.dispatcherRef = defaultDispatcher.register(this.onAction);
         this.themeWatcherRef = SettingsStore.watchSetting("theme", null, this.onThemeChanged);
         this.tagStoreRef = GroupFilterOrderStore.addListener(this.onTagStoreUpdate);
+        MatrixClientPeg.get().on("Room", this.onRoom);
     }
 
     public componentWillUnmount() {
@@ -117,6 +118,11 @@ export default class UserMenu extends React.Component<IProps, IState> {
         if (SettingsStore.getValue("feature_spaces")) {
             SpaceStore.instance.off(UPDATE_SELECTED_SPACE, this.onSelectedSpaceUpdate);
         }
+        MatrixClientPeg.get().removeListener("Room", this.onRoom);
+    }
+
+    private onRoom = (room: Room): void => {
+        this.removePendingJoinRoom(room.roomId);
     }
 
     private onTagStoreUpdate = () => {

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -189,10 +189,6 @@ export default class UserMenu extends React.Component<IProps, IState> {
         }
     }
 
-    get pendingActionsCount(): number {
-        return Array.from(this.state.pendingRoomJoin).length;
-    }
-
     private onOpenMenuClick = (ev: React.MouseEvent) => {
         ev.preventDefault();
         ev.stopPropagation();
@@ -654,11 +650,11 @@ export default class UserMenu extends React.Component<IProps, IState> {
                             />
                         </span>
                         {name}
-                        {this.pendingActionsCount > 0 && (
+                        {this.state.pendingRoomJoin.size > 0 && (
                             <InlineSpinner>
                                 <TooltipButton helpText={_t(
                                     "Currently joining %(count)s rooms",
-                                    { count: this.pendingActionsCount },
+                                    { count: this.state.pendingRoomJoin.size },
                                 )} />
                             </InlineSpinner>
                         )}

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -69,7 +69,7 @@ interface IState {
     contextMenuPosition: PartialDOMRect;
     isDarkTheme: boolean;
     selectedSpace?: Room;
-    pendingRoomJoin: string[]
+    pendingRoomJoin: Set<string>
 }
 
 @replaceableComponent("structures.UserMenu")
@@ -86,7 +86,7 @@ export default class UserMenu extends React.Component<IProps, IState> {
         this.state = {
             contextMenuPosition: null,
             isDarkTheme: this.isUserOnDarkTheme(),
-            pendingRoomJoin: [],
+            pendingRoomJoin: new Set<string>(),
         };
 
         OwnProfileStore.instance.on(UPDATE_EVENT, this.onProfileUpdate);
@@ -168,28 +168,24 @@ export default class UserMenu extends React.Component<IProps, IState> {
         }
     };
 
-    private addPendingJoinRoom(roomId) {
+    private addPendingJoinRoom(roomId: string): void {
         this.setState({
-            pendingRoomJoin: [
-                ...this.state.pendingRoomJoin,
-                roomId,
-            ],
+            pendingRoomJoin: new Set<string>(this.state.pendingRoomJoin)
+                .add(roomId),
         });
     }
 
-    private removePendingJoinRoom(roomId) {
-        const newPendingRoomJoin = this.state.pendingRoomJoin.filter(pendingJoinRoomId => {
-            return pendingJoinRoomId !== roomId;
-        });
-        if (newPendingRoomJoin.length !== this.state.pendingRoomJoin.length) {
+    private removePendingJoinRoom(roomId: string): void {
+        if (this.state.pendingRoomJoin.has(roomId)) {
+            this.state.pendingRoomJoin.delete(roomId);
             this.setState({
-                pendingRoomJoin: newPendingRoomJoin,
+                pendingRoomJoin: new Set<string>(this.state.pendingRoomJoin),
             })
         }
     }
 
     get hasPendingActions(): boolean {
-        return this.state.pendingRoomJoin.length > 0;
+        return Array.from(this.state.pendingRoomJoin).length > 0;
     }
 
     private onOpenMenuClick = (ev: React.MouseEvent) => {

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -190,8 +190,8 @@ export default class UserMenu extends React.Component<IProps, IState> {
         }
     }
 
-    get hasPendingActions(): boolean {
-        return Array.from(this.state.pendingRoomJoin).length > 0;
+    get pendingActionsCount(): number {
+        return Array.from(this.state.pendingRoomJoin).length;
     }
 
     private onOpenMenuClick = (ev: React.MouseEvent) => {
@@ -655,11 +655,11 @@ export default class UserMenu extends React.Component<IProps, IState> {
                             />
                         </span>
                         {name}
-                        {this.hasPendingActions && (
+                        {this.pendingActionsCount > 0 && (
                             <InlineSpinner>
                                 <TooltipButton helpText={_t(
                                     "Currently joining %(count)s rooms",
-                                    { count: this.state.pendingRoomJoin.length },
+                                    { count: this.pendingActionsCount },
                                 )} />
                             </InlineSpinner>
                         )}

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -152,5 +152,5 @@ export enum Action {
     /**
      * Fired when joining a room failed
      */
-    JoinRoomError = "join_room",
+    JoinRoomError = "join_room_error",
 }


### PR DESCRIPTION
Fixes vector-im/element-web#17473

The flooding of request was due to a bad copy paste in the `JoinRoomError` action name.
Now using a `Set` for deduping the pending rooms to be joined and listening to the `sync` update to have a more reliable way to clear out that state