### PR TITLE
Fixes element not remembering widget hidden state per room

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -591,7 +591,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         const isManuallyShown = hideWidgetDrawer === "false";
 
         const widgets = WidgetLayoutStore.instance.getContainerWidgets(room, Container.Top);
-        return widgets.length > 0 || isManuallyShown;
+        return widgets.length > 0 && isManuallyShown;
     }
 
     componentDidMount() {

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -583,15 +583,15 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         // Check if user has previously chosen to hide the app drawer for this
         // room. If so, do not show apps
-        const hideWidgetDrawer = localStorage.getItem(
-            room.roomId + "_hide_widget_drawer");
+        const hideWidgetKey = room.roomId + "_hide_widget_drawer";
+        const hideWidgetDrawer = localStorage.getItem(hideWidgetKey);
 
-        // This is confusing, but it means to say that we default to the tray being
-        // hidden unless the user clicked to open it.
-        const isManuallyShown = hideWidgetDrawer === "false";
+        // If unset show the Tray
+        // Otherwise (in case the user set hideWidgetDrawer by clicking the button) follow the parameter.
+        const isManuallyShown = hideWidgetDrawer ? hideWidgetDrawer === "false": true;
 
         const widgets = WidgetLayoutStore.instance.getContainerWidgets(room, Container.Top);
-        return widgets.length > 0 && isManuallyShown;
+        return isManuallyShown && widgets.length > 0;
     }
 
     componentDidMount() {


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/16672
Fixes: https://github.com/matrix-org/element-web-rageshakes/issues/4407
Fixes: https://github.com/vector-im/element-web/issues/15718
Fixes partially https://github.com/vector-im/element-web/issues/15993
Fixes: https://github.com/vector-im/element-web/issues/15768

The issues are marked as design needed. The code has all the pices to store the hidden state per room in the `localStorage`. It turned out it is just broken.
This makes the following changes to the app drawer so it behaves as expected:
 - First this fixes a bug where the hideWidget setting was not taken into consideration for deciding to show the widgets:
 (`widgets.length > 0 || isManuallyShown` is always true if there is a widget)
 - Second, it defaults to the widget drawer beeing shown if the setting has not been set for this room yet.
This solves most of the issues. 
The issue that is only partially fixed is: https://github.com/vector-im/element-web/issues/15993 
Pinning by default is not a little change and probably needs input from design. (Jitsi is pinned by default so with this change it behaves like the Issue requests for the jitsi widget which might has been the primary motivation)
  	

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fixes element not remembering widget hidden state per room ([\#7136](https://github.com/matrix-org/matrix-react-sdk/pull/7136)). Fixes vector-im/element-web#16672, matrix-org/element-web-rageshakes#4407 vector-im/element-web#15718 and vector-im/element-web#15768. Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61924730f11ca83f6f03c32e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
