### PR TITLE
Scalar messaging: No-op setBotPower if the current PL is greater than the requested PL. 

### DIFF
--- a/src/ScalarMessaging.ts
+++ b/src/ScalarMessaging.ts
@@ -452,7 +452,9 @@ function setBotOptions(event: MessageEvent<any>, roomId: string, userId: string)
     });
 }
 
-function setBotPower(event: MessageEvent<any>, roomId: string, userId: string, level: number, ignoreIfGreater?: boolean): void {
+async function setBotPower(
+    event: MessageEvent<any>, roomId: string, userId: string, level: number, ignoreIfGreater?: boolean,
+): Promise<void> {
     if (!(Number.isInteger(level) && level >= 0)) {
         sendError(event, _t('Power level must be positive integer.'));
         return;
@@ -465,34 +467,34 @@ function setBotPower(event: MessageEvent<any>, roomId: string, userId: string, l
         return;
     }
 
-    client.getStateEvent(roomId, "m.room.power_levels", "").then((powerLevels) => {
-        const powerEvent = new MatrixEvent(
-            {
-                type: "m.room.power_levels",
-                content: powerLevels,
-            },
-        );
+    try {
+        const powerLevels = await client.getStateEvent(roomId, "m.room.power_levels", "");
 
         // If the PL is equal to or greater than the requested PL, ignore.
-        if (ignoreIfGreater) {
+        if (ignoreIfGreater === true) {
             // As per https://matrix.org/docs/spec/client_server/r0.6.0#m-room-power-levels
-            const currentPl = (powerLevels.content.users && powerLevels.content.users[userId]) || powerLevels.content.users_default || 0;
+            const currentPl = (
+                powerLevels.content.users && powerLevels.content.users[userId]
+            ) || powerLevels.content.users_default || 0;
 
             if (currentPl >= level) {
-                sendResponse(event, {
+                return sendResponse(event, {
                     success: true,
                 });
             }
         }
-
-        client.setPowerLevel(roomId, userId, level, powerEvent).then(() => {
-            sendResponse(event, {
-                success: true,
-            });
-        }, (err) => {
-            sendError(event, err.message ? err.message : _t('Failed to send request.'), err);
+        await client.setPowerLevel(roomId, userId, level, new MatrixEvent(
+            {
+                type: "m.room.power_levels",
+                content: powerLevels,
+            },
+        ));
+        return sendResponse(event, {
+            success: true,
         });
-    });
+    } catch (err) {
+        sendError(event, err.message ? err.message : _t('Failed to send request.'), err);
+    }
 }
 
 function getMembershipState(event: MessageEvent<any>, roomId: string, userId: string): void {


### PR DESCRIPTION
The Element-side fix to https://github.com/matrix-org/matrix-appservice-slack/issues/622

Currently, when scalar requests a PL change in the room it will attempt to set the PL of the bot to exactly the requested value even if it's greater than what's required. This is often not desirable as it means the request will fail if the user has already given the bot admin permissions, and they will be unable to degrade it.

Instead of introducing a new API to the scalar API, this instead introduces a new key `ignoreIfGreater`. When true this will no-op any requests to set a PL to less than the current PL. This shouldn't break any existing integration systems, as the default is still to explicitly set the PL.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://615dc93e2558d24f2d267f2d--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
