### PR TITLE
Fix abuse of MainSplit in LegacyCommunityPreview and build

### DIFF
--- a/src/components/structures/LegacyCommunityPreview.tsx
+++ b/src/components/structures/LegacyCommunityPreview.tsx
@@ -28,7 +28,6 @@ import { linkifyElement } from "../../HtmlUtils";
 import defaultDispatcher from "../../dispatcher/dispatcher";
 import { Action } from "../../dispatcher/actions";
 import { UserTab } from "../views/dialogs/UserSettingsDialog";
-import MainSplit from './MainSplit';
 
 interface IProps {
     groupId: string;
@@ -49,11 +48,11 @@ const LegacyCommunityPreview = ({ groupId }: IProps) => {
 
     if (!groupSummary) {
         return <main className="mx_SpaceRoomView">
-            <MainSplit>
+            <div className="mx_MainSplit">
                 <div className="mx_SpaceRoomView_preview">
                     <Spinner />
                 </div>
-            </MainSplit>
+            </div>
         </main>;
     }
 
@@ -70,7 +69,7 @@ const LegacyCommunityPreview = ({ groupId }: IProps) => {
 
     return <main className="mx_SpaceRoomView">
         <ErrorBoundary>
-            <MainSplit>
+            <div className="mx_MainSplit">
                 <div className="mx_SpaceRoomView_preview">
                     <GroupAvatar
                         groupId={groupId}
@@ -108,7 +107,7 @@ const LegacyCommunityPreview = ({ groupId }: IProps) => {
                         }
                     </div>
                 </div>
-            </MainSplit>
+            </div>
         </ErrorBoundary>
     </main>;
 };

--- a/src/components/structures/MainSplit.tsx
+++ b/src/components/structures/MainSplit.tsx
@@ -24,7 +24,7 @@ import { Direction } from "re-resizable/lib/resizer";
 interface IProps {
     resizeNotifier: ResizeNotifier;
     collapsedRhs?: boolean;
-    panel: JSX.Element;
+    panel?: JSX.Element;
 }
 
 @replaceableComponent("structures.MainSplit")


### PR DESCRIPTION
this would cause a TS fail, but worked otherwise, shown by MainSplit having been TSified

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61431c2373bd76f32ea0502f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
