### PR TITLE
Fix symbol entry in the in-call dialpad

### DIFF
--- a/res/css/views/voip/_DialPadContextMenu.scss
+++ b/res/css/views/voip/_DialPadContextMenu.scss
@@ -69,7 +69,6 @@ limitations under the License.
     overflow: hidden;
     max-width: 185px;
     text-align: left;
-    direction: rtl;
     padding: 8px 0px;
     background-color: rgb(0, 0, 0, 0);
 }


### PR DESCRIPTION
The field had RTL direction set on it, which meant symbols like `*` appeared at the beginning of the field instead of the end.

RTL was introduced in https://github.com/matrix-org/matrix-react-sdk/pull/5786, however its removal seems to have had no adverse affects from testing (and I'm not currently sure why it was necessary).

Before:
![before-rtl](https://user-images.githubusercontent.com/1342360/127693904-79366fdd-8d78-4515-82e2-49e1b876ef7e.gif)

After:
![Peek 2021-07-30 18-42](https://user-images.githubusercontent.com/1342360/127693898-ebb0f651-7fb0-437b-bab0-f08dd05e970a.gif)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

Notes: Fix confusing results when entering the `*` character while using the in-call dial pad.

`Signed-off-by: Andrew Morgan <andrewm@element.io>`
