### PR TITLE
Add padding between controls on edit form in message bubbles

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -232,7 +232,7 @@ limitations under the License.
     .mx_EditMessageComposer_buttons {
         position: static;
         padding: 0;
-        margin: 0;
+        margin: 8px 0 0;
         background: transparent;
     }
 


### PR DESCRIPTION
8px arbitrarily to make it not squishy

Before:
![image](https://user-images.githubusercontent.com/1190097/138998320-c57a2f01-2e6a-4901-9919-2f555ff7f6be.png)


Now:
![image](https://user-images.githubusercontent.com/1190097/138998268-bd6473d4-5ce3-426a-9c3b-1f31cdf53a69.png)


----

Links:
* https://element-io.atlassian.net/browse/PSFD-454

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add padding between controls on edit form in message bubbles ([\#7039](https://github.com/matrix-org/matrix-react-sdk/pull/7039)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6178d17ac0a2da6e89655219--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
