### PR TITLE
Fix broken layout of the space hierarchy view

### DIFF
--- a/res/css/structures/_SpaceRoomDirectory.scss
+++ b/res/css/structures/_SpaceRoomDirectory.scss
@@ -190,7 +190,6 @@ limitations under the License.
         position: relative;
         padding: 8px 16px;
         border-radius: 8px;
-        min-height: 56px;
         box-sizing: border-box;
 
         display: grid;


### PR DESCRIPTION
Not sure what this min-height was trying to achieve but removing it prevents the grid layout collapsing on itself

Notes: none

Fixes https://github.com/vector-im/element-web/issues/18250

![image](https://user-images.githubusercontent.com/2403652/127151264-fe2fc1fa-b1c5-4871-9796-d4611aed76b9.png)
