### PR TITLE
Make toast dismiss button less prominent

### DIFF
--- a/src/components/views/toasts/GenericToast.tsx
+++ b/src/components/views/toasts/GenericToast.tsx
@@ -50,7 +50,7 @@ const GenericToast: React.FC<XOR<IPropsExtended, IProps>> = ({
             {detailContent}
         </div>
         <div className="mx_Toast_buttons" aria-live="off">
-            {onReject && rejectLabel && <AccessibleButton kind="danger" onClick={onReject}>
+            {onReject && rejectLabel && <AccessibleButton kind="danger_outline" onClick={onReject}>
                 { rejectLabel }
             </AccessibleButton> }
             <AccessibleButton onClick={onAccept} kind="primary">

--- a/test/end-to-end-tests/src/usecases/toasts.js
+++ b/test/end-to-end-tests/src/usecases/toasts.js
@@ -40,7 +40,7 @@ async function acceptToast(session, expectedTitle) {
 
 async function rejectToast(session, expectedTitle) {
     await assertToast(session, expectedTitle);
-    const btn = await session.query('.mx_Toast_buttons .mx_AccessibleButton_kind_danger');
+    const btn = await session.query('.mx_Toast_buttons .mx_AccessibleButton_kind_danger_outline');
     await btn.click();
 }
 


### PR DESCRIPTION
Partially addresses vector-im/element-web#17730

<img width="412" alt="Screen Shot 2021-06-25 at 15 55 18" src="https://user-images.githubusercontent.com/769871/123600245-6284f100-d7ee-11eb-9cd0-b55bddb11e9c.png">
