### PR TITLE
Improve accessibility of opening space create menu

### DIFF
--- a/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -357,6 +357,7 @@ const SpaceCreateMenu = ({ onFinished }) => {
         onFinished={onFinished}
         wrapperClassName="mx_SpaceCreateMenu_wrapper"
         managed={false}
+        focusLock={true}
     >
         { body }
     </ContextMenu>;


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/20099

Fixes
> when I go to the spaces treeview and press on add a space, the button changes to cancel but there is no indication as to what to do next to actually complete the action.
If the information is at the bottom of the page, consider displaying a popup dialog containing all required controlls, with the usual close dialog buttons and sensitivity to the esc key as you're doing with other dialogs in some parts of the interface.
Alternatively, consider updating the aria live region with the fact that more info is at the bottom of the page or some other brief instruction of what to do, though the first option would be prefered.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve accessibility of opening space create menu ([\#7316](https://github.com/matrix-org/matrix-react-sdk/pull/7316)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b1cbda5d821715d2539aee--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
