### PR TITLE
Render guest settings only in public rooms/spaces

### DIFF
--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -616,6 +616,22 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
             historySection = null;
         }
 
+        let advanced;
+        if (this.state.joinRule === JoinRule.Public) {
+            advanced = (
+                <>
+                    <AccessibleButton
+                        onClick={this.toggleAdvancedSection}
+                        kind="link"
+                        className="mx_SettingsTab_showAdvanced"
+                    >
+                        { this.state.showAdvancedSection ? _t("Hide advanced") : _t("Show advanced") }
+                    </AccessibleButton>
+                    { this.state.showAdvancedSection && this.renderAdvanced() }
+                </>
+            );
+        }
+
         return (
             <div className="mx_SettingsTab mx_SecurityRoomSettingsTab">
                 <div className="mx_SettingsTab_heading">{ _t("Security & Privacy") }</div>
@@ -641,15 +657,7 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
                     { this.renderJoinRule() }
                 </div>
 
-                <AccessibleButton
-                    onClick={this.toggleAdvancedSection}
-                    kind="link"
-                    className="mx_SettingsTab_showAdvanced"
-                >
-                    { this.state.showAdvancedSection ? _t("Hide advanced") : _t("Show advanced") }
-                </AccessibleButton>
-                { this.state.showAdvancedSection && this.renderAdvanced() }
-
+                { advanced }
                 { historySection }
             </div>
         );

--- a/src/components/views/spaces/SpaceSettingsVisibilityTab.tsx
+++ b/src/components/views/spaces/SpaceSettingsVisibilityTab.tsx
@@ -94,30 +94,32 @@ const SpaceSettingsVisibilityTab = ({ matrixClient: cli, space }: IProps) => {
     const canonicalAliasEv = space.currentState.getStateEvents(EventType.RoomCanonicalAlias, "");
 
     let advancedSection;
-    if (showAdvancedSection) {
-        advancedSection = <>
-            <AccessibleButton onClick={toggleAdvancedSection} kind="link" className="mx_SettingsTab_showAdvanced">
-                { _t("Hide advanced") }
-            </AccessibleButton>
+    if (visibility === SpaceVisibility.Unlisted) {
+        if (showAdvancedSection) {
+            advancedSection = <>
+                <AccessibleButton onClick={toggleAdvancedSection} kind="link" className="mx_SettingsTab_showAdvanced">
+                    { _t("Hide advanced") }
+                </AccessibleButton>
 
-            <LabelledToggleSwitch
-                value={guestAccessEnabled}
-                onChange={setGuestAccessEnabled}
-                disabled={!canSetGuestAccess}
-                label={_t("Enable guest access")}
-            />
-            <p>
-                { _t("Guests can join a space without having an account.") }
-                <br />
-                { _t("This may be useful for public spaces.") }
-            </p>
-        </>;
-    } else {
-        advancedSection = <>
-            <AccessibleButton onClick={toggleAdvancedSection} kind="link" className="mx_SettingsTab_showAdvanced">
-                { _t("Show advanced") }
-            </AccessibleButton>
-        </>;
+                <LabelledToggleSwitch
+                    value={guestAccessEnabled}
+                    onChange={setGuestAccessEnabled}
+                    disabled={!canSetGuestAccess}
+                    label={_t("Enable guest access")}
+                />
+                <p>
+                    { _t("Guests can join a space without having an account.") }
+                    <br />
+                    { _t("This may be useful for public spaces.") }
+                </p>
+            </>;
+        } else {
+            advancedSection = <>
+                <AccessibleButton onClick={toggleAdvancedSection} kind="link" className="mx_SettingsTab_showAdvanced">
+                    { _t("Show advanced") }
+                </AccessibleButton>
+            </>;
+        }
     }
 
     let addressesSection;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18776
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Render guest settings only in public rooms/spaces ([\#6693](https://github.com/matrix-org/matrix-react-sdk/pull/6693)). Fixes vector-im/element-web#18776. Contributed by [SimonBrandner](https://github.com/SimonBrandner).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6127b70b9331d1134e06bff3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
