### PR TITLE
Fix TimeZone to be UTC in Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "testMatch": [
       "<rootDir>/test/**/*-test.[jt]s?(x)"
     ],
+    "globalSetup":  "<rootDir>/test/globalSetup.js",
     "setupFiles": [
       "jest-canvas-mock"
     ],

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+    process.env.TZ = 'UTC';
+}

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -1,3 +1,3 @@
 module.exports = async () => {
     process.env.TZ = 'UTC';
-}
+};


### PR DESCRIPTION
Fix an issue where developers using a non UTC time would have the test fail due to different timezones configuration.

Problem introduced by https://github.com/matrix-org/matrix-react-sdk/pull/7068

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://6183b61209557dd09741b2a8--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
