### PR TITLE
Fix colour variable references in composer format bar

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -21,7 +21,7 @@ limitations under the License.
     position: absolute;
     cursor: pointer;
     border-radius: 8px;
-    background-color: $primary-bg-color;
+    background-color: $background;
     border: 1px solid $input-border-color;
     user-select: none;
     // equal to z-index of mx_ReplyPreview and mx_RoomView_statusArea (1000)
@@ -61,11 +61,11 @@ limitations under the License.
         width: 100%;
         mask-repeat: no-repeat;
         mask-position: center;
-        background-color: $secondary-fg-color;
+        background-color: $secondary-content;
     }
 
     .mx_MessageComposerFormatBar_button:hover::after {
-        background-color: $primary-fg-color;
+        background-color: $primary-content;
     }
 
     .mx_MessageComposerFormatBar_buttonIconBold::after {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1190097/138129108-b00847bd-03e7-4b9f-a5c8-02e4edc7575e.png)

Regressed from https://github.com/matrix-org/matrix-react-sdk/pull/6351 due to colour variables getting changed around between open and merge.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61703e6efd47e4595afcbd81--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
