### PR TITLE
Make clear button images visible in high contrast theme

### DIFF
--- a/res/themes/light-high-contrast/css/_light-high-contrast.scss
+++ b/res/themes/light-high-contrast/css/_light-high-contrast.scss
@@ -105,3 +105,23 @@ $roomtopic-color: $secondary-content;
 .mx_ThemeChoicePanel > .mx_ThemeSelectors > .mx_StyledRadioButton.mx_StyledRadioButton_disabled {
     color: $primary-content;
 }
+
+.mx_RoomSearch {
+    &.mx_RoomSearch_focused, &.mx_RoomSearch_hasQuery {
+        .mx_RoomSearch_clearButton {
+            &::before {
+                background-color: $background !important;
+            }
+        }
+    }
+}
+
+.mx_PollCreateDialog {
+    .mx_PollCreateDialog_option {
+        .mx_PollCreateDialog_removeOption {
+            &::before {
+                background-color: $background !important;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19931

**Before:**
(Clear buttons are just filled circles)

![image](https://user-images.githubusercontent.com/76812/145078789-960bca64-1903-4204-a42d-fb58b3783cda.png)
![image](https://user-images.githubusercontent.com/76812/145078802-12f2b597-b3ce-4a3f-9be4-16cf2f1ff027.png)


**After:**
(Clear buttons contain "x")

![image](https://user-images.githubusercontent.com/76812/145078825-2476542c-a3e0-4b4c-875e-cf9a49dab8f2.png)
![image](https://user-images.githubusercontent.com/76812/145078834-d9e63cf5-c1d4-4a8b-85fe-e2ed2499ee9b.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make clear button images visible in high contrast theme ([\#7306](https://github.com/matrix-org/matrix-react-sdk/pull/7306)). Fixes vector-im/element-web#19931. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61af9d0e3bc14c1dc0a3cd04--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
