### PR TITLE
Adjust recovery key button sizes depending on text width

### DIFF
--- a/res/css/views/dialogs/security/_CreateSecretStorageDialog.scss
+++ b/res/css/views/dialogs/security/_CreateSecretStorageDialog.scss
@@ -74,6 +74,11 @@ limitations under the License.
 .mx_CreateSecretStorageDialog_primaryContainer {
     /* FIXME: plinth colour in new theme(s). background-color: $accent-color; */
     padding-top: 20px;
+
+    &.mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer {
+        display: flex;
+        justify-content: center;
+    }
 }
 
 .mx_CreateSecretStorageDialog_primaryContainer::after {
@@ -127,9 +132,7 @@ limitations under the License.
 }
 
 .mx_CreateSecretStorageDialog_recoveryKeyContainer {
-    width: 380px;
-    margin-left: auto;
-    margin-right: auto;
+    display: inline-block;
 }
 
 .mx_CreateSecretStorageDialog_recoveryKey {
@@ -141,18 +144,29 @@ limitations under the License.
     border-radius: 6px;
     word-spacing: 1em;
     margin-bottom: 20px;
+
+    code {
+        display: inline-block;
+        width: 30rem;
+    }
 }
 
 .mx_CreateSecretStorageDialog_recoveryKeyButtons {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
+    display: flex;
+    gap: 16px;
+}
+
+.mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn {
+    flex-direction: column;
+}
+
+.mx_CreateSecretStorageDialog_recoveryKeyCopyButtonText {
+    overflow-y: hidden;
 }
 
 .mx_CreateSecretStorageDialog_recoveryKeyButtons .mx_AccessibleButton {
-    width: 160px;
-    padding-left: 0px;
-    padding-right: 0px;
+    flex-grow: 1;
     white-space: nowrap;
 }
 

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -714,12 +714,13 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                 <InlineSpinner />
             </div>;
         }
+
         return <div>
             <p>{ _t(
                 "Store your Security Key somewhere safe, like a password manager or a safe, " +
                 "as it’s used to safeguard your encrypted data.",
             ) }</p>
-            <div className="mx_CreateSecretStorageDialog_primaryContainer">
+            <div className="mx_CreateSecretStorageDialog_primaryContainer mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer">
                 <div className="mx_CreateSecretStorageDialog_recoveryKeyContainer">
                     <div className="mx_CreateSecretStorageDialog_recoveryKey">
                         <code ref={this.recoveryKeyNode}>{ this.recoveryKey.encodedPrivateKey }</code>
@@ -739,7 +740,20 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                             onClick={this.onCopyClick}
                             disabled={this.state.phase === Phase.Storing}
                         >
-                            { this.state.copied ? _t("Copied!") : _t("Copy") }
+                            <span
+                                className="mx_CreateSecretStorageDialog_recoveryKeyCopyButtonText"
+                                style={{ height: this.state.copied ? '0' : 'auto' }}
+                                aria-hidden={this.state.copied}
+                            >
+                                { _t("Copy") }
+                            </span>
+                            <span
+                                className="mx_CreateSecretStorageDialog_recoveryKeyCopyButtonText"
+                                style={{ height: this.state.copied ? 'auto' : '0' }}
+                                aria-hidden={!this.state.copied}
+                            >
+                                { _t("Copied!") }
+                            </span>
                         </AccessibleButton>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19511

element-web notes: none

Before (DE)

![before_de](https://user-images.githubusercontent.com/6216686/141676149-2df562c7-2acc-417d-8e7b-2f282149c191.gif)

After (DE)

![after_de](https://user-images.githubusercontent.com/6216686/141676150-9c848db0-3e02-408e-a161-d65891884a13.gif)

After (EN)

![after_en](https://user-images.githubusercontent.com/6216686/141676154-825b7faf-a1d3-4ead-bd2c-494f12e0cdf2.gif)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Adjust recovery key button sizes depending on text width ([\#7134](https://github.com/matrix-org/matrix-react-sdk/pull/7134)). Fixes vector-im/element-web#19511. Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://6193fbc26ef507594c8010d2--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
