### PR TITLE
Replace eventIsReply util with replyEventId getter

### DIFF
--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -136,6 +136,7 @@ export default class ThreadView extends React.Component<IProps, IState> {
                 <MessageComposer
                     room={this.props.room}
                     resizeNotifier={this.props.resizeNotifier}
+                    replyInThread={true}
                     replyToEvent={this.state?.thread?.replyToEvent}
                     showReplyPreview={false}
                     permalinkCreator={this.props.permalinkCreator}

--- a/src/components/views/elements/ReplyThread.tsx
+++ b/src/components/views/elements/ReplyThread.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { _t } from '../../../languageHandler';
 import dis from '../../../dispatcher/dispatcher';
 import { MatrixEvent } from 'matrix-js-sdk/src/models/event';
+import { UNSTABLE_ELEMENT_REPLY_IN_THREAD } from "matrix-js-sdk/src/@types/event";
 import { makeUserPermalink, RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
 import SettingsStore from "../../../settings/SettingsStore";
 import { Layout } from "../../../settings/Layout";
@@ -206,12 +207,13 @@ export default class ReplyThread extends React.Component<IProps, IState> {
         return { body, html };
     }
 
-    public static makeReplyMixIn(ev: MatrixEvent) {
+    public static makeReplyMixIn(ev: MatrixEvent, replyInThread: boolean) {
         if (!ev) return {};
         return {
             'm.relates_to': {
                 'm.in_reply_to': {
                     'event_id': ev.getId(),
+                    [UNSTABLE_ELEMENT_REPLY_IN_THREAD.name]: replyInThread,
                 },
             },
         };

--- a/src/components/views/elements/ReplyThread.tsx
+++ b/src/components/views/elements/ReplyThread.tsx
@@ -209,14 +209,26 @@ export default class ReplyThread extends React.Component<IProps, IState> {
 
     public static makeReplyMixIn(ev: MatrixEvent, replyInThread: boolean) {
         if (!ev) return {};
-        return {
+
+        const replyMixin = {
             'm.relates_to': {
                 'm.in_reply_to': {
                     'event_id': ev.getId(),
-                    [UNSTABLE_ELEMENT_REPLY_IN_THREAD.name]: replyInThread,
                 },
             },
         };
+
+        /**
+         * @experimental
+         * Rendering hint for threads, only attached if true to make
+         * sure that Element does not start sending that property for all events
+         */
+        if (replyInThread) {
+            const inReplyTo = replyMixin['m.relates_to']['m.in_reply_to'];
+            inReplyTo[UNSTABLE_ELEMENT_REPLY_IN_THREAD.name] = replyInThread;
+        }
+
+        return replyMixin;
     }
 
     public static makeThread(

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -43,11 +43,6 @@ import QuestionDialog from "../dialogs/QuestionDialog";
 import { ActionPayload } from "../../../dispatcher/payloads";
 import AccessibleButton from '../elements/AccessibleButton';
 
-function eventIsReply(mxEvent: MatrixEvent): boolean {
-    const relatesTo = mxEvent.getContent()["m.relates_to"];
-    return !!(relatesTo && relatesTo["m.in_reply_to"]);
-}
-
 function getHtmlReplyFallback(mxEvent: MatrixEvent): string {
     const html = mxEvent.getContent().formatted_body;
     if (!html) {
@@ -72,7 +67,7 @@ function createEditContent(model: EditorModel, editedEvent: MatrixEvent): IConte
     if (isEmote) {
         model = stripEmoteCommand(model);
     }
-    const isReply = eventIsReply(editedEvent);
+    const isReply = !!editedEvent.replyEventId;
     let plainPrefix = "";
     let htmlPrefix = "";
 

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -183,6 +183,7 @@ interface IProps {
     resizeNotifier: ResizeNotifier;
     permalinkCreator: RoomPermalinkCreator;
     replyToEvent?: MatrixEvent;
+    replyInThread?: boolean;
     showReplyPreview?: boolean;
     e2eStatus?: E2EStatus;
     compact?: boolean;
@@ -204,6 +205,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
     private voiceRecordingButton: VoiceRecordComposerTile;
 
     static defaultProps = {
+        replyInThread: false,
         showReplyPreview: true,
         compact: false,
     };
@@ -383,6 +385,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                     room={this.props.room}
                     placeholder={this.renderPlaceholderText()}
                     permalinkCreator={this.props.permalinkCreator}
+                    replyInThread={this.props.replyInThread}
                     replyToEvent={this.props.replyToEvent}
                     onChange={this.onChange}
                     disabled={this.state.haveRecording}

--- a/test/components/views/rooms/SendMessageComposer-test.js
+++ b/test/components/views/rooms/SendMessageComposer-test.js
@@ -46,7 +46,7 @@ describe('<SendMessageComposer/>', () => {
             const model = new EditorModel([], createPartCreator(), createRenderer());
             model.update("hello world", "insertText", { offset: 11, atNodeEnd: true });
 
-            const content = createMessageContent(model, permalinkCreator);
+            const content = createMessageContent(model, null, false, permalinkCreator);
 
             expect(content).toEqual({
                 body: "hello world",
@@ -58,7 +58,7 @@ describe('<SendMessageComposer/>', () => {
             const model = new EditorModel([], createPartCreator(), createRenderer());
             model.update("hello *world*", "insertText", { offset: 13, atNodeEnd: true });
 
-            const content = createMessageContent(model, permalinkCreator);
+            const content = createMessageContent(model, null, false, permalinkCreator);
 
             expect(content).toEqual({
                 body: "hello *world*",
@@ -72,7 +72,7 @@ describe('<SendMessageComposer/>', () => {
             const model = new EditorModel([], createPartCreator(), createRenderer());
             model.update("/me blinks __quickly__", "insertText", { offset: 22, atNodeEnd: true });
 
-            const content = createMessageContent(model, permalinkCreator);
+            const content = createMessageContent(model, null, false, permalinkCreator);
 
             expect(content).toEqual({
                 body: "blinks __quickly__",
@@ -86,7 +86,7 @@ describe('<SendMessageComposer/>', () => {
             const model = new EditorModel([], createPartCreator(), createRenderer());
             model.update("//dev/null is my favourite place", "insertText", { offset: 32, atNodeEnd: true });
 
-            const content = createMessageContent(model, permalinkCreator);
+            const content = createMessageContent(model, null, false, permalinkCreator);
 
             expect(content).toEqual({
                 body: "/dev/null is my favourite place",


### PR DESCRIPTION
Fixes vector-im/element-web#18717

To review alongside matrix-org/matrix-js-sdk#1876
Blocked until the JS SDK counterpart has been merged

This makes the composer able to create a new event that will be render in the room timeline or a in thread.

I also removed some duplicated code and aligned the 

It also removes some old code, and aligned the `addReplyToMessageContent` and `createMessageContent` function signatures

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61307ff10a73a583e72611b8--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
