### PR TITLE
Dial pad: move the backspace button into the number field

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -120,6 +120,7 @@
 @import "./views/elements/_AddressTile.scss";
 @import "./views/elements/_DesktopBuildsNotice.scss";
 @import "./views/elements/_DesktopCapturerSourcePicker.scss";
+@import "./views/elements/_DialPadBackspaceButton.scss";
 @import "./views/elements/_DirectorySearchBox.scss";
 @import "./views/elements/_Dropdown.scss";
 @import "./views/elements/_EditableItemList.scss";

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -364,6 +364,11 @@ limitations under the License.
     border-color: #0DBD8B;
 }
 
+.mx_InviteDialog_dialPadField .mx_Field_postfix {
+    /* Remove border separator between postfix and field content */
+    border-left: none;
+}
+
 .mx_InviteDialog_dialPad {
     width: 224px;
     margin-left: auto;

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -352,6 +352,7 @@ limitations under the License.
     border-right: 0;
     border-radius: 0;
     margin-top: 0;
+    border-color: #6F7882;
 
     input {
         font-size: 18px;
@@ -371,6 +372,7 @@ limitations under the License.
 
 .mx_InviteDialog_dialPad {
     width: 224px;
+    margin-top: 16px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/res/css/views/elements/_DialPadBackspaceButton.scss
+++ b/res/css/views/elements/_DialPadBackspaceButton.scss
@@ -14,18 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as React from "react";
-import AccessibleButton from "./AccessibleButton";
+.mx_DialPadBackspaceButton {
+    position: relative;
+    height: 28px;
+    width: 28px;
 
-interface IProps {
-    // Callback for when the button is pressed
-    onBackspacePress: () => void;
-}
+    &::before {
+        /* force this element to appear on the DOM */
+        content: "";
 
-export default class DialPadBackspaceButton extends React.PureComponent<IProps> {
-    render() {
-        return <div className="mx_DialPadBackspaceButtonWrapper">
-            <AccessibleButton className="mx_DialPadBackspaceButton" onClick={this.props.onBackspacePress} />
-        </div>;
+        background-color: #8D97A5;
+        width: 28px;
+        height: 28px;
+        top: 0px;
+        left: 0px;
+        position: absolute;
+        display: inline-block;
+        vertical-align: middle;
+
+        mask-image: url('$(res)/img/element-icons/call/delete.svg');
+        mask-position: 8px;
+        mask-size: 20px;
+        mask-repeat: no-repeat;
     }
 }

--- a/res/css/views/voip/_DialPad.scss
+++ b/res/css/views/voip/_DialPad.scss
@@ -68,6 +68,9 @@ limitations under the License.
 }
 
 .mx_DialPad_dialButton {
+    /* Always show the dial button in the center grid column */
+    grid-column: 2;
+
     background-color: $accent-color;
     &::before {
         mask-image: url('$(res)/img/element-icons/call/voice-call.svg');

--- a/res/css/views/voip/_DialPad.scss
+++ b/res/css/views/voip/_DialPad.scss
@@ -16,12 +16,14 @@ limitations under the License.
 
 .mx_DialPad {
     display: grid;
-    gap: 16px;
+    row-gap: 16px;
+    column-gap: 0px;
+    margin-top: 24px;
+    margin-left: auto;
+    margin-right: auto;
 
     /* squeeze the dial pad buttons together horizontally */
-    grid-template-columns: 2fr 1fr 2fr;
-    margin-left: 32px;
-    margin-right: 32px;
+    grid-template-columns: repeat(3, 1fr);
 }
 
 .mx_DialPad_button {
@@ -59,7 +61,7 @@ limitations under the License.
         mask-repeat: no-repeat;
         mask-size: 20px;
         mask-position: center;
-        background-color: $primary-bg-color;
+        background-color: #FFF; // on all themes
         mask-image: url('$(res)/img/element-icons/call/voice-call.svg');
     }
 }

--- a/res/css/views/voip/_DialPad.scss
+++ b/res/css/views/voip/_DialPad.scss
@@ -46,6 +46,10 @@ limitations under the License.
 }
 
 .mx_DialPad_dialButton {
+    /* Always show the dial button in the center grid column */
+    grid-column: 2;
+    background-color: $accent-color;
+
     &::before {
         content: '';
         display: inline-block;
@@ -56,15 +60,6 @@ limitations under the License.
         mask-size: 20px;
         mask-position: center;
         background-color: $primary-bg-color;
-    }
-}
-
-.mx_DialPad_dialButton {
-    /* Always show the dial button in the center grid column */
-    grid-column: 2;
-
-    background-color: $accent-color;
-    &::before {
         mask-image: url('$(res)/img/element-icons/call/voice-call.svg');
     }
 }

--- a/res/css/views/voip/_DialPad.scss
+++ b/res/css/views/voip/_DialPad.scss
@@ -45,7 +45,7 @@ limitations under the License.
     font-size: 8px;
 }
 
-.mx_DialPad_deleteButton, .mx_DialPad_dialButton {
+.mx_DialPad_dialButton {
     &::before {
         content: '';
         display: inline-block;
@@ -56,14 +56,6 @@ limitations under the License.
         mask-size: 20px;
         mask-position: center;
         background-color: $primary-bg-color;
-    }
-}
-
-.mx_DialPad_deleteButton {
-    background-color: $notice-primary-color;
-    &::before {
-        mask-image: url('$(res)/img/element-icons/call/delete.svg');
-        mask-position: 9px; // delete icon is right-heavy so have to be slightly to the left to look centered
     }
 }
 

--- a/res/css/views/voip/_DialPadContextMenu.scss
+++ b/res/css/views/voip/_DialPadContextMenu.scss
@@ -20,18 +20,30 @@ limitations under the License.
 }
 
 .mx_DialPadContextMenuWrapper {
-    padding: 30px;
+    padding: 15px;
 }
 
 .mx_DialPadContextMenu_header {
     border: none;
-    margin-top: 16px;
-    margin-left: 44px;
-    margin-right: 44px;
+    margin-top: 32px;
+    margin-left: 20px;
+    margin-right: 20px;
 
     /* a separator between the input line and the dial buttons */
-    border-bottom: 1px solid $input-darker-bg-color;
+    border-bottom: 1px solid #6F7882;
     transition: border-bottom 0.25s;
+}
+
+.mx_DialPadContextMenu_cancel {
+    float: right;
+    mask: url('$(res)/img/feather-customised/cancel.svg');
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: cover;
+    width: 14px;
+    height: 14px;
+    background-color: $dialog-close-fg-color;
+    cursor: pointer;
 }
 
 .mx_DialPadContextMenu_header:focus-within {
@@ -55,7 +67,7 @@ limitations under the License.
     font-size: 18px;
     font-weight: 600;
     overflow: hidden;
-    max-width: 150px;
+    max-width: 185px;
     text-align: left;
     direction: rtl;
     padding: 8px 0px;

--- a/res/css/views/voip/_DialPadModal.scss
+++ b/res/css/views/voip/_DialPadModal.scss
@@ -19,18 +19,18 @@ limitations under the License.
 }
 
 .mx_DialPadModal {
-    width: 336px;
-    height: 368px;
-    padding: 16px 16px 0px 16px;
+    width: 292px;
+    height: 370px;
+    padding: 16px 0px 0px 0px;
 }
 
 .mx_DialPadModal_header {
-    margin-top: 16px;
-    margin-left: 66px;
-    margin-right: 66px;
+    margin-top: 32px;
+    margin-left: 40px;
+    margin-right: 40px;
 
     /* a separator between the input line and the dial buttons */
-    border-bottom: 1px solid $input-darker-bg-color;
+    border-bottom: 1px solid #6F7882;
     transition: border-bottom 0.25s;
 }
 
@@ -54,6 +54,7 @@ limitations under the License.
     height: 14px;
     background-color: $dialog-close-fg-color;
     cursor: pointer;
+    margin-right: 16px;
 }
 
 .mx_DialPadModal_field {

--- a/res/css/views/voip/_DialPadModal.scss
+++ b/res/css/views/voip/_DialPadModal.scss
@@ -59,6 +59,12 @@ limitations under the License.
 .mx_DialPadModal_field {
     border: none;
     margin: 0px;
+    height: 30px;
+}
+
+.mx_DialPadModal_field .mx_Field_postfix {
+    /* Remove border separator between postfix and field content */
+    border-left: none;
 }
 
 .mx_DialPadModal_field input {

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -118,7 +118,7 @@ $voipcall-plinth-color: #394049;
 // ********************
 
 $theme-button-bg-color: #e3e8f0;
-$dialpad-button-bg-color: #6F7882;
+$dialpad-button-bg-color: #394049;
 
 $roomlist-button-bg-color: rgba(141, 151, 165, 0.2); // Buttons include the filter box, explore button, and sublist buttons
 $roomlist-filter-active-bg-color: $bg-color;

--- a/src/components/views/context_menus/DialpadContextMenu.tsx
+++ b/src/components/views/context_menus/DialpadContextMenu.tsx
@@ -57,7 +57,7 @@ export default class DialpadContextMenu extends React.Component<IProps, IState> 
         return <ContextMenu {...this.props}>
             <div className="mx_DialPadContextMenuWrapper">
                 <div>
-                    <AccessibleButton className="mx_DialPadModal_cancel" onClick={this.onCancelClick} />
+                    <AccessibleButton className="mx_DialPadContextMenu_cancel" onClick={this.onCancelClick} />
                 </div>
                 <div className="mx_DialPadContextMenu_header">
                     <Field className="mx_DialPadContextMenu_dialled"

--- a/src/components/views/context_menus/DialpadContextMenu.tsx
+++ b/src/components/views/context_menus/DialpadContextMenu.tsx
@@ -66,7 +66,7 @@ export default class DialpadContextMenu extends React.Component<IProps, IState> 
                     />
                 </div>
                 <div className="mx_DialPadContextMenu_dialPad">
-                    <DialPad onDigitPress={this.onDigitPress} hasDial={false} hasDelete={false} />
+                    <DialPad onDigitPress={this.onDigitPress} hasDial={false} />
                 </div>
             </div>
         </ContextMenu>;

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1532,7 +1532,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                         onChange={this.onDialChange}
                     />
                 </form>
-                <Dialpad hasDial={false} hasDelete={true}
+                <Dialpad hasDial={false}
                     onDigitPress={this.onDigitPress} onDeletePress={this.onDeletePress}
                 />
             </div>;

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -70,6 +70,7 @@ import Dialpad from '../voip/DialPad';
 import QuestionDialog from "./QuestionDialog";
 import Spinner from "../elements/Spinner";
 import BaseDialog from "./BaseDialog";
+import DialPadBackspaceButton from "../elements/DialPadBackspaceButton";
 
 // we have a number of types defined from the Matrix spec which can't reasonably be altered here.
 /* eslint-disable camelcase */
@@ -1525,12 +1526,30 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                 TabId.UserDirectory, _td("User Directory"), 'mx_InviteDialog_userDirectoryIcon', usersSection,
             ));
 
+            const backspaceButton = (
+                <DialPadBackspaceButton onBackspacePress={this.onDeletePress} />
+            );
+
+            // Only show the backspace button if the field has content
+            let dialPadField;
+            if (this.state.dialPadValue.length !== 0) {
+                dialPadField = <Field className="mx_InviteDialog_dialPadField" id="dialpad_number"
+                    value={this.state.dialPadValue}
+                    autoFocus={true}
+                    onChange={this.onDialChange}
+                    postfixComponent={backspaceButton}
+                />;
+            } else {
+                dialPadField = <Field className="mx_InviteDialog_dialPadField" id="dialpad_number"
+                    value={this.state.dialPadValue}
+                    autoFocus={true}
+                    onChange={this.onDialChange}
+                />;
+            }
+
             const dialPadSection = <div className="mx_InviteDialog_dialPad">
                 <form onSubmit={this.onDialFormSubmit}>
-                    <Field className="mx_InviteDialog_dialPadField" id="dialpad_number"
-                        value={this.state.dialPadValue} autoFocus={true}
-                        onChange={this.onDialChange}
-                    />
+                    {dialPadField}
                 </form>
                 <Dialpad hasDial={false}
                     onDigitPress={this.onDigitPress} onDeletePress={this.onDeletePress}

--- a/src/components/views/elements/DialPadBackspaceButton.tsx
+++ b/src/components/views/elements/DialPadBackspaceButton.tsx
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as React from "react";
+import AccessibleButton from "./AccessibleButton";
+
+interface IProps {
+    // Callback for when the button is pressed
+    onBackspacePress: () => void;
+}
+
+export default class DialPadBackspaceButton extends React.PureComponent<IProps> {
+    render() {
+        return <div className="mx_DialPadBackspaceButton">
+                <div>
+                    <AccessibleButton className="mx_DialPadBackspaceButton" onClick={this.props.onBackspacePress} />
+                </div>
+        </div>;
+    };
+}

--- a/src/components/views/voip/DialPad.tsx
+++ b/src/components/views/voip/DialPad.tsx
@@ -23,7 +23,6 @@ const BUTTON_LETTERS = ['', 'ABC', 'DEF', 'GHI', 'JKL', 'MNO', 'PQRS', 'TUV', 'W
 
 enum DialPadButtonKind {
     Digit,
-    Delete,
     Dial,
 }
 
@@ -48,10 +47,6 @@ class DialPadButton extends React.PureComponent<IButtonProps> {
                         {this.props.digitSubtext}
                     </div>
                 </AccessibleButton>;
-            case DialPadButtonKind.Delete:
-                return <AccessibleButton className="mx_DialPad_button mx_DialPad_deleteButton"
-                    onClick={this.onClick}
-                />;
             case DialPadButtonKind.Dial:
                 return <AccessibleButton className="mx_DialPad_button mx_DialPad_dialButton" onClick={this.onClick} />;
         }
@@ -61,7 +56,6 @@ class DialPadButton extends React.PureComponent<IButtonProps> {
 interface IProps {
     onDigitPress: (string) => void;
     hasDial: boolean;
-    hasDelete: boolean;
     onDeletePress?: (string) => void;
     onDialPress?: (string) => void;
 }
@@ -79,11 +73,6 @@ export default class Dialpad extends React.PureComponent<IProps> {
             />);
         }
 
-        if (this.props.hasDelete) {
-            buttonNodes.push(<DialPadButton key="del" kind={DialPadButtonKind.Delete}
-                onButtonPress={this.props.onDeletePress}
-            />);
-        }
         if (this.props.hasDial) {
             buttonNodes.push(<DialPadButton key="dial" kind={DialPadButtonKind.Dial}
                 onButtonPress={this.props.onDialPress}

--- a/src/components/views/voip/DialPadModal.tsx
+++ b/src/components/views/voip/DialPadModal.tsx
@@ -22,6 +22,7 @@ import dis from '../../../dispatcher/dispatcher';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { DialNumberPayload } from "../../../dispatcher/payloads/DialNumberPayload";
 import { Action } from "../../../dispatcher/actions";
+import DialPadBackspaceButton from "../elements/DialPadBackspaceButton";
 
 interface IProps {
     onFinished: (boolean) => void;
@@ -73,6 +74,10 @@ export default class DialpadModal extends React.PureComponent<IProps, IState> {
     };
 
     render() {
+        const backspaceButton = (
+            <DialPadBackspaceButton onBackspacePress={this.onDeletePress} />
+        );
+
         return <div className="mx_DialPadModal">
             <div>
                 <AccessibleButton className="mx_DialPadModal_cancel" onClick={this.onCancelClick} />
@@ -82,6 +87,7 @@ export default class DialpadModal extends React.PureComponent<IProps, IState> {
                     <Field className="mx_DialPadModal_field" id="dialpad_number"
                         value={this.state.value} autoFocus={true}
                         onChange={this.onChange}
+                        postfixComponent={backspaceButton}
                     />
                 </form>
             </div>

--- a/src/components/views/voip/DialPadModal.tsx
+++ b/src/components/views/voip/DialPadModal.tsx
@@ -78,17 +78,30 @@ export default class DialpadModal extends React.PureComponent<IProps, IState> {
             <DialPadBackspaceButton onBackspacePress={this.onDeletePress} />
         );
 
+        // Only show the backspace button if the field has content
+        let dialPadField;
+        if (this.state.value.length !== 0) {
+            dialPadField = <Field className="mx_DialPadModal_field" id="dialpad_number"
+                value={this.state.value}
+                autoFocus={true}
+                onChange={this.onChange}
+                postfixComponent={backspaceButton}
+            />;
+        } else {
+            dialPadField = <Field className="mx_DialPadModal_field" id="dialpad_number"
+                value={this.state.value}
+                autoFocus={true}
+                onChange={this.onChange}
+            />;
+        }
+
         return <div className="mx_DialPadModal">
             <div>
                 <AccessibleButton className="mx_DialPadModal_cancel" onClick={this.onCancelClick} />
             </div>
             <div className="mx_DialPadModal_header">
                 <form onSubmit={this.onFormSubmit}>
-                    <Field className="mx_DialPadModal_field" id="dialpad_number"
-                        value={this.state.value} autoFocus={true}
-                        onChange={this.onChange}
-                        postfixComponent={backspaceButton}
-                    />
+                    {dialPadField}
                 </form>
             </div>
             <div className="mx_DialPadModal_dialPad">

--- a/src/components/views/voip/DialPadModal.tsx
+++ b/src/components/views/voip/DialPadModal.tsx
@@ -86,7 +86,7 @@ export default class DialpadModal extends React.PureComponent<IProps, IState> {
                 </form>
             </div>
             <div className="mx_DialPadModal_dialPad">
-                <DialPad hasDial={true} hasDelete={true}
+                <DialPad hasDial={true}
                     onDigitPress={this.onDigitPress}
                     onDeletePress={this.onDeletePress}
                     onDialPress={this.onDialPress}


### PR DESCRIPTION
This PR builds on top of #6217, #6301 and #6325, and intends to remove the backspace dial pad button, and replace it with a icon inside of the number field which serves the same purpose, and only appears once text has been entered.

Intended design:
![image](https://user-images.githubusercontent.com/1342360/125055367-05672600-e09f-11eb-841f-f77825e6794e.png)

Implementation:

Dial pad modal
![image](https://user-images.githubusercontent.com/1342360/125066529-01410580-e0ab-11eb-8e63-1079583a3320.png)

Transfer tab
![image](https://user-images.githubusercontent.com/1342360/125066688-30f00d80-e0ab-11eb-8e54-f5cb8d1b2dc7.png)