### PR TITLE
Show updated relation reply from edited message - v2

### DIFF
--- a/src/components/views/elements/ReplyThread.tsx
+++ b/src/components/views/elements/ReplyThread.tsx
@@ -88,6 +88,12 @@ export default class ReplyThread extends React.Component<IProps, IState> {
         // could be used here for replies as well... However, the helper
         // currently assumes the relation has a `rel_type`, which older replies
         // do not, so this block is left as-is for now.
+        //
+        // We're prefer ev.getContent() over ev.getWireContent() to make sure
+        // we grab the latest edit with potentially new relations. But we also
+        // can't just rely on ev.getContent() by itself because historically we
+        // still show the reply from the original message even though the edit
+        // event does not include the relation reply.
         const mRelatesTo = ev.getContent()['m.relates_to'] || ev.getWireContent()['m.relates_to'];
         if (mRelatesTo && mRelatesTo['m.in_reply_to']) {
             const mInReplyTo = mRelatesTo['m.in_reply_to'];

--- a/src/components/views/elements/ReplyThread.tsx
+++ b/src/components/views/elements/ReplyThread.tsx
@@ -88,7 +88,7 @@ export default class ReplyThread extends React.Component<IProps, IState> {
         // could be used here for replies as well... However, the helper
         // currently assumes the relation has a `rel_type`, which older replies
         // do not, so this block is left as-is for now.
-        const mRelatesTo = ev.getWireContent()['m.relates_to'];
+        const mRelatesTo = ev.getContent()['m.relates_to'] || ev.getWireContent()['m.relates_to'];
         if (mRelatesTo && mRelatesTo['m.in_reply_to']) {
             const mInReplyTo = mRelatesTo['m.in_reply_to'];
             if (mInReplyTo && mInReplyTo['event_id']) return mInReplyTo['event_id'];

--- a/test/components/views/elements/ReplyThread-test.js
+++ b/test/components/views/elements/ReplyThread-test.js
@@ -1,0 +1,210 @@
+
+
+import * as testUtils from '../../../test-utils';
+import ReplyThread from '../../../../src/components/views/elements/ReplyThread';
+
+describe("ReplyThread", () => {
+    describe('getParentEventId', () => {
+        it('retrieves relation reply from unedited event', () => {
+            const originalEventWithRelation = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n foo",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
+                        }
+                    }
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+            
+            expect(ReplyThread.getParentEventId(originalEventWithRelation))
+                .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
+        });
+
+        it('retrieves relation reply from original event when edited', () => {
+            const originalEventWithRelation = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n foo",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
+                        }
+                    }
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            const editEvent = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n * foo bar",
+                    "m.new_content": {
+                        "msgtype": "m.text",
+                        "body": "foo bar"
+                    },
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": originalEventWithRelation.event_id
+                    },
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            // The edit replaces the original event
+            originalEventWithRelation.makeReplaced(editEvent);
+            
+            // The relation should be pulled from the original event
+            expect(ReplyThread.getParentEventId(originalEventWithRelation))
+                .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
+        });
+
+        it('retrieves relation reply from edit event when provided', () => {
+            const originalEvent = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "foo",
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            const editEvent = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n * foo bar",
+                    "m.new_content": {
+                        "msgtype": "m.text",
+                        "body": "foo bar",
+                        "m.relates_to": {
+                            "m.in_reply_to": {
+                                "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
+                            }
+                        }
+                    },
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": originalEvent.event_id
+                    },
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            // The edit replaces the original event
+            originalEvent.makeReplaced(editEvent);
+            
+            // The relation should be pulled from the edit event
+            expect(ReplyThread.getParentEventId(originalEvent))
+                .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
+        });
+
+        it('prefers relation reply from edit event over original event', () => {
+            const originalEventWithRelation = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n foo",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": "$111"
+                        }
+                    }
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            const editEvent = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n * foo bar",
+                    "m.new_content": {
+                        "msgtype": "m.text",
+                        "body": "foo bar",
+                        "m.relates_to": {
+                            "m.in_reply_to": {
+                                "event_id": "$999"
+                            }
+                        }
+                    },
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": originalEventWithRelation.event_id
+                    },
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            // The edit replaces the original event
+            originalEventWithRelation.makeReplaced(editEvent);
+            
+            // The relation should be pulled from the edit event
+            expect(ReplyThread.getParentEventId(originalEventWithRelation)).toStrictEqual('$999');
+        });
+
+        it('able to clear relation reply from original event by providing empty relation field', () => {
+            const originalEventWithRelation = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n foo",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": "$111"
+                        }
+                    }
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            const editEvent = testUtils.mkEvent({
+                event: true,
+                type: "m.room.message",
+                content: {
+                    msgtype: "m.text",
+                    body: "> Reply to this message\n\n * foo bar",
+                    "m.new_content": {
+                        "msgtype": "m.text",
+                        "body": "foo bar",
+                        // Clear the relation from the original event
+                        "m.relates_to": {}
+                    },
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": originalEventWithRelation.event_id
+                    },
+                },
+                user: "some_other_user",
+                room: "room_id",
+            });
+
+            // The edit replaces the original event
+            originalEventWithRelation.makeReplaced(editEvent);
+
+            // The relation should be pulled from the edit event
+            expect(ReplyThread.getParentEventId(originalEventWithRelation)).toStrictEqual(undefined);
+        });
+    })
+})

