### PR TITLE
Restore 'large' thumbnails to be 800x600

### DIFF
--- a/src/settings/enums/ImageSize.ts
+++ b/src/settings/enums/ImageSize.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const SIZE_LARGE = { w: 480, h: 360 };
+const SIZE_LARGE = { w: 800, h: 600 };
 const SIZE_NORMAL = { w: 324, h: 220 };
 
 export enum ImageSize {


### PR DESCRIPTION
In order to restore the original behaviour for those who want it, redefine "large" thumbnails to be fit within 800x600px.
This means that timeline screenshots end up typically not being downscaled (which is important given screenshots are our easiest way of copying chunks of history between rooms currently :/).  It also means that photos end up nice and big, which was a deliberate aesthetic choice for the app in the past, which some users will want to retain.


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://619976a1281d3a0b0851e2f6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
