### PR TITLE
Hide kick & ban options in UserInfo when looking at own profile

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -535,8 +535,6 @@ interface IBaseProps {
 const RoomKickButton: React.FC<IBaseProps> = ({ member, startUpdating, stopUpdating }) => {
     const cli = useContext(MatrixClientContext);
 
-    // don't render this button on our own profile, we don't want to kick ourselves
-    if (member.userId === cli.getUserId()) return null;
     // check if user can be kicked/disinvited
     if (member.membership !== "invite" && member.membership !== "join") return null;
 
@@ -660,9 +658,6 @@ const RedactMessagesButton: React.FC<IBaseProps> = ({ member }) => {
 
 const BanToggleButton: React.FC<IBaseProps> = ({ member, startUpdating, stopUpdating }) => {
     const cli = useContext(MatrixClientContext);
-
-    // don't render this button on our own profile, we don't want to ban ourselves and can't unban ourselves anyhow
-    if (member.userId === cli.getUserId()) return null;
 
     const onBanOrUnban = async () => {
         const { finished } = Modal.createTrackedDialog(
@@ -822,7 +817,7 @@ const RoomAdminToolsContainer: React.FC<IBaseRoomProps> = ({
     const isMe = me.userId === member.userId;
     const canAffectUser = member.powerLevel < me.powerLevel || isMe;
 
-    if (canAffectUser && me.powerLevel >= kickPowerLevel) {
+    if (!isMe && canAffectUser && me.powerLevel >= kickPowerLevel) {
         kickButton = <RoomKickButton member={member} startUpdating={startUpdating} stopUpdating={stopUpdating} />;
     }
     if (me.powerLevel >= redactPowerLevel && (!SpaceStore.spacesEnabled || !room.isSpaceRoom())) {
@@ -830,10 +825,10 @@ const RoomAdminToolsContainer: React.FC<IBaseRoomProps> = ({
             <RedactMessagesButton member={member} startUpdating={startUpdating} stopUpdating={stopUpdating} />
         );
     }
-    if (canAffectUser && me.powerLevel >= banPowerLevel) {
+    if (!isMe && canAffectUser && me.powerLevel >= banPowerLevel) {
         banButton = <BanToggleButton member={member} startUpdating={startUpdating} stopUpdating={stopUpdating} />;
     }
-    if (canAffectUser && me.powerLevel >= editPowerLevel && !room.isSpaceRoom()) {
+    if (!isMe && canAffectUser && me.powerLevel >= editPowerLevel && !room.isSpaceRoom()) {
         muteButton = (
             <MuteToggleButton
                 member={member}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19066

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Hide kick & ban options in UserInfo when looking at own profile ([\#6911](https://github.com/matrix-org/matrix-react-sdk/pull/6911)). Fixes vector-im/element-web#19066.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://615dcad7b88bf54819d8c70b--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
