### PR TITLE
Prevent programmatic scrolling within truncated room sublists

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -187,6 +187,7 @@ limitations under the License.
         .mx_RoomSublist_tiles {
             flex: 1 0 0;
             overflow: hidden;
+            overflow: clip;
             // need this to be flex otherwise the overflow hidden from above
             // sometimes vertically centers the clipped list ... no idea why it would do this
             // as the box model should be top aligned. Happens in both FF and Chromium


### PR DESCRIPTION
Fixes case where through keyboard navigation the room sublist gets scrolled causing tiles to unexpectedly clip on the wrong edge

![image](https://user-images.githubusercontent.com/2403652/143049986-806ecb64-fbdf-42b8-b346-61a45dac8496.png)

Here the Element Web tile was scrolled due to the Element Product Feedback tile being scrolled in programmatically

Left the overflow hidden as a fallback for legacy browsers

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://619d0553bf101916ac196b37--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
