### PR TITLE
Fix changelog link colour back to blue

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -381,11 +381,6 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
     font-size: $font-14px;
     color: $primary-content;
     word-wrap: break-word;
-
-    a {
-        color: $accent-color;
-        cursor: pointer;
-    }
 }
 
 .mx_Dialog_buttons {

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -149,10 +149,12 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
                         "To avoid these issues, create a <a>new encrypted room</a> for " +
                         "the conversation you plan to have.",
                         null,
-                        { "a": (sub) => <a onClick={() => {
-                            dialog.close();
-                            this.createNewRoom(false, true);
-                        }}> { sub } </a> },
+                        { "a": (sub) => <a
+                            className="mx_linkButton"
+                            onClick={() => {
+                                dialog.close();
+                                this.createNewRoom(false, true);
+                            }}> { sub } </a> },
                     ) } </p>
                 </div>,
 
@@ -248,10 +250,12 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
                         "you plan to have.",
                         null,
                         {
-                            "a": (sub) => <a onClick={() => {
-                                dialog.close();
-                                this.createNewRoom(true, false);
-                            }}> { sub } </a>,
+                            "a": (sub) => <a
+                                className="mx_linkButton"
+                                onClick={() => {
+                                    dialog.close();
+                                    this.createNewRoom(true, false);
+                                }}> { sub } </a>,
                         },
                     ) } </p>
                 </div>,


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/5698 changed all dialog links to green, which is not expected. In general, we use blue links for information and green links for actions.

This resolves the regression by removing the general change and adjusting the new links added by the above PR to be green as desired there.

Fixes https://github.com/vector-im/element-web/issues/18726

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix changelog link colour back to blue ([\#6692](https://github.com/matrix-org/matrix-react-sdk/pull/6692)). Fixes vector-im/element-web#18726.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://612791f2ee86e22ed267d6b9--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
