### PR TITLE
Adding missing TypeScript dependency

### DIFF
--- a/test/end-to-end-tests/package.json
+++ b/test/end-to-end-tests/package.json
@@ -18,6 +18,7 @@
         "uuid": "^3.3.2"
     },
     "devDependencies": {
-        "@types/puppeteer": "^5.4.4"
+        "@types/puppeteer": "^5.4.4",
+        "typescript": "^4.5.3"
     }
 }

--- a/test/end-to-end-tests/yarn.lock
+++ b/test/end-to-end-tests/yarn.lock
@@ -801,6 +801,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+typescript@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+
 unbzip2-stream@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"


### PR DESCRIPTION
The e2e tests are now using TypeScript. Adding the dependency here to not assume a global dependency

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b3442e1a2fcc10897b6ad7--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
