### PR TITLE
Fix textual message stripping new line

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -36,7 +36,6 @@ import { tryTransformPermalinkToLocalHref } from "./utils/permalinks/Permalinks"
 import { getEmojiFromUnicode } from "./emoji";
 import ReplyChain from "./components/views/elements/ReplyChain";
 import { mediaFromMxc } from "./customisations/Media";
-import Markdown from './Markdown';
 
 linkifyMatrix(linkify);
 
@@ -412,8 +411,9 @@ export interface IOptsReturnString extends IOpts {
 export function bodyToHtml(content: IContent, highlights: string[], opts: IOptsReturnString): string;
 export function bodyToHtml(content: IContent, highlights: string[], opts: IOptsReturnNode): ReactNode;
 export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts = {}) {
-    const isHtmlMessage = content.format === "org.matrix.custom.html" && content.formatted_body;
+    const isFormattedBody = content.format === "org.matrix.custom.html" && content.formatted_body;
     let bodyHasEmoji = false;
+    let isHtmlMessage = false;
 
     let sanitizeParams = sanitizeHtmlParams;
     if (opts.forComposerQuote) {
@@ -423,7 +423,6 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
     let strippedBody: string;
     let safeBody: string;
     let isDisplayedWithHtml: boolean;
-    let hasHtmlWithFormattedBody = false;
     // XXX: We sanitize the HTML whilst also highlighting its text nodes, to avoid accidentally trying
     // to highlight HTML tags themselves.  However, this does mean that we don't highlight textnodes which
     // are interrupted by HTML tags (not that we did before) - e.g. foo<span/>bar won't get highlighted
@@ -447,40 +446,41 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
 
         let formattedBody = typeof content.formatted_body === 'string' ? content.formatted_body : null;
         const plainBody = typeof content.body === 'string' ? content.body : "";
-        const isPlainTextBody = new Markdown(plainBody).isPlainText();
-        hasHtmlWithFormattedBody = !isPlainTextBody && isHtmlMessage;
 
         if (opts.stripReplyFallback && formattedBody) formattedBody = ReplyChain.stripHTMLReply(formattedBody);
         strippedBody = opts.stripReplyFallback ? ReplyChain.stripPlainReply(plainBody) : plainBody;
 
-        bodyHasEmoji = mightContainEmoji(isHtmlMessage ? formattedBody : plainBody);
+        bodyHasEmoji = mightContainEmoji(isFormattedBody ? formattedBody : plainBody);
 
         // Only generate safeBody if the message was sent as org.matrix.custom.html
-        if (isHtmlMessage) {
+        if (isFormattedBody) {
             isDisplayedWithHtml = true;
-            safeBody = sanitizeHtml(formattedBody, sanitizeParams);
-        }
 
-        if (hasHtmlWithFormattedBody && SettingsStore.getValue("feature_latex_maths")) {
+            safeBody = sanitizeHtml(formattedBody, sanitizeParams);
             const phtml = cheerio.load(safeBody, {
                 // @ts-ignore: The `_useHtmlParser2` internal option is the
                 // simplest way to both parse and render using `htmlparser2`.
                 _useHtmlParser2: true,
                 decodeEntities: false,
             });
-            // @ts-ignore - The types for `replaceWith` wrongly expect
-            // Cheerio instance to be returned.
-            phtml('div, span[data-mx-maths!=""]').replaceWith(function(i, e) {
-                return katex.renderToString(
-                    AllHtmlEntities.decode(phtml(e).attr('data-mx-maths')),
-                    {
-                        throwOnError: false,
-                        // @ts-ignore - `e` can be an Element, not just a Node
-                        displayMode: e.name == 'div',
-                        output: "htmlAndMathml",
-                    });
-            });
-            safeBody = phtml.html();
+            const isPlainText = phtml.html() === phtml.root().text();
+            isHtmlMessage = isFormattedBody && !isPlainText;
+
+            if (isHtmlMessage && SettingsStore.getValue("feature_latex_maths")) {
+                // @ts-ignore - The types for `replaceWith` wrongly expect
+                // Cheerio instance to be returned.
+                phtml('div, span[data-mx-maths!=""]').replaceWith(function(i, e) {
+                    return katex.renderToString(
+                        AllHtmlEntities.decode(phtml(e).attr('data-mx-maths')),
+                        {
+                            throwOnError: false,
+                            // @ts-ignore - `e` can be an Element, not just a Node
+                            displayMode: e.name == 'div',
+                            output: "htmlAndMathml",
+                        });
+                });
+                safeBody = phtml.html();
+            }
         }
     } finally {
         delete sanitizeParams.textFilter;
@@ -520,7 +520,7 @@ export function bodyToHtml(content: IContent, highlights: string[], opts: IOpts 
     const className = classNames({
         'mx_EventTile_body': true,
         'mx_EventTile_bigEmoji': emojiBody,
-        'markdown-body': hasHtmlWithFormattedBody && !emojiBody,
+        'markdown-body': isHtmlMessage && !emojiBody,
     });
 
     return isDisplayedWithHtml ?

--- a/test/components/views/messages/TextualBody-test.js
+++ b/test/components/views/messages/TextualBody-test.js
@@ -282,6 +282,30 @@ describe("<TextualBody />", () => {
                 '!ZxbRYPQXDXKGmDnJNg:example.com</a></span> with vias</span>',
             );
         });
+
+        it('renders formatted body without html corretly', () => {
+            const ev = mkEvent({
+                type: "m.room.message",
+                room: "room_id",
+                user: "sender",
+                content: {
+                    body: "escaped \\*markdown\\*",
+                    msgtype: "m.text",
+                    format: "org.matrix.custom.html",
+                    formatted_body: "escaped *markdown*",
+                },
+                event: true,
+            });
+
+            const wrapper = mount(<TextualBody mxEvent={ev} />);
+
+            const content = wrapper.find(".mx_EventTile_body");
+            expect(content.html()).toBe(
+                '<span class="mx_EventTile_body" dir="auto">' +
+                'escaped *markdown*' +
+                '</span>',
+            );
+        });
     });
 
     it("renders url previews correctly", () => {


### PR DESCRIPTION
Signed-off-by: Renan <renancleyson.f@gmail.com>

Fixes vector-im/element-web#15320

# Proposed changes
Element doesn't render HTML on plain text but still adds a `formatted_body`(markdown) to the message's content when there's escaped markdown to remove the backslashes, so we only add the `markdown-body` CSS class(which is currently added when there's `formatted_body`, even if it's only plain text) when it's a `formatted body` with HTML as the bug is caused by the CSS rule `white-space: normal` added by this class.

### Before
![WhatsApp Image 2021-11-30 at 20 38 42](https://user-images.githubusercontent.com/43624243/144145555-d8c2debb-84e8-4d29-94ed-62de75d5c15e.jpeg)

### After
![WhatsApp Image 2021-11-30 at 20 37 04](https://user-images.githubusercontent.com/43624243/144145563-f213f962-da61-4afe-96f6-6cf8ff4901ce.jpeg)


# Steps to reproduce
1. Send a multiline plain text message with escaped markdown
2. Newlines are converted to white-spaces

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix textual message stripping new line ([\#7239](https://github.com/matrix-org/matrix-react-sdk/pull/7239)). Fixes vector-im/element-web#15320. Contributed by @renancleyson-dev.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61a7bf9bf8f071611e704c77--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
