### PR TITLE
Fix pills being cut off in message bubble layout

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -18,7 +18,7 @@ a.mx_Pill {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    max-width: calc(100% - 1ch);
+    max-width: 100%;
 }
 
 .mx_Pill {


### PR DESCRIPTION
|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/48614497/134812108-2a2a9d2e-ee33-40fa-b9f1-5475a46974c9.png)|![after](https://user-images.githubusercontent.com/48614497/134812110-6ac595fa-abf2-496f-82af-d7ba5412361a.png)|
|![before2](https://user-images.githubusercontent.com/48614497/134812225-6ff1e4bc-591d-43c9-a629-e01f4b20d5d0.png)|![after2](https://user-images.githubusercontent.com/48614497/134812232-9a3b64c3-730e-4116-bbb1-19682a988f91.png)|

I can't really see a reason why the `- 1ch` had to be there, as it doesn't look like this change negatively impacts the Modern layout.

Type: defect

Fixes https://github.com/vector-im/element-web/issues/18627.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix pills being cut off in message bubble layout ([\#6865](https://github.com/matrix-org/matrix-react-sdk/pull/6865)). Fixes vector-im/element-web#18627. Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://615085d9faac448266dd33a2--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
