### PR TITLE
Make diff colors in codeblocks more pleasant

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -480,6 +480,11 @@ $hover-select-border: 4px;
         background-color: $header-panel-bg-color;
     }
 
+    pre code > * {
+        display: inline-block;
+        width: 100%;
+    }
+
     pre {
         // have to use overlay rather than auto otherwise Linux and Windows
         // Chrome gets very confused about vertical spacing:

--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -288,3 +288,11 @@ $composer-shadow-color: rgba(0, 0, 0, 0.28);
 .hljs-tag {
     color: inherit; // Without this they'd be weirdly blue which doesn't match the theme
 }
+
+.hljs-addition {
+    background: #1a4b59;
+}
+
+.hljs-deletion {
+    background: #53232a;
+}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17939#issuecomment-878141061

<hr>

#### Before:

![Screenshot_20210712_123422](https://user-images.githubusercontent.com/25768714/125273708-80ce0f00-e30d-11eb-98ac-60a41612c090.png)

#### After:

![Screenshot_20210712_165936](https://user-images.githubusercontent.com/25768714/125310086-9144b080-e332-11eb-98d4-90c2d92d56c1.png)

