### PR TITLE
Rename Copy Link to Copy Room Link

### DIFF
--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -530,7 +530,7 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
                     ) : null}
                     <IconizedContextMenuOption
                         onClick={this.onCopyRoomClick}
-                        label={_t("Copy Link")}
+                        label={_t("Copy Room Link")}
                         iconClassName="mx_RoomTile_iconCopyLink"
                     />
                     <IconizedContextMenuOption

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1657,7 +1657,7 @@
     "Favourite": "Favourite",
     "Low Priority": "Low Priority",
     "Invite People": "Invite People",
-    "Copy Link": "Copy Link",
+    "Copy Room Link": "Copy Room Link",
     "Leave Room": "Leave Room",
     "Room options": "Room options",
     "%(count)s unread messages including mentions.|other": "%(count)s unread messages including mentions.",


### PR DESCRIPTION
Being explicit with the menu title is clearer when this context menu applies to DM rooms, to make it clear that the link will be to the room and not to the person

element-web notes: none