### PR TITLE
Migrate end to end tests to GitHub actions

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,16 +7,7 @@ on:
 jobs:
     end-to-end:
         runs-on: ubuntu-latest
-        defaults:
-            run:
-                shell: bash
-                working-directory: ${{ github.workspace }}
-        container:
-            image: vectorim/element-web-ci-e2etests-env:latest
-            env:
-                CI_PACKAGE: true
-                GITHUB_HEAD_REF: ${{ github.head_ref }}
-                GITHUB_BASE_REF: ${{ github.base_ref }}
+        container: vectorim/element-web-ci-e2etests-env:latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,11 +1,11 @@
-name: "end-to-end_tests"
+name: Develop jobs
 on:
     push:
         branches: [develop]
     pull_request:
         branches: [develop]
 jobs:
-    "end-to-end_tests":
+    end-to-end:
         runs-on: ubuntu-latest
         defaults:
             run:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,5 +1,9 @@
 name: "end-to-end_tests"
-on: [push]
+on:
+    push:
+        branches: [develop]
+    pull_request:
+        branches: [develop]
 jobs:
     "end-to-end_tests":
         runs-on: ubuntu-latest

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,0 +1,32 @@
+name: "end-to-end_tests"
+on: [push]
+jobs:
+    "end-to-end_tests":
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                shell: bash
+                working-directory: ${{ github.workspace }}
+        container:
+            image: vectorim/element-web-ci-e2etests-env:latest
+            env:
+                CI_PACKAGE: true
+                GITHUB_HEAD_REF: ${{ github.head_ref }}
+                GITHUB_BASE_REF: ${{ github.base_ref }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: End-to-End tests
+              run: ./scripts/ci/end-to-end-tests.sh
+            - name: Archive logs
+              uses: actions/upload-artifact@v2
+              with:
+                path: |
+                    test/end-to-end-tests/logs/**/*
+                    test/end-to-end-tests/synapse/installations/consent/homeserver.log
+                retention-days: 14
+            - name: Archive performance benchmark
+              uses: actions/upload-artifact@v2
+              with:
+                name: performance-entries.json
+                path: test/end-to-end-tests/performance-entries.json


### PR DESCRIPTION
Introducing to you, GitHub Actions! This pull request migrates end to end tests pipelines to GitHub

### What is worth noting about the changes
- A `retention_policy` of 14 days has been introduced for the end to end tests logs. I could not think of a good reasons why this would be kept for longer
- There has no concepts of `xlarge` instance in GitHub Actions but the runtime takes 5mn on GitHub on average versus 5mn45s on BuildKite