### PR TITLE
Make tooltips keyboard accessible

### DIFF
--- a/res/css/views/elements/_TextWithTooltip.scss
+++ b/res/css/views/elements/_TextWithTooltip.scss
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+.mx_TextWithTooltip_target {
+    display: inline;
+}
 
 .mx_TextWithTooltip_tooltip {
     display: none;

--- a/src/components/views/elements/AccessibleTooltipButton.tsx
+++ b/src/components/views/elements/AccessibleTooltipButton.tsx
@@ -80,6 +80,8 @@ export default class AccessibleTooltipButton extends React.PureComponent<IToolti
                 {...props}
                 onMouseOver={this.onMouseOver}
                 onMouseLeave={this.onMouseLeave}
+                onFocus={this.onMouseOver}
+                onBlur={this.onMouseLeave}
                 aria-label={title}
             >
                 { children }

--- a/src/components/views/elements/AccessibleTooltipButton.tsx
+++ b/src/components/views/elements/AccessibleTooltipButton.tsx
@@ -52,14 +52,14 @@ export default class AccessibleTooltipButton extends React.PureComponent<IToolti
         }
     }
 
-    onMouseOver = () => {
+    showTooltip = () => {
         if (this.props.forceHide) return;
         this.setState({
             hover: true,
         });
     };
 
-    onMouseLeave = () => {
+    hideTooltip = () => {
         this.setState({
             hover: false,
         });
@@ -78,10 +78,10 @@ export default class AccessibleTooltipButton extends React.PureComponent<IToolti
         return (
             <AccessibleButton
                 {...props}
-                onMouseOver={this.onMouseOver}
-                onMouseLeave={this.onMouseLeave}
-                onFocus={this.onMouseOver}
-                onBlur={this.onMouseLeave}
+                onMouseOver={this.showTooltip}
+                onMouseLeave={this.hideTooltip}
+                onFocus={this.showTooltip}
+                onBlur={this.hideTooltip}
                 aria-label={title}
             >
                 { children }

--- a/src/components/views/elements/ActionButton.tsx
+++ b/src/components/views/elements/ActionButton.tsx
@@ -58,17 +58,17 @@ export default class ActionButton extends React.Component<IProps, IState> {
     };
 
     private onMouseEnter = (): void => {
-        this.onShowTooltip();
+        this.showTooltip();
         if (this.props.mouseOverAction) {
             dis.dispatch({ action: this.props.mouseOverAction });
         }
     };
 
-    private onShowTooltip = (): void => {
+    private showTooltip = (): void => {
         if (this.props.tooltip) this.setState({ showTooltip: true });
     };
 
-    private onHideTooltip = (): void => {
+    private hideTooltip = (): void => {
         this.setState({ showTooltip: false });
     };
 
@@ -92,9 +92,9 @@ export default class ActionButton extends React.Component<IProps, IState> {
                 className={classNames.join(" ")}
                 onClick={this.onClick}
                 onMouseEnter={this.onMouseEnter}
-                onMouseLeave={this.onHideTooltip}
-                onFocus={this.onShowTooltip}
-                onBlur={this.onHideTooltip}
+                onMouseLeave={this.hideTooltip}
+                onFocus={this.showTooltip}
+                onBlur={this.hideTooltip}
                 aria-label={this.props.label}
             >
                 { icon }

--- a/src/components/views/elements/ActionButton.tsx
+++ b/src/components/views/elements/ActionButton.tsx
@@ -66,11 +66,11 @@ export default class ActionButton extends React.Component<IProps, IState> {
 
     private onShowTooltip = (): void => {
         if (this.props.tooltip) this.setState({ showTooltip: true });
-    }
+    };
 
     private onHideTooltip = (): void => {
         this.setState({ showTooltip: false });
-    }
+    };
 
     render() {
         let tooltip;

--- a/src/components/views/elements/ActionButton.tsx
+++ b/src/components/views/elements/ActionButton.tsx
@@ -58,15 +58,19 @@ export default class ActionButton extends React.Component<IProps, IState> {
     };
 
     private onMouseEnter = (): void => {
-        if (this.props.tooltip) this.setState({ showTooltip: true });
+        this.onShowTooltip();
         if (this.props.mouseOverAction) {
             dis.dispatch({ action: this.props.mouseOverAction });
         }
     };
 
-    private onMouseLeave = (): void => {
+    private onShowTooltip = (): void => {
+        if (this.props.tooltip) this.setState({ showTooltip: true });
+    }
+
+    private onHideTooltip = (): void => {
         this.setState({ showTooltip: false });
-    };
+    }
 
     render() {
         let tooltip;
@@ -88,7 +92,9 @@ export default class ActionButton extends React.Component<IProps, IState> {
                 className={classNames.join(" ")}
                 onClick={this.onClick}
                 onMouseEnter={this.onMouseEnter}
-                onMouseLeave={this.onMouseLeave}
+                onMouseLeave={this.onHideTooltip}
+                onFocus={this.onShowTooltip}
+                onBlur={this.onHideTooltip}
                 aria-label={this.props.label}
             >
                 { icon }

--- a/src/components/views/elements/InfoTooltip.tsx
+++ b/src/components/views/elements/InfoTooltip.tsx
@@ -18,9 +18,10 @@ limitations under the License.
 import React from 'react';
 import classNames from 'classnames';
 
-import Tooltip, { Alignment } from './Tooltip';
+import { Alignment } from './Tooltip';
 import { _t } from "../../../languageHandler";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
+import { TooltipTarget } from './TooltipTarget';
 
 export enum InfoTooltipKind {
     Info = "info",
@@ -34,29 +35,10 @@ interface ITooltipProps {
     kind?: InfoTooltipKind;
 }
 
-interface IState {
-    hover: boolean;
-}
-
 @replaceableComponent("views.elements.InfoTooltip")
 export default class InfoTooltip extends React.PureComponent<ITooltipProps, IState> {
     constructor(props: ITooltipProps) {
         super(props);
-        this.state = {
-            hover: false,
-        };
-    }
-
-    onMouseOver = () => {
-        this.setState({
-            hover: true,
-        });
-    };
-
-    onMouseLeave = () => {
-        this.setState({
-            hover: false,
-        });
     };
 
     render() {
@@ -68,22 +50,16 @@ export default class InfoTooltip extends React.PureComponent<ITooltipProps, ISta
         );
 
         // Tooltip are forced on the right for a more natural feel to them on info icons
-        const tip = this.state.hover ? <Tooltip
-            className="mx_InfoTooltip_container"
-            tooltipClassName={classNames("mx_InfoTooltip_tooltip", tooltipClassName)}
-            label={tooltip || title}
-            alignment={Alignment.Right}
-        /> : <div />;
         return (
-            <div
-                onMouseOver={this.onMouseOver}
-                onMouseLeave={this.onMouseLeave}
-                className={classNames("mx_InfoTooltip", className)}
+            <TooltipTarget tooltipTargetClassName={classNames("mx_InfoTooltip", className)}
+                className="mx_InfoTooltip_container"
+                tooltipClassName={classNames("mx_InfoTooltip_tooltip", tooltipClassName)}
+                label={tooltip || title}
+                alignment={Alignment.Right}
             >
                 <span className={classNames("mx_InfoTooltip_icon", iconClassName)} aria-label={title} />
-                { children }
-                { tip }
-            </div>
+                {children}
+            </TooltipTarget>
         );
     }
 }

--- a/src/components/views/elements/InfoTooltip.tsx
+++ b/src/components/views/elements/InfoTooltip.tsx
@@ -39,7 +39,7 @@ interface ITooltipProps {
 export default class InfoTooltip extends React.PureComponent<ITooltipProps, IState> {
     constructor(props: ITooltipProps) {
         super(props);
-    };
+    }
 
     render() {
         const { tooltip, children, tooltipClassName, className, kind } = this.props;
@@ -58,7 +58,7 @@ export default class InfoTooltip extends React.PureComponent<ITooltipProps, ISta
                 alignment={Alignment.Right}
             >
                 <span className={classNames("mx_InfoTooltip_icon", iconClassName)} aria-label={title} />
-                {children}
+                { children }
             </TooltipTarget>
         );
     }

--- a/src/components/views/elements/InfoTooltip.tsx
+++ b/src/components/views/elements/InfoTooltip.tsx
@@ -36,7 +36,7 @@ interface ITooltipProps {
 }
 
 @replaceableComponent("views.elements.InfoTooltip")
-export default class InfoTooltip extends React.PureComponent<ITooltipProps, IState> {
+export default class InfoTooltip extends React.PureComponent<ITooltipProps> {
     constructor(props: ITooltipProps) {
         super(props);
     }

--- a/src/components/views/elements/TextWithTooltip.tsx
+++ b/src/components/views/elements/TextWithTooltip.tsx
@@ -15,8 +15,9 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
-import Tooltip from "./Tooltip";
+import { TooltipTarget } from './TooltipTarget';
 
 interface IProps {
     class?: string;
@@ -26,41 +27,27 @@ interface IProps {
     onClick?: (ev?: React.MouseEvent) => void;
 }
 
-interface IState {
-    hover: boolean;
-}
-
 @replaceableComponent("views.elements.TextWithTooltip")
-export default class TextWithTooltip extends React.Component<IProps, IState> {
+export default class TextWithTooltip extends React.Component<IProps> {
     constructor(props: IProps) {
         super(props);
-
-        this.state = {
-            hover: false,
-        };
     }
-
-    private onMouseOver = (): void => {
-        this.setState({ hover: true });
-    };
-
-    private onMouseLeave = (): void => {
-        this.setState({ hover: false });
-    };
 
     public render(): JSX.Element {
         const { class: className, children, tooltip, tooltipClass, tooltipProps, ...props } = this.props;
 
         return (
-            <span {...props} onMouseOver={this.onMouseOver} onMouseLeave={this.onMouseLeave} onClick={this.props.onClick} className={className}>
+            <TooltipTarget
+                onClick={this.props.onClick}
+                tooltipTargetClassName={classNames("mx_TextWithTooltip_target", className)}
+                {...tooltipProps}
+                label={tooltip}
+                tooltipClassName={tooltipClass}
+                className="mx_TextWithTooltip_tooltip"
+                {...props}
+            >
                 { children }
-                { this.state.hover && <Tooltip
-                    {...tooltipProps}
-                    label={tooltip}
-                    tooltipClassName={tooltipClass}
-                    className="mx_TextWithTooltip_tooltip"
-                /> }
-            </span>
+            </TooltipTarget>
         );
     }
 }

--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -46,6 +46,9 @@ interface IProps {
         label: React.ReactNode;
         alignment?: Alignment; // defaults to Natural
         yOffset?: number;
+        // id describing tooltip
+        // used to associate tooltip with target for a11y
+        id?: string;
 }
 
 @replaceableComponent("views.elements.Tooltip")

--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -33,7 +33,7 @@ export enum Alignment {
     Bottom, // Centered
 }
 
-interface IProps {
+export interface ITooltipProps {
         // Class applied to the element used to position the tooltip
         className?: string;
         // Class applied to the tooltip itself
@@ -52,7 +52,7 @@ interface IProps {
 }
 
 @replaceableComponent("views.elements.Tooltip")
-export default class Tooltip extends React.Component<IProps> {
+export default class Tooltip extends React.Component<ITooltipProps> {
     private tooltipContainer: HTMLElement;
     private tooltip: void | Element | Component<Element, any, any>;
     private parent: Element;

--- a/src/components/views/elements/TooltipButton.tsx
+++ b/src/components/views/elements/TooltipButton.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 
 import React from 'react';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
-import Tooltip from './Tooltip';
+import { TooltipTarget } from './TooltipTarget';
 
 interface IProps {
     helpText: React.ReactNode | string;
@@ -36,29 +36,17 @@ export default class TooltipButton extends React.Component<IProps, IState> {
         };
     }
 
-    private onMouseOver = () => {
-        this.setState({
-            hover: true,
-        });
-    };
-
-    private onMouseLeave = () => {
-        this.setState({
-            hover: false,
-        });
-    };
-
     render() {
-        const tip = this.state.hover ? <Tooltip
-            className="mx_TooltipButton_container"
-            tooltipClassName="mx_TooltipButton_helpText"
-            label={this.props.helpText}
-        /> : <div />;
         return (
-            <div className="mx_TooltipButton" onMouseOver={this.onMouseOver} onMouseLeave={this.onMouseLeave}>
+            <TooltipTarget
+                id='todo'
+                className="mx_TooltipButton"
+                tooltipClassName="mx_TooltipButton_helpText"
+                tooltipContainerClassName="mx_TooltipButton_container"
+                tooltip={this.props.helpText}
+            >
                 ?
-                { tip }
-            </div>
+            </TooltipTarget>
         );
     }
 }

--- a/src/components/views/elements/TooltipButton.tsx
+++ b/src/components/views/elements/TooltipButton.tsx
@@ -23,17 +23,10 @@ interface IProps {
     helpText: React.ReactNode | string;
 }
 
-interface IState {
-    hover: boolean;
-}
-
 @replaceableComponent("views.elements.TooltipButton")
-export default class TooltipButton extends React.Component<IProps, IState> {
+export default class TooltipButton extends React.Component<IProps> {
     constructor(props) {
         super(props);
-        this.state = {
-            hover: false,
-        };
     }
 
     render() {

--- a/src/components/views/elements/TooltipButton.tsx
+++ b/src/components/views/elements/TooltipButton.tsx
@@ -39,11 +39,10 @@ export default class TooltipButton extends React.Component<IProps, IState> {
     render() {
         return (
             <TooltipTarget
-                id='todo'
-                className="mx_TooltipButton"
+                className="mx_TooltipButton_container"
                 tooltipClassName="mx_TooltipButton_helpText"
-                tooltipContainerClassName="mx_TooltipButton_container"
-                tooltip={this.props.helpText}
+                tooltipTargetClassName="mx_TooltipButton"
+                label={this.props.helpText}
             >
                 ?
             </TooltipTarget>

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 New Vector Ltd.
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useState } from 'react';
+import Tooltip from './Tooltip';
+
+interface IProps {
+    tooltip: React.ReactNode | string;
+    className?: string;
+    tooltipClassName?: string;
+    tooltipContainerClassName?: string;
+    id: string;
+}
+
+/**
+ * Generic tooltip target element that handles tooltip visibility state
+ * and displays children
+ */
+export const TooltipTarget: React.FC<IProps> = ({
+    className, id, children, tooltip, tooltipClassName, tooltipContainerClassName,
+}) => {
+    const [isVisible, setIsVisible] = useState(false);
+
+    const show = () => setIsVisible(true);
+    const hide = () => setIsVisible(false);
+
+    return (
+        <div
+            tabIndex={0}
+            aria-describedby={isVisible ? id : undefined}
+            className={className}
+            onMouseOver={show}
+            onMouseLeave={hide}
+            onFocus={show}
+            onBlur={hide}
+        >
+            { children }
+            <Tooltip
+                id={id}
+                className={tooltipContainerClassName}
+                tooltipClassName={tooltipClassName}
+                label={tooltip}
+                visible={isVisible}
+            />
+        </div>
+    );
+};

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -1,6 +1,5 @@
 /*
-Copyright 2017 New Vector Ltd.
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2021 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -15,15 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from 'react';
-import Tooltip from './Tooltip';
+import React, { useState, HTMLAttributes } from 'react';
+import Tooltip, { ITooltipProps } from './Tooltip';
 
-interface IProps {
-    tooltip: React.ReactNode | string;
-    className?: string;
-    tooltipClassName?: string;
-    tooltipContainerClassName?: string;
-    id: string;
+interface IProps extends HTMLAttributes<HTMLSpanElement>, Omit<ITooltipProps, 'visible'> {
+    tooltipTargetClassName?: string;
 }
 
 /**
@@ -31,7 +27,16 @@ interface IProps {
  * and displays children
  */
 export const TooltipTarget: React.FC<IProps> = ({
-    className, id, children, tooltip, tooltipClassName, tooltipContainerClassName,
+    children,
+    tooltipTargetClassName,
+    // tooltip pass through props
+    className,
+    id,
+    label,
+    alignment,
+    yOffset,
+    tooltipClassName,
+    ...rest
 }) => {
     const [isVisible, setIsVisible] = useState(false);
 
@@ -39,23 +44,26 @@ export const TooltipTarget: React.FC<IProps> = ({
     const hide = () => setIsVisible(false);
 
     return (
-        <div
+        <span
             tabIndex={0}
-            aria-describedby={isVisible ? id : undefined}
-            className={className}
+            aria-describedby={id}
+            className={tooltipTargetClassName}
             onMouseOver={show}
             onMouseLeave={hide}
             onFocus={show}
             onBlur={hide}
+            { ...rest }
         >
             { children }
             <Tooltip
                 id={id}
-                className={tooltipContainerClassName}
+                className={className}
                 tooltipClassName={tooltipClassName}
-                label={tooltip}
+                label={label}
+                yOffset={yOffset}
+                alignment={alignment}
                 visible={isVisible}
             />
-        </div>
+        </span>
     );
 };

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -52,7 +52,7 @@ export const TooltipTarget: React.FC<IProps> = ({
             onMouseLeave={hide}
             onFocus={show}
             onBlur={hide}
-            { ...rest }
+            {...rest}
         >
             { children }
             <Tooltip

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -44,7 +44,7 @@ export const TooltipTarget: React.FC<IProps> = ({
     const hide = () => setIsVisible(false);
 
     return (
-        <span
+        <div
             tabIndex={0}
             aria-describedby={id}
             className={tooltipTargetClassName}
@@ -64,6 +64,6 @@ export const TooltipTarget: React.FC<IProps> = ({
                 alignment={alignment}
                 visible={isVisible}
             />
-        </span>
+        </div>
     );
 };

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1202,7 +1202,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             _t(
                 '<requestLink>Re-request encryption keys</requestLink> from your other sessions.',
                 {},
-                { 'requestLink': (sub) => <a onClick={this.onRequestKeysClick}>{ sub }</a> },
+                { 'requestLink': (sub) => <a tabIndex={0} onClick={this.onRequestKeysClick}>{ sub }</a> },
             );
 
         const keyRequestInfo = isEncryptionFailure && !isRedacted ?

--- a/test/components/views/elements/TooltipTarget-test.tsx
+++ b/test/components/views/elements/TooltipTarget-test.tsx
@@ -1,0 +1,90 @@
+// skinned-sdk should be the first import in most tests
+import '../../../skinned-sdk';
+import React from "react";
+import {
+    renderIntoDocument,
+    Simulate,
+} from 'react-dom/test-utils';
+import { act } from "react-dom/test-utils";
+
+import { Alignment } from '../../../../src/components/views/elements/Tooltip';
+import { TooltipTarget } from "../../../../src/components/views/elements/TooltipTarget";
+
+describe('<TooltipTarget />', () => {
+    const defaultProps = {
+        "tooltipTargetClassName": 'test tooltipTargetClassName',
+        "className": 'test className',
+        "tooltipClassName": 'test tooltipClassName',
+        "label": 'test label',
+        "yOffset": 1,
+        "alignment": Alignment.Left,
+        "id": 'test id',
+        'data-test-id': 'test',
+    };
+
+    const getComponent = (props = {}) => {
+        const wrapper = renderIntoDocument<HTMLSpanElement>(
+        // wrap in element so renderIntoDocument can render functional component
+            <span>
+                <TooltipTarget {...defaultProps} {...props}>
+                    <span>child</span>
+                </TooltipTarget>
+            </span>,
+        ) as HTMLSpanElement;
+        return wrapper.querySelector('[data-test-id=test]');
+    };
+
+    const getVisibleTooltip = () => document.querySelector('.mx_Tooltip.mx_Tooltip_visible');
+
+    afterEach(() => {
+        // clean up visible tooltips
+        const tooltipWrapper = document.querySelector('.mx_Tooltip_wrapper');
+        document.body.removeChild(tooltipWrapper);
+    });
+
+    it('renders container', () => {
+        const component = getComponent();
+        expect(component).toMatchSnapshot();
+        expect(getVisibleTooltip()).toBeFalsy();
+    });
+
+    it('displays tooltip on mouseover', () => {
+        const wrapper = getComponent();
+        act(() => {
+            Simulate.mouseOver(wrapper);
+        });
+        expect(getVisibleTooltip()).toMatchSnapshot();
+    });
+
+    it('hides tooltip on mouseleave', () => {
+        const wrapper = getComponent();
+        act(() => {
+            Simulate.mouseOver(wrapper);
+        });
+        expect(getVisibleTooltip()).toBeTruthy();
+        act(() => {
+            Simulate.mouseLeave(wrapper);
+        });
+        expect(getVisibleTooltip()).toBeFalsy();
+    });
+
+    it('displays tooltip on focus', () => {
+        const wrapper = getComponent();
+        act(() => {
+            Simulate.focus(wrapper);
+        });
+        expect(getVisibleTooltip()).toBeTruthy();
+    });
+
+    it('hides tooltip on blur', async () => {
+        const wrapper = getComponent();
+        act(() => {
+            Simulate.focus(wrapper);
+        });
+        expect(getVisibleTooltip()).toBeTruthy();
+        await act(async () => {
+            await Simulate.blur(wrapper);
+        });
+        expect(getVisibleTooltip()).toBeFalsy();
+    });
+});

--- a/test/components/views/elements/__snapshots__/TooltipTarget-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/TooltipTarget-test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TooltipTarget /> displays tooltip on mouseover 1`] = `
+<div
+  class="mx_Tooltip test tooltipClassName mx_Tooltip_visible"
+  style="right: 1008px; top: -26px; display: block;"
+>
+  <div
+    class="mx_Tooltip_chevron"
+  />
+  test label
+</div>
+`;
+
+exports[`<TooltipTarget /> renders container 1`] = `
+<div
+  aria-describedby="test id"
+  class="test tooltipTargetClassName"
+  data-test-id="test"
+  tabindex="0"
+>
+  <span>
+    child
+  </span>
+  <div
+    class="test className"
+  />
+</div>
+`;


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

In this PR:
- add generic `TooltipTarget` component to handle tooltip visibility on hover and focus
- use `TooltipTarget` in `TooltipButton` , `InfoTooltip`, `TextWithTooltip`
- add `onFocus` and `onBlur` handlers to `ActionButton` and `AccessibleActionButton`


https://user-images.githubusercontent.com/3055605/144642603-6abe06c0-48ee-4836-ae6c-48abfc78f561.mp4


![Screenshot at 2021-12-06 11-00-16](https://user-images.githubusercontent.com/3055605/144826393-ea762155-2cc6-4534-8938-243f58472ff9.png)
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make tooltips keyboard accessible ([\#7281](https://github.com/matrix-org/matrix-react-sdk/pull/7281)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->








































<!-- Replace -->
Preview: https://61b07d6ac86af6b67c4e0e70--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
