### PR TITLE
Correctly export `ThreadListContextMenu`

### DIFF
--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -101,3 +101,5 @@ export const ThreadListContextMenu: React.FC<IProps> = ({ mxEvent, permalinkCrea
         </IconizedContextMenu>) }
     </React.Fragment>;
 };
+
+export default ThreadListContextMenu;


### PR DESCRIPTION
Type: task

It needs to be exported by default otherwise component-index goes awry