### PR TITLE
Prevent profile image in left panel's backdrop from being selected

### DIFF
--- a/res/css/structures/_BackdropPanel.scss
+++ b/res/css/structures/_BackdropPanel.scss
@@ -34,4 +34,5 @@ limitations under the License.
     z-index: 0;
     pointer-events: none;
     overflow: hidden;
+    user-select: none;
 }


### PR DESCRIPTION
Type: defect

Double clicking "Expand/Collapse space panel" button in Element Desktop (v1.8.5) caused profile image shown in background to be selected, changing its color until clicked away in another place. Issue is also present in Element Web on Chromium (v94.0.4606.81), but not on Firefox (v93.0).

Before:

https://user-images.githubusercontent.com/46846000/136718487-2d487776-f1c0-4b33-a237-170b5dce0a52.mp4

After:

https://user-images.githubusercontent.com/46846000/136718492-548241c7-bb5f-478e-b406-cc98ed05de90.mp4

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent profile image in left panel's backdrop from being selected ([\#6924](https://github.com/matrix-org/matrix-react-sdk/pull/6924)). Contributed by @rom4nik.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6163ee5e559f6ee8377248ce--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
