### PR TITLE
Fix documentation to make `yarn test` work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ cd matrix-react-sdk
 git checkout develop
 yarn link matrix-js-sdk
 yarn install
+
+# Generate the `component-index.js` file.
+yarn reskindex
 ```
 
 See the [help for `yarn link`](https://classic.yarnpkg.com/docs/cli/link) for

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -18,7 +18,7 @@ clone() {
     if [ -n "$branch" ]
     then
         echo "Trying to use $org/$repo#$branch"
-        git clone git://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
+        git clone https://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
     fi
 }
 


### PR DESCRIPTION
Hi there,

while trying to get the development sandbox up and running [1] in order to invoke `yarn test` [2], we found that `yarn reskindex` had to be invoked beforehand.

This patch adjusts the documentation to make it easier for newcomers, we hope you like it.

With kind regards,
Andreas.

[1] https://github.com/matrix-org/matrix-react-sdk#development
[2] https://github.com/matrix-org/matrix-react-sdk#running-tests


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://618195f9377fc82bd4b0b9ea--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
