### PR TITLE
Use the mimetype from the info property rather than the EncryptedFile

### DIFF
--- a/src/customisations/models/IMediaEventContent.ts
+++ b/src/customisations/models/IMediaEventContent.ts
@@ -31,18 +31,26 @@ export interface IEncryptedFile {
     v: string;
 }
 
-export interface IMediaEventContent {
-    body?: string;
-    url?: string; // required on unencrypted media
-    file?: IEncryptedFile; // required for *encrypted* media
-    info?: {
-        thumbnail_url?: string; // eslint-disable-line camelcase
-        thumbnail_file?: IEncryptedFile; // eslint-disable-line camelcase
+export interface IMediaEventInfo {
+    thumbnail_url?: string; // eslint-disable-line camelcase
+    thumbnail_file?: IEncryptedFile; // eslint-disable-line camelcase
+    thumbnail_info?: { // eslint-disable-line camelcase
         mimetype: string;
         w?: number;
         h?: number;
         size?: number;
     };
+    mimetype: string;
+    w?: number;
+    h?: number;
+    size?: number;
+}
+
+export interface IMediaEventContent {
+    body?: string;
+    url?: string; // required on unencrypted media
+    file?: IEncryptedFile; // required for *encrypted* media
+    info?: IMediaEventInfo;
 }
 
 export interface IPreparedMedia extends IMediaObject {

--- a/src/utils/DecryptFile.ts
+++ b/src/utils/DecryptFile.ts
@@ -31,7 +31,7 @@ import { getBlobSafeMimeType } from "./blobs";
  */
 export function decryptFile(
     file: IEncryptedFile,
-    info: IMediaEventInfo | undefined,
+    info?: IMediaEventInfo,
 ): Promise<Blob> {
     const media = mediaFromContent({ file });
     // Download the encrypted file as an array buffer.

--- a/src/utils/DecryptFile.ts
+++ b/src/utils/DecryptFile.ts
@@ -17,18 +17,22 @@ limitations under the License.
 // Pull in the encryption lib so that we can decrypt attachments.
 import encrypt from 'browser-encrypt-attachment';
 import { mediaFromContent } from "../customisations/Media";
-import { IEncryptedFile } from "../customisations/models/IMediaEventContent";
+import { IEncryptedFile, IMediaEventInfo } from "../customisations/models/IMediaEventContent";
 import { getBlobSafeMimeType } from "./blobs";
 
 /**
  * Decrypt a file attached to a matrix event.
- * @param {IEncryptedFile} file The json taken from the matrix event.
+ * @param {IEncryptedFile} file The encrypted file information taken from the matrix event.
  *   This passed to [link]{@link https://github.com/matrix-org/browser-encrypt-attachments}
  *   as the encryption info object, so will also have the those keys in addition to
  *   the keys below.
+ * @param {IMediaEventInfo} info The info parameter taken from the matrix event.
  * @returns {Promise<Blob>} Resolves to a Blob of the file.
  */
-export function decryptFile(file: IEncryptedFile): Promise<Blob> {
+export function decryptFile(
+    file: IEncryptedFile,
+    info: IMediaEventInfo | undefined,
+): Promise<Blob> {
     const media = mediaFromContent({ file });
     // Download the encrypted file as an array buffer.
     return media.downloadSource().then((response) => {
@@ -44,7 +48,7 @@ export function decryptFile(file: IEncryptedFile): Promise<Blob> {
         // they introduce XSS attacks if the Blob URI is viewed directly in the
         // browser (e.g. by copying the URI into a new tab or window.)
         // See warning at top of file.
-        let mimetype = file.mimetype ? file.mimetype.split(";")[0].trim() : '';
+        let mimetype = info?.mimetype ? info.mimetype.split(";")[0].trim() : '';
         mimetype = getBlobSafeMimeType(mimetype);
 
         return new Blob([dataArray], { type: mimetype });

--- a/src/utils/MediaEventHelper.ts
+++ b/src/utils/MediaEventHelper.ts
@@ -76,7 +76,8 @@ export class MediaEventHelper implements IDestroyable {
 
     private fetchSource = () => {
         if (this.media.isEncrypted) {
-            return decryptFile(this.event.getContent<IMediaEventContent>().file);
+            const content = this.event.getContent<IMediaEventContent>();
+            return decryptFile(content.file, content.info);
         }
         return this.media.downloadSource().then(r => r.blob());
     };
@@ -87,7 +88,7 @@ export class MediaEventHelper implements IDestroyable {
         if (this.media.isEncrypted) {
             const content = this.event.getContent<IMediaEventContent>();
             if (content.info?.thumbnail_file) {
-                return decryptFile(content.info.thumbnail_file);
+                return decryptFile(content.info.thumbnail_file, content.info.thumbnail_info);
             } else {
                 // "Should never happen"
                 console.warn("Media claims to have thumbnail and is encrypted, but no thumbnail_file found");


### PR DESCRIPTION
The mimetype in EncryptedFile is undocumented and redundant.
See https://github.com/matrix-org/matrix-doc/pull/2582

Note: this only affects receiving events, and does not change sending the event, so it does *not* fix issue vector-im/element-web#17145