### PR TITLE
Show an error dialog if poll creation or voting fails

### DIFF
--- a/src/components/views/elements/PollCreateDialog.tsx
+++ b/src/components/views/elements/PollCreateDialog.tsx
@@ -117,7 +117,7 @@ export default class PollCreateDialog extends ScrollableBaseModal<IProps, IState
                         "Sorry, the poll you tried to create was not posted."),
                     button: _t('Try again'),
                     cancelButton: _t('Cancel'),
-                    onFinished: (tryAgain) => {
+                    onFinished: (tryAgain: boolean) => {
                         if (!tryAgain) {
                             this.cancel();
                         } else {

--- a/src/components/views/elements/PollCreateDialog.tsx
+++ b/src/components/views/elements/PollCreateDialog.tsx
@@ -101,7 +101,8 @@ export default class PollCreateDialog extends ScrollableBaseModal<IProps, IState
             this.props.room.roomId,
             POLL_START_EVENT_TYPE.name,
             makePollContent(
-                this.state.question, this.state.options, POLL_KIND_DISCLOSED.name),
+                this.state.question, this.state.options, POLL_KIND_DISCLOSED.name,
+            ),
         ).then(
             () => this.props.onFinished(true),
         ).catch(e => {

--- a/src/components/views/messages/MPollBody.tsx
+++ b/src/components/views/messages/MPollBody.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 import { _t } from '../../../languageHandler';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
+import Modal from '../../../Modal';
 import { IBodyProps } from "./IBodyProps";
 import {
     IPollAnswer,
@@ -29,6 +30,7 @@ import StyledRadioButton from '../elements/StyledRadioButton';
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Relations } from 'matrix-js-sdk/src/models/relations';
 import { MatrixClientPeg } from '../../../MatrixClientPeg';
+import ErrorDialog from '../dialogs/ErrorDialog';
 
 // TODO: [andyb] Use extensible events library when ready
 const TEXT_NODE_TYPE = "org.matrix.msc1767.text";
@@ -123,6 +125,17 @@ export default class MPollBody extends React.Component<IBodyProps, IState> {
             responseContent,
         ).catch(e => {
             console.error("Failed to submit poll response event:", e);
+
+            Modal.createTrackedDialog(
+                'Failed to post poll',
+                '',
+                ErrorDialog,
+                {
+                    title: _t("Vote not registered"),
+                    description: _t(
+                        "Sorry, your vote was not registered. Please try again."),
+                },
+            );
         });
 
         this.setState({ selected: answerId });

--- a/src/components/views/messages/MPollBody.tsx
+++ b/src/components/views/messages/MPollBody.tsx
@@ -127,7 +127,7 @@ export default class MPollBody extends React.Component<IBodyProps, IState> {
             console.error("Failed to submit poll response event:", e);
 
             Modal.createTrackedDialog(
-                'Failed to post poll',
+                'Vote not registered',
                 '',
                 ErrorDialog,
                 {

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -224,8 +224,8 @@ class PollButton extends React.PureComponent<IPollButtonProps> {
                     room: this.props.room,
                 },
                 'mx_CompoundDialog',
-                false,  // isPriorityModal
-                true,   // isStaticModal
+                false, // isPriorityModal
+                true,  // isStaticModal
             );
         }
     };

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -216,9 +216,17 @@ class PollButton extends React.PureComponent<IPollButtonProps> {
                 description: _t("You do not have permission to start polls in this room."),
             });
         } else {
-            Modal.createTrackedDialog('Polls', 'create', PollCreateDialog, {
-                room: this.props.room,
-            }, 'mx_CompoundDialog');
+            Modal.createTrackedDialog(
+                'Polls',
+                'create',
+                PollCreateDialog,
+                {
+                    room: this.props.room,
+                },
+                'mx_CompoundDialog',
+                false,  // isPriorityModal
+                true,   // isStaticModal
+            );
         }
     };
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2201,6 +2201,8 @@
     "%(severalUsers)schanged the <a>pinned messages</a> for the room %(count)s times.|other": "%(severalUsers)schanged the <a>pinned messages</a> for the room %(count)s times.",
     "%(oneUser)schanged the <a>pinned messages</a> for the room %(count)s times.|other": "%(oneUser)schanged the <a>pinned messages</a> for the room %(count)s times.",
     "Create Poll": "Create Poll",
+    "Failed to post poll": "Failed to post poll",
+    "Sorry, the poll you tried to create was not posted.": "Sorry, the poll you tried to create was not posted.",
     "What is your poll question or topic?": "What is your poll question or topic?",
     "Question or topic": "Question or topic",
     "Write something...": "Write something...",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2045,6 +2045,8 @@
     "Declining …": "Declining …",
     "%(name)s wants to verify": "%(name)s wants to verify",
     "You sent a verification request": "You sent a verification request",
+    "Vote not registered": "Vote not registered",
+    "Sorry, your vote was not registered. Please try again.": "Sorry, your vote was not registered. Please try again.",
     "%(count)s votes|other": "%(count)s votes",
     "%(count)s votes|one": "%(count)s vote",
     "Based on %(count)s votes|other": "Based on %(count)s votes",


### PR DESCRIPTION
![poll-failure](https://user-images.githubusercontent.com/76812/143465038-483ff0fe-2c32-44af-aa1d-018afdbcb36d.gif)

This is hard to try out in practice, so I include a video to show what it does.

![vote-failure](https://user-images.githubusercontent.com/76812/143457625-639d3335-a495-48a8-84ba-fb66431fe5a3.gif)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->
















<!-- Replace -->
Preview: https://619fbe515840dd0ccd2c7520--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
