### PR TITLE
Title: Don't show offline status

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1909,9 +1909,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         }
 
         this.subTitleStatus = '';
-        if (state === "ERROR") {
-            this.subTitleStatus += `[${_t("Offline")}] `;
-        }
         if (numUnreadRooms > 0) {
             this.subTitleStatus += `[${numUnreadRooms}]`;
         }


### PR DESCRIPTION
In common browsers, when a tab is pinned, the browser highlights the
pinned tab as soon as the title updates.
Adding and removing the offline status from the page title thus
highlights the tab (e.g. if the user temporarily loses connection). This
unnecessarily drives attention to the tab, as the user might think they
have received a notification.

Even if the tab is not pinned, the title update on connection loss and
reconnection unnecessarily grabs the user's attention.