### PR TITLE
Revert Firefox composer deletion hacks

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -499,9 +499,6 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
             handled = true;
         } else if (event.key === Key.BACKSPACE || event.key === Key.DELETE) {
             this.formatBarRef.current.hide();
-            if (!event.ctrlKey && !event.metaKey) {
-                handled = this.fakeDeletion(event.key === Key.BACKSPACE);
-            }
         }
 
         if (handled) {
@@ -566,29 +563,6 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
             event.stopPropagation();
         }
     };
-
-    /**
-     * TODO: Remove when Debian moves to newer version of Firefox
-     * On Firefox 78 no event emitted when the user tries to delete pills.
-     * Therefore we need to fake what would normally happen
-     * @param direction in which to delete
-     * @returns handled
-     */
-    private fakeDeletion(backward: boolean): boolean {
-        const selection = document.getSelection();
-        // Use the default handling for ranges
-        if (selection.type === "Range") return false;
-
-        this.modifiedFlag = true;
-        const { caret, text } = getCaretOffsetAndText(this.editorRef.current, selection);
-
-        // Do the deletion itself
-        if (backward) caret.offset--;
-        const newText = text.slice(0, caret.offset) + text.slice(caret.offset + 1);
-
-        this.props.model.update(newText, backward ? "deleteContentBackward" : "deleteContentForward", caret);
-        return true;
-    }
 
     private async tabCompleteName(): Promise<void> {
         try {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19103
Opens https://github.com/vector-im/element-web/issues/19077
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert Firefox composer deletion hacks ([\#6844](https://github.com/matrix-org/matrix-react-sdk/pull/6844)). Fixes vector-im/element-web#19103 and vector-im/element-web#19103. Contributed by [SimonBrandner](https://github.com/SimonBrandner).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6148aab482275d3d0121a8d0--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
