### PR TITLE
Fix newline on edit messages with quotes

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -56,12 +56,6 @@ function isAllowedHtmlTag(node: commonmark.Node): boolean {
 function isMultiLine(node: commonmark.Node): boolean {
     let par = node;
     while (par.parent) {
-        // commonmark Parser separate quotes with blank quoted lines between them with
-        // paragraphs, so we need to consider it when the markdown is only a multiline quote.
-        if (par.type === 'block_quote') {
-            break;
-        }
-
         par = par.parent;
     }
     return par.firstChild != par.lastChild;
@@ -135,7 +129,10 @@ export default class Markdown {
             // 'inline', rather than unnecessarily wrapped in its own
             // p tag. If, however, we have multiple nodes, each gets
             // its own p tag to keep them as separate paragraphs.
-            if (isMultiLine(node)) {
+            // However, if it's a blockquote, adds a p tag anyway
+            // in order to avoid deviation to commonmark and unexpected
+            // results when parsing the formatted HTML.
+            if (node.parent.type === 'block_quote'|| isMultiLine(node)) {
                 realParagraph.call(this, node, entering);
             }
         };


### PR DESCRIPTION
Signed-off-by: Renan <renancleyson.f@gmail.com>

Fixes vector-im/element-web#12535

# The issue
The root cause of this bug is the newlines that are inserted on `blockquote` tags by commonmark before and after its children(which are expected to be `p` tags) when the message is sent:
``` javascript
// code from https://github.com/commonmark/commonmark.js/blob/fd28e37ffe159458c3891252b5444f4db77a15a9/lib/render/html.js#L165
function block_quote(node, entering) {
    var attrs = this.attrs(node);
    if (entering) {
        this.cr(); // Adds newline
        this.tag("blockquote", attrs); // add blockquote tag
        this.cr(); // Adds newline
    } else {
        this.cr(); // Adds newline
        this.tag("/blockquote"); // close blockquote tag
        this.cr(); // Adds newline
    }
}
```


When editing the message, the HTML content will be parsed and Element will try to ignore isolated text nodes with only a `\n` char on this function:
https://github.com/matrix-org/matrix-react-sdk/blob/3417c03f41bb59ecce951c0d17a078e5fb013808/src/editor/deserialize.ts#L191-L195


It expects to ignore the newlines added on the `blockquote` tag by commonmark too, but since the renderer may not render a paragraph tag as we override some rendering from commonmark to avoid unnecessary `p` tags:
https://github.com/matrix-org/matrix-react-sdk/blob/d939e45d000cc0a8362949eb134563b9b84edd02/src/Markdown.ts#L132-L141

The newlines will not be isolated anymore, they will be part of the text node of the `blockquote`, and the `n.nodeValue` value will be something like `\nsome text\n`, but what it's expected is something like two text nodes with only a `\n` as node value and a `p` tag with the `some text` text node separated from the newline chars. Thus, the newlines will not be ignored and the user will see a newline after the first `>`.

# Proposed Changes
Render text inside markdown quotes with paragraphs even when it's only a single line of text. This will make my previous PR #7210 obsolete.

### Before
![WhatsApp Image 2021-11-29 at 17 26 27](https://user-images.githubusercontent.com/43624243/143938051-cf15fd6f-2908-464b-a750-349d1ba53b05.jpeg)

### After
![WhatsApp Image 2021-11-29 at 17 26 52](https://user-images.githubusercontent.com/43624243/143938114-826c748f-4915-40ba-af9d-b7b1f45a9804.jpeg)


# Steps to reproduce
1. Send a message with a single line or only with soft breaks(`>a\n>a` is soft break and `>a\n>\n>a` don't)
2. Try to edit it
3. a newline will be inserted after the first `>`.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix newline on edit messages with quotes ([\#7227](https://github.com/matrix-org/matrix-react-sdk/pull/7227)). Fixes vector-im/element-web#12535. Contributed by @renancleyson-dev.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a538b86607cb008e77de21--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
