### PR TITLE
Fix duration placeholder parsing for audio files

### DIFF
--- a/src/voice/PlaybackClock.ts
+++ b/src/voice/PlaybackClock.ts
@@ -103,8 +103,8 @@ export class PlaybackClock implements IDestroyable {
      * @param {MatrixEvent} event The event to use for placeholders.
      */
     public populatePlaceholdersFrom(event: MatrixEvent) {
-        const durationSeconds = Number(event.getContent()['info']?.['duration']);
-        if (Number.isFinite(durationSeconds)) this.placeholderDuration = durationSeconds;
+        const durationMs = Number(event.getContent()['info']?.['duration']);
+        if (Number.isFinite(durationMs)) this.placeholderDuration = durationMs / 1000;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18160

Turns out the spec is in milliseconds. We account for this on the sending side, but not receiving side.

----

Notes: Show the correct audio file duration while loading the file.