### PR TITLE
Remove extra 'are' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Code should be committed as follows:
  * CSS: https://github.com/matrix-org/matrix-react-sdk/tree/master/res/css
  * Theme specific CSS & resources: https://github.com/matrix-org/matrix-react-sdk/tree/master/res/themes
 
-React components in matrix-react-sdk are come in two different flavours:
+React components in matrix-react-sdk come in two different flavours:
 'structures' and 'views'.  Structures are stateful components which handle the
 more complicated business logic of the app, delegating their actual presentation
 rendering to stateless 'view' components.  For instance, the RoomView component


### PR DESCRIPTION
Notes: none
element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://615444dabe4a320a7737eacd--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
