### PR TITLE
Fix small visual regression with the site name on url previews

### DIFF
--- a/res/css/views/rooms/_LinkPreviewWidget.scss
+++ b/res/css/views/rooms/_LinkPreviewWidget.scss
@@ -43,10 +43,10 @@ limitations under the License.
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-}
 
-.mx_LinkPreviewWidget_siteName {
-    display: inline;
+    .mx_LinkPreviewWidget_siteName {
+        font-weight: normal;
+    }
 }
 
 .mx_LinkPreviewWidget_description {

--- a/src/components/views/rooms/LinkPreviewWidget.tsx
+++ b/src/components/views/rooms/LinkPreviewWidget.tsx
@@ -139,8 +139,12 @@ export default class LinkPreviewWidget extends React.Component<IProps, IState> {
             <div className="mx_LinkPreviewWidget">
                 { img }
                 <div className="mx_LinkPreviewWidget_caption">
-                    <div className="mx_LinkPreviewWidget_title"><a href={this.props.link} target="_blank" rel="noreferrer noopener">{ p["og:title"] }</a></div>
-                    <div className="mx_LinkPreviewWidget_siteName">{ p["og:site_name"] ? (" - " + p["og:site_name"]) : null }</div>
+                    <div className="mx_LinkPreviewWidget_title">
+                        <a href={this.props.link} target="_blank" rel="noreferrer noopener">{ p["og:title"] }</a>
+                        { p["og:site_name"] && <span className="mx_LinkPreviewWidget_siteName">
+                            { (" - " + p["og:site_name"]) }
+                        </span> }
+                    </div>
                     <div className="mx_LinkPreviewWidget_description" ref={this.description}>
                         { description }
                     </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2403652/125088191-1d51a080-e0c5-11eb-861f-695b6519791d.png)

Brings the site-name back onto the title line rather than wrapping as my regression caused