### PR TITLE
Make new reply UI clickable

### DIFF
--- a/res/css/views/rooms/_ReplyTile.scss
+++ b/res/css/views/rooms/_ReplyTile.scss
@@ -60,8 +60,6 @@ limitations under the License.
         $reply-lines: 2;
         $line-height: $font-22px;
 
-        pointer-events: none;
-
         text-overflow: ellipsis;
         display: -webkit-box;
         -webkit-box-orient: vertical;


### PR DESCRIPTION
Fixes vector-im/element-web#18017

This changes makes the reply content clickable. If hitting a link within a reply, a user would be moved to the new location. For anything else, the user would be moved to the parent event in the Element's timeline