### PR TITLE
Fix resizer for detaching

### DIFF
--- a/src/resizer/resizer.ts
+++ b/src/resizer/resizer.ts
@@ -84,7 +84,7 @@ export default class Resizer<C extends IConfig = IConfig> {
     }
 
     public detach() {
-        const attachment = this?.config?.handler.parentElement ?? this.container;
+        const attachment = this?.config?.handler?.parentElement ?? this.container;
         attachment.removeEventListener("mousedown", this.onMouseDown, false);
         window.removeEventListener("resize", this.onResize);
     }


### PR DESCRIPTION
FIxes case where the app crashes when hiding pinned widget.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->