### PR TITLE
Fix crash on joining rooms

### DIFF
--- a/src/components/views/rooms/RoomPreviewBar.tsx
+++ b/src/components/views/rooms/RoomPreviewBar.tsx
@@ -323,7 +323,7 @@ export default class RoomPreviewBar extends React.Component<IProps, IState> {
         const messageCase = this.getMessageCase();
         switch (messageCase) {
             case MessageCase.Joining: {
-                title = this.props.oobData.roomType === RoomType.Space ? _t("Joining space …") : _t("Joining room …");
+                title = this.props.oobData?.roomType === RoomType.Space ? _t("Joining space …") : _t("Joining room …");
                 showSpinner = true;
                 break;
             }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/6818 passed roomType
in obbData & then used oobData without null checking, but we don't always
have oobData so joining a room from /join or from an invite would crash.

Fixes https://github.com/vector-im/element-web/issues/19085

Type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix crash on joining rooms ([\#6841](https://github.com/matrix-org/matrix-react-sdk/pull/6841)). Fixes vector-im/element-web#19085.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6148745ff5df65a5aee3d1c1--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
