### PR TITLE
Format autocomplete suggestions vertically

### DIFF
--- a/res/css/views/rooms/_Autocomplete.scss
+++ b/res/css/views/rooms/_Autocomplete.scss
@@ -60,7 +60,7 @@
 .mx_Autocomplete_Completion_container_pill {
     margin: 12px;
     display: flex;
-    flex-flow: wrap;
+    flex-direction: column;
 }
 
 .mx_Autocomplete_Completion_container_truncate {
@@ -68,7 +68,6 @@
     .mx_Autocomplete_Completion_subtitle,
     .mx_Autocomplete_Completion_description {
         /* Ellipsis for long names/subtitles/descriptions */
-        max-width: 150px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
Type: enhancement
Fixes https://github.com/vector-im/element-web/issues/17574

<hr>

![Screenshot_20210816_101524](https://user-images.githubusercontent.com/25768714/129533003-3e4cd58e-f13a-43cc-97d9-29f8b3d4faf0.png)

<hr>

With https://github.com/matrix-org/matrix-react-sdk/pull/5659 merged we can't navigate the autocomplete with tab anymore and <kbd>Up</kbd> and <kbd>Down</kbd> are the only way. It is confusing for the users that they have to use these keys while the autocomplete has the suggestions listed in a horizontal manner. Therefore this PR changes that into showing the suggestions vertically. 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Format autocomplete suggestions vertically ([\#6620](https://github.com/matrix-org/matrix-react-sdk/pull/6620)). Fixes vector-im/element-web#17574. Contributed by [SimonBrandner](https://github.com/SimonBrandner).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://611a2073056e6a028f1cab8e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
