### PR TITLE
Always trigger the first amplitude capture from the worklet

### DIFF
--- a/src/audio/RecorderWorklet.ts
+++ b/src/audio/RecorderWorklet.ts
@@ -45,7 +45,13 @@ class MxVoiceWorklet extends AudioWorkletProcessor {
 
     process(inputs, outputs, parameters) {
         const currentSecond = roundTimeToTargetFreq(currentTime);
-        if (currentSecond === this.nextAmplitudeSecond) {
+        // We special case the first ping because there's a fairly good chance that we'll miss the zeroth
+        // update. Firefox for instance takes 0.06 seconds (roughly) to call this function for the first
+        // time. Edge and Chrome occasionally lag behind too, but for the most part are on time.
+        //
+        // When this doesn't work properly we end up producing a waveform of nulls and no live preview
+        // of the recorded message.
+        if (currentSecond === this.nextAmplitudeSecond || this.nextAmplitudeSecond === 0) {
             // We're expecting exactly one mono input source, so just grab the very first frame of
             // samples for the analysis.
             const monoChan = inputs[0][0];


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18587

See diff.

----

Notes: Fix improper voice messages being produced in Firefox and sometimes other browsers.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix improper voice messages being produced in Firefox and sometimes other browsers. ([\#6696](https://github.com/matrix-org/matrix-react-sdk/pull/6696)). Fixes vector-im/element-web#18587.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61280cf01b0c490be1ee79c4--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
