### PR TITLE
Make message bubble font size consistent

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -28,6 +28,7 @@ limitations under the License.
     margin-top: var(--gutterSize);
     margin-left: 50px;
     margin-right: 100px;
+    font-size: $font-14px;
 
     &.mx_EventTile_continuation {
         margin-top: 2px;
@@ -81,6 +82,7 @@ limitations under the License.
         position: relative;
         top: -2px;
         left: 2px;
+        font-size: $font-15px;
     }
 
     &[data-self=false] {


### PR DESCRIPTION
Previously, the message bubbles layout displayed formatted messages with 14px fonts, and plaintext messages with 15px fonts, which looked odd if you stared at it long enough. This homogenizes them to 14px, which is the same as the Modern layout and seems to be the intended appearance.

Before:

![Screenshot 2021-09-13 at 23-44-10 Element  1  #element-dev matrix org](https://user-images.githubusercontent.com/48614497/133191679-f6abf416-ec8d-46a1-8130-cf9518891f66.png)

After:

![Screenshot 2021-09-13 at 23-39-58 Element  1  #element-dev matrix org](https://user-images.githubusercontent.com/48614497/133191668-90045c72-e176-4c7b-a010-2e9aeba4148c.png)

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make message bubble font size consistent ([\#6795](https://github.com/matrix-org/matrix-react-sdk/pull/6795)). Contributed by [robintown](https://github.com/robintown).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61401c76646cf630a8000889--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
