### PR TITLE
Use VERSION as sentry release (set by packaging scripts)

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -201,7 +201,7 @@ export async function initSentry(sentryConfig: ISentryConfig): Promise<void> {
     if (!sentryConfig) return;
     Sentry.init({
         dsn: sentryConfig.dsn,
-        release: process.env.RELEASE,
+        release: process.env.VERSION,
         environment: sentryConfig.environment,
         defaultIntegrations: false,
         autoSessionTracking: false,


### PR DESCRIPTION
This variable needs to match the `release` set during build so source-maps can be found.

Set by element-web packaging script here: https://github.com/vector-im/element-web/pull/19474

This will be undefined for builds that don't set it (dev, and users other than `element-web`) - which is fine.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61729d7f935e4413d5947293--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
