### PR TITLE
Share a URL to chat

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1751,7 +1751,9 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             });
         } else if (screen === 'share') {
             if (this.props.startingFragmentQueryParams.url) {
-                this.openSendToDialog(this.props.startingFragmentQueryParams.url);
+                let url = this.props.startingFragmentQueryParams.url;
+                if (Array.isArray(url)) url = url[0];
+                this.openSendToDialog(url);
             } else {
                 dis.dispatch({
                     action: 'view_home_page',

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1005,7 +1005,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
         Modal.createTrackedDialog(
             'Send To Dialog', '', ForwardDialog, {
-                title: _t("Send to"),
+                dialogTitle: _t("Send to"),
                 matrixClient: cli,
                 event: mockEvent,
             },

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -830,9 +830,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 SettingsStore.setValue("showCookieBar", null, SettingLevel.DEVICE, false);
                 hideAnalyticsToast();
                 break;
-            case 'view_send_to_dialog':
-                this.viewSendToDialog(payload);
-                break;
         }
     };
 
@@ -975,7 +972,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         this.notifyNewScreen('group/' + groupId);
     }
 
-    private async viewSendToDialog(payload) {
+    private async openSendToDialog(url: string) {
         // open the home page in the background
         this.setPage(PageTypes.HomePage);
 
@@ -994,7 +991,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             sender: cli.getUserId(),
             content: {
                 msgtype: "m.text",
-                body: this.props.startingFragmentQueryParams.url,
+                body: url,
             },
             unsigned: {
                 age: 97,
@@ -1754,9 +1751,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             });
         } else if (screen === 'share') {
             if (this.props.startingFragmentQueryParams.url) {
-                dis.dispatch({
-                    action: 'view_send_to_dialog',
-                });
+                this.openSendToDialog(this.props.startingFragmentQueryParams.url);
             } else {
                 dis.dispatch({
                     action: 'view_home_page',

--- a/src/components/views/dialogs/ForwardDialog.tsx
+++ b/src/components/views/dialogs/ForwardDialog.tsx
@@ -49,11 +49,13 @@ const AVATAR_SIZE = 30;
 
 interface IProps extends IDialogProps {
     matrixClient: MatrixClient;
+    // dialog title
+    dialogTitle?: string;
     // The event to forward
     event: MatrixEvent;
     // We need a permalink creator for the source room to pass through to EventTile
     // in case the event is a reply (even though the user can't get at the link)
-    permalinkCreator: RoomPermalinkCreator;
+    permalinkCreator?: RoomPermalinkCreator;
 }
 
 interface IEntryProps {
@@ -147,7 +149,13 @@ const Entry: React.FC<IEntryProps> = ({ room, event, matrixClient: cli, onFinish
     </div>;
 };
 
-const ForwardDialog: React.FC<IProps> = ({ matrixClient: cli, event, permalinkCreator, onFinished }) => {
+const ForwardDialog: React.FC<IProps> = ({
+    dialogTitle = _t("Forward message"),
+    matrixClient: cli,
+    event,
+    permalinkCreator,
+    onFinished,
+}) => {
     const userId = cli.getUserId();
     const [profileInfo, setProfileInfo] = useState<any>({});
     useEffect(() => {
@@ -212,7 +220,7 @@ const ForwardDialog: React.FC<IProps> = ({ matrixClient: cli, event, permalinkCr
     }
 
     return <BaseDialog
-        title={_t("Forward message")}
+        title={dialogTitle}
         className="mx_ForwardDialog"
         contentId="mx_ForwardList"
         onFinished={onFinished}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2664,6 +2664,7 @@
     "Upgrade to %(hostSignupBrand)s": "Upgrade to %(hostSignupBrand)s",
     "Open dial pad": "Open dial pad",
     "Failed to reject invitation": "Failed to reject invitation",
+    "Send to": "Send to",
     "Cannot create rooms in this community": "Cannot create rooms in this community",
     "You do not have permission to create rooms in this community.": "You do not have permission to create rooms in this community.",
     "You are the only person here. If you leave, no one will be able to join in the future, including you.": "You are the only person here. If you leave, no one will be able to join in the future, including you.",


### PR DESCRIPTION
Raised in https://gitlab.com/minds/front/-/issues/4666

This adds a new `InviteDialog` kind, which is opened on `https://app.element.io/#/share?url=something.com`, and that allows the user to send a url to a chat or chats.

![output](https://user-images.githubusercontent.com/16239413/123505416-3e9da000-d674-11eb-8720-88990cce8153.gif)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Share a URL to chat ([\#6273](https://github.com/matrix-org/matrix-react-sdk/pull/6273)). Contributed by @manishoo.<!-- CHANGELOG_PREVIEW_END -->