### PR TITLE
If public room creation fails, retry without publishing it (#19194)

### DIFF
--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -221,6 +221,14 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
     let roomId;
     return client.createRoom(createOpts).finally(function() {
         if (modal) modal.close();
+    }).catch(function(err) {
+        if (err.httpStatus === 403 && err.errcode == "M_UNKNOWN") {
+            console.warn("Failed to publish room, try again without publishing it");
+            createOpts.visibility = Visibility.Private;
+            return client.createRoom(createOpts);
+        } else {
+            return Promise.reject(err);
+        }
     }).then(function(res) {
         roomId = res.room_id;
         if (opts.dmUserId) {


### PR DESCRIPTION
Signed-off-by: Andrew Ferrazzutti <fair@miscworks.net>

Note that using this against Synapse requires https://github.com/matrix-org/synapse/pull/10930 , lest the retried room creation gets blocked due to the room's alias being consumed by the first room creation attempt.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
