### PR TITLE
Add vertical spacing between buttons when they go over multiple lines

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -413,6 +413,7 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
     @mixin mx_DialogButton;
     margin-left: 0px;
     margin-right: 8px;
+    margin-bottom: 5px;
 
     // flip colours for the secondary ones
     font-weight: 600;

--- a/res/css/views/settings/_CryptographyPanel.scss
+++ b/res/css/views/settings/_CryptographyPanel.scss
@@ -20,4 +20,7 @@
 
 .mx_CryptographyPanel_importExportButtons {
     margin-bottom: 15px;
+    display: inline-flex;
+    flex-flow: wrap;
+    row-gap: 10px;
 }

--- a/res/css/views/settings/_SecureBackupPanel.scss
+++ b/res/css/views/settings/_SecureBackupPanel.scss
@@ -34,6 +34,9 @@ limitations under the License.
 
 .mx_SecureBackupPanel_buttonRow {
     margin: 1em 0;
+    display: inline-flex;
+    flex-flow: wrap;
+    row-gap: 10px;
 
     :nth-child(n + 1) {
         margin-inline-end: 10px;


### PR DESCRIPTION
**Description:**

Fixes the vertical spacing between buttons. This is relevant in
languages with long texts, like French, where the buttons don't
fit on one line.

Before:
![before1](https://user-images.githubusercontent.com/36052282/145356895-591c0120-0052-43b0-b8df-3cbcdeb3703b.png)
![before2](https://user-images.githubusercontent.com/36052282/145356903-51e94484-377d-4a17-8dc9-136652cfa995.png)
![before3](https://user-images.githubusercontent.com/36052282/145356908-52eebc48-8445-499e-a6ce-a4ac97d94bcf.png)

After:
![after1](https://user-images.githubusercontent.com/36052282/145356949-190c7972-7cb3-4430-93ff-e95ea62d9dd0.png)
![after2](https://user-images.githubusercontent.com/36052282/145356956-813d1bed-48f9-44c9-bb8a-83934fc5bcda.png)
![after3](https://user-images.githubusercontent.com/36052282/145356966-89b1481b-f8ab-420d-83b7-a2114083a512.png)


Fixes [element-web/issues/19853](https://github.com/vector-im/element-web/issues/19853)

Signed-off-by: Ingrid Budau inigiri@posteo.jp


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add vertical spacing between buttons when they go over multiple lines ([\#7314](https://github.com/matrix-org/matrix-react-sdk/pull/7314)). Contributed by @twigleingrid.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b1c8e04920e12ff7469c01--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
