### PR TITLE
Reorder buttons in the Image View

### DIFF
--- a/src/components/views/elements/ImageView.tsx
+++ b/src/components/views/elements/ImageView.tsx
@@ -452,6 +452,8 @@ export default class ImageView extends React.Component<IProps, IState> {
                 <div className="mx_ImageView_panel">
                     { info }
                     <div className="mx_ImageView_toolbar">
+                        { zoomOutButton }
+                        { zoomInButton }
                         <AccessibleTooltipButton
                             className="mx_ImageView_button mx_ImageView_button_rotateCCW"
                             title={_t("Rotate Left")}
@@ -462,8 +464,6 @@ export default class ImageView extends React.Component<IProps, IState> {
                             title={_t("Rotate Right")}
                             onClick={this.onRotateClockwiseClick}>
                         </AccessibleTooltipButton>
-                        { zoomOutButton }
-                        { zoomInButton }
                         <AccessibleTooltipButton
                             className="mx_ImageView_button mx_ImageView_button_download"
                             title={_t("Download")}


### PR DESCRIPTION
![Screenshot_20210713_202958](https://user-images.githubusercontent.com/25768714/125505868-4acb928e-9f78-41b7-8b8c-4d701ae9e907.png)

The zoom buttons are shown based on the image size relative to the screen size. This means that without this change the rotation buttons could get replaced by the zoom buttons under your cursor which is pretty annoying 