### PR TITLE
Fix multiline paragraph rendering as single line

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -56,6 +56,12 @@ function isAllowedHtmlTag(node: commonmark.Node): boolean {
 function isMultiLine(node: commonmark.Node): boolean {
     let par = node;
     while (par.parent) {
+        // commonmark Parser separate quotes with blank quoted lines between them with
+        // paragraphs, so we need to consider it when the markdown is only a multiline quote.
+        if (par.type === 'block_quote') {
+            break;
+        }
+
         par = par.parent;
     }
     return par.firstChild != par.lastChild;


### PR DESCRIPTION
Signed-off-by: Renan <renancleyson.f@gmail.com>

Fixes vector-im/element-web#8786

# Proposed changes
Fix multiline paragraph inside a quote with blank lines between the text being removed when rendered.

### Before
![WhatsApp Image 2021-11-26 at 19 00 22 (3)](https://user-images.githubusercontent.com/43624243/143658247-941e9804-3ebf-42c5-9e98-70fba339fc9d.jpeg)

### After
![WhatsApp Image 2021-11-26 at 19 00 22 (2)](https://user-images.githubusercontent.com/43624243/143658253-221c62d2-9934-4521-adb2-1c5783ad0494.jpeg)

# Steps to reproduce
1. Add a message with 2 lines of text and a blank line between.
2. Quote the message and send only it.
3. The blank line will vanish and the 2 lines with text will be only one.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix multiline paragraph rendering as single line ([\#7210](https://github.com/matrix-org/matrix-react-sdk/pull/7210)). Fixes vector-im/element-web#8786. Contributed by @renancleyson-dev.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a15ea5a01427a49e58328e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
