### PR TITLE
Fix instances of the Edit Message Composer's save button being wrongly disabled

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -711,6 +711,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     }
 
     public insertMention(userId: string): void {
+        this.modifiedFlag = true;
         const { model } = this.props;
         const { partCreator } = model;
         const member = this.props.room.getMember(userId);
@@ -729,6 +730,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     }
 
     public insertQuotedMessage(event: MatrixEvent): void {
+        this.modifiedFlag = true;
         const { model } = this.props;
         const { partCreator } = model;
         const quoteParts = parseEvent(event, partCreator, { isQuotedMessage: true });
@@ -744,6 +746,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     }
 
     public insertPlaintext(text: string): void {
+        this.modifiedFlag = true;
         const { model } = this.props;
         const { partCreator } = model;
         const caret = this.getCaret();


### PR DESCRIPTION
Also fixed an instance of edit state not saving on browser unload due to wrong `this` context
Also removed unused method

Fixes https://github.com/vector-im/element-web/issues/17858