### PR TITLE
Only show poll events in timeline when we have the polls feature

### DIFF
--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -138,13 +138,19 @@ export function getEventDisplayInfo(mxEvent: MatrixEvent): {
         !isBubbleMessage &&
         eventType === EventType.CallInvite
     );
+
+    const isPollStart = (
+        POLL_START_EVENT_TYPE.matches(eventType) &&
+        SettingsStore.getValue("feature_polls")
+    );
+
     let isInfoMessage = (
         !isBubbleMessage &&
         !isLeftAlignedBubbleMessage &&
+        !isPollStart &&
         eventType !== EventType.RoomMessage &&
         eventType !== EventType.Sticker &&
-        eventType !== EventType.RoomCreate &&
-        eventType !== POLL_START_EVENT_TYPE.name
+        eventType !== EventType.RoomCreate
     );
 
     // If we're showing hidden events in the timeline, we should use the


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20130

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Only show poll events in timeline when we have the polls feature ([\#7329](https://github.com/matrix-org/matrix-react-sdk/pull/7329)). Fixes vector-im/element-web#20130. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b33d921a2fcc01487b72e6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
