### PR TITLE
Move the required CSS for DevicesPanel into its own scss file

### DIFF
--- a/res/css/views/settings/_DevicesPanel.scss
+++ b/res/css/views/settings/_DevicesPanel.scss
@@ -17,7 +17,10 @@ limitations under the License.
 .mx_DevicesPanel {
     display: table;
     table-layout: fixed;
-    width: 880px;
+    // Normally the panel is 880px, however this can easily overflow the container.
+    // TODO: Fix the table to not be squishy
+    width: auto;
+    max-width: 880px;
     border-spacing: 10px;
 }
 

--- a/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_SecurityUserSettingsTab .mx_DevicesPanel {
-    // Normally the panel is 880px, however this can easily overflow the container.
-    // TODO: Fix the table to not be squishy
-    width: auto;
-    max-width: 880px;
-}
-
 .mx_SecurityUserSettingsTab_deviceInfo {
     display: table;
     padding-left: 0;


### PR DESCRIPTION
When attempting screenshot testing (#6938) I found that the DevicesPanel does not render correctly outside of its parent container because some vital CSS is defined in `_SecurityUserSettingsTab.scss`.

Since DevicesPanel is only ever used in this context, it seemed right to me to move this CSS into `_DevicesPanel.scss`.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->