### PR TITLE
[Release] Add config option to turn on in-room event sending timing metrics 

### DIFF
--- a/src/sendTimePerformanceMetrics.ts
+++ b/src/sendTimePerformanceMetrics.ts
@@ -37,12 +37,10 @@ export function decorateStartSendingTime(content: object) {
 export function sendRoundTripMetric(client: MatrixClient, inRoomId: string, forEventId: string) {
     // noinspection JSIgnoredPromiseFromCall
     client.sendEvent(inRoomId, 'io.element.performance_metric', {
-        // XXX: We stick all of this into `m.relates_to` so it doesn't end up encrypted.
-        "m.relates_to": {
-            rel_type: "io.element.metric",
-            event_id: forEventId,
+        "io.element.performance_metrics": {
+            forEventId: forEventId,
             responseTs: Date.now(),
             kind: 'send_time',
-        } as any, // override types because we're actually allowed to add extra metadata to relates_to
+        },
     });
 }

--- a/src/sendTimePerformanceMetrics.ts
+++ b/src/sendTimePerformanceMetrics.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { MatrixClient } from "matrix-js-sdk";
+
+/**
+ * Decorates the given event content object with the "send start time". The
+ * object will be modified in-place.
+ * @param {object} content The event content.
+ */
+export function decorateStartSendingTime(content: object) {
+    content['io.element.performance_metrics'] = {
+        sendStartTs: Date.now(),
+    };
+}
+
+/**
+ * Called when an event decorated with `decorateStartSendingTime()` has been sent
+ * by the server (the client now knows the event ID).
+ * @param {MatrixClient} client The client to send as.
+ * @param {string} inRoomId The room ID where the original event was sent.
+ * @param {string} forEventId The event ID for the decorated event.
+ */
+export function sendRoundTripMetric(client: MatrixClient, inRoomId: string, forEventId: string) {
+    // noinspection JSIgnoredPromiseFromCall
+    client.sendEvent(inRoomId, 'io.element.performance_metric', {
+        // XXX: We stick all of this into `m.relates_to` so it doesn't end up encrypted.
+        "m.relates_to": {
+            rel_type: "io.element.metric",
+            event_id: forEventId,
+            responseTs: Date.now(),
+            kind: 'send_time',
+        } as any, // override types because we're actually allowed to add extra metadata to relates_to
+    });
+}

--- a/src/sendTimePerformanceMetrics.ts
+++ b/src/sendTimePerformanceMetrics.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src";
 
 /**
  * Decorates the given event content object with the "send start time". The

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -759,6 +759,10 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: true,
         controller: new ReducedMotionController(),
     },
+    "Performance.addSendMessageTimingMetadata": {
+        supportedLevels: [SettingLevel.CONFIG],
+        default: false,
+    },
     "Widgets.pinned": { // deprecated
         supportedLevels: LEVELS_ROOM_OR_ACCOUNT,
         default: {},


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/6766 to release

element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * [Release] Add config option to turn on in-room event sending timing metrics  ([\#6773](https://github.com/matrix-org/matrix-react-sdk/pull/6773)).<!-- CHANGELOG_PREVIEW_END -->