### PR TITLE
Ensure that creation continuation event is shown even if no other events are shown

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -1090,15 +1090,22 @@ class CreationGrouper extends BaseGrouper {
     }
 
     public getTiles(): ReactNode[] {
+        const panel = this.panel;
+        const ret = [];
+        const createEvent = this.event;
+
+        // If this m.room.create event should be shown (room upgrade) then show it before the summary
+        if (panel.shouldShowEvent(createEvent)) {
+            // pass in the createEvent as prevEvent as well so no extra DateSeparator is rendered
+            ret.push(...panel.getTilesForEvent(createEvent, createEvent));
+        }
+
         // If we don't have any events to group, don't even try to group them. The logic
         // below assumes that we have a group of events to deal with, but we might not if
         // the events we were supposed to group were redacted.
-        if (!this.events || !this.events.length) return [];
+        if (!this.events || !this.events.length) return ret;
 
-        const panel = this.panel;
-        const ret = [];
         const isGrouped = true;
-        const createEvent = this.event;
         const lastShownEvent = this.lastShownEvent;
 
         if (panel.wantsDateSeparator(this.prevEvent, createEvent.getDate())) {
@@ -1106,12 +1113,6 @@ class CreationGrouper extends BaseGrouper {
             ret.push(
                 <li key={ts+'~'}><DateSeparator key={ts+'~'} ts={ts} /></li>,
             );
-        }
-
-        // If this m.room.create event should be shown (room upgrade) then show it before the summary
-        if (panel.shouldShowEvent(createEvent)) {
-            // pass in the createEvent as prevEvent as well so no extra DateSeparator is rendered
-            ret.push(...panel.getTilesForEvent(createEvent, createEvent));
         }
 
         for (const ejected of this.ejectedEvents) {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

At Beeper, we do not show any of the room creation header (we do this by modifying `shouldShowEvent`). Because of this, when `getTiles` is called, there are no events to group under the creation event.

However, if the creation event references a previous conversation, we do want to show the link to the previous conversation. This change allows us to do that.

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: ensure that creation continuation event is shown even if no other events are shown

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://617ff51bd8361f5bdd4fcd09--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
