### PR TITLE
Fix [object Object] in Widget Permissions

### DIFF
--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -62,10 +62,10 @@ export default class AppPermission extends React.Component<IProps, IState> {
 
         // Set all this into the initial state
         this.state = {
-            ...urlInfo,
-            roomMember,
-            isWrapped: null,
             widgetDomain: null,
+            isWrapped: null,
+            roomMember,
+            ...urlInfo,
         };
     }
 


### PR DESCRIPTION
Due to two-step translations we could sometimes end up in a case where
instead of a string we'd get a React Node wrapper, which tried being
translated for the second time. This commit solves this problem by
verifying if we have passed both Tags and Variables.

Fixes https://github.com/vector-im/element-web/issues/18384

Attaching a screenshot of current behavior with the fix: 
![CleanShot 2021-08-05 at 14 33 58](https://user-images.githubusercontent.com/3636685/128351387-50ad0d7f-c6b6-4e5e-802b-af00412c382a.png)
