### PR TITLE
Render error state for audio components

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2601,6 +2601,7 @@
     "Use email to optionally be discoverable by existing contacts.": "Use email to optionally be discoverable by existing contacts.",
     "Sign in with SSO": "Sign in with SSO",
     "Unnamed audio": "Unnamed audio",
+    "Error downloading audio": "Error downloading audio",
     "Pause": "Pause",
     "Play": "Play",
     "Couldn't load page": "Couldn't load page",

--- a/src/voice/Playback.ts
+++ b/src/voice/Playback.ts
@@ -135,18 +135,23 @@ export class Playback extends EventEmitter implements IDestroyable {
         // Safari compat: promise API not supported on this function
         this.audioBuf = await new Promise((resolve, reject) => {
             this.context.decodeAudioData(this.buf, b => resolve(b), async e => {
-                // This error handler is largely for Safari as well, which doesn't support Opus/Ogg
-                // very well.
-                console.error("Error decoding recording: ", e);
-                console.warn("Trying to re-encode to WAV instead...");
+                try {
+                    // This error handler is largely for Safari as well, which doesn't support Opus/Ogg
+                    // very well.
+                    console.error("Error decoding recording: ", e);
+                    console.warn("Trying to re-encode to WAV instead...");
 
-                const wav = await decodeOgg(this.buf);
+                    const wav = await decodeOgg(this.buf);
 
-                // noinspection ES6MissingAwait - not needed when using callbacks
-                this.context.decodeAudioData(wav, b => resolve(b), e => {
-                    console.error("Still failed to decode recording: ", e);
+                    // noinspection ES6MissingAwait - not needed when using callbacks
+                    this.context.decodeAudioData(wav, b => resolve(b), e => {
+                        console.error("Still failed to decode recording: ", e);
+                        reject(e);
+                    });
+                } catch (e) {
+                    console.error("Caught decoding error:", e);
                     reject(e);
-                });
+                }
             });
         });
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17148

Both `AudioPlayer` and `RecordingPlayback` got a fragment added to their DOM structure, to incorporate the rarely seen error message below it. Additionally, a missing try/catch was added to the `Playback` class to handle uncaught decoding issues.

The similarity of the components is tracked in https://github.com/vector-im/element-web/issues/18161

![image](https://user-images.githubusercontent.com/1190097/126564614-3383f79a-cb82-44ee-be53-69a8752fa6ce.png)

(screenshot taken with https://github.com/matrix-org/matrix-react-sdk/pull/6432 's styles)
