### PR TITLE
Make ghost button background transparent

### DIFF
--- a/res/css/views/elements/_AccessibleButton.scss
+++ b/res/css/views/elements/_AccessibleButton.scss
@@ -72,7 +72,7 @@ limitations under the License.
 
 .mx_AccessibleButton_kind_danger_outline {
     color: $button-danger-bg-color;
-    background-color: $button-secondary-bg-color;
+    background-color: transparent;
     border: 1px solid $button-danger-bg-color;
 }
 


### PR DESCRIPTION
Originally discussed with @gaelledel . The ghost button has a background, however when using the light theme that background color is set to `#fff`.
When those buttons are used in a toast context, the background is not `#fff` and ends up looking really odd. 