### PR TITLE
Change CIDER state persistence key to cater for threads

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -164,6 +164,20 @@ export default class SendMessageComposer extends React.Component<IProps> {
         window.addEventListener("beforeunload", this.saveStoredEditorState);
     }
 
+    public componentDidUpdate(prevProps: IProps): void {
+        const replyToEventChanged = this.props.replyToEvent !== prevProps.replyToEvent;
+        if (replyToEventChanged) {
+            this.model.reset([]);
+        }
+
+        if (this.props.replyInThread && this.props.replyToEvent && (!prevProps.replyToEvent || replyToEventChanged)) {
+            const partCreator = new CommandPartCreator(this.props.room, this.context);
+            const parts = this.restoreStoredEditorState(partCreator) || [];
+            this.model.reset(parts);
+            this.editorRef.current?.focus();
+        }
+    }
+
     private onKeyDown = (event: KeyboardEvent): void => {
         // ignore any keypress while doing IME compositions
         if (this.editorRef.current?.isComposing(event)) {
@@ -484,7 +498,12 @@ export default class SendMessageComposer extends React.Component<IProps> {
     }
 
     private get editorStateKey() {
-        return `mx_cider_state_${this.props.room.roomId}`;
+        let key = `mx_cider_state_${this.props.room.roomId}`;
+        const thread = this.props.replyToEvent?.getThread();
+        if (thread) {
+            key += `_${thread.id}`;
+        }
+        return key;
     }
 
     private clearStoredEditorState(): void {
@@ -492,6 +511,10 @@ export default class SendMessageComposer extends React.Component<IProps> {
     }
 
     private restoreStoredEditorState(partCreator: PartCreator): Part[] {
+        if (this.props.replyInThread && !this.props.replyToEvent) {
+            return null;
+        }
+
         const json = localStorage.getItem(this.editorStateKey);
         if (json) {
             try {

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -165,7 +165,7 @@ export default class SendMessageComposer extends React.Component<IProps> {
     }
 
     public componentDidUpdate(prevProps: IProps): void {
-        const replyToEventChanged = this.props.replyToEvent !== prevProps.replyToEvent;
+        const replyToEventChanged = this.props.replyInThread && (this.props.replyToEvent !== prevProps.replyToEvent);
         if (replyToEventChanged) {
             this.model.reset([]);
         }


### PR DESCRIPTION
Fixes vector-im/element-web#18989

Extending the CIDER state persistence to threads and make sure that SendMessageComposer can restore drafts for specific threads

This also prevents the thread's replyToEvent to leaking in the room composer

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://614da5c1964252d109db6b22--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
