### PR TITLE
Show reason in leave event if exists

### DIFF
--- a/src/TextForEvent.ts
+++ b/src/TextForEvent.ts
@@ -90,7 +90,7 @@ function textForMemberEvent(ev): () => string | null {
                 if (prevContent.membership === "invite") {
                     return () => _t('%(targetName)s rejected the invitation.', {targetName});
                 } else {
-                    return () => _t('%(targetName)s left the room.', {targetName});
+                    return () => _t('%(targetName)s left the room.', {targetName}) + ' ' + getReason();
                 }
             } else if (prevContent.membership === "ban") {
                 return () => _t('%(senderName)s unbanned %(targetName)s.', {senderName, targetName});


### PR DESCRIPTION
Some bridges use self kick with a reason to show why a user was
forced to leave a room. Notably matrix-appservice-irc does this.

Other implementations like in Element Android show reason-on-leave
which is useful information when it exists.