### PR TITLE
Make DeviceListener also update on megolm key in SSSS

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -160,7 +160,8 @@ export default class DeviceListener {
         // which result in account data changes affecting checks below.
         if (
             ev.getType().startsWith('m.secret_storage.') ||
-            ev.getType().startsWith('m.cross_signing.')
+            ev.getType().startsWith('m.cross_signing.') ||
+            ev.getType() === 'm.megolm_backup.v1'
         ) {
             this._recheck();
         }


### PR DESCRIPTION
The device listener checks for a megolm key stored in SSSS but didn't
update when one was added, so the encryption upgrade toast would not
disappear after the key was fixed by https://github.com/matrix-org/matrix-js-sdk/pull/1776

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst#sign-off -->
