### PR TITLE
updating from boolean to object in order to track if more than one th…

### DIFF
--- a/src/components/views/room_settings/RoomProfileSettings.tsx
+++ b/src/components/views/room_settings/RoomProfileSettings.tsx
@@ -90,14 +90,14 @@ export default class RoomProfileSettings extends React.Component<IProps, IState>
             avatarFile: null,
             profileFieldsTouched: {
                 ...this.state.profileFieldsTouched,
-                avatar: true
+                avatar: true,
             },
         });
     };
 
     private isSaveEnabled = () => {
-        return Boolean(Object.values(this.state.profileFieldsTouched).length)
-    }
+        return Boolean(Object.values(this.state.profileFieldsTouched).length);
+    };
 
     private cancelProfileChanges = async (e: React.MouseEvent): Promise<void> => {
         e.stopPropagation();
@@ -166,13 +166,14 @@ export default class RoomProfileSettings extends React.Component<IProps, IState>
             this.setState({
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    name: false
-            }, });
+                    name: false,
+                },
+            });
         } else {
             this.setState({
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    name: true
+                    name: true,
                 },
             });
         }
@@ -184,14 +185,14 @@ export default class RoomProfileSettings extends React.Component<IProps, IState>
             this.setState({
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    topic: false
+                    topic: false,
                 },
             });
         } else {
             this.setState({
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    topic: true
+                    topic: true,
                 },
             });
         }
@@ -204,7 +205,7 @@ export default class RoomProfileSettings extends React.Component<IProps, IState>
                 avatarFile: null,
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    avatar: false
+                    avatar: false,
                 },
             });
             return;
@@ -218,7 +219,7 @@ export default class RoomProfileSettings extends React.Component<IProps, IState>
                 avatarFile: file,
                 profileFieldsTouched: {
                     ...this.state.profileFieldsTouched,
-                    avatar: true
+                    avatar: true,
                 },
             });
         };


### PR DESCRIPTION
Fixes this issue https://github.com/vector-im/element-web/issues/19283 from another project which uses the `matrix-react-sdk`. 

The current behavior updated the boolean based on the most recent input that was being interacted with instead of tracking potentially all of the inputs for editing a room. This PR addresses that by tracking on the input level.

Signed-off-by: Logan Arnett <logan@loganarnett.com>

Notes: Updated how save button becomes disabled in room settings to listen for all fields instead of the most recent


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Updated how save button becomes disabled in room settings to listen for all fields instead of the most recent ([\#6917](https://github.com/matrix-org/matrix-react-sdk/pull/6917)). Contributed by @LoganArnett.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61600899682a1900a093a47e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
