### PR TITLE
Support reactions, replies and forwards of polls

### DIFF
--- a/res/css/views/messages/_MPollBody.scss
+++ b/res/css/views/messages/_MPollBody.scss
@@ -139,3 +139,8 @@ limitations under the License.
         font-size: $font-12px;
     }
 }
+
+// Prevent clicking a poll within a reply
+.mx_ReplyTile .mx_MPollBody {
+    pointer-events: none;
+}

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -46,7 +46,10 @@ export function isContentActionable(mxEvent: MatrixEvent): boolean {
             if (content.msgtype && content.msgtype !== 'm.bad.encrypted' && content.hasOwnProperty('body')) {
                 return true;
             }
-        } else if (mxEvent.getType() === 'm.sticker') {
+        } else if (
+            mxEvent.getType() === 'm.sticker' ||
+            POLL_START_EVENT_TYPE.matches(mxEvent.getType())
+        ) {
             return true;
         }
     }


### PR DESCRIPTION
Allow reacting and replying to polls by adding the normal context menu items.  (Also adds forwarding, and if enabled, pinning and replying in a thread.)
![react-to-polls](https://user-images.githubusercontent.com/76812/145378751-21c61d27-f3aa-4e95-ae76-6fb5461a35d9.gif)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b1da187c3a0a3a04dcf938--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
