### PR TITLE
Don't set hidden RRs labs setting at account level

### DIFF
--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.js
@@ -79,7 +79,7 @@ export default class LabsUserSettingsTab extends React.Component {
             let hiddenReadReceipts;
             if (this.state.showHiddenReadReceipts) {
                 hiddenReadReceipts = (
-                    <SettingsFlag name="feature_hidden_read_receipts" level={SettingLevel.ACCOUNT} />
+                    <SettingsFlag name="feature_hidden_read_receipts" level={SettingLevel.DEVICE} />
                 );
             }
 


### PR DESCRIPTION
Not doing this will result in the setting not being settable making it quite useless 

Notes: none
Type: defect