### PR TITLE
Don't show a double stacked invite modals when inviting to Spaces

### DIFF
--- a/src/components/views/spaces/SpacePublicShare.tsx
+++ b/src/components/views/spaces/SpacePublicShare.tsx
@@ -54,8 +54,8 @@ const SpacePublicShare = ({ space, onFinished }: IProps) => {
         { space.canInvite(MatrixClientPeg.get()?.getUserId()) ? <AccessibleButton
             className="mx_SpacePublicShare_inviteButton"
             onClick={() => {
-                showRoomInviteDialog(space.roomId);
                 if (onFinished) onFinished();
+                showRoomInviteDialog(space.roomId);
             }}
         >
             <h3>{ _t("Invite people") }</h3>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18745
Type: defect

<hr>

https://user-images.githubusercontent.com/25768714/131093469-2447f930-15b8-4f26-91a1-18a5fb0dc462.mp4



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't show a double stacked invite modals when inviting to Spaces ([\#6698](https://github.com/matrix-org/matrix-react-sdk/pull/6698)). Fixes vector-im/element-web#18745. Contributed by [SimonBrandner](https://github.com/SimonBrandner).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61289bebc5a191825a876450--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
