### PR TITLE
Clear stored editor state when canceling editing using a shortcut

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.js
+++ b/src/components/views/rooms/EditMessageComposer.js
@@ -168,6 +168,7 @@ export default class EditMessageComposer extends React.Component {
                 if (nextEvent) {
                     dis.dispatch({action: 'edit_event', event: nextEvent});
                 } else {
+                    this._clearStoredEditorState();
                     dis.dispatch({action: 'edit_event', event: null});
                     dis.fire(Action.FocusComposer);
                 }


### PR DESCRIPTION
Fixes [#17491](https://github.com/vector-im/element-web/issues/17491)