### PR TITLE
Add ESLint shared settings to detect React version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,11 @@ module.exports = {
             "@typescript-eslint/ban-ts-comment": "off",
         },
     }],
+    settings: {
+        react: {
+            version: "detect",
+        }
+    }
 };
 
 function buildRestrictedPropertiesOptions(properties, message) {


### PR DESCRIPTION
When running `yarn lint` we would have the following output

```
~/dev/element/matrix-react-sdk develop
❯ yarn lint
yarn run v1.22.10
$ yarn lint:types && yarn lint:js && yarn lint:style
$ tsc --noEmit --jsx react
$ eslint --max-warnings 0 src test
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```

Looking at the [eslint-plugin-react#configuration](https://github.com/yannickcr/eslint-plugin-react#configuration) page, we can see that we should set some ESLint shared settings to automatically detect the installed React version (17.x in our case).
Their example shows a lot more shared settings that do not apply to us as the project does not use any of the tooling it refers to (mobx, pragma, flow, styled-components, ...)

This PR will erase that `Warning:` in the log output

