### PR TITLE
Allow the header container to collapse on itself when room list not minimised

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -176,11 +176,6 @@ limitations under the License.
         }
     }
 
-    // In the general case, we reserve space for each sublist header to prevent
-    // scroll jumps when they become sticky. However, that leaves a gap when
-    // scrolled to the top above the first sublist (whose header can only ever
-    // stick to top), so we make sure to exclude the first visible sublist.
-
     .mx_RoomSublist_resizeBox {
         position: relative;
 


### PR DESCRIPTION
Fixes vector-im/element-web#17068

<img width="474" alt="Screen Shot 2021-10-07 at 10 57 51" src="https://user-images.githubusercontent.com/769871/136362989-afcfde5e-3552-4c7f-97e3-73e99945ca4d.png">
<img width="96" alt="Screen Shot 2021-10-07 at 10 58 01" src="https://user-images.githubusercontent.com/769871/136363006-f2a2b550-6047-471a-9e49-9dc5ad1528c5.png">


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://615f210f3aad185471daf984--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
