### PR TITLE
Fix wrongly sized default sub-space icons in space panel

### DIFF
--- a/res/css/structures/_SpacePanel.scss
+++ b/res/css/structures/_SpacePanel.scss
@@ -275,8 +275,6 @@ $activeBorderColor: $primary-content;
 
         .mx_BaseAvatar:not(.mx_UserMenu_userAvatar_BaseAvatar) .mx_BaseAvatar_initial {
             color: $secondary-content;
-            width: 32px;
-            height: 32px;
             border-radius: 8px;
             background-color: $panel-actions;
             font-size: $font-15px !important; // override inline style
@@ -285,13 +283,6 @@ $activeBorderColor: $primary-content;
 
             & + .mx_BaseAvatar_image {
                 visibility: hidden;
-            }
-        }
-
-        .mx_SpaceTreeLevel {
-            .mx_BaseAvatar_initial {
-                width: 24px;
-                height: 24px;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19973

![image](https://user-images.githubusercontent.com/2403652/144203903-fb9bcff8-0ce7-4625-bb21-b40db9364d61.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrongly sized default sub-space icons in space panel ([\#7243](https://github.com/matrix-org/matrix-react-sdk/pull/7243)). Fixes vector-im/element-web#19973.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61a753e762cebaff895edae5--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
