### PR TITLE
Fix links being parsed as markdown links improperly

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -29,7 +29,7 @@ const TEXT_NODES = ['text', 'softbreak', 'linebreak', 'paragraph', 'document'];
 interface CommonmarkHtmlRendererInternal extends commonmark.HtmlRenderer {
     paragraph: (node: commonmark.Node, entering: boolean) => void;
     link: (node: commonmark.Node, entering: boolean) => void;
-    html_inline: (node: commonmark.Node) => void; // eslint-disable-line camelcazse
+    html_inline: (node: commonmark.Node) => void; // eslint-disable-line camelcase
     html_block: (node: commonmark.Node) => void; // eslint-disable-line camelcase
     text: (node: commonmark.Node) => void;
     out: (text: string) => void;

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -110,6 +110,18 @@ export default class Markdown {
         this.parsed = this.repairLinks(this.parsed);
     }
 
+    /**
+     * This method is modifying the parsed AST in such a way that links are always
+     * properly linkified instead of sometimes being wrongly emphasised in case
+     * if you were to write a link like the example below:
+     * https://my_weird-link_domain.domain.com
+     * ^ this link would be parsed to something like this:
+     * <a href="https://my">https://my</a><b>weird-link</b><a href="https://domain.domain.com">domain.domain.com</a>
+     * This method makes it so the link gets properly modified to a version where it is
+     * not emphasised until it actually ends.
+     * See: https://github.com/vector-im/element-web/issues/4674
+     * @param parsed
+     */
     private repairLinks(parsed: commonmark.Node) {
         const walker = parsed.walker();
         let event: commonmark.NodeWalkingStep = null;

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -173,10 +173,8 @@ export default class Markdown {
                             }
                         }
                     } else {
-                        node.firstChild.literal = '';
                         // Empty string is a sign that we should ignore it in HTML rendering
                         node.literal = '';
-                        // node.unlink();
                     }
                 }
             }

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -315,16 +315,6 @@ export default class Markdown {
             if (isMultiLine(node) && node.next) this.lit('\n\n');
         };
 
-        const realEmph = renderer.emph;
-        renderer.emph = function(node: commonmark.Node) {
-            // We're escaping links with emphasis in the middle of it to act like a real link
-            // This empty string check here is to verify that we have modified the emphasis node properly
-            if (node.type === 'emph' && node.literal === "") {
-                return;
-            }
-            return realEmph(node);
-        };
-
         return renderer.render(this.parsed);
     }
 }

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -107,10 +107,10 @@ export default class Markdown {
 
         const parser = new commonmark.Parser();
         this.parsed = parser.parse(this.input);
-        this.parsed = this.escapeLinks(this.parsed);
+        this.parsed = this.repairLinks(this.parsed);
     }
 
