### PR TITLE
Change radio button border colour to match design

### DIFF
--- a/res/css/views/elements/_StyledRadioButton.scss
+++ b/res/css/views/elements/_StyledRadioButton.scss
@@ -20,7 +20,7 @@ limitations under the License.
 */
 
 .mx_StyledRadioButton {
-    $radio-circle-color: $muted-fg-color;
+    $radio-circle-color: $quaternary-content;
     $active-radio-circle-color: $accent-color;
     position: relative;
 


### PR DESCRIPTION
I noticed our unselected radio buttons don't match our designs - they should be quaternary-content.

**After:**
![image](https://user-images.githubusercontent.com/76812/140497981-cff199d0-9428-4555-9826-4bfcc0b2bc1a.png)
![image](https://user-images.githubusercontent.com/76812/140497996-5d41e414-96b2-4fee-a163-113f85d36f85.png)

**Before:**
![image](https://user-images.githubusercontent.com/76812/140498010-ede224ed-f851-42bc-93ba-6ccf3bf42117.png)
![image](https://user-images.githubusercontent.com/76812/140498031-b502a064-0dcd-4960-a859-f61720b0c323.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61850a83fbb5a9062fe4bd9c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
