### PR TITLE
Remove replies from hidden events when shown with `messages.ViewSourceEvent`

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -337,7 +337,7 @@ export default class EventTile extends React.Component<IProps, IState> {
 
     static defaultProps = {
         // no-op function because onHeightChanged is optional yet some sub-components assume its existence
-        onHeightChanged: function () { },
+        onHeightChanged: function() {},
         layout: Layout.Group,
     };
 
@@ -544,9 +544,9 @@ export default class EventTile extends React.Component<IProps, IState> {
                 }}
             >
                 <span className="mx_EventListSummary_avatars">
-                    {avatars}
+                    { avatars }
                 </span>
-                {thread.length - 1} {thread.length === 2 ? 'reply' : 'replies'}
+                { thread.length - 1 } { thread.length === 2 ? 'reply' : 'replies' }
             </div>
         );
     }
@@ -792,7 +792,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             if (remainder > 0) {
                 remText = <span className="mx_EventTile_readAvatarRemainder"
                     onClick={this.toggleAllReadAvatars}
-                    style={{ right: "calc(" + toRem(-left) + " + " + receiptOffset + "px)" }}>{remainder}+
+                    style={{ right: "calc(" + toRem(-left) + " + " + receiptOffset + "px)" }}>{ remainder }+
                 </span>;
             }
         }
