### PR TITLE
Don't rely on rooms having timelines to use when checking widgets

### DIFF
--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -301,7 +301,9 @@ export class StopGapWidget extends EventEmitter {
         // requests timeline capabilities in other rooms down the road. It's just easier to manage here.
         for (const room of MatrixClientPeg.get().getRooms()) {
             // Timelines are most recent last
-            this.readUpToMap[room.roomId] = arrayFastClone(room.getLiveTimeline().getEvents()).reverse()[0].getId();
+            const roomEvent = arrayFastClone(room.getLiveTimeline()?.getEvents() || []).reverse()[0];
+            if (!roomEvent) continue; // force later code to think the room is fresh
+            this.readUpToMap[room.roomId] = roomEvent.getId();
         }
 
         // Attach listeners for feeding events - the underlying widget classes handle permissions for us


### PR DESCRIPTION
This fixes a fairly serious room-related crash.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://613134bafece251d17f7866a--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
