### PR TITLE
Fix forward dialog message preview display names

### DIFF
--- a/src/components/views/dialogs/ForwardDialog.tsx
+++ b/src/components/views/dialogs/ForwardDialog.tsx
@@ -162,6 +162,7 @@ const ForwardDialog: React.FC<IProps> = ({ matrixClient: cli, event, permalinkCr
     });
     mockEvent.sender = {
         name: profileInfo.displayname || userId,
+        rawDisplayName: profileInfo.displayname,
         userId,
         getAvatarUrl: (..._) => {
             return avatarUrlForUser(


### PR DESCRIPTION
Because of #5880 this is now needed in order to actually show the user's display name in the forward dialog message preview. (currently on develop all you get is your MXID) A similar fix for EventTilePreview is at #6000.