### PR TITLE
don't collapse spaces in inline code blocks

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -469,6 +469,10 @@ $left-gutter: 64px;
             background: transparent;
         }
     }
+    
+    code {
+        white-space: pre; // don't collapse spaces in inline code blocks
+    }
 }
 
 .mx_EventTile_lineNumbers {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -469,7 +469,7 @@ $left-gutter: 64px;
             background: transparent;
         }
     }
-    
+
     code {
         white-space: pre; // don't collapse spaces in inline code blocks
     }


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Fixes vector-im/element-web#6051

before:
![image](https://user-images.githubusercontent.com/2803622/145567711-875ceddb-387c-48d3-a23b-4e8e3a5edffd.png)

after:
![image](https://user-images.githubusercontent.com/2803622/145567736-b6bc1971-4d84-44d8-9076-7f616faa6c85.png)


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
Signed-off-by: Kim Brose <kim.brose@rwth-aachen.de>

<!-- To specify text for the changelog entry (otherwise the PR title will be used):

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

Notes: don't collapse spaces in inline code blocks (https://github.com/vector-im/element-web/issues/6051)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * don't collapse spaces in inline code blocks (https ([\#7328](https://github.com/matrix-org/matrix-react-sdk/pull/7328)). Fixes vector-im/element-web#6051. Contributed by @HarHarLinks.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61b368100619ce41696a3e49--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
