### PR TITLE
Fix maximise icon size in the pinned apps drawer

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -228,15 +228,12 @@ $MinWidth: 240px;
     margin: 0 5px;
 
     &.mx_AppTileMenuBar_iconButton_minWidget {
-        width: 10px;
-        height: 12px;
         mask-size: auto 10px;
         mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
     }
 
     &.mx_AppTileMenuBar_iconButton_maxWidget {
-        width: 11px;
-        height: 11px;
+        mask-size: auto 10px;
         mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
     }
 


### PR DESCRIPTION
Type: task
Before
![image](https://user-images.githubusercontent.com/16718859/142190480-ba488ecf-e39f-4bc0-835c-297be3093e41.png)
After
![image](https://user-images.githubusercontent.com/16718859/142190502-78b032f2-22a8-40ba-9d10-52c042e196ed.png)

The size correction was only done to the minimize icon

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6194e57825d3dc15a9e9efe3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
