### PR TITLE
improve auto fill password/passphrase

### DIFF
--- a/res/css/views/dialogs/security/_AccessSecretStorageDialog.scss
+++ b/res/css/views/dialogs/security/_AccessSecretStorageDialog.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AccessSecretStorageDialog_hidden-encryption-username-for-auto-fill-password {
+.mx_AccessSecretStorageDialog_hiddenEncryptionUsernameForAutoFillPassword {
     visibility: hidden;
 }
 

--- a/res/css/views/dialogs/security/_AccessSecretStorageDialog.scss
+++ b/res/css/views/dialogs/security/_AccessSecretStorageDialog.scss
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_AccessSecretStorageDialog_hidden-encryption-username-for-auto-fill-password {
+    visibility: hidden;
+}
+
 .mx_AccessSecretStorageDialog_reset {
     position: relative;
     padding-left: 24px; // 16px icon + 8px padding

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -344,11 +344,9 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
 
                 <form className="mx_AccessSecretStorageDialog_primaryContainer" onSubmit={this.onPassPhraseNext}>
                     <input
-                            className="mx_AccessSecretStorageDialog_hidden-encryption-username-for-auto-fill-password"
+                            className="mx_AccessSecretStorageDialog_hiddenEncryptionUsernameForAutoFillPassword"
                             name="username" // make it a little easier for browser's remember-password
-                            key="username_input"
                             type="text"
-                            placeholder={_t("Username").toLocaleLowerCase()}
                             value="Passphrase"
                         />
                     <input

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -344,6 +344,14 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
 
                 <form className="mx_AccessSecretStorageDialog_primaryContainer" onSubmit={this.onPassPhraseNext}>
                     <input
+                            className="mx_AccessSecretStorageDialog_hidden-encryption-username-for-auto-fill-password"
+                            name="username" // make it a little easier for browser's remember-password
+                            key="username_input"
+                            type="text"
+                            placeholder={_t("Username").toLocaleLowerCase()}
+                            value="Passphrase"
+                        />
+                    <input
                         type="password"
                         id="mx_passPhraseInput"
                         className="mx_AccessSecretStorageDialog_passPhraseInput"


### PR DESCRIPTION
Add a hidden username input field that has a field to differentiate between password and passphrase autofill

as explained in this issue https://github.com/vector-im/element-web/issues/16484

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst#sign-off -->

Signed-off-by: Chagai Friedlander chagai95@gmail.com

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * improve auto fill password/passphrase ([\#6289](https://github.com/matrix-org/matrix-react-sdk/pull/6289)). Contributed by @chagai95.<!-- CHANGELOG_PREVIEW_END -->