### PR TITLE
Fix labs exploding when lab group is empty

### DIFF
--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
@@ -88,11 +88,11 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
                 );
             });
 
-            groups.get(LabGroup.Widgets).push(
+            groups.getOrCreate(LabGroup.Widgets, []).push(
                 <SettingsFlag name="enableWidgetScreenshots" level={SettingLevel.ACCOUNT} />,
             );
 
-            groups.get(LabGroup.Experimental).push(
+            groups.getOrCreate(LabGroup.Experimental, []).push(
                 <SettingsFlag name="lowBandwidth" level={SettingLevel.DEVICE} />,
             );
 
@@ -101,12 +101,12 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
                 <SettingsFlag name="showHiddenEventsInTimeline" level={SettingLevel.DEVICE} />,
             );
 
-            groups.get(LabGroup.Analytics).push(
+            groups.getOrCreate(LabGroup.Analytics, []).push(
                 <SettingsFlag name="automaticErrorReporting" level={SettingLevel.DEVICE} />,
             );
 
             if (this.state.showHiddenReadReceipts) {
-                groups.get(LabGroup.Messaging).push(
+                groups.getOrCreate(LabGroup.Messaging, []).push(
                     <SettingsFlag name="feature_hidden_read_receipts" level={SettingLevel.DEVICE} />,
                 );
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20051

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix labs exploding when lab group is empty ([\#7290](https://github.com/matrix-org/matrix-react-sdk/pull/7290)). Fixes vector-im/element-web#20051.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61add774e27107b7c44bee17--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
