### PR TITLE
Update room settings dialog title when room name changes

### DIFF
--- a/src/components/views/dialogs/RoomSettingsDialog.tsx
+++ b/src/components/views/dialogs/RoomSettingsDialog.tsx
@@ -59,8 +59,8 @@ export default class RoomSettingsDialog extends React.Component<IProps, IState> 
 
     public componentDidMount() {
         this.dispatcherRef = dis.register(this.onAction);
-        MatrixClientPeg.get().on("Room.name", this.setRoomName);
-        this.setRoomName();
+        MatrixClientPeg.get().on("Room.name", this.onRoomName);
+        this.onRoomName();
     }
 
     public componentWillUnmount() {
@@ -68,7 +68,7 @@ export default class RoomSettingsDialog extends React.Component<IProps, IState> 
             dis.unregister(this.dispatcherRef);
         }
 
-        MatrixClientPeg.get().removeListener("Room.name", this.setRoomName);
+        MatrixClientPeg.get().removeListener("Room.name", this.onRoomName);
     }
 
     private onAction = (payload): void => {
@@ -79,7 +79,7 @@ export default class RoomSettingsDialog extends React.Component<IProps, IState> 
         }
     };
 
-    private setRoomName = (): void => {
+    private onRoomName = (): void => {
         this.setState({
             roomName: MatrixClientPeg.get().getRoom(this.props.roomId).name,
         });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17480

This PR makes it so that the `RoomSettingsDialog` component listens to `Room.name` events, so that the dialog title is updated when the room name changes.

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Update room settings dialog title when room name changes ([\#6916](https://github.com/matrix-org/matrix-react-sdk/pull/6916)). Fixes vector-im/element-web#17480 and vector-im/element-web#17480. Contributed by @psrpinto.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://615f1d9a53eb8b44c0f29ef5--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
