### PR TITLE
Fix possible infinite loop on widget start

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -227,7 +227,7 @@ export default class AppTile extends React.Component<IProps, IState> {
             this.sgWidget.on("ready", this.onWidgetReady);
             this.startWidget();
         } catch (e) {
-            logger.log("Failed to construct widget", e);
+            logger.error("Failed to construct widget", e);
             this.sgWidget = null;
         }
     }
@@ -245,7 +245,9 @@ export default class AppTile extends React.Component<IProps, IState> {
                 if (this.sgWidget) {
                     this.sgWidget.start(ref);
                 }
-            } catch (e) { logger.log("Failed to start widget", e); }
+            } catch (e) {
+                logger.error("Failed to start widget", e);
+            }
         } else {
             this.resetWidget(this.props);
         }

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -241,7 +241,11 @@ export default class AppTile extends React.Component<IProps, IState> {
     private iframeRefChange = (ref: HTMLIFrameElement): void => {
         this.iframe = ref;
         if (ref) {
-            if (this.sgWidget) this.sgWidget.start(ref);
+            try {
+                if (this.sgWidget) {
+                    this.sgWidget.start(ref);
+                }
+            } catch (e) { logger.log("Failed to start widget", e); }
         } else {
             this.resetWidget(this.props);
         }


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/15494
The issue was caused because react reloads the component if the `ref={this.iframeRefChange}` callback throws an error. Catching the error prohibits the reload.
Previous behavior if `sgwidget.start()` throws an error:
 - caught in infinite loop
 
New behavior if `sgwidget.start()` throws an error:
 - the widgets does not display the loading indicator anymore
 - an error is logged in the browser console
 - The widget does not reload

Maybe we want a more specific error message in the widget Iframe? But since an error in the `start` function should not happen a log in the console might be sufficient.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix possible infinite loop on widget start ([\#7071](https://github.com/matrix-org/matrix-react-sdk/pull/7071)). Fixes vector-im/element-web#15494 and vector-im/element-web#15494. Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61825cefaf5e23b261f56701--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
