### PR TITLE
Fix upgraded rooms wrongly showing up in spotlight

### DIFF
--- a/src/components/views/dialogs/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/SpotlightDialog.tsx
@@ -177,7 +177,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", onFinished }) => 
         const lcQuery = trimmedQuery.toLowerCase();
         const normalizedQuery = normalize(trimmedQuery);
 
-        return cli.getRooms().filter(r => {
+        return cli.getVisibleRooms().filter(r => {
             return r.getCanonicalAlias()?.includes(lcQuery) || r.normalizedName.includes(normalizedQuery);
         });
     }, [cli, query]);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20141

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix upgraded rooms wrongly showing up in spotlight ([\#7341](https://github.com/matrix-org/matrix-react-sdk/pull/7341)). Fixes vector-im/element-web#20141.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b713e22de32cc41b893eea--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
