### PR TITLE
Tweak event border radius to match action bar

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -104,7 +104,7 @@ $left-gutter: 64px;
 .mx_EventTile_line, .mx_EventTile_reply {
     position: relative;
     padding-left: $left-gutter;
-    border-radius: 4px;
+    border-radius: 8px;
 }
 
 .mx_RoomView_timeline_rr_enabled,


### PR DESCRIPTION
This adjusts the `border-radius` used when hovering on an event to match the recently changed value for the action bar (changed to `8px` in https://github.com/matrix-org/matrix-react-sdk/pull/6066).

<img width="410" alt="image" src="https://user-images.githubusercontent.com/279572/120464333-b7228100-c394-11eb-8d47-9483f25b5326.png">