### PR TITLE
Hide leave section button if user isn't in the room e.g peeking

### DIFF
--- a/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
@@ -90,6 +90,18 @@ export default class GeneralRoomSettingsTab extends React.Component<IProps, ISta
             </>;
         }
 
+        let leaveSection;
+        if (room.getMyMembership() === "join") {
+            leaveSection = <>
+                <span className='mx_SettingsTab_subheading'>{ _t("Leave room") }</span>
+                <div className='mx_SettingsTab_section'>
+                    <AccessibleButton kind='danger' onClick={this.onLeaveClick}>
+                        { _t('Leave room') }
+                    </AccessibleButton>
+                </div>
+            </>;
+        }
+
         return (
             <div className="mx_SettingsTab mx_GeneralRoomSettingsTab">
                 <div className="mx_SettingsTab_heading">{ _t("General") }</div>
@@ -109,17 +121,7 @@ export default class GeneralRoomSettingsTab extends React.Component<IProps, ISta
                 <div className="mx_SettingsTab_heading">{ _t("Other") }</div>
                 { flairSection }
                 { urlPreviewSettings }
-
-                <span className='mx_SettingsTab_subheading'>{ _t("Leave room") }</span>
-                <div className='mx_SettingsTab_section'>
-                    <AccessibleButton
-                        kind='danger'
-                        onClick={this.onLeaveClick}
-                        disabled={room.getMyMembership() !== "join"}
-                    >
-                        { _t('Leave room') }
-                    </AccessibleButton>
-                </div>
+                { leaveSection }
             </div>
         );
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17410

![image](https://user-images.githubusercontent.com/2403652/136792956-132ddd14-3933-4fa0-9c08-2662a4c886c9.png)

(observe absence of Leave Room section)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Hide leave section button if user isn't in the room e.g peeking ([\#6920](https://github.com/matrix-org/matrix-react-sdk/pull/6920)). Fixes vector-im/element-web#17410 and vector-im/element-web#17410.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://616433f7a841fe7fed8bf70c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
