### PR TITLE
Use a GitHub action to build the Netlify preview build

### DIFF
--- a/.github/workflows/layered-build.yaml
+++ b/.github/workflows/layered-build.yaml
@@ -1,0 +1,19 @@
+name: Layered Preview Build
+on:
+    pull_request:
+        branches: [develop]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Build
+              run: scripts/ci/layered.sh && cd element-web && cp element.io/develop/config.json config.json && CI_PACKAGE=true yarn build
+            - name: Upload Artifact
+              uses: actions/upload-artifact@v2
+              with:
+                  name: Preview Build
+                  path: element-web/webapp
+                  # We'll only use this in a triggered job, then we're done with it
+                  retention-days: 1
+

--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -1,0 +1,32 @@
+name: Upload Preview Build to Netlify
+on:
+    workflow_run:
+        workflows: ["Layered Preview Build"]
+        types:
+            - completed
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        if: >
+            ${{ github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.conclusion == 'success' }}
+        steps:
+            - name: Download Artifact
+              uses: actions/download-artifact@v2
+              with:
+                  name: "Preview Build"
+            - name: Deploy to Netlify
+              uses: nwtgck/actions-netlify@v1.2
+              with:
+                  publish-dir: .
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  alias: deploy-preview-${{ github.event.number }}
+                  deploy-message: "Deploy from GitHub Actions"
+                  enable-pull-request-comment: true
+                  enable-commit-comment: false
+                  overwrites-pull-request-comment: true
+              env:
+                  NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+                  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+              timeout-minutes: 1
+


### PR DESCRIPTION
So we don't need netflify to sit there building the develop branch
for no reason. Also it will comment with the URL rather than having
to dig it out of the checks.

Turns out the way to do this is to have a separate action that runs with the secrets and just downloads an artifact and shoves it back up to netlify.

Upload part not tested yet.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
