### PR TITLE
Edit PR Description instead of commenting 

### DIFF
--- a/.github/workflows/netflify.yaml
+++ b/.github/workflows/netflify.yaml
@@ -68,12 +68,13 @@ jobs:
                   NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
                   NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
               timeout-minutes: 1
-            - name: Comment on PR
-              uses: phulsechinmay/rewritable-pr-comment@v0.3.0
-              with:
+            - name: Edit PR Description
+              uses: velas/pr-description@v1.0.1
+              env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ISSUE_ID: ${{ steps.readctx.outputs.prnumber }}
-                  message: |
+              with:
+                  pull-request-number: ${{ steps.readctx.outputs.prnumber }}
+                  description-message: |
                       Preview: ${{ steps.netlify.outputs.deploy-url }}
                       ⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
 


### PR DESCRIPTION
We could include the magic comments in the PR template so the various
automated comments were always in the same order, if we wanted.

Based on https://github.com/matrix-org/matrix-react-sdk/pull/6599

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->