### PR TITLE
Don't set `font-family` explicitly

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -105,7 +105,6 @@ input[type=text],
 input[type=search],
 input[type=password] {
     padding: 9px;
-    font-family: $font-family;
     font-size: $font-14px;
     font-weight: 600;
     min-width: 0;
@@ -146,7 +145,6 @@ input[type=text], input[type=password], textarea {
 
 /* Required by Firefox */
 textarea {
-    font-family: $font-family;
     color: $primary-fg-color;
 }
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -104,6 +104,7 @@ a:visited {
 input[type=text],
 input[type=search],
 input[type=password] {
+    font-family: inherit;
     padding: 9px;
     font-size: $font-14px;
     font-weight: 600;

--- a/res/css/views/dialogs/_AddressPickerDialog.scss
+++ b/res/css/views/dialogs/_AddressPickerDialog.scss
@@ -29,7 +29,6 @@ limitations under the License.
 .mx_AddressPickerDialog_input:focus {
     height: 26px;
     font-size: $font-14px;
-    font-family: $font-family;
     padding-left: 12px;
     padding-right: 12px;
     margin: 0 !important;

--- a/res/css/views/dialogs/_ConfirmUserActionDialog.scss
+++ b/res/css/views/dialogs/_ConfirmUserActionDialog.scss
@@ -34,7 +34,6 @@ limitations under the License.
 }
 
 .mx_ConfirmUserActionDialog_reasonField {
-    font-family: $font-family;
     font-size: $font-14px;
     color: $primary-fg-color;
     background-color: $primary-bg-color;

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -55,22 +55,6 @@ limitations under the License.
     padding-right: 24px;
 }
 
-.mx_DevTools_inputCell {
-    display: table-cell;
-    width: 240px;
-}
-
-.mx_DevTools_inputCell input {
-    display: inline-block;
-    border: 0;
-    border-bottom: 1px solid $input-underline-color;
-    padding: 0;
-    width: 240px;
-    color: $input-fg-color;
-    font-family: $font-family;
-    font-size: $font-16px;
-}
-
 .mx_DevTools_textarea {
     font-size: $font-12px;
     max-width: 684px;

--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -123,7 +123,6 @@ limitations under the License.
     + .mx_DevTools_tgl-btn {
         padding: 2px;
         transition: all .2s ease;
-        font-family: sans-serif;
         perspective: 100px;
         &::after,
         &::before {

--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -39,7 +39,6 @@ limitations under the License.
 .mx_Field select,
 .mx_Field textarea {
     font-weight: normal;
-    font-family: $font-family;
     font-size: $font-14px;
     border: none;
     // Even without a border here, we still need this avoid overlapping the rounded

--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -165,8 +165,6 @@ limitations under the License.
     font-size: $font-14px;
     max-height: 120px;
     overflow: auto;
-    /* needed for FF */
-    font-family: $font-family;
 }
 
 /* hack for FF as vertical alignment of custom placeholder text is broken */

--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -36,7 +36,6 @@ limitations under the License.
 .mx_SettingsTab_subheading {
     font-size: $font-16px;
     display: block;
-    font-family: $font-family;
     font-weight: 600;
     color: $primary-fg-color;
     margin-bottom: 10px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/14163

Some parts of the code say that the `font-family` is necessary for FF, though a quick test didn't show any problems :man_shrugging: I've left out code blocks as those should be always monospace