### PR TITLE
Validate email address in forgot password dialog

### DIFF
--- a/src/components/structures/auth/ForgotPassword.tsx
+++ b/src/components/structures/auth/ForgotPassword.tsx
@@ -171,10 +171,13 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
         // refresh the server errors, just in case the server came back online
         await this.handleHttpRequest(this.checkServerLiveliness(this.props.serverConfig));
 
+        await this['email_field'].validate({ allowEmpty: false });
         await this['password_field'].validate({ allowEmpty: false });
 
         if (!this.state.email) {
             this.showErrorDialog(_t('The email address linked to your account must be entered.'));
+        } else if (!this.state.emailFieldValid) {
+            this.showErrorDialog(_t("The email address doesn't appear to be valid."));
         } else if (!this.state.password || !this.state.password2) {
             this.showErrorDialog(_t('A new password must be entered.'));
         } else if (!this.state.passwordFieldValid) {
@@ -305,6 +308,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
                         label={_t('Email')}
                         value={this.state.email}
                         onChange={this.onInputChanged.bind(this, "email")}
+                        ref={field => this['email_field'] = field}
                         autoFocus
                         onValidate={this.onEmailValidate}
                         onFocus={() => CountlyAnalytics.instance.track("onboarding_forgot_password_email_focus")}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3015,6 +3015,7 @@
     "Skip verification for now": "Skip verification for now",
     "Failed to send email": "Failed to send email",
     "The email address linked to your account must be entered.": "The email address linked to your account must be entered.",
+    "The email address doesn't appear to be valid.": "The email address doesn't appear to be valid.",
     "A new password must be entered.": "A new password must be entered.",
     "Please choose a strong password": "Please choose a strong password",
     "New passwords must match each other.": "New passwords must match each other.",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/9978

This PR validates the email address field in the _forgot password_ dialog, in a similar way to the validation in the login and registration dialogs.

---

<img width="639" alt="Screenshot 2021-10-19 at 14 32 08" src="https://user-images.githubusercontent.com/550401/137920773-94018c0a-885c-49c7-8b0e-5fbdffb98363.png">

<img width="844" alt="Screenshot 2021-10-19 at 14 32 21" src="https://user-images.githubusercontent.com/550401/137920835-05f75a2f-951c-409f-a19c-fa07009d0687.png">

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Validate email address in forgot password dialog ([\#6983](https://github.com/matrix-org/matrix-react-sdk/pull/6983)). Fixes vector-im/element-web#9978. Contributed by @psrpinto.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://616ecb3b0074fa110022c0f4--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
