### PR TITLE
Disable debug in Sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -205,7 +205,6 @@ export async function initSentry(sentryConfig: ISentryConfig): Promise<void> {
         environment: sentryConfig.environment,
         defaultIntegrations: false,
         autoSessionTracking: false,
-        debug: true,
         integrations: [
             // specifically disable Integrations.GlobalHandlers, which hooks uncaught exceptions - we don't
             // want to capture those at this stage, just explicit rageshakes


### PR DESCRIPTION
Disable the debug flag in sentry as it's spamming our logging and shouldn't really be on in prod.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6172dd5e95ef1f593a7eccf6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
