### PR TITLE
Add basic support for attachments (as per MSC2881)

### DIFF
--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -434,7 +434,7 @@ export default class ContentMessages {
 
     async sendContentListToRoom(
         files: File[], roomId: string, matrixClient: MatrixClient,
-        attachToMessage?: (ISendEventResponse) => Promise<any>
+        attachToMessage?: (ISendEventResponse) => Promise<any>,
     ) {
         if (matrixClient.isGuest()) {
             dis.dispatch({ action: 'require_registration' });
@@ -535,9 +535,11 @@ export default class ContentMessages {
         }
     }
 
-    private sendContentToRoom(file: File, roomId: string, matrixClient: MatrixClient, promBefore: Promise<any>, attachment: boolean) {
+    private sendContentToRoom(
+        file: File, roomId: string, matrixClient: MatrixClient, promBefore: Promise<any>, attachment: boolean,
+    ) {
         const startTime = CountlyAnalytics.getTimestamp();
-        let content: IContent = {
+        const content: IContent = {
             body: file.name || 'Attachment',
             info: {
                 size: file.size,

--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -430,7 +430,7 @@ export default class ContentMessages {
         }
     }
 
-    async sendContentListToRoom(files: File[], roomId: string, matrixClient: MatrixClient) {
+    async sendContentListToRoom(files: File[], roomId: string, matrixClient: MatrixClient, promAfter?: (ISendEventResponse) => Promise<any>) {
         if (matrixClient.isGuest()) {
             dis.dispatch({ action: 'require_registration' });
             return;
@@ -508,6 +508,7 @@ export default class ContentMessages {
             }
             promBefore = this.sendContentToRoom(file, roomId, matrixClient, promBefore);
         }
+        promBefore.then(promAfter);
     }
 
     getCurrentUploads() {

--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -66,6 +66,7 @@ interface IContent {
     };
     file?: string;
     url?: string;
+    // eslint-disable-next-line camelcase
     is_attachment?: boolean;
 }
 
@@ -431,7 +432,10 @@ export default class ContentMessages {
         }
     }
 
-    async sendContentListToRoom(files: File[], roomId: string, matrixClient: MatrixClient, attachToMessage?: (ISendEventResponse) => Promise<any>) {
+    async sendContentListToRoom(
+        files: File[], roomId: string, matrixClient: MatrixClient,
+        attachToMessage?: (ISendEventResponse) => Promise<any>
+    ) {
         if (matrixClient.isGuest()) {
             dis.dispatch({ action: 'require_registration' });
             return;
@@ -541,8 +545,9 @@ export default class ContentMessages {
             msgtype: "", // set later
         };
 
-        if (attachment)
+        if (attachment) {
             content.is_attachment = true;
+        }
 
         // if we have a mime type for the file, add it to the message metadata
         if (file.type) {

--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -39,6 +39,7 @@ import {
 import { IUpload } from "./models/IUpload";
 import { IAbortablePromise, IImageInfo } from "matrix-js-sdk/src/@types/partials";
 import { BlurhashEncoder } from "./BlurhashEncoder";
+import SettingsStore from "./settings/SettingsStore";
 
 const MAX_WIDTH = 800;
 const MAX_HEIGHT = 600;
@@ -442,7 +443,7 @@ export default class ContentMessages {
         }
 
         const isQuoting = Boolean(RoomViewStore.getQuotingEvent());
-        if (isQuoting) {
+        if (isQuoting && !SettingsStore.getValue("feature_message_attachments")) {
             // FIXME: Using an import will result in Element crashing
             const QuestionDialog = sdk.getComponent("dialogs.QuestionDialog");
             const { finished } = Modal.createTrackedDialog<[boolean]>('Upload Reply Warning', '', QuestionDialog, {

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -753,9 +753,11 @@ export default class RoomView extends React.Component<IProps, IState> {
                     payload.data.description || payload.data.name);
                 break;
             case 'picture_snapshot':
-                let promAfter = SettingsStore.getValue("feature_message_attachments") && this.messageComposer && !this.messageComposer.state.isComposerEmpty ? (event: ISendEventResponse) => {
-                    return this.messageComposer.sendMessage(event.event_id);
-                } : null
+                const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
+                    && !this.messageComposer.state.isComposerEmpty) ?
+                    (event: ISendEventResponse) => {
+                        return this.messageComposer.sendMessage(event.event_id);
+                    } : null;
                 ContentMessages.sharedInstance().sendContentListToRoom(
                     [payload.file], this.state.room.roomId, this.context, promAfter,
                 );
@@ -1251,9 +1253,11 @@ export default class RoomView extends React.Component<IProps, IState> {
     private onDrop = ev => {
         ev.stopPropagation();
         ev.preventDefault();
-        let promAfter = SettingsStore.getValue("feature_message_attachments") && this.messageComposer && ev.dataTransfer.files.length === 1 && !this.messageComposer.state.isComposerEmpty ? (event: ISendEventResponse) => {
-            return this.messageComposer.sendMessage(event.event_id);
-        } : null
+        let promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
+            && ev.dataTransfer.files.length === 1 && !this.messageComposer.state.isComposerEmpty) ?
+            (event: ISendEventResponse) => {
+                return this.messageComposer.sendMessage(event.event_id);
+            } : null
         ContentMessages.sharedInstance().sendContentListToRoom(
             ev.dataTransfer.files, this.state.room.roomId, this.context, promAfter,
         );

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -754,7 +754,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                 break;
             case 'picture_snapshot': {
                 const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
-                    && !this.messageComposer.state.isComposerEmpty) ?
+                    && (!this.messageComposer.state.isComposerEmpty || this.messageComposer.props.replyToEvent)) ?
                     (event: ISendEventResponse) => {
                         return this.messageComposer.sendMessage(event.event_id);
                     } : null;
@@ -1255,7 +1255,8 @@ export default class RoomView extends React.Component<IProps, IState> {
         ev.stopPropagation();
         ev.preventDefault();
         const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
-            && ev.dataTransfer.files.length === 1 && !this.messageComposer.state.isComposerEmpty) ?
+            && ev.dataTransfer.files.length === 1
+            && (!this.messageComposer.state.isComposerEmpty || this.messageComposer.props.replyToEvent)) ?
             (event: ISendEventResponse) => {
                 return this.messageComposer.sendMessage(event.event_id);
             } : null;

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -752,7 +752,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                     payload.data.content.info,
                     payload.data.description || payload.data.name);
                 break;
-            case 'picture_snapshot':
+            case 'picture_snapshot': {
                 const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
                     && !this.messageComposer.state.isComposerEmpty) ?
                     (event: ISendEventResponse) => {
@@ -762,6 +762,7 @@ export default class RoomView extends React.Component<IProps, IState> {
                     [payload.file], this.state.room.roomId, this.context, promAfter,
                 );
                 break;
+            }
             case 'notifier_enabled':
             case Action.UploadStarted:
             case Action.UploadFinished:
@@ -1253,11 +1254,11 @@ export default class RoomView extends React.Component<IProps, IState> {
     private onDrop = ev => {
         ev.stopPropagation();
         ev.preventDefault();
-        let promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
+        const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.messageComposer
             && ev.dataTransfer.files.length === 1 && !this.messageComposer.state.isComposerEmpty) ?
             (event: ISendEventResponse) => {
                 return this.messageComposer.sendMessage(event.event_id);
-            } : null
+            } : null;
         ContentMessages.sharedInstance().sendContentListToRoom(
             ev.dataTransfer.files, this.state.room.roomId, this.context, promAfter,
         );

--- a/src/components/views/messages/MessageEvent.tsx
+++ b/src/components/views/messages/MessageEvent.tsx
@@ -137,7 +137,7 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
 
         let attachment = null;
         if (SettingsStore.getValue("feature_message_attachments")) {
-            if (this.props.mxEvent.isRelation("m.attachment")) {
+            if (this.props.mxEvent.isRelation("org.matrix.msc2881.m.attachment")) {
                 const relation = this.props.mxEvent.getRelation();
                 if (this.room && relation && relation.event_id) {
                     const event = this.room.findEventById(relation.event_id);

--- a/src/components/views/messages/MessageEvent.tsx
+++ b/src/components/views/messages/MessageEvent.tsx
@@ -134,13 +134,13 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
                 }
             }
         }
-        
+
         let attachment = null;
         if (SettingsStore.getValue("feature_message_attachments")) {
             if (this.props.mxEvent.isRelation("m.attachment")) {
-                let relation = this.props.mxEvent.getRelation();
+                const relation = this.props.mxEvent.getRelation();
                 if (this.room && relation && relation.event_id) {
-                    let event = this.room.findEventById(relation.event_id);
+                    const event = this.room.findEventById(relation.event_id);
                     if (event) {
                         attachment = (
                             <MessageEvent
@@ -162,7 +162,7 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
         }
 
         // @ts-ignore - this is a dynamic react component
-        let body = BodyType ? <BodyType
+        const body = BodyType ? <BodyType
             ref={this.body}
             mxEvent={this.props.mxEvent}
             highlights={this.props.highlights}

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1210,7 +1210,7 @@ export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean) {
         return hasText(e, showHiddenEvents);
     } else if (handler === 'messages.RoomCreate') {
         return Boolean(e.getContent()['predecessor']);
-    } else if (SettingsStore.getValue("feature_message_attachments") && e.getContent()['is_attachment']) {
+    } else if (SettingsStore.getValue("feature_message_attachments") && e.getContent().is_attachment) {
         return false;
     } else {
         return true;

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -55,6 +55,7 @@ import ReadReceiptMarker from "./ReadReceiptMarker";
 import MessageActionBar from "../messages/MessageActionBar";
 import ReactionsRow from '../messages/ReactionsRow';
 import { getEventDisplayInfo } from '../../../utils/EventUtils';
+import SettingsStore from "../../../settings/SettingsStore";
 
 const eventTileTypes = {
     [EventType.RoomMessage]: 'messages.MessageEvent',
@@ -1209,6 +1210,8 @@ export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean) {
         return hasText(e, showHiddenEvents);
     } else if (handler === 'messages.RoomCreate') {
         return Boolean(e.getContent()['predecessor']);
+    } else if (SettingsStore.getValue("feature_message_attachments") && e.getContent()['is_attachment']) {
+        return false;
     } else {
         return true;
     }

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -150,7 +150,8 @@ class UploadButton extends React.Component<IUploadButtonProps> {
         }
 
         const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.props.composer
-            && ev.target.files.length === 1 && !this.props.composer.state.isComposerEmpty) ?
+            && ev.target.files.length === 1
+            && (!this.props.composer.state.isComposerEmpty || this.props.composer.props.replyToEvent)) ?
             (event: ISendEventResponse) => {
                 return this.props.composer.sendMessage(event.event_id);
             } : null;

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -148,10 +148,12 @@ class UploadButton extends React.Component<IUploadButtonProps> {
         for (let i = 0; i < ev.target.files.length; ++i) {
             tfiles.push(ev.target.files[i]);
         }
-        
-        let promAfter = SettingsStore.getValue("feature_message_attachments") && this.props.composer && ev.target.files.length === 1 && !this.props.composer.state.isComposerEmpty ? (event: ISendEventResponse) => {
-            return this.props.composer.sendMessage(event.event_id);
-        } : null;
+
+        const promAfter = (SettingsStore.getValue("feature_message_attachments") && this.props.composer
+            && ev.target.files.length === 1 && !this.props.composer.state.isComposerEmpty) ?
+            (event: ISendEventResponse) => {
+                return this.props.composer.sendMessage(event.event_id);
+            } : null;
 
         ContentMessages.sharedInstance().sendContentListToRoom(
             tfiles, this.props.roomId, MatrixClientPeg.get(), promAfter,

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -83,7 +83,7 @@ function addAttachmentToMessageContent(
         'm.relates_to': {
             'rel_type': 'm.attachment',
             'event_id': attachEventId,
-        }
+        },
     };
     Object.assign(content, attachContent);
 }
@@ -118,7 +118,7 @@ export function createMessageContent(
     if (replyToEvent) {
         addReplyToMessageContent(content, replyToEvent, permalinkCreator);
     }
-    
+
     if (attachEventId) {
         addAttachmentToMessageContent(content, attachEventId);
     }
@@ -422,7 +422,9 @@ export default class SendMessageComposer extends React.Component<IProps> {
             const startTime = CountlyAnalytics.getTimestamp();
             const { roomId } = this.props.room;
             if (!content) {
-                content = createMessageContent(this.model, this.props.permalinkCreator, replyToEvent, attachmentEventId);
+                content = createMessageContent(
+                    this.model, this.props.permalinkCreator, replyToEvent, attachmentEventId,
+                );
             }
             // don't bother sending an empty message
             if (!content.body.trim()) return;
@@ -541,9 +543,11 @@ export default class SendMessageComposer extends React.Component<IProps> {
         // We check text/rtf instead of text/plain as when copy+pasting a file from Finder or Gnome Image Viewer
         // it puts the filename in as text/plain which we want to ignore.
         if (clipboardData.files.length && !clipboardData.types.includes("text/rtf")) {
-            let promAfter = SettingsStore.getValue("feature_message_attachments") && clipboardData.files.length === 1 && !this.model.isEmpty ? (event: ISendEventResponse) => {
-                return this.sendMessage(event.event_id);
-            } : null;
+            const promAfter = (SettingsStore.getValue("feature_message_attachents")
+                && clipboardData.files.length === 1 && !this.model.isEmpty) ?
+                (event: ISendEventResponse) => {
+                    return this.sendMessage(event.event_id);
+                } : null;
             ContentMessages.sharedInstance().sendContentListToRoom(
                 Array.from(clipboardData.files), this.props.room.roomId, this.context, promAfter,
             );

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -81,7 +81,7 @@ function addAttachmentToMessageContent(
 ): void {
     const attachContent = {
         'm.relates_to': {
-            'rel_type': 'm.attachment',
+            'rel_type': 'org.matrix.msc2881.m.attachment',
             'event_id': attachEventId,
         },
     };

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -819,6 +819,7 @@
     "Show message previews for reactions in all rooms": "Show message previews for reactions in all rooms",
     "Offline encrypted messaging using dehydrated devices": "Offline encrypted messaging using dehydrated devices",
     "Send pseudonymous analytics data": "Send pseudonymous analytics data",
+    "Message attachments": "Message attachments",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
     "New layout switcher (with message bubbles)": "New layout switcher (with message bubbles)",
     "Don't send read receipts": "Don't send read receipts",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -276,6 +276,12 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: false,
         controller: new PseudonymousAnalyticsController(),
     },
+    "feature_message_attachments": {
+        isFeature: true,
+        supportedLevels: LEVELS_FEATURE,
+        displayName: _td('Message attachments'),
+        default: false,
+    },
     "doNotDisturb": {
         supportedLevels: [SettingLevel.DEVICE],
         default: false,


### PR DESCRIPTION
Type: enhancement

See https://github.com/matrix-org/matrix-doc/pull/2881/

Ideally, m.relates_to needs to be an array for multiple attachments to work, and to implement file/image replies properly, but that would require way more changes (including in Synapse) to make all relations code work with arrays. Currently, I just show "In reply to" without the message actually being a reply.

In this implementation, if any text is already in the composer during upload, files get sent as an attachment (and after they finish uploading, text gets sent immediately). Naturally, a better UI will be needed.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add basic support for attachments (as per MSC2881) ([\#6683](https://github.com/matrix-org/matrix-react-sdk/pull/6683)). Contributed by @chayleaf.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://612723cb1e11b2602d882f7e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
