### PR TITLE
Allow EventTile to be rendered with mock events

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -478,7 +478,7 @@ export default class EventTile extends React.Component<IProps, IState> {
         }
 
         const room = this.context.getRoom(this.props.mxEvent.getRoomId());
-        room.on(ThreadEvent.New, this.onNewThread);
+        room?.on(ThreadEvent.New, this.onNewThread);
     }
 
     private updateThread = (thread) => {
@@ -522,7 +522,7 @@ export default class EventTile extends React.Component<IProps, IState> {
         }
 
         const room = this.context.getRoom(this.props.mxEvent.getRoomId());
-        room.off(ThreadEvent.New, this.onNewThread);
+        room?.off(ThreadEvent.New, this.onNewThread);
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -553,7 +553,7 @@ export default class EventTile extends React.Component<IProps, IState> {
          * when we are at the sync stage
          */
         const room = MatrixClientPeg.get().getRoom(this.props.mxEvent.getRoomId());
-        const thread = room.threads.get(this.props.mxEvent.getId());
+        const thread = room?.threads.get(this.props.mxEvent.getId());
 
         if (thread && !thread.ready) {
             thread.addEvent(this.props.mxEvent, true);


### PR DESCRIPTION
Earlier changes made the `EventTile` relying on the `Room` model, which should not be required

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://616993500c9d4f007492f4ec--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
