### PR TITLE
fix leaking unit test for Registration

### DIFF
--- a/test/components/structures/auth/Registration-test.js
+++ b/test/components/structures/auth/Registration-test.js
@@ -14,12 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import sdk from '../../../skinned-sdk';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import sdk from '../../../skinned-sdk';
+import { createClient } from 'matrix-js-sdk/src/matrix';
+
 import SdkConfig from '../../../../src/SdkConfig';
-import { mkServerConfig } from "../../../test-utils";
+import { createTestClient, mkServerConfig } from "../../../test-utils";
+
+jest.mock('matrix-js-sdk/src/matrix');
+jest.useFakeTimers();
 
 const Registration = sdk.getComponent(
     'structures.auth.Registration',
@@ -31,6 +37,7 @@ describe('Registration', function() {
     beforeEach(function() {
         parentDiv = document.createElement('div');
         document.body.appendChild(parentDiv);
+        createClient.mockImplementation(() => createTestClient());
     });
 
     afterEach(function() {
@@ -48,13 +55,13 @@ describe('Registration', function() {
         />, parentDiv);
     }
 
-    it('should show server picker', function() {
+    it('should show server picker', async function() {
         const root = render();
         const selector = ReactTestUtils.findRenderedDOMComponentWithClass(root, "mx_ServerPicker");
         expect(selector).toBeTruthy();
     });
 
-    it('should show form when custom URLs disabled', function() {
+    it('should show form when custom URLs disabled', async function() {
         jest.spyOn(SdkConfig, "get").mockReturnValue({
             disable_custom_urls: true,
         });
@@ -77,7 +84,7 @@ describe('Registration', function() {
         expect(form).toBeTruthy();
     });
 
-    it("should show SSO options if those are available", () => {
+    it("should show SSO options if those are available", async () => {
         jest.spyOn(SdkConfig, "get").mockReturnValue({
             disable_custom_urls: true,
         });


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->


After adding new test suites in https://github.com/matrix-org/matrix-react-sdk/pull/7302 this test for `Registration` started failing, I think because it did not handle `Registration`s async updates. 

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61af93ac1770953af1200747--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
