### PR TITLE
Make e2e tests pass in CI by using an older Synapse version

### DIFF
--- a/test/end-to-end-tests/synapse/install.sh
+++ b/test/end-to-end-tests/synapse/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # config
-SYNAPSE_BRANCH=develop
+SYNAPSE_BRANCH=release-v1.47
 INSTALLATION_NAME=consent
 SERVER_DIR=installations/$INSTALLATION_NAME
 CONFIG_TEMPLATE=consent


### PR DESCRIPTION
It appears that a regression was introduced in Synapse v1.4.8. This PR fixes the version used in our tests until the Synapse teams can deal with the issue

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a7450bc2bf62f0408c2580--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
