### PR TITLE
Upgrade browserlist target versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,9 +2345,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001173:
-  version "1.0.30001178"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz#3ad813b2b2c7d585b0be0a2440e1e233c6eabdbc"
-  integrity sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==
+  version "1.0.30001241"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz"
+  integrity sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
A warning recently appeared in the build

> Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating

I ran the command

```
npx browserslist@latest --update-db
```

```diff
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 87
+ and_chr 91
- and_ff 83
+ and_ff 89
- android 81
+ android 91
- chrome 87
- chrome 86
+ chrome 91
+ chrome 90
+ chrome 89
- edge 87
- edge 86
+ edge 91
+ edge 90
- firefox 84
- firefox 83
+ firefox 89
+ firefox 88
- ios_saf 14.0-14.3
- ios_saf 12.2-12.4
+ ios_saf 14.5-14.6
+ ios_saf 14.0-14.4
- op_mob 59
+ op_mob 62
- opera 72
- opera 71
+ opera 77
+ opera 76
- safari 13.1
+ safari 14.1
- samsung 12.0
+ samsung 14.0
```