### PR TITLE
Prevent custom power levels from breaking roles & permissions tab

### DIFF
--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -414,9 +414,9 @@ export default class RolesRoomSettingsTab extends React.Component<IProps> {
         }
 
         const eventPowerSelectors = Object.keys(eventsLevels).map((eventType, i) => {
-            if (isSpaceRoom && plEventsToShow[eventType].hideForSpace) {
+            if (isSpaceRoom && plEventsToShow[eventType]?.hideForSpace) {
                 return null;
-            } else if (!isSpaceRoom && plEventsToShow[eventType].hideForRoom) {
+            } else if (!isSpaceRoom && plEventsToShow[eventType]?.hideForRoom) {
                 return null;
             }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19812

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent custom power levels from breaking roles & permissions tab ([\#7160](https://github.com/matrix-org/matrix-react-sdk/pull/7160)). Fixes vector-im/element-web#19812.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6197761947bc37bd1154a6b8--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
