### PR TITLE
Always render disabled settings as disabled

### DIFF
--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -288,14 +288,10 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
     private renderGroup(
         settingIds: string[],
         level = SettingLevel.ACCOUNT,
-        includeDisabled = false,
     ): React.ReactNodeArray {
-        if (!includeDisabled) {
-            settingIds = settingIds.filter(SettingsStore.isEnabled);
-        }
-
         return settingIds.map(i => {
-            return <SettingsFlag key={i} name={i} level={level} />;
+            const disabled = !SettingsStore.isEnabled(i);
+            return <SettingsFlag key={i} name={i} level={level} disabled={disabled} />;
         });
     }
 
@@ -343,7 +339,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
 
                 <div className="mx_SettingsTab_section">
                     <span className="mx_SettingsTab_subheading">{ _t("Spaces") }</span>
-                    { this.renderGroup(PreferencesUserSettingsTab.SPACES_SETTINGS, SettingLevel.ACCOUNT, true) }
+                    { this.renderGroup(PreferencesUserSettingsTab.SPACES_SETTINGS, SettingLevel.ACCOUNT) }
                 </div>
 
                 <div className="mx_SettingsTab_section">


### PR DESCRIPTION
This is to prevent user confusion about whether or not a setting exists, or even what its value is. By rendering it with `disabled=true` the user is at least aware that the setting is set to a specific value, though we could (and should) do better in the future to communicate *why* a setting is disabled.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Always render disabled settings as disabled ([\#7014](https://github.com/matrix-org/matrix-react-sdk/pull/7014)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6172eeabe6fa8f66a7ee7b1e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
