### PR TITLE
Add history entry before completing emoji

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -477,6 +477,8 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
             switch (autocompleteAction) {
                 case AutocompleteAction.ForceComplete:
                 case AutocompleteAction.Complete:
+                    this.historyManager.ensureLastChangesPushed(this.props.model);
+                    this.modifiedFlag = true;
                     autoComplete.confirmCompletion();
                     handled = true;
                     break;


### PR DESCRIPTION
This partially fixes https://github.com/vector-im/element-web/issues/19177. One still has to `ctrl+Z` 2 times before change happens.

Behaviour before commit:
![before](https://user-images.githubusercontent.com/8217676/138162486-d37b138a-ff5a-43ed-97b1-38c5a73c1b54.gif)

Behaviour after commit:
![after](https://user-images.githubusercontent.com/8217676/138162494-4abaf437-4d0b-46eb-8a7f-715211b9916e.gif)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add history entry before completing emoji ([\#7007](https://github.com/matrix-org/matrix-react-sdk/pull/7007)). Fixes vector-im/element-web#19177. Contributed by @RafaelGoncalves8.<!-- CHANGELOG_PREVIEW_END -->