### PR TITLE
Fix state initialisation for DevicesPanel

### DIFF
--- a/src/components/views/settings/DevicesPanel.tsx
+++ b/src/components/views/settings/DevicesPanel.tsx
@@ -35,13 +35,21 @@ interface IProps {
 interface IState {
     devices: IMyDevice[];
     deviceLoadError?: string;
-    selectedDevices?: string[];
+    selectedDevices: string[];
     deleting?: boolean;
 }
 
 @replaceableComponent("views.settings.DevicesPanel")
 export default class DevicesPanel extends React.Component<IProps, IState> {
     private unmounted = false;
+
+    constructor(props: IProps) {
+        super(props);
+        this.state = {
+            devices: [],
+            selectedDevices: [],
+        };
+    }
 
     public componentDidMount(): void {
         this.loadDevices();


### PR DESCRIPTION
Fixes vector-im/element-web#18876
Regressed by matrix-org/matrix-react-sdk#6619

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6131eb23aa4cec1588ce98d9--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
