### PR TITLE
Add matrix: to the list of permitted URL schemes

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -58,7 +58,7 @@ const BIGEMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})+$`, 'i');
 
 const COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
-export const PERMITTED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'magnet'];
+export const PERMITTED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'magnet', 'matrix'];
 
 const MEDIA_API_MXC_REGEX = /\/_matrix\/media\/r0\/(?:download|thumbnail)\/(.+?)\/(.+?)(?:[?/]|$)/;
 


### PR DESCRIPTION
This PR doesn't linkify matrix: when written plain text in chat since linkifyjs doesn't allow custom protocols yet but it at least allows you to click on a message that was sent like `/html <a href="matrix:r/someroom:example.org">Join my room!</a>`

I think https://github.com/vector-im/element-web/issues/8720#issuecomment-640265465 should be revisited. Yes linkifyjs won't linkify schemes it doesn't support but when a scheme isn't on this list then even an explicit link using `<a>` will not work. It seems like Element should probably just allow all the same schemes that Firefox allows https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler.