### PR TITLE
Fix notif panel timestamp padding

### DIFF
--- a/res/css/structures/_NotificationPanel.scss
+++ b/res/css/structures/_NotificationPanel.scss
@@ -82,7 +82,6 @@ limitations under the License.
     color: $primary-fg-color;
     font-size: $font-12px;
     display: inline;
-    padding-left: 0px;
 }
 
 .mx_NotificationPanel .mx_EventTile_senderDetails {
@@ -103,6 +102,7 @@ limitations under the License.
     visibility: visible;
     position: initial;
     display: inline;
+    padding-left: 5px;
 }
 
 .mx_NotificationPanel .mx_EventTile_line {


### PR DESCRIPTION
This restores some space around the timestamp in the notif panel. We were previously relying somewhat randomly on the presence on empty flair elements to create space.

<img width="183" alt="image" src="https://user-images.githubusercontent.com/279572/121043883-f134be00-c7ac-11eb-90a7-bd5980952191.png">

Fixes https://github.com/vector-im/element-web/issues/17580