### PR TITLE
Give videos a max height

### DIFF
--- a/res/css/views/messages/_MVideoBody.scss
+++ b/res/css/views/messages/_MVideoBody.scss
@@ -17,7 +17,7 @@ limitations under the License.
 span.mx_MVideoBody {
     video.mx_MVideoBody {
         max-width: 100%;
-        height: auto;
+        max-height: 600px;
         border-radius: 4px;
     }
 }


### PR DESCRIPTION
Context: friends send portrait videos which, due to their height being unbounded, often end up being 1.5 to 2 times the viewport height! While #5682 sets a max height as well, the situation in the meantime is practically unusable, so I'm proposing to at least give them the same max height as images currently have.