### PR TITLE
Fix pagination when filtering space hierarchy

### DIFF
--- a/src/components/structures/SpaceHierarchy.tsx
+++ b/src/components/structures/SpaceHierarchy.tsx
@@ -452,7 +452,7 @@ export const useSpaceSummary = (space: Room): {
         await hierarchy.load(pageSize);
         setRooms(hierarchy.rooms);
         setLoading(false);
-    }, [hierarchy]);
+    }, [loading, hierarchy]);
 
     return { loading, rooms, hierarchy, loadMore };
 };

--- a/src/components/structures/SpaceHierarchy.tsx
+++ b/src/components/structures/SpaceHierarchy.tsx
@@ -446,7 +446,7 @@ export const useSpaceSummary = (space: Room): {
     }));
 
     const loadMore = useCallback(async (pageSize?: number) => {
-        if (!hierarchy.canLoadMore || hierarchy.noSupport) return;
+        if (loading || !hierarchy.canLoadMore || hierarchy.noSupport) return;
 
         setLoading(true);
         await hierarchy.load(pageSize);
@@ -648,8 +648,6 @@ const SpaceHierarchy = ({
     return <RovingTabIndexProvider onKeyDown={onKeyDown} handleHomeEnd handleUpDown>
         { ({ onKeyDownHandler }) => {
             let content: JSX.Element;
-            let loader: JSX.Element;
-
             if (loading && !rooms.length) {
                 content = <Spinner />;
             } else {
@@ -671,16 +669,17 @@ const SpaceHierarchy = ({
                             }}
                         />
                     </>;
-
-                    if (hierarchy.canLoadMore) {
-                        loader = <div ref={loaderRef}>
-                            <Spinner />
-                        </div>;
-                    }
-                } else {
+                } else if (!hierarchy.canLoadMore) {
                     results = <div className="mx_SpaceHierarchy_noResults">
                         <h3>{ _t("No results found") }</h3>
                         <div>{ _t("You may want to try a different search or check for typos.") }</div>
+                    </div>;
+                }
+
+                let loader: JSX.Element;
+                if (hierarchy.canLoadMore) {
+                    loader = <div ref={loaderRef}>
+                        <Spinner />
                     </div>;
                 }
 


### PR DESCRIPTION
Previously if you filtered down to 0 results it would not allow any further pagination to happen so your result may never show up.

Fixes https://github.com/vector-im/element-web/issues/19235

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix pagination when filtering space hierarchy ([\#6876](https://github.com/matrix-org/matrix-react-sdk/pull/6876)). Fixes vector-im/element-web#19235.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://6153138b8269f638c7738bb7--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
