### PR TITLE
Fix issue with room list resizer getting clipped in firefox

### DIFF
--- a/res/css/views/rooms/_RoomSublist.scss
+++ b/res/css/views/rooms/_RoomSublist.scss
@@ -194,6 +194,8 @@ limitations under the License.
             display: flex;
             flex-direction: column;
             align-self: stretch;
+            // without this Firefox will prefer pushing the resizer & show more/less button into the overflow
+            min-height: 0;
 
             mask-image: linear-gradient(0deg, transparent, black 4px);
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20076

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issue with room list resizer getting clipped in firefox ([\#7303](https://github.com/matrix-org/matrix-react-sdk/pull/7303)). Fixes vector-im/element-web#20076.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61af935e0bf3310c2fa792ba--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
