### PR TITLE
Do the PR comment a different way

### DIFF
--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -35,16 +35,24 @@ jobs:
                   fs.writeFileSync('${{github.workspace}}/previewbuild.zip', Buffer.from(download.data));
             - run: unzip previewbuild.zip && rm previewbuild.zip
             - name: Deploy to Netlify
+              id: netlify
               uses: nwtgck/actions-netlify@v1.2
               with:
                   publish-dir: .
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   deploy-message: "Deploy from GitHub Actions"
-                  enable-pull-request-comment: true
+                  # These don't work because we're in workflow_run
+                  enable-pull-request-comment: false
                   enable-commit-comment: false
-                  overwrites-pull-request-comment: true
               env:
                   NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
                   NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
               timeout-minutes: 1
+            - name: Comment on PR
+              uses: phulsechinmay/rewritable-pr-comment@v0.3.0
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  ISSUE_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+                  message: |
+                      Preview: ${{ steps.netlify.deploy-url }}
+                      ⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
 


### PR DESCRIPTION
Because the built in netlify action's way doesn't work in workflow_run

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
