### PR TITLE
Null guard space inviter to prevent the app exploding

### DIFF
--- a/src/components/structures/SpaceRoomView.tsx
+++ b/src/components/structures/SpaceRoomView.tsx
@@ -192,11 +192,11 @@ const SpacePreview = ({ space, onJoinButtonClicked, onRejectButtonClicked }) => 
 
         if (inviteSender) {
             inviterSection = <div className="mx_SpaceRoomView_preview_inviter">
-                <MemberAvatar member={inviter} width={32} height={32} />
+                <MemberAvatar member={inviter} fallbackUserId={inviteSender} width={32} height={32} />
                 <div>
                     <div className="mx_SpaceRoomView_preview_inviter_name">
                         { _t("<inviter/> invites you", {}, {
-                            inviter: () => <b>{ inviter.name || inviteSender }</b>,
+                            inviter: () => <b>{ inviter?.name || inviteSender }</b>,
                         }) }
                     </div>
                     { inviter ? <div className="mx_SpaceRoomView_preview_inviter_mxid">


### PR DESCRIPTION
Prevents 

```
2021-08-05T09:16:51.817Z E i is null
inviter@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:881170
v@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:86062
_/r<@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:85201
_@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:85217
ee@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:881128
na@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2781934
Gs@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2834370
wc@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2821384
yc@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2821312
Ec@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2821173
hc@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2818160
zo/<@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2767829
t.unstable_runWithPriority@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2851014
Vo@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2767606
zo@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2767776
Ho@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2767709
sc@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2815537
enqueueSetState@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2771683
f.prototype.setState@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2842554
viewRoom/<@https://app.element.io/bundles/3b75e5617009d13d08af/vendors~init.js:2:2568196
```
