### PR TITLE
Improve right panel resize handle usability

### DIFF
--- a/res/css/structures/_MainSplit.scss
+++ b/res/css/structures/_MainSplit.scss
@@ -28,15 +28,16 @@ limitations under the License.
     margin-left: 8px;
     height: calc(100vh - 51px); // height of .mx_RoomHeader.light-panel
 
-    &:hover .mx_RightPanel_ResizeHandle {
-        // Need to use important to override element style attributes
-        // set by re-resizable
-        top: 50% !important;
+    &:hover .mx_ResizeHandle_horizontal::before {
+        position: absolute;
+        top: 50%;
         transform: translate(0, -50%);
 
-        height: 64px !important; // to match width of the ones on roomlist
-        width: 4px !important;
-        border-radius: 4px !important;
+        height: 64px; // to match width of the ones on roomlist
+        width: 4px;
+        border-radius: 4px;
+
+        content: '';
 
         background-color: $primary-content;
         opacity: 0.8;

--- a/src/components/structures/MainSplit.tsx
+++ b/src/components/structures/MainSplit.tsx
@@ -83,7 +83,7 @@ export default class MainSplit extends React.Component<IProps> {
                 onResize={this.onResize}
                 onResizeStop={this.onResizeStop}
                 className="mx_RightPanel_ResizeWrapper"
-                handleClasses={{ left: "mx_RightPanel_ResizeHandle" }}
+                handleClasses={{ left: "mx_ResizeHandle_horizontal" }}
             >
                 { panelView }
             </Resizable>;


### PR DESCRIPTION
Before

![before](https://user-images.githubusercontent.com/6216686/143491828-3fdbf504-fa72-4acb-ab61-4891a62acfcd.gif)

After

![after](https://user-images.githubusercontent.com/6216686/143491836-5c1e78aa-0a34-4186-98b7-b273e2221839.gif)

closes vector-im/element-web#15145

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve right panel resize handle usability ([\#7204](https://github.com/matrix-org/matrix-react-sdk/pull/7204)). Fixes vector-im/element-web#15145. Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://619fe24cfa5440249da2c9ba--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
