### PR TITLE
Force refresh threads timeline

### DIFF
--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -50,6 +50,7 @@ interface IState {
 @replaceableComponent("structures.ThreadView")
 export default class ThreadView extends React.Component<IProps, IState> {
     private dispatcherRef: string;
+    private timelinePanelRef: React.RefObject<TimelinePanel> = React.createRef();
 
     constructor(props: IProps) {
         super(props);
@@ -110,10 +111,13 @@ export default class ThreadView extends React.Component<IProps, IState> {
 
     private updateThread = (thread?: Thread) => {
         if (thread) {
-            this.setState({ thread });
-        } else {
-            this.forceUpdate();
+            this.setState({
+                thread,
+                replyToEvent: thread.replyToEvent,
+            });
         }
+
+        this.timelinePanelRef.current?.refreshTimeline();
     };
 
     public render(): JSX.Element {
@@ -126,6 +130,7 @@ export default class ThreadView extends React.Component<IProps, IState> {
             >
                 { this.state.thread && (
                     <TimelinePanel
+                        ref={this.timelinePanelRef}
                         manageReadReceipts={false}
                         manageReadMarkers={false}
                         timelineSet={this.state?.thread?.timelineSet}

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -1179,6 +1179,12 @@ class TimelinePanel extends React.Component<IProps, IState> {
         this.setState(this.getEvents());
     }
 
+    // Force refresh the timeline before threads support pending events
+    public refreshTimeline(): void {
+        this.loadTimeline();
+        this.reloadEvents();
+    }
+
     // get the list of events from the timeline window and the pending event list
     private getEvents(): Pick<IState, "events" | "liveEvents" | "firstVisibleEventIndex"> {
         const events: MatrixEvent[] = this.timelineWindow.getEvents();


### PR DESCRIPTION
Fixes vector-im/element-web#18947

In the absence of a proper pending events / remote echo setup it seems fairly difficult to get the timeline to update

Adding a temporary helper to force refresh the timeline and not swallow local events when sending a message from the thread sidebar

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://613a37a5d397c52b679017a1--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
