### PR TITLE
Fix bug where room list would get stuck showing no rooms

### DIFF
--- a/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
+++ b/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
@@ -52,7 +52,7 @@ const CATEGORY_ORDER = [
  *
  * The importance of a room is defined by the kind of notifications, if any, are
  * present on the room. These are classified internally as Unsent, Red, Grey,
- * Bold, and Idle. 'Unsent' rooms habe unsent messages, Red rooms have mentions,
+ * Bold, and Idle. 'Unsent' rooms have unsent messages, Red rooms have mentions,
  * grey have unread messages, bold is a less noisy version of grey, and idle
  * means all activity has been seen by the user.
  *


### PR DESCRIPTION
If you had an unsent message in a room that was in a sublist with
the 'Show rooms with unread messages first' option enabled, the
room list would show no rooms next time you restarted element and
get stuck that way.

This was because there was a different notification category for
rooms with unsent messages but the algorithm is hard-coded to add
only a fixed set of categories to its list, and it missed 'unsent',
so it NPEed when it encountered a room with an unsent message.

This just adds the category (assuming that we want to show rooms
with unsent messages first). It doesn't make it less hard-coded, or
fix the fact that an exception in the room list code causes everything
to break.

Fixes https://github.com/vector-im/element-web/issues/19373

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix bug where room list would get stuck showing no rooms ([\#6939](https://github.com/matrix-org/matrix-react-sdk/pull/6939)). Fixes vector-im/element-web#19373.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://6166f1602bb7ec0af9d3e455--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
