### PR TITLE
Make image size height constraint when using the ImageSize.Large option

### DIFF
--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -379,13 +379,15 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         // check for any height constraints
         const imageSize = SettingsStore.getValue("Images.size") as ImageSize;
         const suggestedAndPossibleWidth = Math.min(suggestedImageSize(imageSize).w, infoWidth);
+        const suggestedAndPossibleHeight = Math.min(suggestedImageSize(imageSize).h, infoHeight);
         const aspectRatio = infoWidth / infoHeight;
 
         let maxWidth;
         let maxHeight;
-        const maxHeightConstraint = forcedHeight || this.props.maxImageHeight || undefined;
-        if (maxHeightConstraint && maxHeightConstraint * aspectRatio < suggestedAndPossibleWidth) {
+        const maxHeightConstraint = forcedHeight || this.props.maxImageHeight || suggestedAndPossibleHeight;
+        if (maxHeightConstraint * aspectRatio < suggestedAndPossibleWidth || imageSize === ImageSize.Large) {
             // width is dictated by the maximum height that was defined by the props or the function param `forcedHeight`
+            // If the thumbnail size is set to Large, we always let the size be dictated by the height.
             maxWidth = maxHeightConstraint * aspectRatio;
             // there is no need to check for infoHeight here since this is done with `maxHeightConstraint * aspectRatio < suggestedAndPossibleWidth`
             maxHeight = maxHeightConstraint;


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/19788
 - It adds a height check for "`height > width` images"
 - And, this skips the width constraint when using the Large setting. (always making the height now 480px (or the info image height) the dictating parameter)