### PR TITLE
null-guard space store getParents relation lookup

### DIFF
--- a/src/stores/SpaceStore.ts
+++ b/src/stores/SpaceStore.ts
@@ -315,7 +315,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
                 // child relations, as per MSC1772.
                 // https://github.com/matrix-org/matrix-doc/blob/main/proposals/1772-groups-as-rooms.md#relationship-between-rooms-and-spaces
                 const parent = this.matrixClient.getRoom(ev.getStateKey());
-                const relation = parent.currentState.getStateEvents(EventType.SpaceChild, roomId);
+                const relation = parent?.currentState.getStateEvents(EventType.SpaceChild, roomId);
                 if (!parent?.currentState.maySendStateEvent(EventType.SpaceChild, userId) ||
                     // also skip this relation if the parent had this child added but then since removed it
                     (relation && !Array.isArray(relation.getContent().via))


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19503
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/6944

marking as task because the PR which broke it hasn't been release yet

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6176b6cd667ae2816b25684e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
