### PR TITLE
Fix spacing for message composer buttons

### DIFF
--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -185,16 +185,26 @@ limitations under the License.
     }
 }
 
+.mx_ContextualMenu {
+    .mx_MessageComposer_button {
+        padding-left: calc(var(--size) + 6px);
+    }
+}
+
 .mx_MessageComposer_button {
     --size: 26px;
     position: relative;
-    margin-right: 6px;
     cursor: pointer;
     height: var(--size);
     line-height: var(--size);
     width: auto;
-    padding-left: calc(var(--size) + 5px);
+    padding-left: var(--size);
     border-radius: 100%;
+    margin-right: 6px;
+
+    &:last-child {
+        margin-right: auto;
+    }
 
     &::before {
         content: '';


### PR DESCRIPTION
Fixes vector-im/element-web#18999

<img width="169" alt="Screen Shot 2021-09-22 at 11 55 44" src="https://user-images.githubusercontent.com/769871/134331601-85ed1903-ccd9-47f4-b94b-d3cfc66148e4.png">
<img width="230" alt="Screen Shot 2021-09-22 at 11 55 50" src="https://user-images.githubusercontent.com/769871/134331603-27d456fc-bf53-4eca-93c1-20dd18fa50e0.png">

Some extra padding was needed when icons have some text in the contextual menu, but that unfortunately got applied for the normal message composer buttons too, creating this extra space

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix spacing for message composer buttons ([\#6852](https://github.com/matrix-org/matrix-react-sdk/pull/6852)). Fixes vector-im/element-web#18999.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://614b0ce2fb9b01ac7f74dbc3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
