### PR TITLE
Allow modal widget buttons to be disabled when the modal opens

### DIFF
--- a/src/components/views/dialogs/ModalWidgetDialog.tsx
+++ b/src/components/views/dialogs/ModalWidgetDialog.tsx
@@ -63,7 +63,8 @@ export default class ModalWidgetDialog extends React.PureComponent<IProps, IStat
     private appFrame: React.RefObject<HTMLIFrameElement> = React.createRef();
 
     state: IState = {
-        disabledButtonIds: [],
+        disabledButtonIds: (this.props.widgetDefinition.buttons || []).filter(b => b.disabled)
+            .map(b => b.id),
     };
 
     constructor(props) {


### PR DESCRIPTION
This is a small change that would allow us to initialize modal widget buttons as disabled.

Related PR: https://github.com/matrix-org/matrix-widget-api/pull/38

Signed-off-by: Steffen Kolmer steffen.kolmer@nordeck.net