### PR TITLE
better telegram gif/sticker handling

### DIFF
--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -240,6 +240,8 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         let width = null;
         let poster = null;
         let preload = "metadata";
+        let loop = false;
+        let controls = true;
         if (content.info) {
             const scale = this.thumbScale(content.info.w, content.info.h);
             if (scale) {
@@ -251,6 +253,12 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
                 poster = thumbUrl;
                 preload = "none";
             }
+            if (content.info["fi.mau.loop"] == true){
+                loop = true;
+            }
+            if (content.info["fi.mau.hide_controls"] == true){
+                controls = false;
+            }
         }
         return (
             <span className="mx_MVideoBody">
@@ -259,13 +267,20 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
                     ref={this.videoRef}
                     src={contentUrl}
                     title={content.body}
-                    controls
+                    controls={controls}
+                    loop={loop}
                     preload={preload}
                     muted={autoplay}
                     autoPlay={autoplay}
                     height={height}
                     width={width}
                     poster={poster}
+                    onMouseOver={!autoplay && !controls ? event => (event.target as HTMLVideoElement).play() : () => { }}
+                    onMouseOut={!autoplay && !controls ?
+                        event => {
+                            (event.target as HTMLVideoElement).pause();
+                            (event.target as HTMLVideoElement).currentTime = 0;
+                        } : () => { }}
                     onPlay={this.videoOnPlay}
                 />
                 { this.props.tileShape && <MFileBody {...this.props} showGenericPlaceholder={false} /> }


### PR DESCRIPTION
Respects tg bridge info fields to loop and hide the video player
controls. If autoplay is disabled it plays on hover instead.

Flags can be seen i.e. here: https://github.com/mautrix/telegram/commit/64107fab177ac7a31f811fa5f2409230b020bcbe


<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * better telegram gif/sticker handling ([\#6642](https://github.com/matrix-org/matrix-react-sdk/pull/6642)). Contributed by [Bubu](https://github.com/Bubu).<!-- CHANGELOG_PREVIEW_END -->