### PR TITLE
For space invite previews, use room summary API to get the right member count

### DIFF
--- a/res/css/structures/_SpaceRoomView.scss
+++ b/res/css/structures/_SpaceRoomView.scss
@@ -511,10 +511,11 @@ $SpaceRoomViewInnerWidth: 428px;
         mask-image: url("$(res)/img/element-icons/lock.svg");
     }
 
-    .mx_AccessibleButton_kind_link {
+    .mx_SpaceRoomView_info_memberCount {
         color: inherit;
         position: relative;
-        padding-left: 16px;
+        padding: 0 0 0 16px;
+        font-size: $font-15px;
 
         &::before {
             content: "·"; // visual separator


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/1988
Fixes https://github.com/vector-im/element-web/issues/19123

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * For space invite previews, use room summary API to get the right member count ([\#6982](https://github.com/matrix-org/matrix-react-sdk/pull/6982)). Fixes vector-im/element-web#19123.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://616e98397783b20b6c463dba--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
