### PR TITLE
Don't show options button when the user can't modify widgets

### DIFF
--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -96,6 +96,11 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
     const name = WidgetUtils.getWidgetName(app);
     const dataTitle = WidgetUtils.getWidgetDataTitle(app);
     const subtitle = dataTitle && " - " + dataTitle;
+    const [canModifyWidget, setCanModifyWidget] = useState<boolean>();
+
+    useEffect(() => {
+        setCanModifyWidget(WidgetUtils.canUserModifyWidgets(room.roomId));
+    }, [room.roomId]);
 
     const onOpenWidgetClick = () => {
         defaultDispatcher.dispatch<SetRightPanelPhasePayload>({
@@ -167,7 +172,7 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
             { subtitle }
         </AccessibleTooltipButton>
 
-        <ContextMenuTooltipButton
+        { canModifyWidget && <ContextMenuTooltipButton
             className={classNames({
                 "mx_RoomSummaryCard_app_options": true,
                 "mx_RoomSummaryCard_maximised_widget": SettingsStore.getValue("feature_maximised_widgets"),
@@ -176,7 +181,7 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
             onClick={openMenu}
             title={_t("Options")}
             yOffset={-24}
-        />
+        /> }
 
         <AccessibleTooltipButton
             className="mx_RoomSummaryCard_app_pinToggle"


### PR DESCRIPTION
Type: defect
Fixes https://github.com/vector-im/element-web/issues/20114

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't show options button when the user can't modify widgets ([\#7324](https://github.com/matrix-org/matrix-react-sdk/pull/7324)). Fixes vector-im/element-web#20114. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b253bf197024f5a662eca2--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
