### PR TITLE
Auto select "Other homeserver" when user press "Edit" in homeserver field

### DIFF
--- a/src/components/views/dialogs/ServerPickerDialog.tsx
+++ b/src/components/views/dialogs/ServerPickerDialog.tsx
@@ -219,6 +219,7 @@ export default class ServerPickerDialog extends React.PureComponent<IProps, ISta
                         value={this.state.otherHomeserver}
                         validateOnChange={false}
                         validateOnFocus={false}
+                        autoFocus={true}
                         id="mx_homeserverInput"
                     />
                 </StyledRadioButton>


### PR DESCRIPTION
Type: enhancement
Fixes https://github.com/vector-im/element-web/issues/20125

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Auto select "Other homeserver" when user press "Edit" in homeserver field ([\#7337](https://github.com/matrix-org/matrix-react-sdk/pull/7337)). Fixes vector-im/element-web#20125. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b45438695b2e767f623de4--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
