### PR TITLE
Do not shift buttons in high contrast theme

### DIFF
--- a/res/themes/light-high-contrast/css/_light-high-contrast.scss
+++ b/res/themes/light-high-contrast/css/_light-high-contrast.scss
@@ -58,14 +58,27 @@ $roomtopic-color: $secondary-content;
     text-decoration: none;
 }
 
-.mx_AccessibleButton {
-    margin-left: 4px;
-}
-
+// Draw an outline on buttons with focus
 .mx_AccessibleButton:focus {
     outline: 2px solid $accent-color;
     outline-offset: 2px;
 }
+
+// Add padding (and remove margin to compensate), so the outline is not
+// chopped off on the left
+.mx_TabbedView_tabPanel {
+    margin-left: 236px !important;  // Remove 4 to allow 4 in mx_SettingsTab
+}
+.mx_SettingsTab {
+    padding-left: 4px !important;
+}
+.mx_BaseCard {
+    padding-left: 4px !important;  // Remove 4 to allow 4 in mx_BaseCard_Group
+}
+.mx_BaseCard_Group {
+    padding-left: 4px !important;
+}
+
 
 .mx_BasicMessageComposer .mx_BasicMessageComposer_inputEmpty > :first-child::before {
     color: $secondary-content;


### PR DESCRIPTION
**Before**, we shifted buttons 4px to the right, to leave space for the focus outline:
![image](https://user-images.githubusercontent.com/76812/140911525-eea41b65-0bce-4702-b242-137adaf4974d.png)

**After**, the unfocussed button is left-aligned with the other items - the focus outline extends to the left:
![image](https://user-images.githubusercontent.com/76812/140911632-37d58428-1054-45bb-b6c4-dcca2a52ac4c.png)

Comparison with the default light theme - the unfocussed button lines up.
![image](https://user-images.githubusercontent.com/76812/140911686-0a6fbc54-3e7d-48e0-b648-a35a9278c4e3.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://618a54950cdeea36fa457c0f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
