### PR TITLE
Add utility method mxLoginWithAccessToken to login with existing access token

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -100,6 +100,7 @@ declare global {
         mxOnRecaptchaLoaded?: () => void;
         electron?: Electron;
         mxSendSentryReport: (userText: string, issueUrl: string, error: Error) => Promise<void>;
+        mxLoginWithAccessToken: (hsUrl: string, accessToken: string) => Promise<void>;
     }
 
     interface DesktopCapturerSource {

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -538,8 +538,8 @@ export function hydrateSession(credentials: IMatrixClientCreds): Promise<MatrixC
  * fires on_logging_in, optionally clears localstorage, persists new credentials
  * to localstorage, starts the new client.
  *
- * @param {MatrixClientCreds} credentials
- * @param {Boolean} clearStorage
+ * @param {IMatrixClientCreds} credentials
+ * @param {Boolean} clearStorageEnabled
  *
  * @returns {Promise} promise which resolves to the new MatrixClient once it has been started
  */
@@ -918,3 +918,17 @@ export function stopMatrixClient(unsetClient = true): void {
         }
     }
 }
+
+// Utility method to perform a login with an existing access_token
+window.mxLoginWithAccessToken = async (hsUrl: string, accessToken: string): Promise<void> => {
+    const tempClient = createClient({
+        baseUrl: hsUrl,
+        accessToken,
+    });
+    const { user_id: userId } = await tempClient.whoami();
+    await doSetLoggedIn({
+        homeserverUrl: hsUrl,
+        accessToken,
+        userId,
+    }, true);
+};

--- a/src/MatrixClientPeg.ts
+++ b/src/MatrixClientPeg.ts
@@ -40,7 +40,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 
 export interface IMatrixClientCreds {
     homeserverUrl: string;
-    identityServerUrl: string;
+    identityServerUrl?: string;
     userId: string;
     deviceId?: string;
     accessToken: string;


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2046
Fixes https://github.com/vector-im/element-web/issues/15528

Developer utility method

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61a8bcece030f81c21b7f159--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
