### PR TITLE
Fix commit edit history

### DIFF
--- a/res/css/structures/_ScrollPanel.scss
+++ b/res/css/structures/_ScrollPanel.scss
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 .mx_ScrollPanel {
-    contain: strict;
-
     .mx_RoomView_MessageList {
         position: relative;
         display: flex;


### PR DESCRIPTION
Fix https://github.com/vector-im/element-web/issues/18742

This PR fixes improper `contain` css for an element it shouldn't have; it was previously added as an experiment of mine in a different PR I took over, but it's no longer necessary after the top-level DOM tree refactor.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://6127928485c8ca2c286046b3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
