### PR TITLE
Fix multiple timeline panels handling composer and edit events

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2025,6 +2025,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                 manageReadReceipts={!this.state.isPeeking}
                 sendReadReceiptOnLoad={!this.state.wasContextSwitch}
                 manageReadMarkers={!this.state.isPeeking}
+                manageComposerDispatches={true}
                 hidden={hideMessagePanel}
                 highlightedEventId={highlightedEventId}
                 eventId={this.state.initialEventId}

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -843,6 +843,10 @@ export default class RoomView extends React.Component<IProps, IState> {
                 }
                 break;
             }
+
+            case "scroll_to_bottom":
+                this.messagePanel?.jumpToLiveTimeline();
+                break;
         }
     };
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -82,6 +82,7 @@ import SpaceRoomView from "./SpaceRoomView";
 import { IOpts } from "../../createRoom";
 import { replaceableComponent } from "../../utils/replaceableComponent";
 import UIStore from "../../stores/UIStore";
+import EditorStateTransfer from "../../utils/EditorStateTransfer";
 
 const DEBUG = false;
 let debuglog = function(msg: string) {};
@@ -192,6 +193,7 @@ export interface IState {
     // whether or not a spaces context switch brought us here,
     // if it did we don't want the room to be marked as read as soon as it is loaded.
     wasContextSwitch?: boolean;
+    editState?: EditorStateTransfer;
 }
 
 @replaceableComponent("structures.RoomView")
@@ -815,6 +817,32 @@ export default class RoomView extends React.Component<IProps, IState> {
             case 'focus_search':
                 this.onSearchClick();
                 break;
+
+            case "edit_event": {
+                const editState = payload.event ? new EditorStateTransfer(payload.event) : null;
+                this.setState({ editState }, () => {
+                    if (payload.event) {
+                        this.messagePanel?.scrollToEventIfNeeded(payload.event.getId());
+                    }
+                });
+                break;
+            }
+
+            case Action.ComposerInsert: {
+                // re-dispatch to the correct composer
+                if (this.state.editState) {
+                    dis.dispatch({
+                        ...payload,
+                        action: "edit_composer_insert",
+                    });
+                } else {
+                    dis.dispatch({
+                        ...payload,
+                        action: "send_composer_insert",
+                    });
+                }
+                break;
+            }
         }
     };
 
@@ -2025,7 +2053,6 @@ export default class RoomView extends React.Component<IProps, IState> {
                 manageReadReceipts={!this.state.isPeeking}
                 sendReadReceiptOnLoad={!this.state.wasContextSwitch}
                 manageReadMarkers={!this.state.isPeeking}
-                manageComposerDispatches={true}
                 hidden={hideMessagePanel}
                 highlightedEventId={highlightedEventId}
                 eventId={this.state.initialEventId}

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -446,10 +446,6 @@ class TimelinePanel extends React.Component {
             case "ignore_state_changed":
                 this.forceUpdate();
                 break;
-
-            case "scroll_to_bottom":
-                this.jumpToLiveTimeline();
-                break;
         }
     };
 

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -72,6 +72,8 @@ class TimelinePanel extends React.Component {
         manageReadReceipts: PropTypes.bool,
         sendReadReceiptOnLoad: PropTypes.bool,
         manageReadMarkers: PropTypes.bool,
+        // with this enabled it'll listen and react to Action.ComposerInsert and `edit_event`
+        manageComposerDispatches: PropTypes.bool,
 
         // true to give the component a 'display: none' style.
         hidden: PropTypes.bool,
@@ -446,29 +448,33 @@ class TimelinePanel extends React.Component {
                 break;
 
             case "edit_event": {
-                const editState = payload.event ? new EditorStateTransfer(payload.event) : null;
-                this.setState({editState}, () => {
-                    if (payload.event && this._messagePanel.current) {
-                        this._messagePanel.current.scrollToEventIfNeeded(
-                            payload.event.getId(),
-                        );
-                    }
-                });
+                if (this.props.manageComposerDispatches) {
+                    const editState = payload.event ? new EditorStateTransfer(payload.event) : null;
+                    this.setState({editState}, () => {
+                        if (payload.event && this._messagePanel.current) {
+                            this._messagePanel.current.scrollToEventIfNeeded(
+                                payload.event.getId(),
+                            );
+                        }
+                    });
+                }
                 break;
             }
 
             case Action.ComposerInsert: {
-                // re-dispatch to the correct composer
-                if (this.state.editState) {
-                    dis.dispatch({
-                        ...payload,
-                        action: "edit_composer_insert",
-                    });
-                } else {
-                    dis.dispatch({
-                        ...payload,
-                        action: "send_composer_insert",
-                    });
+                if (this.props.manageComposerDispatches) {
+                    // re-dispatch to the correct composer
+                    if (this.state.editState) {
+                        dis.dispatch({
+                            ...payload,
+                            action: "edit_composer_insert",
+                        });
+                    } else {
+                        dis.dispatch({
+                            ...payload,
+                            action: "send_composer_insert",
+                        });
+                    }
                 }
                 break;
             }

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -34,12 +34,10 @@ import * as sdk from "../../index";
 import { Key } from '../../Keyboard';
 import Timer from '../../utils/Timer';
 import shouldHideEvent from '../../shouldHideEvent';
-import EditorStateTransfer from '../../utils/EditorStateTransfer';
 import { haveTileForEvent } from "../views/rooms/EventTile";
 import { UIFeature } from "../../settings/UIFeature";
 import { replaceableComponent } from "../../utils/replaceableComponent";
 import { arrayFastClone } from "../../utils/arrays";
-import { Action } from "../../dispatcher/actions";
 
 const PAGINATE_SIZE = 20;
 const INITIAL_SIZE = 20;

--- a/src/components/structures/TimelinePanel.js
+++ b/src/components/structures/TimelinePanel.js
@@ -447,38 +447,6 @@ class TimelinePanel extends React.Component {
                 this.forceUpdate();
                 break;
 
-            case "edit_event": {
-                if (this.props.manageComposerDispatches) {
-                    const editState = payload.event ? new EditorStateTransfer(payload.event) : null;
-                    this.setState({editState}, () => {
-                        if (payload.event && this._messagePanel.current) {
-                            this._messagePanel.current.scrollToEventIfNeeded(
-                                payload.event.getId(),
-                            );
-                        }
-                    });
-                }
-                break;
-            }
-
-            case Action.ComposerInsert: {
-                if (this.props.manageComposerDispatches) {
-                    // re-dispatch to the correct composer
-                    if (this.state.editState) {
-                        dis.dispatch({
-                            ...payload,
-                            action: "edit_composer_insert",
-                        });
-                    } else {
-                        dis.dispatch({
-                            ...payload,
-                            action: "send_composer_insert",
-                        });
-                    }
-                }
-                break;
-            }
-
             case "scroll_to_bottom":
                 this.jumpToLiveTimeline();
                 break;
@@ -871,6 +839,12 @@ class TimelinePanel extends React.Component {
             }
         }
     };
+
+    scrollToEventIfNeeded = (eventId) => {
+        if (this._messagePanel.current) {
+            this._messagePanel.current.scrollToEventIfNeeded(eventId);
+        }
+    }
 
     /* scroll to show the read-up-to marker. We put it 1/3 of the way down
      * the container.
@@ -1479,7 +1453,7 @@ class TimelinePanel extends React.Component {
                 tileShape={this.props.tileShape}
                 resizeNotifier={this.props.resizeNotifier}
                 getRelationsForEvent={this.getRelationsForEvent}
-                editState={this.state.editState}
+                editState={this.props.editState}
                 showReactions={this.props.showReactions}
                 layout={this.props.layout}
                 enableFlair={SettingsStore.getValue(UIFeature.Flair)}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17738

Thanks @SimonBrandner for debugging this one

Also fixes additional issue I spotted that FilePanel/NotifPanel jumped to bottom whenever you sent a message when the intent was only for the room main timeline panel to do this.