### PR TITLE
Update muting in calls to work with the js-sdk call upgrade changes 

### DIFF
--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -214,6 +214,8 @@ export default class CallView extends React.Component<IProps, IState> {
         this.setState({
             primaryFeed: primary,
             secondaryFeeds: secondary,
+            micMuted: this.props.call.isMicrophoneMuted(),
+            vidMuted: this.props.call.isLocalVideoMuted(),
         });
     };
 
@@ -258,18 +260,14 @@ export default class CallView extends React.Component<IProps, IState> {
         return { primary, secondary };
     }
 
-    private onMicMuteClick = (): void => {
+    private onMicMuteClick = async (): Promise<void> => {
         const newVal = !this.state.micMuted;
-
-        this.props.call.setMicrophoneMuted(newVal);
-        this.setState({ micMuted: newVal });
+        this.setState({ micMuted: await this.props.call.setMicrophoneMuted(newVal) });
     };
 
-    private onVidMuteClick = (): void => {
+    private onVidMuteClick = async (): Promise<void> => {
         const newVal = !this.state.vidMuted;
-
-        this.props.call.setLocalVideoMuted(newVal);
-        this.setState({ vidMuted: newVal });
+        this.setState({ vidMuted: await this.props.call.setLocalVideoMuted(newVal) });
     };
 
     private onScreenshareClick = async (): Promise<void> => {


### PR DESCRIPTION
Type: task
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/1827**

<hr>

This is **not** call upgrade support

<hr>

Since design is busy with other stuff I've decided to land call upgrade support in the js-sdk without support in Element. Once this lands we can experiment with call upgrades in group calls and similar things

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://6146cf49d86da16b8d552342--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
