### PR TITLE
Respect the roomState right container request for the Jitsi widget

### DIFF
--- a/src/stores/widgets/WidgetLayoutStore.ts
+++ b/src/stores/widgets/WidgetLayoutStore.ts
@@ -210,9 +210,8 @@ export class WidgetLayoutStore extends ReadyWatchingStore {
             let targetContainer = defaultContainer;
             if (!!manualContainer || !!stateContainer) {
                 targetContainer = (manualContainer) ? manualContainer : stateContainer;
-            }
-            // Special legacy case
-            else if (isLegacyPinned && !stateContainer) {
+            } else if (isLegacyPinned && !stateContainer) {
+                // Special legacy case
                 targetContainer = Container.Top;
             }
             (targetContainer === Container.Top ? topWidgets : rightWidgets).push(widget);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16552

The logic was missing the case(`stateContainer === Container.Right && manualContainer === undefined`), that a widget is has no userLayout but a room(state)Layout. (This means the issue should have also append the other way around for other widgets)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Respect the roomState right container request for the Jitsi widget ([\#7033](https://github.com/matrix-org/matrix-react-sdk/pull/7033)). Fixes vector-im/element-web#16552. Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://6177e96c340ef914a92a0ead--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
