### PR TITLE
Exclude state events from widgets reading room events

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -159,7 +159,7 @@ export class StopGapWidgetDriver extends WidgetDriver {
             if (results.length >= limit) break;
 
             const ev = events[i];
-            if (ev.getType() !== eventType) continue;
+            if (ev.getType() !== eventType || ev.isState()) continue;
             if (eventType === EventType.RoomMessage && msgtype && msgtype !== ev.getContent()['msgtype']) continue;
             results.push(ev);
         }


### PR DESCRIPTION
They can request state reading permissions to read state.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst#sign-off -->
