### PR TITLE
Allow all of the URL schemes that Firefox allows

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -57,7 +57,10 @@ const BIGEMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})+$`, 'i');
 
 const COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
-export const PERMITTED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'magnet', 'matrix'];
+export const PERMITTED_URL_SCHEMES = ["bitcoin", "ftp", "geo", "http", "https", "im", "irc",
+                                     "ircs", "magnet", "mailto", "matrix", "mms", "news",
+                                     "nntp", "openpgp4fpr", "sip", "sftp", "sms", "smsto",
+                                     "ssh", "tel", "urn", "webcal", "wtai", "xmpp"];
 
 const MEDIA_API_MXC_REGEX = /\/_matrix\/media\/r0\/(?:download|thumbnail)\/(.+?)\/(.+?)(?:[?/]|$)/;
 


### PR DESCRIPTION
This PR allows users to click on links using any of the URL schemes that Firefox allows + ftp (which Element already allowed) and sftp. Using the same list as Firefox was chosen arbitrarily but if Firefox allows them then they are probably  safe enough to allow links to.

This PR implements what my comment in https://github.com/matrix-org/matrix-react-sdk/pull/6388 asked for

> I think vector-im/element-web#8720 (comment) should be revisited. Yes linkifyjs won't linkify schemes it doesn't support but when a scheme isn't on this list then even an explicit link using <a> will not work. It seems like Element should probably just allow all the same schemes that Firefox allows https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler.

