### PR TITLE
[Release] Fix commit edit history

### DIFF
--- a/res/css/structures/_ScrollPanel.scss
+++ b/res/css/structures/_ScrollPanel.scss
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 .mx_ScrollPanel {
-    contain: strict;
-
     .mx_RoomView_MessageList {
         position: relative;
         display: flex;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18742
Original PR: #6644

This PR fixes improper `contain` css for an element it shouldn't have; it was previously added as an experiment of mine in a different PR I took over, but it's no longer necessary after the top-level DOM tree refactor.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * [Release] Fix commit edit history ([\#6690](https://github.com/matrix-org/matrix-react-sdk/pull/6690)). Fixes vector-im/element-web#18742. Contributed by [Palid](https://github.com/Palid).<!-- CHANGELOG_PREVIEW_END -->