### PR TITLE
Allow scrolling right in reply-quoted code block

### DIFF
--- a/res/css/views/rooms/_ReplyTile.scss
+++ b/res/css/views/rooms/_ReplyTile.scss
@@ -78,7 +78,7 @@ limitations under the License.
 
         // Hack to cut content in <pre> tags too
         .mx_EventTile_pre_container > pre {
-            overflow-y: scroll;
+            overflow-x: scroll;
             overflow-y: hidden;
             text-overflow: ellipsis;
             display: -webkit-box;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19487
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Allow scrolling right in reply-quoted code block ([\#7024](https://github.com/matrix-org/matrix-react-sdk/pull/7024)). Fixes vector-im/element-web#19487. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://617675d4b25196041c6c8a05--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
