### PR TITLE
Break long words in pinned messages to prevent overflow

### DIFF
--- a/res/css/views/right_panel/_PinnedMessagesCard.scss
+++ b/res/css/views/right_panel/_PinnedMessagesCard.scss
@@ -87,4 +87,8 @@ limitations under the License.
             }
         }
     }
+
+    .mx_EventTile_body {
+        word-break: break-word;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19985

![image](https://user-images.githubusercontent.com/2403652/144277227-bcf557d0-7c57-4c68-a6a3-dcb5375dc4ac.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Break long words in pinned messages to prevent overflow ([\#7251](https://github.com/matrix-org/matrix-react-sdk/pull/7251)). Fixes vector-im/element-web#19985.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a7a8a343214f494349c625--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
