### PR TITLE
Decrease profile button touch target

### DIFF
--- a/res/css/views/settings/_ProfileSettings.scss
+++ b/res/css/views/settings/_ProfileSettings.scss
@@ -67,5 +67,7 @@ limitations under the License.
 
     > .mx_AccessibleButton_kind_link {
         padding-left: 0; // to align with left side
+        padding-right: 0;
+        margin-right: 10px;
     }
 }


### PR DESCRIPTION
Type: enhancement

---

Decrease size of irregular touch target in user/room profile setting tab (under General). This way there is an unclickable region between the buttons, as in the other menus. If it were up to me, I'd make all four padding directions symmetrical, but it looks like someone already decided to make the left side of the text line up with the edge of the menu.

## Before

![image](https://user-images.githubusercontent.com/52425971/135767604-11714a20-c9d7-45fd-be48-624bf6e3e9fa.png)

## After

![image](https://user-images.githubusercontent.com/52425971/135767614-db6cb101-9884-4c9e-8d71-6babfacca29f.png)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Decrease profile button touch target ([\#6900](https://github.com/matrix-org/matrix-react-sdk/pull/6900)). Contributed by @ColonisationCaptain.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6159fca90314156883e80b7f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
