### PR TITLE
Don't throw exception from setStickyRoom as it split-brains the RoomListStore

### DIFF
--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -124,7 +124,11 @@ export class Algorithm extends EventEmitter {
      * @param val The new room to sticky.
      */
     public setStickyRoom(val: Room) {
-        this.updateStickyRoom(val);
+        try {
+            this.updateStickyRoom(val);
+        } catch (e) {
+            console.warn("Failed to update sticky room", e);
+        }
     }
 
     public getTagSorting(tagId: TagID): SortAlgorithm {


### PR DESCRIPTION
Hilariously, prior to fixing the race conditions this just about worked as the throw was early enough that the state was updated by the other racing code.

Fixes https://github.com/vector-im/element-web/issues/18032