### PR TITLE
Avoid cyclic dependencies by moving watchers out of constructor

### DIFF
--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -73,13 +73,6 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
 
     constructor() {
         super(defaultDispatcher);
-
-        this.checkLoggingEnabled();
-        for (const settingName of this.watchedSettings) SettingsStore.monitorSetting(settingName, null);
-        RoomViewStore.addListener(() => this.handleRVSUpdate({}));
-        this.algorithm.on(LIST_UPDATED_EVENT, this.onAlgorithmListUpdated);
-        this.algorithm.on(FILTER_CHANGED, this.onAlgorithmFilterUpdated);
-        this.setupWatchers();
     }
 
     private setupWatchers() {
@@ -126,6 +119,12 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
         }
 
         this.checkLoggingEnabled();
+
+        for (const settingName of this.watchedSettings) SettingsStore.monitorSetting(settingName, null);
+        RoomViewStore.addListener(() => this.handleRVSUpdate({}));
+        this.algorithm.on(LIST_UPDATED_EVENT, this.onAlgorithmListUpdated);
+        this.algorithm.on(FILTER_CHANGED, this.onAlgorithmFilterUpdated);
+        this.setupWatchers();
 
         // Update any settings here, as some may have happened before we were logically ready.
         // Update any settings here, as some may have happened before we were logically ready.


### PR DESCRIPTION
Fixes vector-im/element-web#17836

There is a cyclic dependency only when spaces are enabled between
* `SpaceStore`
* `SpaceWatcher`
* `RoomListStore`

This regression was introduced by #6283 which only happened to change the loading order of components by chance in `src/component-index.js`.

A proper fix might be to have layer boundaries and ensure that things are only referenced in a certain direction to avoid this kind of issue. Or to maybe have a `.start()` method that would initialise things outside of the construction phase
In this case it takes a bit of a hybrid approach and delays the watchers setup to when the application notifies it is ready