### PR TITLE
Changed position for data scroll token

### DIFF
--- a/src/components/structures/MessagePanel.js
+++ b/src/components/structures/MessagePanel.js
@@ -648,37 +648,39 @@ export default class MessagePanel extends React.Component {
 
         // use txnId as key if available so that we don't remount during sending
         ret.push(
-            <TileErrorBoundary key={mxEv.getTxnId() || eventId} mxEvent={mxEv}>
-                <EventTile
-                    as="li"
-                    data-scroll-tokens={scrollToken}
-                    ref={this._collectEventNode.bind(this, eventId)}
-                    alwaysShowTimestamps={this.props.alwaysShowTimestamps}
-                    mxEvent={mxEv}
-                    continuation={continuation}
-                    isRedacted={mxEv.isRedacted()}
-                    replacingEventId={mxEv.replacingEventId()}
-                    editState={isEditing && this.props.editState}
-                    onHeightChanged={this._onHeightChanged}
-                    readReceipts={readReceipts}
-                    readReceiptMap={this._readReceiptMap}
-                    showUrlPreview={this.props.showUrlPreview}
-                    checkUnmounting={this._isUnmounting}
-                    eventSendStatus={mxEv.getAssociatedStatus()}
-                    tileShape={this.props.tileShape}
-                    isTwelveHour={this.props.isTwelveHour}
-                    permalinkCreator={this.props.permalinkCreator}
-                    last={last}
-                    lastInSection={willWantDateSeparator}
-                    lastSuccessful={isLastSuccessful}
-                    isSelectedEvent={highlight}
-                    getRelationsForEvent={this.props.getRelationsForEvent}
-                    showReactions={this.props.showReactions}
-                    layout={this.props.layout}
-                    enableFlair={this.props.enableFlair}
-                    showReadReceipts={this.props.showReadReceipts}
-                />
-            </TileErrorBoundary>,
+            <li
+                key={mxEv.getTxnId() || eventId}
+                ref={this._collectEventNode.bind(this, eventId)}
+                data-scroll-tokens={scrollToken}
+            >
+                <TileErrorBoundary mxEvent={mxEv}>
+                    <EventTile
+                        mxEvent={mxEv}
+                        continuation={continuation}
+                        isRedacted={mxEv.isRedacted()}
+                        replacingEventId={mxEv.replacingEventId()}
+                        editState={isEditing && this.props.editState}
+                        onHeightChanged={this._onHeightChanged}
+                        readReceipts={readReceipts}
+                        readReceiptMap={this._readReceiptMap}
+                        showUrlPreview={this.props.showUrlPreview}
+                        checkUnmounting={this._isUnmounting}
+                        eventSendStatus={mxEv.getAssociatedStatus()}
+                        tileShape={this.props.tileShape}
+                        isTwelveHour={this.props.isTwelveHour}
+                        permalinkCreator={this.props.permalinkCreator}
+                        last={last}
+                        lastInSection={willWantDateSeparator}
+                        lastSuccessful={isLastSuccessful}
+                        isSelectedEvent={highlight}
+                        getRelationsForEvent={this.props.getRelationsForEvent}
+                        showReactions={this.props.showReactions}
+                        layout={this.props.layout}
+                        enableFlair={this.props.enableFlair}
+                        showReadReceipts={this.props.showReadReceipts}
+                    />
+                </TileErrorBoundary>
+            </li>,
         );
 
         return ret;


### PR DESCRIPTION
Moved the data-scroll-token back to li

Fixes vector-im/element-web/issues/17567

![ezgif com-gif-maker](https://user-images.githubusercontent.com/43457420/120916979-5ebbee00-c6ca-11eb-8e2b-ffa0c5315b34.gif)


From how much I could understand the changes that occurred in #6079

Specifically changing the `EventTile` to be rendered as `li` and changing the `data-scroll-token` to be in the list

https://github.com/matrix-org/matrix-react-sdk/blob/abfe6d85a0e284c4a2f6e6e91d641b4712ca8374/src/components/structures/MessagePanel.js#L653-L654


In short `data-scroll-token`s were missing and caused the scrollstate to be back at the beginning as no scroll state is saved resets to start after every state change

<br><br>
<hr>


### Detailed Explanation (That might help find an alternative rather than just reverting it back )


This specifically caused a few issues namely the `EventTile` list due to being rendered as `li` is now a series of divs that don't make use of much of the `data-scroll-token` (Screen shot below)

![Screenshot from 2021-06-06 12-59-26](https://user-images.githubusercontent.com/43457420/120916457-54e4bb80-c6c7-11eb-810b-03bdd7429f3a.png)

This is really different from the list with `data-scroll-token` from the `<li>` approach where the `EventTile` is wrapped around an `li` element with `data-scroll-token`

![Screenshot from 2021-06-06 13-03-36](https://user-images.githubusercontent.com/43457420/120916531-c45aab00-c6c7-11eb-9d34-0565941b98d6.png)

The token is important as it is used in the `ScrollPanel`'s `getScrollState` to mark the scroll state of the list. 

This caused the bug so every state update for `FilePanel` or its children caused it to reset to the end of the list. This explains the part in vector-im/element-web/issues/17567 where `onFillRequest` causes  `backpaginating` state to change.

An alternative could be adding the token to the `EventTile` but for now this might suffice.

_PS: The failing tests are the ones that had been adjusted previously for the later approach, can be updated if we get approval for this change, otherwise the current approach could be changed to fit with them_


Signed-off-by: Ayush Pratap Singh <ayushpratap16@gmail.com>