### PR TITLE
Fix scroll being stuck at bottom

### DIFF
--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -275,8 +275,8 @@ export default class ScrollPanel extends React.Component<IProps> {
         // fractional values (both too big and too small)
         // for scrollTop happen on certain browsers/platforms
         // when scrolled all the way down. E.g. Chrome 72 on debian.
-        // so check difference <= 1;
-        return Math.abs(sn.scrollHeight - (sn.scrollTop + sn.clientHeight)) <= 1;
+        // so check difference < 1;
+        return Math.abs(sn.scrollHeight - (sn.scrollTop + sn.clientHeight)) < 1;
     };
 
     // returns the vertical height in the given direction that can be removed from


### PR DESCRIPTION
The check for whether we're at the bottom or not allowed for a
difference of 1 to account for fractional scroll values, but
allowed the difference of exactly 1 too, meaning we'd consider
the timeline to be at the bottom if you were scrolled up by exactly
a single pixel. If your scrolling was set up to be precise enough and
the event handlers fired fast enough that they'd evaluate each time
you scrolled up by a single pixel, it would reset you back to the bottom
each time and you'd never be able to scroll up.

Fixes https://github.com/vector-im/element-web/issues/18903

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix scroll being stuck at bottom ([\#6751](https://github.com/matrix-org/matrix-react-sdk/pull/6751)). Fixes vector-im/element-web#18903.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://613658bf512f0f3745178878--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
