### PR TITLE
Fix issue that caused the value of certain settings to be inverted

### DIFF
--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -164,6 +164,7 @@ export default class SettingsStore {
 
         const localizedCallback = (changedInRoomId, atLevel, newValAtLevel) => {
             const newValue = SettingsStore.getValue(originalSettingName);
+            newValAtLevel = SettingsStore.getValueAt(atLevel, originalSettingName);
             callbackFn(originalSettingName, changedInRoomId, atLevel, newValAtLevel, newValue);
         };
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19201

When using the `SettingsStore.watchSetting()` method for settings which have an `invertedSettingName`, the `newValueAt` argument passed to the callback function, would erroneously contain the inverted value.

This was making it so that such settings appeared to be disabled when they should in fact be enabled, or vice-versa. This was however only the case for code which took in account the `newValueAt` argument. Code using the `newValue` argument was not affected.

The settings which have an `invertedSettingName`, and were thus potentially impacted are:

- MessageComposerInput.dontSuggestEmoji
- hideRedactions
- hideJoinLeaves
- hideAvatarChanges
- hideDisplaynameChanges
- hideReadReceipts
- Pill.shouldHidePillAvatar
- TextualBody.disableBigEmoji
- dontSendTypingNotifications
- TagPanel.disableTagPanel
- webRtcForceTURN

This appears to be a regression introduced in https://github.com/matrix-org/matrix-react-sdk/pull/6261.

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
