### PR TITLE
Fix ConfirmUserActionDialog returning an input field rather than text

### DIFF
--- a/src/components/views/dialogs/ConfirmUserActionDialog.tsx
+++ b/src/components/views/dialogs/ConfirmUserActionDialog.tsx
@@ -38,7 +38,7 @@ interface IProps {
     // be the string entered.
     askReason?: boolean;
     danger?: boolean;
-    onFinished: (success: boolean, reason?: HTMLInputElement) => void;
+    onFinished: (success: boolean, reason?: string) => void;
 }
 
 /*
@@ -59,11 +59,7 @@ export default class ConfirmUserActionDialog extends React.Component<IProps> {
     };
 
     public onOk = (): void => {
-        let reason;
-        if (this.reasonField) {
-            reason = this.reasonField.current;
-        }
-        this.props.onFinished(true, reason);
+        this.props.onFinished(true, this.reasonField.current?.value);
     };
 
     public onCancel = (): void => {


### PR DESCRIPTION
Regressed by https://github.com/matrix-org/matrix-react-sdk/commit/c2aaba1f796c58f6be7f8d1c08237dd3918f1ef5

Broke the ban button and probably more.

![image](https://user-images.githubusercontent.com/2403652/122646444-17484f80-d117-11eb-8334-6296ffc8bfa7.png)
![image](https://user-images.githubusercontent.com/2403652/122646445-19121300-d117-11eb-8d50-783d4fea9b45.png)
