### PR TITLE
Fix wrong indentation with nested ordered list unnesting list on edit

### DIFF
--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -129,7 +129,9 @@ function parseElement(n: HTMLElement, partCreator: PartCreator, lastNode: HTMLEl
         case "U":
             return partCreator.plain(`<u>${n.textContent}</u>`);
         case "LI": {
-            const indent = "  ".repeat(state.listDepth - 1);
+            const BASE_INDENT = 4;
+            const depth = state.listDepth - 1;
+            const indent = " ".repeat(BASE_INDENT * depth);
             if (n.parentElement.nodeName === "OL") {
                 // The markdown parser doesn't do nested indexed lists at all, but this supports it anyway.
                 const index = state.listIndex[state.listIndex.length - 1];

--- a/test/editor/deserialize-test.js
+++ b/test/editor/deserialize-test.js
@@ -18,6 +18,8 @@ import '../skinned-sdk'; // Must be first for skinning to work
 import { parseEvent } from "../../src/editor/deserialize";
 import { createPartCreator } from "./mock";
 
+const FOUR_SPACES = " ".repeat(4);
+
 function htmlMessage(formattedBody, msgtype = "m.text") {
     return {
         getContent() {
@@ -234,6 +236,26 @@ describe('editor/deserialize', function() {
             expect(parts[2]).toStrictEqual({ type: "plain", text: "2. Continue" });
             expect(parts[3]).toStrictEqual({ type: "newline", text: "\n" });
             expect(parts[4]).toStrictEqual({ type: "plain", text: "3. Finish" });
+        });
+        it('nested unordered lists', () => {
+            const html = "<ul><li>Oak<ul><li>Spruce<ul><li>Birch</li></ul></li></ul></li></ul>";
+            const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
+            expect(parts.length).toBe(5);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "- Oak" });
+            expect(parts[1]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[2]).toStrictEqual({ type: "plain", text: `${FOUR_SPACES}- Spruce` });
+            expect(parts[3]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[4]).toStrictEqual({ type: "plain", text: `${FOUR_SPACES.repeat(2)}- Birch` });
+        });
+        it('nested ordered lists', () => {
+            const html = "<ol><li>Oak<ol><li>Spruce<ol><li>Birch</li></ol></li></ol></li></ol>";
+            const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
+            expect(parts.length).toBe(5);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "1. Oak" });
+            expect(parts[1]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[2]).toStrictEqual({ type: "plain", text: `${FOUR_SPACES}1. Spruce` });
+            expect(parts[3]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[4]).toStrictEqual({ type: "plain", text: `${FOUR_SPACES.repeat(2)}1. Birch` });
         });
         it('mx-reply is stripped', function() {
             const html = "<mx-reply>foo</mx-reply>bar";


### PR DESCRIPTION
Signed-off-by: Renan <renancleyson.f@gmail.com>

Fixes a bug from vector-im/element-web#13474, I think the other problems pointed out on the issue need a deeper discussion about the edit composer.

# Proposed changes
Adding four spaces as indentation when nesting lists.

The current code adds only two spaces to indent unordered lists, but the bug is caused by an extra space needed by the ordered list to be considered nested by commonmark. According to the [spec](https://spec.commonmark.org/0.30/#list-items), the indentation is at least *W*(width of the marker) + *N*(spaces after the marker) so if we have an unordered list which has only a `-` so *W* = 1  and only one space after it so *N* = 1, then we need only two spaces which is the current indentation. However, this isn't correct with ordered lists as we have `1.` to be *W* = 2, thus an extra space of indentation too.

Honestly, fixing it with 3 spaces of indentation for ordered lists looks strange, and more strange is a different indentation to ordered and unordered lists so I choose four spaces to indent any list when editing.

### Before
![WhatsApp Image 2021-12-06 at 21 51 12](https://user-images.githubusercontent.com/43624243/144946490-f46b6b43-7537-4e2e-b201-6661112e671c.jpeg)
### After
![WhatsApp Image 2021-12-06 at 21 51 43](https://user-images.githubusercontent.com/43624243/144946436-4e2f0618-9ea8-41ed-a119-7e59ff52ce98.jpeg)
# Steps to reproduce
1. Send a message with a nested ordered list
2. Edit it and save a simple change
3. the list formatting is lost

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrong indentation with nested ordered list unnesting list on edit ([\#7300](https://github.com/matrix-org/matrix-react-sdk/pull/7300)). Contributed by @renancleyson-dev.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61aeb23a263a040f0d21931f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
