### PR TITLE
Add edits and replies to the right panel timeline & prepare the timelineCard to share code with threads

### DIFF
--- a/src/components/structures/RightPanel.tsx
+++ b/src/components/structures/RightPanel.tsx
@@ -339,8 +339,12 @@ export default class RightPanel extends React.Component<IProps, IState> {
                 if (!SettingsStore.getValue("feature_maximised_widgets")) break;
                 panel = <TimelineCard
                     room={this.props.room}
+                    timelineSet={this.props.room.getUnfilteredTimelineSet()}
                     resizeNotifier={this.props.resizeNotifier}
-                    onClose={this.onClose} />;
+                    onClose={this.onClose}
+                    permalinkCreator={this.props.permalinkCreator}
+                    e2eStatus={this.props.e2eStatus}
+                />;
                 break;
             case RightPanelPhases.FilePanel:
                 panel = <FilePanel roomId={roomId} resizeNotifier={this.props.resizeNotifier} onClose={this.onClose} />;

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -155,7 +155,7 @@ export default class TimelineCard extends React.Component<IProps, IState> {
         return (
             <RoomContext.Provider value={{
                 ...this.context,
-                timelineRenderingType: this.props.timelineRenderingType || TimelineRenderingType.Room,
+                timelineRenderingType: this.props.timelineRenderingType ?? this.context.timelineRenderingType,
                 liveTimeline: this.props.timelineSet.getLiveTimeline(),
             }}>
                 <BaseCard

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -28,7 +28,7 @@ import { Layout } from '../../../settings/enums/Layout';
 import TimelinePanel from '../../structures/TimelinePanel';
 import { E2EStatus } from '../../../utils/ShieldUtils';
 import EditorStateTransfer from '../../../utils/EditorStateTransfer';
-import RoomContext from '../../../contexts/RoomContext';
+import RoomContext, { TimelineRenderingType } from '../../../contexts/RoomContext';
 import dis from '../../../dispatcher/dispatcher';
 import { _t } from '../../../languageHandler';
 import { replaceableComponent } from '../../../utils/replaceableComponent';
@@ -42,6 +42,7 @@ interface IProps {
     permalinkCreator?: RoomPermalinkCreator;
     e2eStatus?: E2EStatus;
     timelineSet?: EventTimelineSet;
+    timelineRenderingType?: TimelineRenderingType;
 }
 interface IState {
     thread?: Thread;
@@ -141,6 +142,7 @@ export default class TimelineCard extends React.Component<IProps, IState> {
         return (
             <RoomContext.Provider value={{
                 ...this.context,
+                timelineRenderingType: this.props.timelineRenderingType || TimelineRenderingType.Room,
                 liveTimeline: this.props.timelineSet.getLiveTimeline(),
             }}>
                 <BaseCard

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import { EventSubscription } from "fbemitter";
-import { EventTimelineSet, MatrixEvent, Room } from 'matrix-js-sdk/src';
+import { EventTimelineSet, IEventRelation, MatrixEvent, Room } from 'matrix-js-sdk/src';
 import { Thread } from 'matrix-js-sdk/src/models/thread';
 
 import BaseCard from "./BaseCard";
@@ -35,6 +35,8 @@ import { replaceableComponent } from '../../../utils/replaceableComponent';
 import { ActionPayload } from '../../../dispatcher/payloads';
 import { Action } from '../../../dispatcher/actions';
 import RoomViewStore from '../../../stores/RoomViewStore';
+import ContentMessages from '../../../ContentMessages';
+import UploadBar from '../../structures/UploadBar';
 interface IProps {
     room: Room;
     onClose: () => void;
@@ -43,6 +45,8 @@ interface IProps {
     e2eStatus?: E2EStatus;
     timelineSet?: EventTimelineSet;
     timelineRenderingType?: TimelineRenderingType;
+    showComposer?: boolean;
+    composerRelation?: IEventRelation;
 }
 interface IState {
     thread?: Thread;
@@ -173,8 +177,13 @@ export default class TimelineCard extends React.Component<IProps, IState> {
                         onUserScroll={this.onScroll}
                     />
 
+                    { ContentMessages.sharedInstance().getCurrentUploads(this.props.composerRelation).length > 0 && (
+                        <UploadBar room={this.props.room} relation={this.props.composerRelation} />
+                    ) }
+
                     <MessageComposer
                         room={this.props.room}
+                        relation={this.props.composerRelation}
                         resizeNotifier={this.props.resizeNotifier}
                         replyToEvent={this.state.replyToEvent}
                         permalinkCreator={this.props.permalinkCreator}

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 import React from 'react';
-import { MatrixEvent, Room } from 'matrix-js-sdk/src';
+import { EventSubscription } from "fbemitter";
+import { EventTimelineSet, MatrixEvent, Room } from 'matrix-js-sdk/src';
 import { Thread } from 'matrix-js-sdk/src/models/thread';
 
 import BaseCard from "./BaseCard";
@@ -28,33 +29,103 @@ import TimelinePanel from '../../structures/TimelinePanel';
 import { E2EStatus } from '../../../utils/ShieldUtils';
 import EditorStateTransfer from '../../../utils/EditorStateTransfer';
 import RoomContext from '../../../contexts/RoomContext';
-
+import dis from '../../../dispatcher/dispatcher';
 import { _t } from '../../../languageHandler';
 import { replaceableComponent } from '../../../utils/replaceableComponent';
-
+import { ActionPayload } from '../../../dispatcher/payloads';
+import { Action } from '../../../dispatcher/actions';
+import RoomViewStore from '../../../stores/RoomViewStore';
 interface IProps {
     room: Room;
     onClose: () => void;
     resizeNotifier: ResizeNotifier;
     permalinkCreator?: RoomPermalinkCreator;
     e2eStatus?: E2EStatus;
-    initialEvent?: MatrixEvent;
-    initialEventHighlighted?: boolean;
+    timelineSet?: EventTimelineSet;
 }
 interface IState {
     thread?: Thread;
     editState?: EditorStateTransfer;
     replyToEvent?: MatrixEvent;
+    initialEventId?: string;
+    initialEventHighlighted?: boolean;
 }
 
 @replaceableComponent("structures.TimelineCard")
 export default class TimelineCard extends React.Component<IProps, IState> {
     static contextType = RoomContext;
 
+    private dispatcherRef: string;
+    private timelinePanelRef: React.RefObject<TimelinePanel> = React.createRef();
+    private roomStoreToken: EventSubscription;
     constructor(props: IProps) {
         super(props);
         this.state = {};
     }
+
+    public componentDidMount(): void {
+        this.roomStoreToken = RoomViewStore.addListener(this.onRoomViewStoreUpdate);
+        this.dispatcherRef = dis.register(this.onAction);
+    }
+
+    public componentWillUnmount(): void {
+        // Remove RoomStore listener
+        if (this.roomStoreToken) {
+            this.roomStoreToken.remove();
+        }
+        dis.unregister(this.dispatcherRef);
+    }
+
+    private onRoomViewStoreUpdate = async (initial?: boolean): Promise<void> => {
+        const newState: Pick<IState, any> = {
+            // roomId,
+            // roomAlias: RoomViewStore.getRoomAlias(),
+            // roomLoading: RoomViewStore.isRoomLoading(),
+            // roomLoadError: RoomViewStore.getRoomLoadError(),
+            // joining: RoomViewStore.isJoining(),
+            // replyToEvent: RoomViewStore.getQuotingEvent(),
+            // // we should only peek once we have a ready client
+            // shouldPeek: this.state.matrixClientIsReady && RoomViewStore.shouldPeek(),
+            // showReadReceipts: SettingsStore.getValue("showReadReceipts", roomId),
+            // showRedactions: SettingsStore.getValue("showRedactions", roomId),
+            // showJoinLeaves: SettingsStore.getValue("showJoinLeaves", roomId),
+            // showAvatarChanges: SettingsStore.getValue("showAvatarChanges", roomId),
+            // showDisplaynameChanges: SettingsStore.getValue("showDisplaynameChanges", roomId),
+            // wasContextSwitch: RoomViewStore.getWasContextSwitch(),
+            initialEventId: RoomViewStore.getInitialEventId(),
+            initialEventHighlighted: RoomViewStore.isInitialEventHighlighted(),
+            replyToEvent: RoomViewStore.getQuotingEvent(),
+        };
+        this.setState(newState);
+    };
+
+    private onAction = (payload: ActionPayload): void => {
+        switch (payload.action) {
+            case Action.EditEvent:
+                this.setState({
+                    editState: payload.event ? new EditorStateTransfer(payload.event) : null,
+                }, () => {
+                    if (payload.event) {
+                        this.timelinePanelRef.current?.scrollToEventIfNeeded(payload.event.getId());
+                    }
+                });
+                break;
+            default:
+                break;
+        }
+    };
+
+    private onScroll = (): void => {
+        if (this.state.initialEventId && this.state.initialEventHighlighted) {
+            dis.dispatch({
+                action: Action.ViewRoom,
+                room_id: this.props.room.roomId,
+                event_id: this.state.initialEventId,
+                highlighted: false,
+                replyingToEvent: this.state.replyToEvent,
+            });
+        }
+    };
 
     private renderTimelineCardHeader = (): JSX.Element => {
         return <div className="mx_TimelineCard__header">
@@ -63,41 +134,53 @@ export default class TimelineCard extends React.Component<IProps, IState> {
     };
 
     public render(): JSX.Element {
-        return (
-            <BaseCard
-                className="mx_ThreadPanel mx_TimelineCard"
-                onClose={this.props.onClose}
-                withoutScrollContainer={true}
-                header={this.renderTimelineCardHeader()}
-            >
-                <TimelinePanel
-                    showReadReceipts={false} // TODO: RR's cause issues with limited horizontal space
-                    manageReadReceipts={true}
-                    manageReadMarkers={false} // No RM support in the TimelineCard
-                    sendReadReceiptOnLoad={true}
-                    timelineSet={this.props.room.getUnfilteredTimelineSet()}
-                    showUrlPreview={true}
-                    layout={Layout.Group}
-                    hideThreadedMessages={false}
-                    hidden={false}
-                    showReactions={true}
-                    className="mx_RoomView_messagePanel mx_GroupLayout"
-                    permalinkCreator={this.props.permalinkCreator}
-                    membersLoaded={true}
-                    editState={this.state.editState}
-                    eventId={this.props.initialEvent?.getId()}
-                    resizeNotifier={this.props.resizeNotifier}
-                />
+        const highlightedEventId = this.state.initialEventHighlighted
+            ? this.state.initialEventId
+            : null;
 
-                <MessageComposer
-                    room={this.props.room}
-                    resizeNotifier={this.props.resizeNotifier}
-                    replyToEvent={this.state.replyToEvent}
-                    permalinkCreator={this.props.permalinkCreator}
-                    e2eStatus={this.props.e2eStatus}
-                    compact={true}
-                />
-            </BaseCard>
+        return (
+            <RoomContext.Provider value={{
+                ...this.context,
+                liveTimeline: this.props.timelineSet.getLiveTimeline(),
+            }}>
+                <BaseCard
+                    className="mx_ThreadPanel mx_TimelineCard"
+                    onClose={this.props.onClose}
+                    withoutScrollContainer={true}
+                    header={this.renderTimelineCardHeader()}
+                >
+                    <TimelinePanel
+                        ref={this.timelinePanelRef}
+                        showReadReceipts={false} // TODO: RR's cause issues with limited horizontal space
+                        manageReadReceipts={true}
+                        manageReadMarkers={false} // No RM support in the TimelineCard
+                        sendReadReceiptOnLoad={true}
+                        timelineSet={this.props.timelineSet}
+                        showUrlPreview={true}
+                        layout={Layout.Group}
+                        hideThreadedMessages={false}
+                        hidden={false}
+                        showReactions={true}
+                        className="mx_RoomView_messagePanel mx_GroupLayout"
+                        permalinkCreator={this.props.permalinkCreator}
+                        membersLoaded={true}
+                        editState={this.state.editState}
+                        eventId={this.state.initialEventId}
+                        resizeNotifier={this.props.resizeNotifier}
+                        highlightedEventId={highlightedEventId}
+                        onUserScroll={this.onScroll}
+                    />
+
+                    <MessageComposer
+                        room={this.props.room}
+                        resizeNotifier={this.props.resizeNotifier}
+                        replyToEvent={this.state.replyToEvent}
+                        permalinkCreator={this.props.permalinkCreator}
+                        e2eStatus={this.props.e2eStatus}
+                        compact={true}
+                    />
+                </BaseCard>
+            </RoomContext.Provider>
         );
     }
 }

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -74,6 +74,7 @@ export default class TimelineCard extends React.Component<IProps, IState> {
         this.state = {
             showReadReceipts: false,
         };
+        this.settingWatchers = [];
     }
 
     public componentDidMount(): void {

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -38,6 +38,7 @@ import RoomViewStore from '../../../stores/RoomViewStore';
 import ContentMessages from '../../../ContentMessages';
 import UploadBar from '../../structures/UploadBar';
 import SettingsStore from '../../../settings/SettingsStore';
+
 interface IProps {
     room: Room;
     onClose: () => void;

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -95,14 +95,9 @@ export default class TimelineCard extends React.Component<IProps, IState> {
     private onRoomViewStoreUpdate = async (initial?: boolean): Promise<void> => {
         const roomId = this.props.room.roomId;
         const newState: Pick<IState, any> = {
-            // roomId,
-            // roomAlias: RoomViewStore.getRoomAlias(),
             // roomLoading: RoomViewStore.isRoomLoading(),
             // roomLoadError: RoomViewStore.getRoomLoadError(),
-            // joining: RoomViewStore.isJoining(),
-            // replyToEvent: RoomViewStore.getQuotingEvent(),
-            // // we should only peek once we have a ready client
-            // shouldPeek: this.state.matrixClientIsReady && RoomViewStore.shouldPeek(),
+
             showReadReceipts: SettingsStore.getValue("showReadReceipts", roomId),
             initialEventId: RoomViewStore.getInitialEventId(),
             initialEventHighlighted: RoomViewStore.isInitialEventHighlighted(),

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -49,7 +49,6 @@ interface IProps {
     timelineRenderingType?: TimelineRenderingType;
     showComposer?: boolean;
     composerRelation?: IEventRelation;
-
 }
 interface IState {
     thread?: Thread;

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -57,7 +57,7 @@ interface IState {
     initialEventId?: string;
     initialEventHighlighted?: boolean;
 
-    // settigns:
+    // settings:
     showReadReceipts?: boolean;
 }
 

--- a/src/components/views/right_panel/TimelineCard.tsx
+++ b/src/components/views/right_panel/TimelineCard.tsx
@@ -70,6 +70,7 @@ export default class TimelineCard extends React.Component<IProps, IState> {
     private timelinePanelRef: React.RefObject<TimelinePanel> = React.createRef();
     private roomStoreToken: EventSubscription;
     private settingWatchers: string[];
+
     constructor(props: IProps) {
         super(props);
         this.state = {


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/20012
Fixes: https://github.com/vector-im/element-web/issues/19928

This also lays the groundwork to remove duplicate code between the right panel timeline and the threads view.
the timlineCard(WithComposer) component should have the following properties:
```js
IProps {
    room: Room;
    onClose: () => void;
    resizeNotifier: ResizeNotifier;
    permalinkCreator?: RoomPermalinkCreator;
    e2eStatus?: E2EStatus;
    timelineSet?: EventTimelineSet;
    timelineRenderingType?: TimelineRenderingType;
    showComposer?: boolean;
    composerRelation?: IEventRelation;
}
```
those should be enough to allow the threadsView and the right panel chat to use this component.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add edits and replies to the right panel timeline & prepare the timelineCard to share code with threads ([\#7262](https://github.com/matrix-org/matrix-react-sdk/pull/7262)). Fixes vector-im/element-web#20012 and vector-im/element-web#19928. Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->




























<!-- Replace -->
Preview: https://61aa264e93ea444beca4ea18--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
