### PR TITLE
Fix call crashing because `element` was undefined

### DIFF
--- a/src/components/views/voip/VideoFeed.tsx
+++ b/src/components/views/voip/VideoFeed.tsx
@@ -80,7 +80,10 @@ export default class VideoFeed extends React.Component<IProps, IState> {
     }
 
     private setElementRef = (element: HTMLVideoElement): void => {
-        if (!element) element.removeEventListener('resize', this.onResize);
+        if (!element) {
+            this.element?.removeEventListener('resize', this.onResize);
+            return;
+        }
 
         this.element = element;
         element.addEventListener('resize', this.onResize);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18270