### PR TITLE
Add alias and directory customisation points

### DIFF
--- a/res/css/views/elements/_ToggleSwitch.scss
+++ b/res/css/views/elements/_ToggleSwitch.scss
@@ -24,6 +24,8 @@ limitations under the License.
 
     background-color: $togglesw-off-color;
     opacity: 0.5;
+
+    cursor: unset;
 }
 
 .mx_ToggleSwitch_enabled {

--- a/res/css/views/elements/_ToggleSwitch.scss
+++ b/res/css/views/elements/_ToggleSwitch.scss
@@ -24,8 +24,6 @@ limitations under the License.
 
     background-color: $togglesw-off-color;
     opacity: 0.5;
-
-    cursor: unset;
 }
 
 .mx_ToggleSwitch_enabled {

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { Room } from "matrix-js-sdk/src/models/room";
 
 import { MatrixClientPeg } from './MatrixClientPeg';
+import AliasCustomisations from './customisations/Alias';
 
 /**
  * Given a room object, return the alias we should use for it,
@@ -36,6 +37,9 @@ export function getDisplayAliasForRoom(room: Room): string {
 // The various display alias getters all feed through this one path so there's a
 // single place to change the logic.
 export function getDisplayAliasForAliasSet(canonicalAlias: string, altAliases: string[]): string {
+    if (AliasCustomisations.getDisplayAliasForAliasSet) {
+        return AliasCustomisations.getDisplayAliasForAliasSet(canonicalAlias, altAliases);
+    }
     return canonicalAlias || altAliases?.[0];
 }
 

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -28,7 +28,15 @@ import { MatrixClientPeg } from './MatrixClientPeg';
  * @returns {string} A display alias for the given room
  */
 export function getDisplayAliasForRoom(room: Room): string {
-    return room.getCanonicalAlias() || room.getAltAliases()[0];
+    return getDisplayAliasForAliasSet(
+        room.getCanonicalAlias(), room.getAltAliases(),
+    );
+}
+
+// The various display alias getters all feed through this one path so there's a
+// single place to change the logic.
+export function getDisplayAliasForAliasSet(canonicalAlias: string, altAliases: string[]): string {
+    return canonicalAlias || altAliases?.[0];
 }
 
 export function looksLikeDirectMessageRoom(room: Room, myUserId: string): boolean {

--- a/src/Rooms.ts
+++ b/src/Rooms.ts
@@ -34,8 +34,8 @@ export function getDisplayAliasForRoom(room: Room): string {
     );
 }
 
-// The various display alias getters all feed through this one path so there's a
-// single place to change the logic.
+// The various display alias getters should all feed through this one path so
+// there's a single place to change the logic.
 export function getDisplayAliasForAliasSet(canonicalAlias: string, altAliases: string[]): string {
     if (AliasCustomisations.getDisplayAliasForAliasSet) {
         return AliasCustomisations.getDisplayAliasForAliasSet(canonicalAlias, altAliases);

--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -44,6 +44,7 @@ import NetworkDropdown from "../views/directory/NetworkDropdown";
 import ScrollPanel from "./ScrollPanel";
 import Spinner from "../views/elements/Spinner";
 import { ActionPayload } from "../../dispatcher/payloads";
+import { getDisplayAliasForAliasSet } from "../../Rooms";
 
 const MAX_NAME_LENGTH = 80;
 const MAX_TOPIC_LENGTH = 800;
@@ -854,5 +855,5 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
 // Similar to matrix-react-sdk's MatrixTools.getDisplayAliasForRoom
 // but works with the objects we get from the public room list
 function getDisplayAliasForRoom(room: IRoom) {
-    return room.canonical_alias || room.aliases?.[0] || "";
+    return getDisplayAliasForAliasSet(room.canonical_alias, room.aliases);
 }

--- a/src/components/structures/SpaceRoomDirectory.tsx
+++ b/src/components/structures/SpaceRoomDirectory.tsx
@@ -42,6 +42,7 @@ import { useStateToggle } from "../../hooks/useStateToggle";
 import { getChildOrder } from "../../stores/SpaceStore";
 import AccessibleTooltipButton from "../views/elements/AccessibleTooltipButton";
 import { linkifyElement } from "../../HtmlUtils";
+import { getDisplayAliasForAliasSet } from "../../Rooms";
 
 interface IHierarchyProps {
     space: Room;
@@ -666,5 +667,5 @@ export default SpaceRoomDirectory;
 // Similar to matrix-react-sdk's MatrixTools.getDisplayAliasForRoom
 // but works with the objects we get from the public room list
 function getDisplayAliasForRoom(room: ISpaceSummaryRoom) {
-    return room.canonical_alias || (room.aliases ? room.aliases[0] : "");
+    return getDisplayAliasForAliasSet(room.canonical_alias, room.aliases);
 }

--- a/src/components/views/room_settings/RoomPublishSetting.tsx
+++ b/src/components/views/room_settings/RoomPublishSetting.tsx
@@ -20,6 +20,7 @@ import LabelledToggleSwitch from "../elements/LabelledToggleSwitch";
 import { _t } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
+import DirectoryCustomisations from '../../../customisations/Directory';
 
 interface IProps {
     roomId: string;
@@ -66,10 +67,15 @@ export default class RoomPublishSetting extends React.PureComponent<IProps, ISta
     render() {
         const client = MatrixClientPeg.get();
 
+        const enabled = (
+            DirectoryCustomisations.requireCanonicalAliasAccessToPublish?.() === false ||
+            this.props.canSetCanonicalAlias
+        );
+
         return (
             <LabelledToggleSwitch value={this.state.isRoomPublished}
                 onChange={this.onRoomPublishChange}
-                disabled={!this.props.canSetCanonicalAlias}
+                disabled={!enabled}
                 label={_t("Publish this room to the public in %(domain)s's room directory?", {
                     domain: client.getDomain(),
                 })}

--- a/src/components/views/rooms/RoomDetailRow.js
+++ b/src/components/views/rooms/RoomDetailRow.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 New Vector Ltd.
+Copyright 2017-2021 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,9 +21,10 @@ import { linkifyElement } from '../../../HtmlUtils';
 import PropTypes from 'prop-types';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { mediaFromMxc } from "../../../customisations/Media";
+import { getDisplayAliasForAliasSet } from '../../../Rooms';
 
 export function getDisplayAliasForRoom(room) {
-    return room.canonicalAlias || (room.aliases ? room.aliases[0] : "");
+    return getDisplayAliasForAliasSet(room.canonicalAlias, room.aliases);
 }
 
 export const roomShape = PropTypes.shape({

--- a/src/customisations/Alias.ts
+++ b/src/customisations/Alias.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+function getDisplayAliasForAliasSet(canonicalAlias: string, altAliases: string[]): string {
+    // E.g. prefer one of the aliases over another
+    return null;
+}
+
+// This interface summarises all available customisation points and also marks
+// them all as optional. This allows customisers to only define and export the
+// customisations they need while still maintaining type safety.
+export interface IAliasCustomisations {
+    getDisplayAliasForAliasSet?: typeof getDisplayAliasForAliasSet;
+}
+
+// A real customisation module will define and export one or more of the
+// customisation points that make up `IAliasCustomisations`.
+export default {} as IAliasCustomisations;

--- a/src/customisations/Directory.ts
+++ b/src/customisations/Directory.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+function requireCanonicalAliasAccessToPublish(): boolean {
+    // Some environments may not care about this requirement and could return false
+    return true;
+}
+
+// This interface summarises all available customisation points and also marks
+// them all as optional. This allows customisers to only define and export the
+// customisations they need while still maintaining type safety.
+export interface IDirectoryCustomisations {
+    requireCanonicalAliasAccessToPublish?: typeof requireCanonicalAliasAccessToPublish;
+}
+
+// A real customisation module will define and export one or more of the
+// customisation points that make up `IDirectoryCustomisations`.
+export default {} as IDirectoryCustomisations;


### PR DESCRIPTION
These are useful for alternative environments, such as P2P, where alias and directory handling expectations are a bit different.