### PR TITLE
Keep all previously approved widget capabilities when requesting new capabilities

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -34,7 +34,7 @@ import { IContent, IEvent, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { logger } from "matrix-js-sdk/src/logger";
 
-import { iterableDiff, iterableUnion } from "../../utils/iterables";
+import { iterableDiff, iterableMerge } from "../../utils/iterables";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import ActiveRoomObserver from "../../ActiveRoomObserver";
 import Modal from "../../Modal";
@@ -131,7 +131,7 @@ export class StopGapWidgetDriver extends WidgetDriver {
             }
         }
 
-        const allAllowed = new Set(iterableUnion(allowedSoFar, requested));
+        const allAllowed = new Set(iterableMerge(allowedSoFar, requested));
 
         if (rememberApproved) {
             setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allAllowed));

--- a/src/utils/iterables.ts
+++ b/src/utils/iterables.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { arrayDiff, arrayUnion } from "./arrays";
+import { arrayDiff, arrayMerge, arrayUnion } from "./arrays";
+
+export function iterableMerge<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
+    return arrayMerge(Array.from(a), Array.from(b));
+}
 
 export function iterableUnion<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
     return arrayUnion(Array.from(a), Array.from(b));

--- a/test/utils/iterables-test.ts
+++ b/test/utils/iterables-test.ts
@@ -14,9 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { iterableDiff, iterableUnion } from "../../src/utils/iterables";
+import { iterableDiff, iterableMerge, iterableUnion } from "../../src/utils/iterables";
 
 describe('iterables', () => {
+    describe('iterableMerge', () => {
+        it('should return a merged array', () => {
+            const a = [1, 2, 3];
+            const b = [1, 2, 4]; // note diff
+            const result = iterableMerge(a, b);
+            expect(result).toBeDefined();
+            expect(result).toHaveLength(4);
+            expect(result).toEqual([1, 2, 3, 4]);
+        });
+    });
+
     describe('iterableUnion', () => {
         it('should return a union', () => {
             const a = [1, 2, 3];


### PR DESCRIPTION
When using `widgetApi.updateRequestedCapabilities()`, all previously approved capabilities are discarded and are replaced with the list of newly approved capabilities. `iterableUnion` is a bit misleading, because it doesn't do a [union operation](https://en.wikipedia.org/wiki/Union_(set_theory)) but rather an [intersection operation](https://en.wikipedia.org/wiki/Intersection_(set_theory)).

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Keep all previously approved widget capabilities when requesting new capabilities ([\#7340](https://github.com/matrix-org/matrix-react-sdk/pull/7340)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b72086edfd110b3fe40caf--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