--- a/test/components/views/elements/ReplyThread-test.js
+++ b/test/components/views/elements/ReplyThread-test.js
@@ -1,4 +1,4 @@
-
+import "../../../skinned-sdk";
 import * as testUtils from '../../../test-utils';
 import ReplyThread from '../../../../src/components/views/elements/ReplyThread';
 

--- a/test/components/views/elements/ReplyThread-test.js
+++ b/test/components/views/elements/ReplyThread-test.js
@@ -1,5 +1,4 @@
 
-
 import * as testUtils from '../../../test-utils';
 import ReplyThread from '../../../../src/components/views/elements/ReplyThread';
 
@@ -10,18 +9,18 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n foo",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n foo",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
-                        }
-                    }
+                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og",
+                        },
+                    },
                 },
                 user: "some_other_user",
                 room: "room_id",
             });
-            
+
             expect(ReplyThread.getParentEventId(originalEventWithRelation))
                 .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
         });
@@ -31,13 +30,13 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n foo",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n foo",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
-                        }
-                    }
+                            "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og",
+                        },
+                    },
                 },
                 user: "some_other_user",
                 room: "room_id",
@@ -47,15 +46,15 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n * foo bar",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n * foo bar",
                     "m.new_content": {
                         "msgtype": "m.text",
-                        "body": "foo bar"
+                        "body": "foo bar",
                     },
                     "m.relates_to": {
                         "rel_type": "m.replace",
-                        "event_id": originalEventWithRelation.event_id
+                        "event_id": originalEventWithRelation.event_id,
                     },
                 },
                 user: "some_other_user",
@@ -64,7 +63,7 @@ describe("ReplyThread", () => {
 
             // The edit replaces the original event
             originalEventWithRelation.makeReplaced(editEvent);
-            
+
             // The relation should be pulled from the original event
             expect(ReplyThread.getParentEventId(originalEventWithRelation))
                 .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
@@ -86,20 +85,20 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n * foo bar",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n * foo bar",
                     "m.new_content": {
                         "msgtype": "m.text",
                         "body": "foo bar",
                         "m.relates_to": {
                             "m.in_reply_to": {
-                                "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
-                            }
-                        }
+                                "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og",
+                            },
+                        },
                     },
                     "m.relates_to": {
                         "rel_type": "m.replace",
-                        "event_id": originalEvent.event_id
+                        "event_id": originalEvent.event_id,
                     },
                 },
                 user: "some_other_user",
@@ -108,7 +107,7 @@ describe("ReplyThread", () => {
 
             // The edit replaces the original event
             originalEvent.makeReplaced(editEvent);
-            
+
             // The relation should be pulled from the edit event
             expect(ReplyThread.getParentEventId(originalEvent))
                 .toStrictEqual('$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og');
@@ -119,13 +118,13 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n foo",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n foo",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                            "event_id": "$111"
-                        }
-                    }
+                            "event_id": "$111",
+                        },
+                    },
                 },
                 user: "some_other_user",
                 room: "room_id",