@@ -800,8 +800,8 @@ export default class EventTile extends React.Component<IProps, IState> {
         return (
             <div className="mx_EventTile_msgOption">
                 <span className="mx_EventTile_readAvatars">
-                    {remText}
-                    {avatars}
+                    { remText }
+                    { avatars }
                 </span>
             </div>
         );
@@ -924,21 +924,6 @@ export default class EventTile extends React.Component<IProps, IState> {
             isLeftAlignedBubbleMessage,
         } = getEventDisplayInfo(this.props.mxEvent);
 
-        if (
-            this.props.mxEvent.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
-            [
-                // The event being replied to
-                '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
-                // The original "foo" message
-                '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
-                // The replacing event
-                '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
-            ].includes(this.props.mxEvent.event.event_id)
-        ) {
-            console.log('render', tileHandler, this.props.mxEvent.event.event_id)
-        }
-
-
         // This shouldn't happen: the caller should check we support this type
         // before trying to instantiate us
         if (!tileHandler) {
@@ -946,7 +931,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             console.warn(`Event type not supported: type:${eventType} isState:${mxEvent.isState()}`);
             return <div className="mx_EventTile mx_EventTile_info mx_MNoticeBody">
                 <div className="mx_EventTile_line">
-                    {_t('This event could not be displayed')}
+                    { _t('This event could not be displayed') }
                 </div>
             </div>;
         }
@@ -1073,9 +1058,9 @@ export default class EventTile extends React.Component<IProps, IState> {
 
         const showTimestamp = this.props.mxEvent.getTs()
             && (this.props.alwaysShowTimestamps
-                || this.props.last
-                || this.state.hover
-                || this.state.actionBarFocused);
+            || this.props.last
+            || this.state.hover
+            || this.state.actionBarFocused);
 
         const timestamp = showTimestamp ?
             <MessageTimestamp showTwelveHour={this.props.isTwelveHour} ts={this.props.mxEvent.getTs()} /> : null;
@@ -1083,17 +1068,17 @@ export default class EventTile extends React.Component<IProps, IState> {
         const keyRequestHelpText =
             <div className="mx_EventTile_keyRequestInfo_tooltip_contents">
                 <p>
-                    {this.state.previouslyRequestedKeys ?
-                        _t('Your key share request has been sent - please check your other sessions ' +
+                    { this.state.previouslyRequestedKeys ?
+                        _t( 'Your key share request has been sent - please check your other sessions ' +
                             'for key share requests.') :
-                        _t('Key share requests are sent to your other sessions automatically. If you ' +
+                        _t( 'Key share requests are sent to your other sessions automatically. If you ' +
                             'rejected or dismissed the key share request on your other sessions, click ' +
                             'here to request the keys for this session again.')
                     }
                 </p>
                 <p>
-                    {_t('If your other sessions do not have the key for this message you will not ' +
-                        'be able to decrypt them.')
+                    { _t( 'If your other sessions do not have the key for this message you will not ' +
+                            'be able to decrypt them.')
                     }
                 </p>
             </div>;
@@ -1102,13 +1087,13 @@ export default class EventTile extends React.Component<IProps, IState> {
             _t(
                 '<requestLink>Re-request encryption keys</requestLink> from your other sessions.',
                 {},
-                { 'requestLink': (sub) => <a onClick={this.onRequestKeysClick}>{sub}</a> },
+                { 'requestLink': (sub) => <a onClick={this.onRequestKeysClick}>{ sub }</a> },
             );
 
         const keyRequestInfo = isEncryptionFailure && !isRedacted ?
             <div className="mx_EventTile_keyRequestInfo">
                 <span className="mx_EventTile_keyRequestInfo_text">
-                    {keyRequestInfoContent}
+                    { keyRequestInfoContent }
                 </span>
                 <TooltipButton helpText={keyRequestHelpText} />
             </div> : null;
@@ -1126,7 +1111,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             onClick={this.onPermalinkClicked}
             aria-label={formatTime(new Date(this.props.mxEvent.getTs()), this.props.isTwelveHour)}
         >
-            {timestamp}
+            { timestamp }
         </a>;
 
         const useIRCLayout = this.props.layout == Layout.IRC;
@@ -1153,14 +1138,14 @@ export default class EventTile extends React.Component<IProps, IState> {
                     <div className="mx_EventTile_roomName" key="mx_EventTile_roomName">
                         <RoomAvatar room={room} width={28} height={28} />
                         <a href={permalink} onClick={this.onPermalinkClicked}>
-                            {room ? room.name : ''}
+                            { room ? room.name : '' }
                         </a>
                     </div>,
                     <div className="mx_EventTile_senderDetails" key="mx_EventTile_senderDetails">
-                        {avatar}
+                        { avatar }
                         <a href={permalink} onClick={this.onPermalinkClicked}>
-                            {sender}
-                            {timestamp}
+                            { sender }
+                            { timestamp }
                         </a>
                     </div>,
                     <div className="mx_EventTile_line" key="mx_EventTile_line">
@@ -1199,15 +1184,15 @@ export default class EventTile extends React.Component<IProps, IState> {
                         onClick={this.onPermalinkClicked}
                     >
                         <div className="mx_EventTile_senderDetails">
-                            {sender}
-                            {timestamp}
+                            { sender }
+                            { timestamp }
                         </div>
                     </a>,
                 ]);
             }
 
             default: {
-                let thread = null;
+                let thread;
                 if (haveTileForEvent(this.props.mxEvent)) {
                     thread = ReplyThread.makeThread(
                         this.props.mxEvent,
@@ -1217,20 +1202,6 @@ export default class EventTile extends React.Component<IProps, IState> {
                         this.props.layout,
                         this.props.alwaysShowTimestamps || this.state.hover,
                     );
-                }
-
-                if (
-                    this.props.mxEvent.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
-                    [
-                        // The event being replied to
-                        '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
-                        // The original "foo" message
-                        '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
-                        // The replacing event
-                        '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
-                    ].includes(this.props.mxEvent.event.event_id)
-                ) {
-                    console.log('thread', thread, this.props.mxEvent.event.event_id);
                 }
 
                 const isOwnEvent = this.props.mxEvent?.sender?.userId === MatrixClientPeg.get().getUserId();
@@ -1250,14 +1221,14 @@ export default class EventTile extends React.Component<IProps, IState> {
                         "onMouseEnter": () => this.setState({ hover: true }),
                         "onMouseLeave": () => this.setState({ hover: false }),
                     }, <>
-                        {ircTimestamp}
-                        {sender}
-                        {ircPadlock}
-                        {avatar}
+                        { ircTimestamp }
+                        { sender }
+                        { ircPadlock }
+                        { avatar }
                         <div className="mx_EventTile_line" key="mx_EventTile_line">
-                            {groupTimestamp}
-                            {groupPadlock}
-                            {thread}
+                            { groupTimestamp }
+                            { groupPadlock }
+                            { thread }
                             <EventTileType ref={this.tile}
                                 mxEvent={this.props.mxEvent}
                                 replacingEventId={this.props.replacingEventId}
@@ -1269,13 +1240,13 @@ export default class EventTile extends React.Component<IProps, IState> {
                                 onHeightChanged={this.props.onHeightChanged}
                                 callEventGrouper={this.props.callEventGrouper}
                             />
-                            {keyRequestInfo}
-                            {actionBar}
-                            {this.props.layout === Layout.IRC && (reactionsRow)}
-                            {this.renderThreadInfo()}
+                            { keyRequestInfo }
+                            { actionBar }
+                            { this.props.layout === Layout.IRC && (reactionsRow) }
+                            { this.renderThreadInfo() }
                         </div>
-                        {this.props.layout !== Layout.IRC && (reactionsRow)}
-                        {msgOption}
+                        { this.props.layout !== Layout.IRC && (reactionsRow) }
+                        { msgOption }
                     </>)
                 );
             }
@@ -1294,19 +1265,6 @@ export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean) {
     if (e.isRedacted() && !isMessageEvent(e)) return false;
 
     // No tile for replacement events since they update the original tile
-    if (
-        e.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
-        [
-            // The event being replied to
-            '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
-            // The original "foo" message
-            '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
-            // The replacing event
-            '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
-        ].includes(e.event.event_id)
-    ) {
-        console.log('haveTileForEvent', e.isRelation("m.replace"), e.event.event_id)
-    }
     if (e.isRelation("m.replace")) return false;
 
     const handler = getHandlerTile(e);
@@ -1392,7 +1350,7 @@ class E2ePadlock extends React.Component<IE2ePadlockProps, IE2ePadlockState> {
                 className={classes}
                 onMouseEnter={this.onHoverStart}
                 onMouseLeave={this.onHoverEnd}
-            >{tooltip}</div>
+            >{ tooltip }</div>
         );
     }
 }
@@ -1456,8 +1414,8 @@ class SentReceipt extends React.PureComponent<ISentReceiptProps, ISentReceiptSta
             <div className="mx_EventTile_msgOption">
                 <span className="mx_EventTile_readAvatars">
                     <span className={receiptClasses} onMouseEnter={this.onHoverStart} onMouseLeave={this.onHoverEnd}>
-                        {nonCssBadge}
-                        {tooltip}
+                        { nonCssBadge }
+                        { tooltip }
                     </span>
                 </span>
             </div>

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1193,6 +1193,8 @@ export default class EventTile extends React.Component<IProps, IState> {
 
             default: {
                 let thread;
+                // When the "showHiddenEventsInTimeline" lab is enabled,
+                // avoid showing replies for hidden events (events without tiles)
                 if (haveTileForEvent(this.props.mxEvent)) {
                     thread = ReplyThread.makeThread(
                         this.props.mxEvent,

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -337,7 +337,7 @@ export default class EventTile extends React.Component<IProps, IState> {
 
     static defaultProps = {
         // no-op function because onHeightChanged is optional yet some sub-components assume its existence
-        onHeightChanged: function() {},
+        onHeightChanged: function () { },
         layout: Layout.Group,
     };
 
@@ -544,9 +544,9 @@ export default class EventTile extends React.Component<IProps, IState> {
                 }}
             >
                 <span className="mx_EventListSummary_avatars">
-                    { avatars }
+                    {avatars}
                 </span>
-                { thread.length - 1 } { thread.length === 2 ? 'reply' : 'replies' }
+                {thread.length - 1} {thread.length === 2 ? 'reply' : 'replies'}
             </div>
         );
     }
@@ -792,7 +792,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             if (remainder > 0) {
                 remText = <span className="mx_EventTile_readAvatarRemainder"
                     onClick={this.toggleAllReadAvatars}
-                    style={{ right: "calc(" + toRem(-left) + " + " + receiptOffset + "px)" }}>{ remainder }+
+                    style={{ right: "calc(" + toRem(-left) + " + " + receiptOffset + "px)" }}>{remainder}+
                 </span>;
             }
         }
@@ -800,8 +800,8 @@ export default class EventTile extends React.Component<IProps, IState> {
         return (
             <div className="mx_EventTile_msgOption">
                 <span className="mx_EventTile_readAvatars">
-                    { remText }
-                    { avatars }
+                    {remText}
+                    {avatars}
                 </span>
             </div>
         );
@@ -924,6 +924,21 @@ export default class EventTile extends React.Component<IProps, IState> {
             isLeftAlignedBubbleMessage,
         } = getEventDisplayInfo(this.props.mxEvent);
 
+        if (
+            this.props.mxEvent.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
+            [
+                // The event being replied to
+                '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
+                // The original "foo" message
+                '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
+                // The replacing event
+                '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
+            ].includes(this.props.mxEvent.event.event_id)
+        ) {
+            console.log('render', tileHandler, this.props.mxEvent.event.event_id)
+        }
+
+
         // This shouldn't happen: the caller should check we support this type
         // before trying to instantiate us
         if (!tileHandler) {
@@ -931,7 +946,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             console.warn(`Event type not supported: type:${eventType} isState:${mxEvent.isState()}`);
             return <div className="mx_EventTile mx_EventTile_info mx_MNoticeBody">
                 <div className="mx_EventTile_line">
-                    { _t('This event could not be displayed') }
+                    {_t('This event could not be displayed')}
                 </div>
             </div>;
         }
@@ -1058,9 +1073,9 @@ export default class EventTile extends React.Component<IProps, IState> {
 
         const showTimestamp = this.props.mxEvent.getTs()
             && (this.props.alwaysShowTimestamps
-            || this.props.last
-            || this.state.hover
-            || this.state.actionBarFocused);
+                || this.props.last
+                || this.state.hover
+                || this.state.actionBarFocused);
 
         const timestamp = showTimestamp ?
             <MessageTimestamp showTwelveHour={this.props.isTwelveHour} ts={this.props.mxEvent.getTs()} /> : null;
@@ -1068,17 +1083,17 @@ export default class EventTile extends React.Component<IProps, IState> {
         const keyRequestHelpText =
             <div className="mx_EventTile_keyRequestInfo_tooltip_contents">
                 <p>
-                    { this.state.previouslyRequestedKeys ?
-                        _t( 'Your key share request has been sent - please check your other sessions ' +
+                    {this.state.previouslyRequestedKeys ?
+                        _t('Your key share request has been sent - please check your other sessions ' +
                             'for key share requests.') :
-                        _t( 'Key share requests are sent to your other sessions automatically. If you ' +
+                        _t('Key share requests are sent to your other sessions automatically. If you ' +
                             'rejected or dismissed the key share request on your other sessions, click ' +
                             'here to request the keys for this session again.')
                     }
                 </p>
                 <p>
-                    { _t( 'If your other sessions do not have the key for this message you will not ' +
-                            'be able to decrypt them.')
+                    {_t('If your other sessions do not have the key for this message you will not ' +
+                        'be able to decrypt them.')
                     }
                 </p>
             </div>;
@@ -1087,13 +1102,13 @@ export default class EventTile extends React.Component<IProps, IState> {
             _t(
                 '<requestLink>Re-request encryption keys</requestLink> from your other sessions.',
                 {},
-                { 'requestLink': (sub) => <a onClick={this.onRequestKeysClick}>{ sub }</a> },
+                { 'requestLink': (sub) => <a onClick={this.onRequestKeysClick}>{sub}</a> },
             );
 
         const keyRequestInfo = isEncryptionFailure && !isRedacted ?
             <div className="mx_EventTile_keyRequestInfo">
                 <span className="mx_EventTile_keyRequestInfo_text">
-                    { keyRequestInfoContent }
+                    {keyRequestInfoContent}
                 </span>
                 <TooltipButton helpText={keyRequestHelpText} />
             </div> : null;
@@ -1111,7 +1126,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             onClick={this.onPermalinkClicked}
             aria-label={formatTime(new Date(this.props.mxEvent.getTs()), this.props.isTwelveHour)}
         >
-            { timestamp }
+            {timestamp}
         </a>;
 
         const useIRCLayout = this.props.layout == Layout.IRC;
@@ -1138,14 +1153,14 @@ export default class EventTile extends React.Component<IProps, IState> {
                     <div className="mx_EventTile_roomName" key="mx_EventTile_roomName">
                         <RoomAvatar room={room} width={28} height={28} />
                         <a href={permalink} onClick={this.onPermalinkClicked}>
-                            { room ? room.name : '' }
+                            {room ? room.name : ''}
                         </a>
                     </div>,
                     <div className="mx_EventTile_senderDetails" key="mx_EventTile_senderDetails">
-                        { avatar }
+                        {avatar}
                         <a href={permalink} onClick={this.onPermalinkClicked}>
-                            { sender }
-                            { timestamp }
+                            {sender}
+                            {timestamp}
                         </a>
                     </div>,
                     <div className="mx_EventTile_line" key="mx_EventTile_line">
@@ -1184,22 +1199,39 @@ export default class EventTile extends React.Component<IProps, IState> {
                         onClick={this.onPermalinkClicked}
                     >
                         <div className="mx_EventTile_senderDetails">
-                            { sender }
-                            { timestamp }
+                            {sender}
+                            {timestamp}
                         </div>
                     </a>,
                 ]);
             }
 
             default: {
-                const thread = ReplyThread.makeThread(
-                    this.props.mxEvent,
-                    this.props.onHeightChanged,
-                    this.props.permalinkCreator,
-                    this.replyThread,
-                    this.props.layout,
-                    this.props.alwaysShowTimestamps || this.state.hover,
-                );
+                let thread = null;
+                if (haveTileForEvent(this.props.mxEvent)) {
+                    thread = ReplyThread.makeThread(
+                        this.props.mxEvent,
+                        this.props.onHeightChanged,
+                        this.props.permalinkCreator,
+                        this.replyThread,
+                        this.props.layout,
+                        this.props.alwaysShowTimestamps || this.state.hover,
+                    );
+                }
+
+                if (
+                    this.props.mxEvent.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
+                    [
+                        // The event being replied to
+                        '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
+                        // The original "foo" message
+                        '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
+                        // The replacing event
+                        '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
+                    ].includes(this.props.mxEvent.event.event_id)
+                ) {
+                    console.log('thread', thread, this.props.mxEvent.event.event_id);
+                }
 
                 const isOwnEvent = this.props.mxEvent?.sender?.userId === MatrixClientPeg.get().getUserId();
 
@@ -1218,14 +1250,14 @@ export default class EventTile extends React.Component<IProps, IState> {
                         "onMouseEnter": () => this.setState({ hover: true }),
                         "onMouseLeave": () => this.setState({ hover: false }),
                     }, <>
-                        { ircTimestamp }
-                        { sender }
-                        { ircPadlock }
-                        { avatar }
+                        {ircTimestamp}
+                        {sender}
+                        {ircPadlock}
+                        {avatar}
                         <div className="mx_EventTile_line" key="mx_EventTile_line">
-                            { groupTimestamp }
-                            { groupPadlock }
-                            { thread }
+                            {groupTimestamp}
+                            {groupPadlock}
+                            {thread}
                             <EventTileType ref={this.tile}
                                 mxEvent={this.props.mxEvent}
                                 replacingEventId={this.props.replacingEventId}
@@ -1237,13 +1269,13 @@ export default class EventTile extends React.Component<IProps, IState> {
                                 onHeightChanged={this.props.onHeightChanged}
                                 callEventGrouper={this.props.callEventGrouper}
                             />
-                            { keyRequestInfo }
-                            { actionBar }
-                            { this.props.layout === Layout.IRC && (reactionsRow) }
-                            { this.renderThreadInfo() }
+                            {keyRequestInfo}
+                            {actionBar}
+                            {this.props.layout === Layout.IRC && (reactionsRow)}
+                            {this.renderThreadInfo()}
                         </div>
-                        { this.props.layout !== Layout.IRC && (reactionsRow) }
-                        { msgOption }
+                        {this.props.layout !== Layout.IRC && (reactionsRow)}
+                        {msgOption}
                     </>)
                 );
             }
@@ -1262,6 +1294,19 @@ export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean) {
     if (e.isRedacted() && !isMessageEvent(e)) return false;
 
     // No tile for replacement events since they update the original tile
+    if (
+        e.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
+        [
+            // The event being replied to
+            '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
+            // The original "foo" message
+            '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
+            // The replacing event
+            '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
+        ].includes(e.event.event_id)
+    ) {
+        console.log('haveTileForEvent', e.isRelation("m.replace"), e.event.event_id)
+    }
     if (e.isRelation("m.replace")) return false;
 
     const handler = getHandlerTile(e);
@@ -1347,7 +1392,7 @@ class E2ePadlock extends React.Component<IE2ePadlockProps, IE2ePadlockState> {
                 className={classes}
                 onMouseEnter={this.onHoverStart}
                 onMouseLeave={this.onHoverEnd}
-            >{ tooltip }</div>
+            >{tooltip}</div>
         );
     }
 }
@@ -1411,8 +1456,8 @@ class SentReceipt extends React.PureComponent<ISentReceiptProps, ISentReceiptSta
             <div className="mx_EventTile_msgOption">
                 <span className="mx_EventTile_readAvatars">
                     <span className={receiptClasses} onMouseEnter={this.onHoverStart} onMouseLeave={this.onHoverEnd}>
-                        { nonCssBadge }
-                        { tooltip }
+                        {nonCssBadge}
+                        {tooltip}
                     </span>
                 </span>
             </div>

--- a/src/shouldHideEvent.ts
+++ b/src/shouldHideEvent.ts
@@ -65,19 +65,6 @@ export default function shouldHideEvent(ev: MatrixEvent, ctx?: IState): boolean 
     if (ev.isRedacted() && !isEnabled('showRedactions')) return true;
 
     // Hide replacement events since they update the original tile (if enabled)
-    if (
-        ev.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
-        [
-            // The event being replied to
-            '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
-            // The original "foo" message
-            '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
-            // The replacing event
-            '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
-        ].includes(ev.event.event_id)
-    ) {
-        console.log('shouldHideEvent', ev.isRelation("m.replace"), ev.event.event_id)
-    }
     if (ev.isRelation("m.replace")) return true;
 
     const eventDiff = memberEventDiff(ev);

--- a/src/shouldHideEvent.ts
+++ b/src/shouldHideEvent.ts
@@ -65,6 +65,19 @@ export default function shouldHideEvent(ev: MatrixEvent, ctx?: IState): boolean 
     if (ev.isRedacted() && !isEnabled('showRedactions')) return true;
 
     // Hide replacement events since they update the original tile (if enabled)
+    if (
+        ev.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
+        [
+            // The event being replied to
+            '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
+            // The original "foo" message
+            '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
+            // The replacing event
+            '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
+        ].includes(ev.event.event_id)
+    ) {
+        console.log('shouldHideEvent', ev.isRelation("m.replace"), ev.event.event_id)
+    }
     if (ev.isRelation("m.replace")) return true;
 
     const eventDiff = memberEventDiff(ev);


### PR DESCRIPTION
Remove replies from hidden events when shown with `messages.ViewSourceEvent`

As discovered in https://github.com/vector-im/element-web/issues/10391#is

Previously, if you turned on the `showHiddenEventsInTimeline` labs flag, edit (`m.replace`) events
that also have a `m.in_reply_to` field, would show the reply in the timeline.

Before | After
--- | ---
<img width="355" alt="" src="https://user-images.githubusercontent.com/558581/133211546-f70a5c78-c18d-48cb-be28-fcafb9da451f.png">  | <img width="361" alt="" src="https://user-images.githubusercontent.com/558581/133211529-0e17a8c2-d556-40d5-b108-aecddb9a8604.png">

ex.
```json
{
  "type": "m.room.message",
  "content": {
    "body": " * foo",
    "msgtype": "m.text",
    "m.new_content": {
      "body": "foo",
      "msgtype": "m.text"
    },
    "m.relates_to": {
      "rel_type": "m.replace",
      "event_id": "$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg",
      "m.in_reply_to": {
        "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
      }
    }
  }
}
```





## Dev notes

```js
if (
    e.event.room_id === "!iaiMnvSLPTbPYMnjvJ:my.matrix.host" &&
    [
        // The event being replied to
        '$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og',
        // The original "foo" message
        '$yvuev9bF2nLRf8fscG55njpVjY3FHJzWgZ4BKI9_0eg',
        // The replacing event
        '$4gJk89MFndw_By0dJoxwF2fekM-0ufw7kkdlUD2DNUQ'
    ].includes(e.event.event_id)
) {
    console.log('haveTileForEvent', e.isRelation("m.replace"), e.event.event_id)
}
```





<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove replies from hidden events when shown with `messages.ViewSourceEvent` ([\#6796](https://github.com/matrix-org/matrix-react-sdk/pull/6796)). Contributed by [MadLittleMods](https://github.com/MadLittleMods).<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://6140d9b1161ce009721f897d--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
