### PR TITLE
When we only show one compose button, show upload

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -472,6 +472,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
     };
 
     private renderButtons(menuPosition): JSX.Element | JSX.Element[] {
+        let uploadButtonIndex = 0;
         const buttons: JSX.Element[] = [];
         if (!this.state.haveRecording) {
             if (SettingsStore.getValue("feature_polls")) {
@@ -479,6 +480,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                     <PollButton key="polls" room={this.props.room} />,
                 );
             }
+            uploadButtonIndex = buttons.length;
             buttons.push(
                 <UploadButton
                     key="controls_upload"
@@ -528,7 +530,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             });
 
             return <>
-                { buttons[0] }
+                { buttons[uploadButtonIndex] }
                 <AccessibleTooltipButton
                     className={classnames}
                     onClick={this.toggleButtonMenu}


### PR DESCRIPTION
Now, we show the "Upload" button if the compose window is narrow:
![image](https://user-images.githubusercontent.com/76812/142620777-0536e5b2-1fb7-466e-9c32-7021f308f0a3.png)

Before, if polls were enabled, we showed the "Create Poll" button:
![image](https://user-images.githubusercontent.com/76812/142620980-c70f307a-29dc-44e1-b8ad-3486fe63b999.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://619795edb47741105452b72c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
