### PR TITLE
Move timestamp to the right in thread's context

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -732,6 +732,11 @@ $hover-select-border: 4px;
         margin-top: 0;
         padding-bottom: 5px;
         margin-bottom: 5px;
+
+        .mx_MessageTimestamp {
+            left: auto;
+            right: 0;
+        }
     }
 
     .mx_MessageComposer_sendMessage {


### PR DESCRIPTION
Adds a temporary fix before we implement the thread's UI properly

# Before 🙅

<img width="370" alt="Screen Shot 2021-09-24 at 11 44 39" src="https://user-images.githubusercontent.com/769871/134662349-1426ed1b-e217-40de-9c62-1eb88d348da2.png">

# After 💅 

<img width="355" alt="Screen Shot 2021-09-24 at 11 44 31" src="https://user-images.githubusercontent.com/769871/134662358-4437d5f5-4d9f-40c7-b91f-20e0b65c4f58.png">


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://614dad3314819ac4b658ebea--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
