### PR TITLE
Disable comment-on-alert

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -31,9 +31,7 @@ jobs:
                 tool: 'jsperformanceentry'
                 output-file-path: test/end-to-end-tests/performance-entries.json
                 fail-on-alert: false
-                # Secrets are not passed to fork, the action won't be able to comment
-                # for community PRs
-                comment-on-alert: ${{ github.repository_owner == 'matrix-org' }}
+                comment-on-alert: false
                 # Only temporary to monitor where failures occur
                 alert-comment-cc-users: '@gsouquet'
                 github-token: ${{ secrets.DEPLOY_GH_PAGES }}


### PR DESCRIPTION
Following up on #6188 
To fix the linter on #6188

Disabling that functionality to not block community PR and will revisit that with less time pressure