### PR TITLE
Remove leading slash from /addwidget Jitsi confs

### DIFF
--- a/src/widgets/Jitsi.ts
+++ b/src/widgets/Jitsi.ts
@@ -92,7 +92,7 @@ export class Jitsi {
         const parsed = new URL(url);
         if (parsed.hostname !== this.preferredDomain) return null; // invalid
         return {
-            conferenceId: parsed.pathname,
+            conferenceId: parsed.pathname.substr(1),
             domain: parsed.hostname,
             isAudioOnly: false,
         };

--- a/src/widgets/Jitsi.ts
+++ b/src/widgets/Jitsi.ts
@@ -92,7 +92,9 @@ export class Jitsi {
         const parsed = new URL(url);
         if (parsed.hostname !== this.preferredDomain) return null; // invalid
         return {
-            conferenceId: parsed.pathname.substr(1),
+            // URL pathnames always contain a leading slash.
+            // Remove it to be left with just the conference name.
+            conferenceId: parsed.pathname.substring(1),
             domain: parsed.hostname,
             isAudioOnly: false,
         };


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19839

Signed-off-by: Andrew Ferrazzutti <fair@miscworks.net>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove leading slash from /addwidget Jitsi confs ([\#7175](https://github.com/matrix-org/matrix-react-sdk/pull/7175)). Fixes vector-im/element-web#19839. Contributed by @AndrewFerr.<!-- CHANGELOG_PREVIEW_END -->