### PR TITLE
Fix Netflify builds from fork PRs

### DIFF
--- a/.github/workflows/layered-build.yaml
+++ b/.github/workflows/layered-build.yaml
@@ -16,4 +16,16 @@ jobs:
                   path: element-web/webapp
                   # We'll only use this in a triggered job, then we're done with it
                   retention-days: 1
+            - uses: actions/github-script@v3.1.0
+              with:
+                script: |
+                    var fs = require('fs');
+                    fs.writeFileSync('${{github.workspace}}/context.json', JSON.stringify(context));
+            - name: Upload Context
+              uses: actions/upload-artifact@v2
+              with:
+                  name: context.json
+                  path: context.json
+                  # We'll only use this in a triggered job, then we're done with it
+                  retention-days: 1
 

--- a/.github/workflows/layered-build.yaml
+++ b/.github/workflows/layered-build.yaml
@@ -20,12 +20,12 @@ jobs:
               with:
                 script: |
                     var fs = require('fs');
-                    fs.writeFileSync('${{github.workspace}}/context.json', JSON.stringify(context));
-            - name: Upload Context
+                    fs.writeFileSync('${{github.workspace}}/pr.json', JSON.stringify(context.payload.pull_request));
+            - name: Upload PR Info
               uses: actions/upload-artifact@v2
               with:
-                  name: context.json
-                  path: context.json
+                  name: pr.json
+                  path: pr.json
                   # We'll only use this in a triggered job, then we're done with it
                   retention-days: 1
 

--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -59,7 +59,7 @@ jobs:
               id: netlify
               uses: nwtgck/actions-netlify@v1.2
               with:
-                  publish-dir: .
+                  publish-dir: webapp
                   deploy-message: "Deploy from GitHub Actions"
                   # These don't work because we're in workflow_run
                   enable-pull-request-comment: false

--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -34,27 +34,27 @@ jobs:
                   var fs = require('fs');
                   fs.writeFileSync('${{github.workspace}}/previewbuild.zip', Buffer.from(download.data));
 
-                  var contextArtifact = artifacts.data.artifacts.filter((artifact) => {
-                    return artifact.name == "context.json"
+                  var prInfoArtifact = artifacts.data.artifacts.filter((artifact) => {
+                    return artifact.name == "pr.json"
                   })[0];
                   var download = await github.actions.downloadArtifact({
                      owner: context.repo.owner,
                      repo: context.repo.repo,
-                     artifact_id: contextArtifact.id,
+                     artifact_id: prInfoArtifact.id,
                      archive_format: 'zip',
                   });
                   var fs = require('fs');
-                  fs.writeFileSync('${{github.workspace}}/context.json.zip', Buffer.from(download.data));
+                  fs.writeFileSync('${{github.workspace}}/pr.json.zip', Buffer.from(download.data));
             - name: Extract Artifacts
-              run: unzip -d webapp previewbuild.zip && rm previewbuild.zip && unzip context.json && rm context.json.zip
-            - name: 'Read Context'
+              run: unzip -d webapp previewbuild.zip && rm previewbuild.zip && unzip pr.json.zip && rm pr.json.zip
+            - name: 'Read PR Info'
               id: readctx
               uses: actions/github-script@v3.1.0
               with:
                 script: |
                     var fs = require('fs');
-                    var ctx = JSON.parse(fs.readFileSync('${{github.workspace}}/context.json'));
-                    console.log(`::set-output name=prnumber::${ctx.payload.pull_request.number}`);
+                    var pr = JSON.parse(fs.readFileSync('${{github.workspace}}/pr.json'));
+                    console.log(`::set-output name=prnumber::${pr.number}`);
             - name: Deploy to Netlify
               id: netlify
               uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -33,7 +33,28 @@ jobs:
                   });
                   var fs = require('fs');
                   fs.writeFileSync('${{github.workspace}}/previewbuild.zip', Buffer.from(download.data));
-            - run: unzip previewbuild.zip && rm previewbuild.zip
+
+                  var contextArtifact = artifacts.data.artifacts.filter((artifact) => {
+                    return artifact.name == "context.json"
+                  })[0];
+                  var download = await github.actions.downloadArtifact({
+                     owner: context.repo.owner,
+                     repo: context.repo.repo,
+                     artifact_id: contextArtifact.id,
+                     archive_format: 'zip',
+                  });
+                  var fs = require('fs');
+                  fs.writeFileSync('${{github.workspace}}/context.json.zip', Buffer.from(download.data));
+            - name: Extract Artifacts
+              run: unzip -d webapp previewbuild.zip && rm previewbuild.zip && unzip context.json && rm context.json.zip
+            - name: 'Read Context'
+              id: readctx
+              uses: actions/github-script@v3.1.0
+              with:
+                script: |
+                    var fs = require('fs');
+                    var ctx = JSON.parse(fs.readFileSync('${{github.workspace}}/context.json'));
+                    console.log(`::set-output name=prnumber::${ctx.payload.pull_request.number}`);
             - name: Deploy to Netlify
               id: netlify
               uses: nwtgck/actions-netlify@v1.2
@@ -51,7 +72,7 @@ jobs:
               uses: phulsechinmay/rewritable-pr-comment@v0.3.0
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ISSUE_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+                  ISSUE_ID: ${{ steps.readctx.outputs.prnumber }}
                   message: |
                       Preview: ${{ steps.netlify.outputs.deploy-url }}
                       ⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.


### PR DESCRIPTION
Some absolutely horrenous hacks to upload the context as an artifact
then download it, unzip it and set the PR number as a variable we can
use, because GitHub Actions just doesn't offer any other way of doing
this.

Maybe we'd be better off going back to Netlify...

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
