### PR TITLE
Expose PL control for pinned events when lab enabled

### DIFF
--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -29,6 +29,7 @@ import ErrorDialog from '../../../dialogs/ErrorDialog';
 import PowerSelector from "../../../elements/PowerSelector";
 
 import { logger } from "matrix-js-sdk/src/logger";
+import SettingsStore from "../../../../../settings/SettingsStore";
 
 interface IEventShowOpts {
     isState?: boolean;
@@ -54,6 +55,7 @@ const plEventsToShow: Record<string, IEventShowOpts> = {
     [EventType.RoomTombstone]: { isState: true, hideForSpace: true },
     [EventType.RoomEncryption]: { isState: true, hideForSpace: true },
     [EventType.RoomServerAcl]: { isState: true, hideForSpace: true },
+    [EventType.RoomPinnedEvents]: { isState: true, hideForSpace: true },
 
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
     "im.vector.modular.widgets": { isState: true, hideForSpace: true },
@@ -236,6 +238,10 @@ export default class RolesRoomSettingsTab extends React.Component<IProps> {
             // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
             "im.vector.modular.widgets": isSpaceRoom ? null : _td("Modify widgets"),
         };
+
+        if (SettingsStore.getValue("feature_pinning")) {
+            plEventsToLabels[EventType.RoomPinnedEvents] = _td("Manage pinned events");
+        }
 
         const powerLevelDescriptors: Record<string, IPowerLevelDescriptor> = {
             "users_default": {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1526,6 +1526,7 @@
     "Enable room encryption": "Enable room encryption",
     "Change server ACLs": "Change server ACLs",
     "Modify widgets": "Modify widgets",
+    "Manage pinned events": "Manage pinned events",
     "Default role": "Default role",
     "Send messages": "Send messages",
     "Invite users": "Invite users",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/5396

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Expose PL control for pinned events when lab enabled ([\#7278](https://github.com/matrix-org/matrix-react-sdk/pull/7278)). Fixes vector-im/element-web#5396.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61aa0a302b5ca3fa6dc7f51f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
