### PR TITLE
Make inline events feel less claustrophobic in bubble layout

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -221,6 +221,7 @@ limitations under the License.
         display: flex;
         align-items: center;
         justify-content: center;
+        padding: 5px 0;
 
         .mx_EventTile_avatar {
             position: static;
@@ -287,7 +288,7 @@ limitations under the License.
     & + .mx_EventListSummary {
         .mx_EventTile {
             margin-top: 0;
-            padding: 0;
+            padding: 2px 0;
         }
     }
 


### PR DESCRIPTION
Fixes vector-im/element-web#18126

<img width="697" alt="Screen Shot 2021-07-23 at 12 39 26" src="https://user-images.githubusercontent.com/769871/126771017-b400d8f2-e052-49c6-902d-8f900ec6016e.png">
