### PR TITLE
Add a condition to only activate the resizer which belongs to the clicked handle

### DIFF
--- a/src/resizer/resizer.ts
+++ b/src/resizer/resizer.ts
@@ -122,9 +122,14 @@ export default class Resizer<C extends IConfig = IConfig> {
         // child dom nodes that can be the target
         const resizeHandle = event.target && (<HTMLDivElement>event.target).closest(`.${this.classNames.handle}`);
         const hasHandler = this?.config?.handler;
-        if (!resizeHandle || (!hasHandler && resizeHandle.parentElement !== this.container)) {
+        // prevent that stacked resizer's are both activated with one mouse event
+        // (this is possible because the mouse events are connected to the containers not the handles)
+        if (!resizeHandle || // if no resizeHandle exist / mouse event hit the container not the handle
+            (!hasHandler && resizeHandle.parentElement !== this.container) || // no handler from config -> check if the containers match
+            (hasHandler && resizeHandle !== hasHandler)) { // handler from config -> check if the handlers match
             return;
         }
+
         // prevent starting a drag operation
         event.preventDefault();
 


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/19521
This prohibits multiple (wrong) resizer's being activated at once.
Before we were only checking if the containers match when there is no handle in the config(`!hasHandler`). This PR covers the case where there is a handle in the resizer config(`if (hasHandler)`). In this case it needs to be checked that the handle from the config matches the clicked handle. Or in other words, the resize need to be canceled if `resizeHandle !== hasHandler`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add a condition to only activate the resizer which belongs to the clicked handle ([\#7055](https://github.com/matrix-org/matrix-react-sdk/pull/7055)). Fixes vector-im/element-web#19521 and vector-im/element-web#19521. Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://617bd548f0301bd45347031a--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
