### PR TITLE
Autofocus device panel entry when renaming device

### DIFF
--- a/src/components/views/settings/DevicesPanelEntry.tsx
+++ b/src/components/views/settings/DevicesPanelEntry.tsx
@@ -175,6 +175,7 @@ export default class DevicesPanelEntry extends React.Component<IProps, IState> {
                     value={this.state.displayName}
                     autoComplete="off"
                     onChange={this.onChangeDisplayName}
+                    autoFocus
                 />
                 <AccessibleButton onClick={this.onRenameSubmit} kind="confirm_sm" />
                 <AccessibleButton onClick={this.onRenameCancel} kind="cancel_sm" />


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19984

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Autofocus device panel entry when renaming device ([\#7249](https://github.com/matrix-org/matrix-react-sdk/pull/7249)). Fixes vector-im/element-web#19984.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a75aa187842707098085ee--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
