### PR TITLE
Fix event tile cut off in share preview

### DIFF
--- a/res/css/views/dialogs/_ForwardDialog.scss
+++ b/res/css/views/dialogs/_ForwardDialog.scss
@@ -36,6 +36,10 @@ limitations under the License.
         flex-shrink: 0;
         overflow-y: auto;
 
+        .mx_EventTile[data-layout=bubble] {
+            margin-top: 20px;
+        }
+
         div {
             pointer-events: none;
         }


### PR DESCRIPTION
Fixes vector-im/element-web#18127