### PR TITLE
Fix recent css regression

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -141,12 +141,6 @@ input[type=search]::-webkit-search-results-decoration {
 input::placeholder,
 textarea::placeholder {
     opacity: initial;
-    font-weight: 400;
-}
-input::-moz-placeholder,
-textarea::-moz-placeholder {
-    opacity: .6;
-    font-weight: 400;
 }
 
 input[type=text], input[type=password], textarea {


### PR DESCRIPTION
Type: defect

Fixes https://github.com/vector-im/element-web/issues/19470

**before**:

![image](https://user-images.githubusercontent.com/52425971/138566326-c7ce9200-be98-49f2-b39d-fe895f13138f.png)

**after**:

![image](https://user-images.githubusercontent.com/52425971/138566333-b0d3399b-7ad1-4571-9598-669fb40ffb12.png)


---

https://github.com/matrix-org/matrix-react-sdk/pull/6992 makes https://github.com/matrix-org/matrix-react-sdk/pull/6870 redundant. Looks like I can just revert https://github.com/matrix-org/matrix-react-sdk/pull/6870 without re-introducing https://github.com/vector-im/element-web/issues/19006 :

**Firefox v93.0**:

![image](https://user-images.githubusercontent.com/52425971/138566158-11ce88d6-cf27-4b0e-8e89-c45ca06c40d5.png)


**Chrome 95.0.4638.54**:

![image](https://user-images.githubusercontent.com/52425971/138566147-1bf21894-b4dc-4698-a630-e4a78ee81cce.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix recent css regression ([\#7022](https://github.com/matrix-org/matrix-react-sdk/pull/7022)). Fixes vector-im/element-web#19470. Contributed by @CicadaCinema.<!-- CHANGELOG_PREVIEW_END -->