### PR TITLE
Fix right panel not closing user info when changing rooms

### DIFF
--- a/src/stores/RightPanelStore.ts
+++ b/src/stores/RightPanelStore.ts
@@ -68,6 +68,7 @@ const MEMBER_INFO_PHASES = [
 export default class RightPanelStore extends Store<ActionPayload> {
     private static instance: RightPanelStore;
     private state: RightPanelStoreState;
+    private lastRoomId: string;
 
     constructor() {
         super(dis);
@@ -147,8 +148,10 @@ export default class RightPanelStore extends Store<ActionPayload> {
     __onDispatch(payload: ActionPayload) {
         switch (payload.action) {
             case 'view_room':
+                if (payload.room_id === this.lastRoomId) break; // skip this transition, probably a permalink
+                // fallthrough
             case 'view_group':
-                if (payload.room_id === RoomViewStore.getRoomId()) break; // skip this transition, probably a permalink
+                this.lastRoomId = payload.room_id;
 
                 // Reset to the member list if we're viewing member info
                 if (MEMBER_INFO_PHASES.includes(this.state.lastRoomPhase)) {

--- a/src/stores/RightPanelStore.ts
+++ b/src/stores/RightPanelStore.ts
@@ -22,7 +22,6 @@ import { RightPanelPhases, RIGHT_PANEL_PHASES_NO_ARGS } from "./RightPanelStoreP
 import { ActionPayload } from "../dispatcher/payloads";
 import { Action } from '../dispatcher/actions';
 import { SettingLevel } from "../settings/SettingLevel";
-import RoomViewStore from './RoomViewStore';
 
 interface RightPanelStoreState {
     // Whether or not to show the right panel at all. We split out rooms and groups


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17910

RVS updates its state before this dispatch handler fires so we need to keep track of lastRoomId ourselves