### PR TITLE
Fix conflicting CSS on syntax highlighted blocks

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -589,10 +589,6 @@ $hover-select-border: 4px;
     padding: 0 10px;
 }
 
-.mx_EventTile_content .markdown-body .hljs {
-    display: inline !important;
-}
-
 /*
 // actually, removing the Italic TTF provides
 // better results seemingly

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -232,7 +232,6 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
             );
             return;
         }
-        console.log('highlighting');
 
         let advertisedLang;
         for (const cl of code.className.split(/\s+/)) {
@@ -258,7 +257,11 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
             // User has language detection enabled and the code is within a pre
             // we only auto-highlight if the code block is in a pre), so highlight
             // the block with auto-highlighting enabled.
-            highlight.highlightElement(code);
+            // We pass highlightjs the text to highlight rather than letting it
+            // work on the DOM with highlightElement because that also adds CSS
+            // classes to the pre/code element that we don't want (the CSS
+            // conflicts with our own).
+            code.innerHTML = highlight.highlightAuto(code.textContent).value;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19445

Also removes rogue debug logging

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix conflicting CSS on syntax highlighted blocks ([\#6991](https://github.com/matrix-org/matrix-react-sdk/pull/6991)). Fixes vector-im/element-web#19445 and vector-im/element-web#19445.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://616eff4e5aad9e499717477c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
