### PR TITLE
Fix issue with preview panel close button not appearing for certain messages containing a URL

### DIFF
--- a/src/components/views/rooms/LinkPreviewGroup.tsx
+++ b/src/components/views/rooms/LinkPreviewGroup.tsx
@@ -87,7 +87,10 @@ const fetchPreviews = (cli: MatrixClient, links: string[], ts: number):
         Promise<[string, IPreviewUrlResponse][]> => {
     return Promise.all<[string, IPreviewUrlResponse] | void>(links.map(async link => {
         try {
-            return [link, await cli.getUrlPreview(link, ts)];
+            const preview = await cli.getUrlPreview(link, ts);
+            if (preview && Object.keys(preview).length > 0) {
+                return [link, preview];
+            }
         } catch (error) {
             console.error("Failed to get URL preview: " + error);
         }

--- a/src/components/views/rooms/LinkPreviewGroup.tsx
+++ b/src/components/views/rooms/LinkPreviewGroup.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useContext, useEffect } from "react";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
-import { IPreviewUrlResponse } from "matrix-js-sdk/src/client";
+import { IPreviewUrlResponse, MatrixClient } from "matrix-js-sdk/src/client";
 
 import { useStateToggle } from "../../../hooks/useStateToggle";
 import LinkPreviewWidget from "./LinkPreviewWidget";
@@ -40,13 +40,7 @@ const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick, onH
 
     const ts = mxEvent.getTs();
     const previews = useAsyncMemo<[string, IPreviewUrlResponse][]>(async () => {
-        return Promise.all<[string, IPreviewUrlResponse] | void>(links.map(async link => {
-            try {
-                return [link, await cli.getUrlPreview(link, ts)];
-            } catch (error) {
-                console.error("Failed to get URL preview: " + error);
-            }
-        })).then(a => a.filter(Boolean)) as Promise<[string, IPreviewUrlResponse][]>;
+        return fetchPreviews(cli, links, ts);
     }, [links, ts], []);
 
     useEffect(() => {
@@ -87,6 +81,17 @@ const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick, onH
         )) }
         { toggleButton }
     </div>;
+};
+
+const fetchPreviews = (cli: MatrixClient, links: string[], ts: number):
+        Promise<[string, IPreviewUrlResponse][]> => {
+    return Promise.all<[string, IPreviewUrlResponse] | void>(links.map(async link => {
+        try {
+            return [link, await cli.getUrlPreview(link, ts)];
+        } catch (error) {
+            console.error("Failed to get URL preview: " + error);
+        }
+    })).then(a => a.filter(Boolean)) as Promise<[string, IPreviewUrlResponse][]>;
 };
 
 export default LinkPreviewGroup;


### PR DESCRIPTION
Fixes vector-im/element-web#19138

Whenever a message contained at least two URLs, and the preview of the first URL was empty (i.e. the call to `/media/r0/preview_url` returns `{}`), the close button for the preview panel would not be rendered. 

This was caused by the `render()` method of `LinkPreviewWidget` returning early whenever a preview is invalid. Since the close button is passed to the first `LinkPreviewWidget`, and that `LinkPreviewWidget` didn't render, the close button wouldn't be rendered either.

This PR fixes the issue by removing invalid previews immediately after the calls to `cli.getUrlPreview()`.

Notes: Fix [issue](https://github.com/vector-im/element-web/issues/19138) with preview panel close button not appearing for certain messages containing a URL

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix [issue](https ([\#6871](https://github.com/matrix-org/matrix-react-sdk/pull/6871)). Fixes vector-im/element-web#19138. Contributed by @psrpinto.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6151fd9c6db04c762902d882--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
