### PR TITLE
Fix mx_Event containment rules and empty read avatar row

### DIFF
--- a/res/css/structures/_RoomView.scss
+++ b/res/css/structures/_RoomView.scss
@@ -222,7 +222,6 @@ limitations under the License.
 
 .mx_RoomView_MessageList li {
     clear: both;
-    contain: content;
 }
 
 li.mx_RoomView_myReadMarker_container {

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -19,7 +19,7 @@ limitations under the License.
     margin-bottom: 4px;
     padding: 4px;
 
-    contain: strict;
+    contain: content; // Not strict as it will break when resizing a sublist vertically
     height: 40px;
     box-sizing: border-box;
 

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -631,7 +631,7 @@ export default class EventTile extends React.Component<IProps, IState> {
 
         // return early if there are no read receipts
         if (!this.props.readReceipts || this.props.readReceipts.length === 0) {
-            return (<span className="mx_EventTile_readAvatars" />);
+            return null;
         }
 
         const ReadReceiptMarker = sdk.getComponent('rooms.ReadReceiptMarker');


### PR DESCRIPTION
A scenario that I did not think to test before created a visual regression (introduced by matrix-org/matrix-react-sdk#6127) 

This PR reverts it and also remove an empty DOM node if all the read avatar count is 0