### PR TITLE
Remove the `Screen sharing is here!` dialog

### DIFF
--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -28,8 +28,6 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
 import RoomTopic from "../elements/RoomTopic";
 import RoomName from "../elements/RoomName";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
-import Modal from '../../../Modal';
-import InfoDialog from "../dialogs/InfoDialog";
 import { throttle } from 'lodash';
 import { MatrixEvent, Room, RoomState } from 'matrix-js-sdk/src';
 import { E2EStatus } from '../../../utils/ShieldUtils';
@@ -112,14 +110,6 @@ export default class RoomHeader extends React.Component<IProps, IState> {
     private rateLimitedUpdate = throttle(() => {
         this.forceUpdate();
     }, 500, { leading: true, trailing: true });
-
-    private displayInfoDialogAboutScreensharing() {
-        Modal.createDialog(InfoDialog, {
-            title: _t("Screen sharing is here!"),
-            description: _t("You can now share your screen by pressing the \"screen share\" " +
-            "button during a call. You can even do this in audio calls if both sides support it!"),
-        });
-    }
 
     private onContextMenuOpenClick = (ev: React.MouseEvent) => {
         ev.preventDefault();
@@ -219,8 +209,7 @@ export default class RoomHeader extends React.Component<IProps, IState> {
             />;
             const videoCallButton = <AccessibleTooltipButton
                 className="mx_RoomHeader_button mx_RoomHeader_videoCallButton"
-                onClick={(ev: React.MouseEvent<Element>) => ev.shiftKey ?
-                    this.displayInfoDialogAboutScreensharing() : this.props.onCallPlaced(CallType.Video)}
+                onClick={() => this.props.onCallPlaced(CallType.Video)}
                 title={_t("Video call")}
                 key="video"
             />;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1704,8 +1704,6 @@
     "Unnamed room": "Unnamed room",
     "World readable": "World readable",
     "Guests can join": "Guests can join",
-    "Screen sharing is here!": "Screen sharing is here!",
-    "You can now share your screen by pressing the \"screen share\" button during a call. You can even do this in audio calls if both sides support it!": "You can now share your screen by pressing the \"screen share\" button during a call. You can even do this in audio calls if both sides support it!",
     "(~%(count)s results)|other": "(~%(count)s results)",
     "(~%(count)s results)|one": "(~%(count)s result)",
     "Join Room": "Join Room",


### PR DESCRIPTION
Type: enhancement
Fixes https://github.com/vector-im/element-web/issues/18824
element-web notes: none

<hr>

It's been quite some time since proper screen-sharing became a thing, so the dialog can now be removed. It was targeted at more advanced users who knew about the hidden screen-sharing feature, so it's quite safe to assume that those users are now aware of the new feature.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove the `Screen sharing is here!` dialog ([\#7266](https://github.com/matrix-org/matrix-react-sdk/pull/7266)). Fixes vector-im/element-web#18824. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61a8e3cb34e9341dda936500--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
