### PR TITLE
Fix thread creation flow

### DIFF
--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -32,6 +32,7 @@ import dis from "../../dispatcher/dispatcher";
 import { ActionPayload } from '../../dispatcher/payloads';
 import { SetRightPanelPhasePayload } from '../../dispatcher/payloads/SetRightPanelPhasePayload';
 import { Action } from '../../dispatcher/actions';
+import { MatrixClientPeg } from '../../MatrixClientPeg';
 
 interface IProps {
     room: Room;
@@ -89,12 +90,15 @@ export default class ThreadView extends React.Component<IProps, IState> {
     };
 
     private setupThread = (mxEv: MatrixEvent) => {
-        const thread = mxEv.getThread();
-        if (thread) {
-            thread.on("Thread.update", this.updateThread);
-            thread.once("Thread.ready", this.updateThread);
-            this.updateThread(thread);
+        let thread = mxEv.getThread();
+        if (!thread) {
+            const client = MatrixClientPeg.get();
+            thread = new Thread([mxEv], this.props.room, client);
+            mxEv.setThread(thread);
         }
+        thread.on("Thread.update", this.updateThread);
+        thread.once("Thread.ready", this.updateThread);
+        this.updateThread(thread);
     };
 
     private teardownThread = () => {


### PR DESCRIPTION
Issue introduced by #6658

When trying to reply to an event in a thread, the process would silently fail if no thread already existed

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61372af210020266d1bc0fd7--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
