### PR TITLE
Fix inconsistent styling for links on hover

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -459,8 +459,14 @@ $hover-select-border: 4px;
 
 /* Various markdown overrides */
 
-.mx_EventTile_body pre {
-    border: 1px solid transparent;
+.mx_EventTile_body {
+    a:hover {
+        text-decoration: underline;
+    }
+
+    pre {
+        border: 1px solid transparent;
+    }
 }
 
 .mx_EventTile_content .markdown-body {


### PR DESCRIPTION
Signed-off-by: Jano Garcia <jano@janogarcia.com>

Notes:

Fix the inconsistent styling between non-markdown and markdown parsed links on hover.

It also improves accessibility by not relying exclusively on color for the hover state. That is even more evident for links that are contained within a parent block link (e.g., a quoted message block linking to the source message).

https://webaim.org/techniques/hypertext/link_text#underlining

