### PR TITLE
Restore branch matching support for GitHub Actions e2e tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,10 +11,13 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
-            - name: End-to-End tests
-              run: ./scripts/ci/end-to-end-tests.sh
+            - name: Prepare End-to-End tests
+              run: ./scripts/ci/prepare-end-to-end-tests.sh
+            - name: Run End-to-End tests
+              run: ./scripts/ci/run-end-to-end-tests.sh
             - name: Archive logs
               uses: actions/upload-artifact@v2
+              if: ${{ always() }}
               with:
                 path: |
                     test/end-to-end-tests/logs/**/*

--- a/scripts/ci/prepare-end-to-end-tests.sh
+++ b/scripts/ci/prepare-end-to-end-tests.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-#
-# script which is run by the CI build (after `yarn test`).
-#
-# clones element-web develop and runs the tests against our version of react-sdk.
 
 set -ev
 
@@ -19,7 +15,7 @@ cd element-web
 element_web_dir=`pwd`
 CI_PACKAGE=true yarn build
 cd ..
-# run end to end tests
+# prepare end to end tests
 pushd test/end-to-end-tests
 ln -s $element_web_dir element/element-web
 # PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true ./install.sh
@@ -28,9 +24,4 @@ echo "--- Install synapse & other dependencies"
 ./install.sh
 # install static webserver to server symlinked local copy of element
 ./element/install-webserver.sh
-rm -r logs || true
-mkdir logs
-echo "+++ Running end-to-end tests"
-TESTS_STARTED=1
-./run.sh --no-sandbox --log-directory logs/
 popd

--- a/scripts/ci/run-end-to-end-tests.sh
+++ b/scripts/ci/run-end-to-end-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ev
+
+handle_error() {
+    EXIT_CODE=$?
+    exit $EXIT_CODE
+}
+
+trap 'handle_error' ERR
+
+# run end to end tests
+pushd test/end-to-end-tests
+rm -r logs || true
+mkdir logs
+echo "--- Running end-to-end tests"
+TESTS_STARTED=1
+./run.sh --no-sandbox --log-directory logs/
+popd

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -22,15 +22,18 @@ clone() {
 }
 
 # Try the PR author's branch in case it exists on the deps as well.
-# First we check if BUILDKITE_BRANCH is defined,
+# First we check if GITHUB_HEAD_REF is defined,
+# Then we check if BUILDKITE_BRANCH is defined,
 # if it isn't we can assume this is a Netlify build
-if [ -z ${BUILDKITE_BRANCH+x} ]; then 
+if [ -n ${GITHUB_HEAD_REF+x} ]; then
+	head=$GITHUB_HEAD_REF
+elif [ -n ${BUILDKITE_BRANCH+x} ]; then
+	head=$BUILDKITE_BRANCH
+else
 	# Netlify doesn't give us info about the fork so we have to get it from GitHub API
 	apiEndpoint="https://api.github.com/repos/matrix-org/matrix-react-sdk/pulls/"
 	apiEndpoint+=$REVIEW_ID
 	head=$(curl $apiEndpoint | jq -r '.head.label')
-else 
-	head=$BUILDKITE_BRANCH
 fi
 
 # If head is set, it will contain either:
@@ -39,12 +42,18 @@ fi
 # We can split on `:` into an array to check.
 BRANCH_ARRAY=(${head//:/ })
 if [[ "${#BRANCH_ARRAY[@]}" == "1" ]]; then
-    clone $deforg $defrepo $BUILDKITE_BRANCH
+    clone $deforg $defrepo $head
 elif [[ "${#BRANCH_ARRAY[@]}" == "2" ]]; then
     clone ${BRANCH_ARRAY[0]} $defrepo ${BRANCH_ARRAY[1]}
 fi
+
 # Try the target branch of the push or PR.
-clone $deforg $defrepo $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+if [ -n ${GITHUB_BASE_REF+x} ]; then
+    clone $deforg $defrepo $GITHUB_BASE_REF
+elif [ -n ${BUILDKITE_PULL_REQUEST_BASE_BRANCH+x} ]; then
+    clone $deforg $defrepo $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+fi
+
 # Try HEAD which is the branch name in Netlify (not BRANCH which is pull/xxxx/head for PR builds)
 clone $deforg $defrepo $HEAD
 # Use the default branch as the last resort.

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -36,13 +36,19 @@ else
 	head=$(curl $apiEndpoint | jq -r '.head.label')
 fi
 
-# If head is set, it will contain either:
+# If head is set, it will contain on BuilKite either:
 #   * "branch" when the author's branch and target branch are in the same repo
 #   * "fork:branch" when the author's branch is in their fork or if this is a Netlify build
 # We can split on `:` into an array to check.
+# For GitHub Actions we need to inspect GITHUB_REPOSITORY and GITHUB_ACTOR
+# to determine whether the branch is from a fork or not
 BRANCH_ARRAY=(${head//:/ })
 if [[ "${#BRANCH_ARRAY[@]}" == "1" ]]; then
-    clone $deforg $defrepo $head
+    if [[ "$GITHUB_REPOSITORY" = "$deforg/$defrepo" ]]; then
+        clone $deforg $defrepo $head
+    else
+        clone $GITHUB_ACTOR $defrepo $head
+    fi
 elif [[ "${#BRANCH_ARRAY[@]}" == "2" ]]; then
     clone ${BRANCH_ARRAY[0]} $defrepo ${BRANCH_ARRAY[1]}
 fi


### PR DESCRIPTION
Fixes vector-im/element-web#17707
Fixes vector-im/element-web#17697
Fixes vector-im/element-web#17696

Fixes branch matching when running CI in GitHub actions

To test that this is working I have added a `postinstall` hook in a `matrix-js-sdk` branch that has the same name as this branch saying 

> Branch matching is working ! ✅