### PR TITLE
Fade Call View Buttons after `componentDidMount`

### DIFF
--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -153,6 +153,7 @@ export default class CallView extends React.Component<IProps, IState> {
     public componentDidMount() {
         this.dispatcherRef = dis.register(this.onAction);
         document.addEventListener('keydown', this.onNativeKeyDown);
+        this.showControls();
     }
 
     public componentWillUnmount() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18439