### PR TITLE
Restore composer focus after event edit

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -207,7 +207,10 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
                         event: null,
                         timelineRenderingType: this.context.timelineRenderingType,
                     });
-                    dis.fire(Action.FocusSendMessageComposer);
+                    dis.dispatch({
+                        action: Action.FocusSendMessageComposer,
+                        context: this.context.timelineRenderingType,
+                    });
                 }
                 event.preventDefault();
                 break;
@@ -237,7 +240,10 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             event: null,
             timelineRenderingType: this.context.timelineRenderingType,
         });
-        dis.fire(Action.FocusSendMessageComposer);
+        dis.dispatch({
+            action: Action.FocusSendMessageComposer,
+            context: this.context.timelineRenderingType,
+        });
     };
 
     private get shouldSaveStoredEditorState(): boolean {
@@ -431,7 +437,10 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             event: null,
             timelineRenderingType: this.context.timelineRenderingType,
         });
-        dis.fire(Action.FocusSendMessageComposer);
+        dis.dispatch({
+            action: Action.FocusSendMessageComposer,
+            context: this.context.timelineRenderingType,
+        });
     };
 
     private cancelPreviousPendingEdit(): void {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19469

Regressed as part of some composer work in threading

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Restore composer focus after event edit ([\#7065](https://github.com/matrix-org/matrix-react-sdk/pull/7065)). Fixes vector-im/element-web#19469.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6180f6a0bfd315a41480c741--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
