### PR TITLE
Add 'm.thread' relation to replies when replying to a threaded event

### DIFF
--- a/src/components/views/elements/ReplyThread.tsx
+++ b/src/components/views/elements/ReplyThread.tsx
@@ -35,7 +35,6 @@ import Spinner from './Spinner';
 import ReplyTile from "../rooms/ReplyTile";
 import Pill from './Pill';
 import { Room } from 'matrix-js-sdk/src/models/room';
-import { threadId } from 'worker_threads';
 import { RelationType } from 'matrix-js-sdk/src/@types/event';
 
 /**


### PR DESCRIPTION
Fixes vector-im/element-web#19389

This is especially important during the transition period where some people will have threads enabled and others won't.
Even if you have the threads labs flag disabled, we want to send the `m.thread` relation if you reply to a threaded event so that other clients can render that accurately

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->