### PR TITLE
Fix colour of subheading text on export chat modal

### DIFF
--- a/res/css/views/dialogs/_ExportDialog.scss
+++ b/res/css/views/dialogs/_ExportDialog.scss
@@ -20,7 +20,6 @@ limitations under the License.
         display: block;
         font-family: $font-family;
         font-weight: $font-semi-bold;
-        color: $accent-fg-color;
         margin-top: 18px;
         margin-bottom: 12px;
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19238

![image](https://user-images.githubusercontent.com/2403652/135485403-62db7a9d-100e-4c45-a0cf-66c87ee36c85.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->