### PR TITLE
Add CSS containment rules for shorter reflow operations

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -291,6 +291,7 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
 
 .mx_Dialog_staticWrapper .mx_Dialog {
     z-index: 4010;
+    contain: content;
 }
 
 .mx_Dialog_background {

--- a/res/css/structures/_ContextualMenu.scss
+++ b/res/css/structures/_ContextualMenu.scss
@@ -38,6 +38,7 @@ limitations under the License.
     position: absolute;
     font-size: $font-14px;
     z-index: 5001;
+    contain: content;
 }
 
 .mx_ContextualMenu_right {

--- a/res/css/structures/_LeftPanel.scss
+++ b/res/css/structures/_LeftPanel.scss
@@ -25,6 +25,7 @@ $roomListCollapsedWidth: 68px;
 
     // Create a row-based flexbox for the GroupFilterPanel and the room list
     display: flex;
+    contain: content;
 
     .mx_LeftPanel_GroupFilterPanelContainer {
         flex-grow: 0;
@@ -70,6 +71,7 @@ $roomListCollapsedWidth: 68px;
             // aligned correctly. This is also a row-based flexbox.
             display: flex;
             align-items: center;
+            contain: content;
 
             &.mx_IndicatorScrollbar_leftOverflow {
                 mask-image: linear-gradient(90deg, transparent, black 5%);

--- a/res/css/structures/_RightPanel.scss
+++ b/res/css/structures/_RightPanel.scss
@@ -25,6 +25,7 @@ limitations under the License.
     padding: 4px 0;
     box-sizing: border-box;
     height: 100%;
+    contain: strict;
 
     .mx_RoomView_MessageList {
         padding: 14px 18px; // top and bottom is 4px smaller to balance with the padding set above

--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -152,6 +152,7 @@ limitations under the License.
     flex: 1;
     display: flex;
     flex-direction: column;
+    contain: content;
 }
 
 .mx_RoomView_statusArea {
@@ -221,6 +222,7 @@ limitations under the License.
 
 .mx_RoomView_MessageList li {
     clear: both;
+    contain: content;
 }
 
 li.mx_RoomView_myReadMarker_container {

--- a/res/css/structures/_ScrollPanel.scss
+++ b/res/css/structures/_ScrollPanel.scss
@@ -21,5 +21,8 @@ limitations under the License.
         display: flex;
         flex-direction: column;
         justify-content: flex-end;
+
+        content-visibility: auto;
+        contain-intrinsic-size: 50px;
     }
 }

--- a/res/css/views/avatars/_DecoratedRoomAvatar.scss
+++ b/res/css/views/avatars/_DecoratedRoomAvatar.scss
@@ -16,6 +16,7 @@ limitations under the License.
 
 .mx_DecoratedRoomAvatar, .mx_ExtraTile {
     position: relative;
+    contain: content;
 
     &.mx_DecoratedRoomAvatar_cutout .mx_BaseAvatar {
         mask-image: url('$(res)/img/element-icons/roomlist/decorated-avatar-mask.svg');

--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -198,6 +198,7 @@ limitations under the License.
             // as the box model should be top aligned. Happens in both FF and Chromium
             display: flex;
             flex-direction: column;
+            align-self: stretch;
 
             mask-image: linear-gradient(0deg, transparent, black 4px);
         }

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -19,6 +19,10 @@ limitations under the License.
     margin-bottom: 4px;
     padding: 4px;
 
+    contain: strict;
+    height: 40px;
+    box-sizing: border-box;
+
     // The tile is also a flexbox row itself
     display: flex;
 


### PR DESCRIPTION
This introduces [CSS containment](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Containment) to the codebase

> improve performance of web pages by allowing developers to isolate a subtree of the page from the rest of the page. If the browser knows that a part of the page is independent, rendering can be optimized and performance improved

I am using mainly three CSS properties
* [contain](https://developer.mozilla.org/en-US/docs/Web/CSS/contain)
* [content-visiblity](https://web.dev/content-visibility/)
* [contain-intrinsic-size](https://web.dev/content-visibility/#specifying-the-natural-size-of-an-element-with-contain-intrinsic-size)

You can see the perf benchmark below where I frantically scroll up and down the timeline in Matrix HQ, this PR focuses on reducing the purple (layout) and green (paint). Another PR is looking at reducing the yellow (script) check #6079

# contain

Here is a list of all the areas of the page that will now isolate its subtree from the rest of the page. They looked like correct candidates and from my research no content bleeds out of them, making them great candidates for CSS containment

* Dialog
* ContextualMenu
* LeftPanel
* Breadcrumbs
* RightPanel
* RoomViewTimeline
* MessageListEvent
* DecoratedRoomAvatar
* RoomTile (the fixed height allows to use `contain: strict`)

There are probably a lot more area that could benefit from that, but they seemed like some logical blocks of content that will unlikely ever bleed content outside of themselves

# content-visiblity

```
content-visibility: auto;
contain-intrinsic-size: 50px;
```

The above lets us almost create a virtualised list of events purely using CSS. This has not landed in every browser but will progressively enhance the experience as this feature lands in more ecosystems

`contain-intrinsic-size` is an estimation of the height of every event in the timeline. This value is arbitrary and subject to change. As far as I understand it's a signal browsers will use to decide when to start rendering components and almost create a better estimated `scrollHeight` so that the scrollbar is not "jumpy"

# Before 🐌 

<img width="895" alt="Screen Shot 2021-06-01 at 12 22 07" src="https://user-images.githubusercontent.com/769871/120315764-9a267900-c2d4-11eb-8693-5e78c65224f9.png">

# After 🐎 

<img width="894" alt="Screen Shot 2021-06-01 at 12 25 20" src="https://user-images.githubusercontent.com/769871/120315815-a7436800-c2d4-11eb-9abf-6537a0c14b01.png">
