### PR TITLE
Make loading encrypted images look snappier

### DIFF
--- a/res/css/_animations.scss
+++ b/res/css/_animations.scss
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * React Transition Group animations are prefixed with 'mx_rtg--' so that we
+ * know they should not be used anywhere outside of React Transition Groups.
+*/
+
+.mx_rtg--fade {
+    &-enter {
+        opacity: 0;
+        &-active {
+            opacity: 1;
+            transition: opacity 300ms ease;
+        }
+    }
+    &-exit {
+        opacity: 1;
+        &-active {
+            opacity: 0;
+            transition: opacity 300ms ease;
+        }
+    }
+}
+
+
+@keyframes mx--anim-pulse {
+    0% { opacity: 1; }
+    50% { opacity: 0.7; }
+    100% { opacity: 1; }
+}
+
+
+@media (prefers-reduced-motion) {
+    @keyframes mx--anim-pulse {
+        // Override all keyframes in reduced-motion
+    }
+    .mx_rtg--fade-enter-active {
+        transition: none;
+    }
+    .mx_rtg--fade-exit-active {
+        transition: none;
+    }
+}

--- a/res/css/_animations.scss
+++ b/res/css/_animations.scss
@@ -19,21 +19,19 @@ limitations under the License.
  * know they should not be used anywhere outside of React Transition Groups.
 */
 
-.mx_rtg--fade {
-    &-enter {
-        opacity: 0;
-        &-active {
-            opacity: 1;
-            transition: opacity 300ms ease;
-        }
-    }
-    &-exit {
-        opacity: 1;
-        &-active {
-            opacity: 0;
-            transition: opacity 300ms ease;
-        }
-    }
+.mx_rtg--fade-enter {
+    opacity: 0;
+}
+.mx_rtg--fade-enter-active {
+    opacity: 1;
+    transition: opacity 300ms ease;
+}
+.mx_rtg--fade-exit {
+    opacity: 1;
+}
+.mx_rtg--fade-exit-active {
+    opacity: 0;
+    transition: opacity 300ms ease;
 }
 
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -18,6 +18,7 @@ limitations under the License.
 
 @import "./_font-sizes.scss";
 @import "./_font-weights.scss";
+@import "./_animations.scss";
 
 $hover-transition: 0.08s cubic-bezier(.46, .03, .52, .96); // quadratic
 

--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -16,6 +16,12 @@ limitations under the License.
 
 $timelineImageBorderRadius: 4px;
 
+.mx_MImageBody_thumbnail--blurhash {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
 .mx_MImageBody_thumbnail {
     object-fit: contain;
     border-radius: $timelineImageBorderRadius;
@@ -23,8 +29,11 @@ $timelineImageBorderRadius: 4px;
     display: flex;
     justify-content: center;
     align-items: center;
+    height: 100%;
+    width: 100%;
 
-    > div > canvas {
+    .mx_Blurhash > canvas {
+        animation: mx--anim-pulse 1.75s infinite cubic-bezier(.4, 0, .6, 1);
         border-radius: $timelineImageBorderRadius;
     }
 }

--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -393,6 +393,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
                         key={`img-${showPlaceholder}`}
                         timeout={300}
                     >
+                        { /* This weirdly looking div is necessary here, otherwise SwitchTransition fails */ }
                         <div>
                             { showPlaceholder && <div
                                 className={classes}


### PR DESCRIPTION
Adds proper react css transition to encrypted images placeholders, so that we can animate it's entrance and exit properly.

In addition, adds simple css animations file to properly handle all of the animations in one place, so that it's much easier to properly handle prefers-reduced-motion media query.

Fixes https://github.com/vector-im/element-web/issues/17878
Fixes https://github.com/vector-im/element-web/issues/17862 (we don't care about this anymore as of new design guidelines)