### PR TITLE
Optimize input label transition on focus

### DIFF
--- a/res/css/views/elements/_Field.scss
+++ b/res/css/views/elements/_Field.scss
@@ -98,14 +98,14 @@ limitations under the License.
     transition:
         font-size 0.25s ease-out 0.1s,
         color 0.25s ease-out 0.1s,
-        top 0.25s ease-out 0.1s,
+        transform 0.25s ease-out 0.1s,
         background-color 0.25s ease-out 0.1s;
     color: $primary-content;
     background-color: transparent;
     font-size: $font-14px;
+    transform: translateY(0);
     position: absolute;
     left: 0px;
-    top: 0px;
     margin: 7px 8px;
     padding: 2px;
     pointer-events: none; // Allow clicks to fall through to the input
@@ -124,10 +124,10 @@ limitations under the License.
     transition:
         font-size 0.25s ease-out 0s,
         color 0.25s ease-out 0s,
-        top 0.25s ease-out 0s,
+        transform 0.25s ease-out 0s,
         background-color 0.25s ease-out 0s;
     font-size: $font-10px;
-    top: -13px;
+    transform: translateY(-13px);
     padding: 0 2px;
     background-color: $field-focused-label-bg-color;
     pointer-events: initial;


### PR DESCRIPTION
Optimize input label transition on focus. Using `transform` because it is hardware accelerated, https://developer.mozilla.org/en-US/docs/Web/Performance/Fundamentals#use_css_transforms

Fix https://github.com/vector-im/element-web/issues/12876

The Before/After is using Windows 10, Firefox 92.0 where I could only perceive it as slightly crunchy. Other platforms seem good enough using `position`. Although probably more noticeable on low end mobile device.


Before:

https://user-images.githubusercontent.com/558581/132748825-4828f2b1-ffb0-461e-acea-4457de746908.mp4 

After:

https://user-images.githubusercontent.com/558581/132939880-2eca8bbd-4dc4-4046-943f-419beb6e42c3.mp4




<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Optimize input label transition on focus ([\#6783](https://github.com/matrix-org/matrix-react-sdk/pull/6783)). Fixes vector-im/element-web#12876. Contributed by [MadLittleMods](https://github.com/MadLittleMods).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://613c5b20ed232a0d972fb3e7--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
