### PR TITLE
Fix Notifications settings view when threepids is undefined

### DIFF
--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -480,7 +480,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
             return masterSwitch;
         }
 
-        const emailSwitches = this.state.threepids.filter(t => t.medium === ThreepidMedium.Email)
+        const emailSwitches = (this.state.threepids || []).filter(t => t.medium === ThreepidMedium.Email)
             .map(e => <LabelledToggleSwitch
                 key={e.address}
                 value={this.state.pushers.some(p => p.kind === "email" && p.pushkey === e.address)}


### PR DESCRIPTION

Fixes vector-im/element-web#18731 where the 'Notifications' settings would immediately close if running under a non-Synapse homeserver that returns `{}` instead of `{ "threepids": [] }` for the optional third-party IDs field.

Related:

- https://github.com/vector-im/element-web/issues/18469
- https://github.com/ruma/ruma/pull/689

Either the spec needs to be updated to mark this field as required, or `matrix-react-sdk`-based clients (Element) need to bring in this change.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://614b57ef41f2e6034614f7c6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
