### PR TITLE
Fix client forgetting which capabilities a widget was approved for

### DIFF
--- a/src/components/views/dialogs/WidgetCapabilitiesPromptDialog.tsx
+++ b/src/components/views/dialogs/WidgetCapabilitiesPromptDialog.tsx
@@ -31,14 +31,6 @@ import LabelledToggleSwitch from "../elements/LabelledToggleSwitch";
 import { CapabilityText } from "../../../widgets/CapabilityText";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 
-export function getRememberedCapabilitiesForWidget(widget: Widget): Capability[] {
-    return JSON.parse(localStorage.getItem(`widget_${widget.id}_approved_caps`) || "[]");
-}
-
-function setRememberedCapabilitiesForWidget(widget: Widget, caps: Capability[]) {
-    localStorage.setItem(`widget_${widget.id}_approved_caps`, JSON.stringify(caps));
-}
-
 interface IProps extends IDialogProps {
     requestedCapabilities: Set<Capability>;
     widget: Widget;
@@ -95,10 +87,7 @@ export default class WidgetCapabilitiesPromptDialog extends React.PureComponent<
     };
 
     private closeAndTryRemember(approved: Capability[]) {
-        if (this.state.rememberSelection) {
-            setRememberedCapabilitiesForWidget(this.props.widget, approved);
-        }
-        this.props.onFinished({ approved });
+        this.props.onFinished({ approved, remember: this.state.rememberSelection });
     }
 
     public render() {

--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -33,9 +33,7 @@ import { MatrixClientPeg } from "../../MatrixClientPeg";
 import ActiveRoomObserver from "../../ActiveRoomObserver";
 import Modal from "../../Modal";
 import WidgetOpenIDPermissionsDialog from "../../components/views/dialogs/WidgetOpenIDPermissionsDialog";
-import WidgetCapabilitiesPromptDialog, {
-    getRememberedCapabilitiesForWidget,
-} from "../../components/views/dialogs/WidgetCapabilitiesPromptDialog";
+import WidgetCapabilitiesPromptDialog from "../../components/views/dialogs/WidgetCapabilitiesPromptDialog";
 import { WidgetPermissionCustomisations } from "../../customisations/WidgetPermissions";
 import { OIDCState, WidgetPermissionStore } from "./WidgetPermissionStore";
 import { WidgetType } from "../../widgets/WidgetType";
@@ -47,6 +45,14 @@ import { tryTransformPermalinkToLocalHref } from "../../utils/permalinks/Permali
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 
 // TODO: Purge this from the universe
+
+function getRememberedCapabilitiesForWidget(widget: Widget): Capability[] {
+    return JSON.parse(localStorage.getItem(`widget_${widget.id}_approved_caps`) || "[]");
+}
+
+function setRememberedCapabilitiesForWidget(widget: Widget, caps: Capability[]) {
+    localStorage.setItem(`widget_${widget.id}_approved_caps`, JSON.stringify(caps));
+}
 
 export class StopGapWidgetDriver extends WidgetDriver {
     private allowedCapabilities: Set<Capability>;
@@ -100,6 +106,7 @@ export class StopGapWidgetDriver extends WidgetDriver {
             }
         }
         // TODO: Do something when the widget requests new capabilities not yet asked for
+        let rememberApproved = false;
         if (missing.size > 0) {
             try {
                 const [result] = await Modal.createTrackedDialog(
@@ -111,12 +118,19 @@ export class StopGapWidgetDriver extends WidgetDriver {
                         widgetKind: this.forWidgetKind,
                     }).finished;
                 (result.approved || []).forEach(cap => allowedSoFar.add(cap));
+                rememberApproved = result.remember;
             } catch (e) {
                 console.error("Non-fatal error getting capabilities: ", e);
             }
         }
 
-        return new Set(iterableUnion(allowedSoFar, requested));
+        const allAllowed = new Set(iterableUnion(allowedSoFar, requested));
+
+        if (rememberApproved) {
+            setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allAllowed));
+        }
+
+        return allAllowed;
     }
 
     public async sendEvent(eventType: string, content: any, stateKey: string = null): Promise<ISendEventDetails> {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18786

Instead of replacing the remembered set, we now add to it. This should be safe as the user expectation was previously to remember the capabilities, so we can keep appending to that list.

This commit also moves the utility functions closer to the widget driver as they aren't needed in the dialog anymore.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix client forgetting which capabilities a widget was approved for ([\#6685](https://github.com/matrix-org/matrix-react-sdk/pull/6685)). Fixes vector-im/element-web#18786 and vector-im/element-web#18786.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://612719fc3503ac605cf42cac--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
