### PR TITLE
Moce reactions in IRC layouts to the right

### DIFF
--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -116,10 +116,56 @@ $irc-line-height: $font-18px;
         .mx_EditMessageComposer_buttons {
             position: relative;
         }
+    }
+
+    // Reactions are not in bubble messages
+    .mx_EventTile:not(.mx_EventTile_bubbleContainer):not(.mx_EventTile_leftAlignedBubble) {
+        .mx_EventTile_content {
+            margin-right: 0.5em;
+        }
+
+        .mx_EventTile_line {
+            display: grid;
+            justify-content: space-between;
+            // First column: all content, take as much width as possible
+            // Second column: Minimum 2 reactions, 18px (icon) 1.1em (number as text) 14px (padding and border) 2px (gap)
+            // Use auto-fit to collapse if the second column is empty (no reaction), and give place for event line
+            grid-template-columns: minmax(0, auto) repeat(auto-fit, minmax(calc(2 * (18px + 1.1em + 14px + 2px)), 1fr));
+            // Repeat 5 rows to ensure reactions span all rows.
+            // Assume there's no more than 5 element in the message.
+            grid-template-rows: repeat(5, min-content);
+
+            > *:not(.mx_ReactionsRow) {
+                grid-column: 1;
+            }
+
+            > .mx_ReactionsRow {
+                grid-row: 1/-1;
+                grid-column: 2;
+            }
+        }
 
         .mx_ReactionsRow {
+            align-self: start;
+
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2px;
+
             padding-left: 0;
             padding-right: 0;
+
+            justify-content: flex-end;
+        }
+
+        .mx_ReactionsRowButton {
+            margin: 0;
+        }
+
+        .mx_ReactionsRow_addReactionButton {
+            // Reactions are just below the action bar
+            // So the "add reaction" is redundant here
+            display: none;
         }
     }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/297578/131233196-d24aa721-4292-4e02-94b4-8b7d580d80e9.png)
After:
![image](https://user-images.githubusercontent.com/297578/131233230-d1b740fb-94c7-40e9-80fb-69dfed16f4db.png)

Better showcase:
![image](https://user-images.githubusercontent.com/297578/131233366-6e3f555b-c859-4c53-aff6-a82b09e989d5.png)


I hope I tested all event line cases:
- Bubbles (not touched, like calls or special events)
- Images
- Videos
- Replies
- ?

I honestly would like to submit this for the main layout, but:
- I am not an UX designer
- I don't know how it feels to have a lot of space between text and reactions for normal people
- I am not an UX designer, again

Anyway, feel free to review. Especially the `grid-template-columns` that took me so long to get well.

Signed-off-by: Adrien CLERC <bugs-github@antipoul.fr>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Notes: Reactions in IRC layout are displayed at the message right for even more compact text lines.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Reactions in IRC layout are displayed at the message right for even more compact text lines. ([\#6706](https://github.com/matrix-org/matrix-react-sdk/pull/6706)). Contributed by @Glandos.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://612b8c09db24b07543075dc0--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