-    private escapeLinks(parsed: commonmark.Node) {
+    private repairLinks(parsed: commonmark.Node) {
         const walker = parsed.walker();
         let event: commonmark.NodeWalkingStep = null;
         let text = '';

--- a/test/Markdown-test.ts
+++ b/test/Markdown-test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+import Markdown from "../src/Markdown";
+
+describe("Markdown parser test", () => {
+    describe("autolinks", () => {
+        const testString = [
+            "Test1:",
+            "#_foonetic_xkcd:matrix.org",
+            "http://google.com/_thing_",
+            "https://matrix.org/_matrix/client/foo/123_",
+            "#_foonetic_xkcd:matrix.org",
+            "",
+            "Test1A:",
+            "#_foonetic_xkcd:matrix.org",
+            "http://google.com/_thing_",
+            "https://matrix.org/_matrix/client/foo/123_",
+            "#_foonetic_xkcd:matrix.org",
+            "",
+            "Test2:",
+            "http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg",
+            "http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg",
+            "",
+            "Test3:",
+            "https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org",
+            "https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org",
+        ].join("\n");
+
+        it('tests that links are getting properly HTML formatted', () => {
+            /* eslint-disable max-len */
+            const expectedResult = [
+                "<p>Test1:<br />#_foonetic_xkcd:matrix.org<br />http://google.com/_thing_<br />https://matrix.org/_matrix/client/foo/123_<br />#_foonetic_xkcd:matrix.org</p>",
+                "<p>Test1A:<br />#_foonetic_xkcd:matrix.org<br />http://google.com/_thing_<br />https://matrix.org/_matrix/client/foo/123_<br />#_foonetic_xkcd:matrix.org</p>",
+                "<p>Test2:<br />http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg<br />http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg</p>",
+                "<p>Test3:<br />https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org<br />https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org</p>",
+                "",
+            ].join("\n");
+            /* eslint-enable max-len */
+            const md = new Markdown(testString);
+            expect(md.toHTML()).toEqual(expectedResult);
+        });
+        it('tests that links with autolinks are not touched at all and are still properly formatted', () => {
+            const test = [
+                "Test1:",
+                "<#_foonetic_xkcd:matrix.org>",
+                "<http://google.com/_thing_>",
+                "<https://matrix.org/_matrix/client/foo/123_>",
+                "<#_foonetic_xkcd:matrix.org>",
+                "",
+                "Test1A:",
+                "<#_foonetic_xkcd:matrix.org>",
+                "<http://google.com/_thing_>",
+                "<https://matrix.org/_matrix/client/foo/123_>",
+                "<#_foonetic_xkcd:matrix.org>",
+                "",
+                "Test2:",
+                "<http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg>",
+                "<http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg>",
+                "",
+                "Test3:",
+                "<https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org>",
+                "<https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org>",
+            ].join("\n");
+            /* eslint-disable max-len */
+            /**
+             * NOTE: I'm not entirely sure if those "<"" and ">" should be visible in here for #_foonetic_xkcd:matrix.org
+             * but it seems to be actually working properly
+             */
+            const expectedResult = [
+                "<p>Test1:<br />&lt;#_foonetic_xkcd:matrix.org&gt;<br /><a href=\"http://google.com/_thing_\">http://google.com/_thing_</a><br /><a href=\"https://matrix.org/_matrix/client/foo/123_\">https://matrix.org/_matrix/client/foo/123_</a><br />&lt;#_foonetic_xkcd:matrix.org&gt;</p>",
+                "<p>Test1A:<br />&lt;#_foonetic_xkcd:matrix.org&gt;<br /><a href=\"http://google.com/_thing_\">http://google.com/_thing_</a><br /><a href=\"https://matrix.org/_matrix/client/foo/123_\">https://matrix.org/_matrix/client/foo/123_</a><br />&lt;#_foonetic_xkcd:matrix.org&gt;</p>",
+                "<p>Test2:<br /><a href=\"http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg\">http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg</a><br /><a href=\"http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg\">http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg</a></p>",
+                "<p>Test3:<br /><a href=\"https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org\">https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org</a><br /><a href=\"https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org\">https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org</a></p>",
+                "",
+            ].join("\n");
+            /* eslint-enable max-len */
+            const md = new Markdown(test);
+            expect(md.toHTML()).toEqual(expectedResult);
+        });
+
+        it('expects that links in codeblock are not modified', () => {
+            const expectedResult = [
+                '<pre><code class="language-Test1:">#_foonetic_xkcd:matrix.org',
+                'http://google.com/_thing_',
+                'https://matrix.org/_matrix/client/foo/123_',
+                '#_foonetic_xkcd:matrix.org',
+                '',
+                'Test1A:',
+                '#_foonetic_xkcd:matrix.org',
+                'http://google.com/_thing_',
+                'https://matrix.org/_matrix/client/foo/123_',
+                '#_foonetic_xkcd:matrix.org',
+                '',
+                'Test2:',
+                'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg',
+                'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg',
+                '',
+                'Test3:',
+                'https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org',
+                'https://riot.im/app/#/room/#_foonetic_xkcd:matrix.org```',
+                '</code></pre>',
+                '',
+            ].join('\n');
+            const md = new Markdown("```" + testString + "```");
+            expect(md.toHTML()).toEqual(expectedResult);
+        });
+    });
+});

--- a/test/Markdown-test.ts
+++ b/test/Markdown-test.ts
@@ -1,6 +1,18 @@
-/**
- * @jest-environment jsdom
- */
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 import * as linkifyjs from 'linkifyjs';
 import Markdown from "../src/Markdown";
 import matrixLinkify from '../src/linkify-matrix';

--- a/test/Markdown-test.ts
+++ b/test/Markdown-test.ts
@@ -1,10 +1,17 @@
 /**
  * @jest-environment jsdom
  */
+import * as linkifyjs from 'linkifyjs';
 import Markdown from "../src/Markdown";
+import matrixLinkify from '../src/linkify-matrix';
+
+beforeAll(() => {
+    // We need to call linkifier plugins before running those tests
+    matrixLinkify(linkifyjs);
+});
 
 describe("Markdown parser test", () => {
-    describe("autolinks", () => {
+    describe("fixing HTML links", () => {
         const testString = [
             "Test1:",
             "#_foonetic_xkcd:matrix.org",
@@ -103,6 +110,21 @@ describe("Markdown parser test", () => {
                 '',
             ].join('\n');
             const md = new Markdown("```" + testString + "```");
+            expect(md.toHTML()).toEqual(expectedResult);
+        });
+
+        it('expects that links in one line will be "escaped" properly', () => {
+            /* eslint-disable max-len */
+            const testString = [
+                'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg' + " " + 'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg',
+                'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg' + " " + 'http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg',
+            ].join('\n');
+            const expectedResult = [
+                "http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg",
+                "http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg http://domain.xyz/foo/bar-_stuff-like-this_-in-it.jpg",
+            ].join('<br />');
+            /* eslint-enable max-len */
+            const md = new Markdown(testString);
             expect(md.toHTML()).toEqual(expectedResult);
         });
     });

--- a/test/editor/deserialize-test.js
+++ b/test/editor/deserialize-test.js
@@ -197,7 +197,6 @@ describe('editor/deserialize', function() {
         it('code block with no trailing text', function() {
             const html = "<pre><code>0xDEADBEEF\n</code></pre>\n";
             const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
-            console.log(parts);
             expect(parts.length).toBe(5);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "```" });
             expect(parts[1]).toStrictEqual({ type: "newline", text: "\n" });


### PR DESCRIPTION
This adds some additional overhead when figuring out links and should probably change the AST in a bit smarter way, but if that's not going to create visible performance regressions/overheads I think we can roll with it.

Fixes [#4674](https://github.com/vector-im/element-web/issues/4674)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix links being parsed as markdown links improperly ([\#7200](https://github.com/matrix-org/matrix-react-sdk/pull/7200)). Contributed by @Palid.<!-- CHANGELOG_PREVIEW_END -->
















<!-- Replace -->
Preview: https://619ff4ba5f0e9134aa0a9756--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
