### PR TITLE
Fix modal opening race condition

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -385,7 +385,7 @@ export class ModalManager {
                 </div>
             );
 
-            ReactDOM.render(dialog, ModalManager.getOrCreateContainer());
+            setImmediate(() => ReactDOM.render(dialog, ModalManager.getOrCreateContainer()));
         } else {
             // This is safe to call repeatedly if we happen to do that
             ReactDOM.unmountComponentAtNode(ModalManager.getOrCreateContainer());


### PR DESCRIPTION
Fixes vector-im/element-web#17716

React 17 is hitting a race condition when a modal is closing and is trying to open another one within the same tick.
A proper long term fix would be using React.createPortal to avoid manually mounting and unmounting new React roots