@@ -135,20 +134,20 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n * foo bar",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n * foo bar",
                     "m.new_content": {
                         "msgtype": "m.text",
                         "body": "foo bar",
                         "m.relates_to": {
                             "m.in_reply_to": {
-                                "event_id": "$999"
-                            }
-                        }
+                                "event_id": "$999",
+                            },
+                        },
                     },
                     "m.relates_to": {
                         "rel_type": "m.replace",
-                        "event_id": originalEventWithRelation.event_id
+                        "event_id": originalEventWithRelation.event_id,
                     },
                 },
                 user: "some_other_user",
@@ -157,7 +156,7 @@ describe("ReplyThread", () => {
 
             // The edit replaces the original event
             originalEventWithRelation.makeReplaced(editEvent);
-            
+
             // The relation should be pulled from the edit event
             expect(ReplyThread.getParentEventId(originalEventWithRelation)).toStrictEqual('$999');
         });
@@ -167,13 +166,13 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n foo",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n foo",
                     "m.relates_to": {
                         "m.in_reply_to": {
-                            "event_id": "$111"
-                        }
-                    }
+                            "event_id": "$111",
+                        },
+                    },
                 },
                 user: "some_other_user",
                 room: "room_id",
@@ -183,17 +182,17 @@ describe("ReplyThread", () => {
                 event: true,
                 type: "m.room.message",
                 content: {
-                    msgtype: "m.text",
-                    body: "> Reply to this message\n\n * foo bar",
+                    "msgtype": "m.text",
+                    "body": "> Reply to this message\n\n * foo bar",
                     "m.new_content": {
                         "msgtype": "m.text",
                         "body": "foo bar",
                         // Clear the relation from the original event
-                        "m.relates_to": {}
+                        "m.relates_to": {},
                     },
                     "m.relates_to": {
                         "rel_type": "m.replace",
-                        "event_id": originalEventWithRelation.event_id
+                        "event_id": originalEventWithRelation.event_id,
                     },
                 },
                 user: "some_other_user",
@@ -206,5 +205,5 @@ describe("ReplyThread", () => {
             // The relation should be pulled from the edit event
             expect(ReplyThread.getParentEventId(originalEventWithRelation)).toStrictEqual(undefined);
         });
-    })
-})
+    });
+});


### PR DESCRIPTION
*Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/6809*

---

Show updated relation reply from edited message


 - Part of https://github.com/vector-im/element-web/issues/10391#issuecomment-906131724
 - My goal is to use this for https://gitlab.com/gitterHQ/webapp/-/merge_requests/2229#note_659864130 so I can import all messages in one pass, and then in second pass, update the messages with their threaded conversation relations.
 - Related MSC discussion: https://github.com/matrix-org/matrix-doc/pull/2676#discussion_r696791776

When `m.relates_to` -> `m.in_reply_to` is provided in `m.new_content`
for an edited message, use the updated reply.


Before | After
--- | ---
<img width="306" alt="" src="https://user-images.githubusercontent.com/558581/133334444-a18432ad-ab4b-4320-a791-ab01f1ab77cd.png"> | <img width="364" alt="" src="https://user-images.githubusercontent.com/558581/133334459-09e1bb2e-d87a-494b-82c5-e0a5163afb7f.png">

ex.

```json
{
  "type": "m.room.message",
  "content": {
    "body": " * foo bar",
    "msgtype": "m.text",
    "m.new_content": {
      "body": "foo bar",
      "msgtype": "m.text",
      "m.relates_to": {
        "m.in_reply_to": {
          "event_id": "$qkjmFBTEc0VvfVyzq1CJuh1QZi_xDIgNEFjZ4Pq34og"
        }
      }
    },
    "m.relates_to": {
      "rel_type": "m.replace",
      "event_id": "$lX9MRe9ZTFOOvnU8PRVbvr1wqGtYvNQ1rSot-iUTN5k"
    }
  }
}
```



## Dev notes

```
npm test -- test/components/views/elements/ReplyThread-test.js
```



<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Show updated relation reply from edited message - v2 ([\#6817](https://github.com/matrix-org/matrix-react-sdk/pull/6817)). Contributed by [MadLittleMods](https://github.com/MadLittleMods).<!-- CHANGELOG_PREVIEW_END -->
















<!-- Replace -->
Preview: https://6142e26957e9c0d62cdb9763--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
