### PR TITLE
Don't call `showControls()` which was moved

### DIFF
--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -135,7 +135,6 @@ export default class CallView extends React.Component<IProps, IState> {
     public componentDidMount() {
         this.dispatcherRef = dis.register(this.onAction);
         document.addEventListener('keydown', this.onNativeKeyDown);
-        this.showControls();
     }
 
     public componentWillUnmount() {


### PR DESCRIPTION
Notes: none
Type: defect