### PR TITLE
Add VS Code to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ package-lock.json
 
 .DS_Store
 *.tmp
+
+.vscode
+.vscode/


### PR DESCRIPTION
We ignore both the directory and file since a symlink acts as a file and you might want to symlink a global config directory for all Element related projects