### PR TITLE
Add spacing between right panel and main timeline

### DIFF
--- a/res/css/structures/_MainSplit.scss
+++ b/res/css/structures/_MainSplit.scss
@@ -25,6 +25,7 @@ limitations under the License.
 .mx_MainSplit > .mx_RightPanel_ResizeWrapper {
     // no padding on the left. The spacing is taken care of by the main split content.
     padding: 5px 5px 5px 0px;
+    margin-left: 8px;
     height: calc(100vh - 51px); // height of .mx_RoomHeader.light-panel
 
     &:hover .mx_RightPanel_ResizeHandle {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19795

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/7098/

@toger5 to flesh out a long term fix for the maximised widget project

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
