### PR TITLE
Change media devices mid-call

### DIFF
--- a/src/components/views/voip/VideoFeed.tsx
+++ b/src/components/views/voip/VideoFeed.tsx
@@ -163,6 +163,7 @@ export default class VideoFeed extends React.PureComponent<IProps, IState> {
             audioMuted: this.props.feed.isAudioMuted(),
             videoMuted: this.props.feed.isVideoMuted(),
         });
+        this.playMedia();
     };
 
     private onMuteStateChanged = () => {


### PR DESCRIPTION
Companion to https://github.com/matrix-org/matrix-js-sdk/pull/1977 in which we add support for changing media devices mid-call. In the matrix-react-sdk this requires a one line change which updates the stream in the `VideoFeed` when it changes.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Change media devices mid-call ([\#6935](https://github.com/matrix-org/matrix-react-sdk/pull/6935)). Contributed by @robertlong.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6165fcc949fb1e009f8278fd--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
