### PR TITLE
Start a call immediately after creating a room via the dial pad

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -914,6 +914,8 @@ export default class CallHandler extends EventEmitter {
             action: 'view_room',
             room_id: roomId,
         });
+
+        this.placeCall(roomId, PlaceCallType.Voice, null);
     }
 
     private async startTransferToPhoneNumber(call: MatrixCall, destination: string, consultFirst: boolean) {


### PR DESCRIPTION
This PR simply starts a call in the DM that's created/found when dialing someone via the dial pad (if your client has that enabled).

Otherwise currently it simply just shows the room. The user then needs to click the Video or Voice call button, which is a little confusing.

I've gone with starting a voice call here by default, but we may want to alter that flow to allow the user to choose...

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

Note: Immediately start a call after dialing a user via the dial pad.

`Signed-off-by: Andrew Morgan <andrewm@element.io>`