### PR TITLE
Prevent backspace and delete functionality in the in-call dial pad.

### DIFF
--- a/src/components/views/context_menus/DialpadContextMenu.tsx
+++ b/src/components/views/context_menus/DialpadContextMenu.tsx
@@ -49,6 +49,13 @@ export default class DialpadContextMenu extends React.Component<IProps, IState> 
         this.props.onFinished();
     };
 
+    onKeyDown = (ev) => {
+        // Prevent Backspace and Delete keys from functioning in the entry field
+        if (ev.code === "Backspace" || ev.code === "Delete") {
+            ev.preventDefault();
+        }
+    };
+
     onChange = (ev) => {
         this.setState({ value: ev.target.value });
     };
@@ -64,6 +71,7 @@ export default class DialpadContextMenu extends React.Component<IProps, IState> 
                         className="mx_DialPadContextMenu_dialled"
                         value={this.state.value}
                         autoFocus={true}
+                        onKeyDown={this.onKeyDown}
                         onChange={this.onChange}
                     />
                 </div>


### PR DESCRIPTION
This PR prevents the backspace and delete keyboard keys from functioning in the in-call dial pad dialog text field.

Just as one cannot do when there inputting number while on a call on their phone, it doesn't make much sense to be able to do so while on a call in Element. The DTMF tone history should be preserved.

This essentially lines up with the lack of backspace UI button that appear on the in-call dial pad.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

Notes: Prevent backspace and delete functionality in the in-call dial pad.

`Signed-off-by: Andrew Morgan <andrewm@element.io>`