### PR TITLE
Fix scroll Panel rendering for threads

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -133,7 +133,7 @@ limitations under the License.
         padding-right: 0px;
         -ms-overflow-style: none;  // IE and Edge
         scrollbar-width: none;  // Firefox
-        
+
         &::-webkit-scrollbar {
             display: none; // Chrome, Safari, Opera
         }

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -18,8 +18,6 @@ limitations under the License.
     display: flex;
     flex-direction: column;
 
-    padding-right: 0;
-
     .mx_BaseCard_header {
         .mx_BaseCard_close,
         .mx_BaseCard_back {
@@ -132,6 +130,13 @@ limitations under the License.
 
     .mx_AutoHideScrollbar {
         border-radius: 8px;
+        padding-right: 0px;
+        -ms-overflow-style: none;  // IE and Edge
+        scrollbar-width: none;  // Firefox
+        
+        &::-webkit-scrollbar {
+            display: none; // Chrome, Safari, Opera
+        }
     }
 
     .mx_RoomView_messageListWrapper {
@@ -176,7 +181,7 @@ limitations under the License.
         background-color: $background;
         border-radius: 8px;
         margin-top: 8px;
-        width: calc(100% - 8px);
+        width: 100%;
         padding: 0 8px;
         box-sizing: border-box;
     }


### PR DESCRIPTION
When using rounded corners the current mx_AutoHideScrollbar css class causes issues. 
If we use the browser specific scrollbar hiding flags, we can make it look better. If there are reasons not to use those, this can be closed.

Before:
![Screenshot from 2021-11-10 12-44-01](https://user-images.githubusercontent.com/16718859/141107536-a2bbd0de-6f68-407e-bcf1-d5ca8a0a4bee.png)
After:
![Screenshot from 2021-11-10 12-41-32](https://user-images.githubusercontent.com/16718859/141107539-cbb26f81-71a6-425c-b3a9-d8cb9faba3e3.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix scroll Panel rendering for threads ([\#7105](https://github.com/matrix-org/matrix-react-sdk/pull/7105)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://618bb4b2cdbaed0bb8c8ea81--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
