### PR TITLE
Beistrich isn't used in most german speaking areas

### DIFF
--- a/src/i18n/strings/de_DE.json
+++ b/src/i18n/strings/de_DE.json
@@ -708,7 +708,7 @@
     "Messages containing <span>keywords</span>": "Nachrichten mit <span>Schlüsselwörtern</span>",
     "Error saving email notification preferences": "Fehler beim Speichern der E-Mail-Benachrichtigungseinstellungen",
     "Tuesday": "Dienstag",
-    "Enter keywords separated by a comma:": "Gib die Schlüsselwörter durch einen Beistrich getrennt ein:",
+    "Enter keywords separated by a comma:": "Gib die Schlüsselwörter durch ein Komma getrennt ein:",
     "Forward Message": "Weiterleiten",
     "You have successfully set a password and an email address!": "Du hast erfolgreich ein Passwort und eine E-Mail-Adresse gesetzt!",
     "Remove %(name)s from the directory?": "Soll der Raum %(name)s aus dem Verzeichnis entfernt werden?",


### PR DESCRIPTION
A user stumbled across this translation and had to motivate a search engine first.

Apparently "Beistrich" is mostly used in southern Austria. However, "Komma" is a far more common translation for "comma".

Signed-off-by: Thore Krüss <thore@kruess.xyz>