### PR TITLE
Fix naming of set-theory utils to match convention

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -34,7 +34,7 @@ import { IContent, IEvent, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { logger } from "matrix-js-sdk/src/logger";
 
-import { iterableDiff, iterableMerge } from "../../utils/iterables";
+import { iterableDiff, iterableUnion } from "../../utils/iterables";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import ActiveRoomObserver from "../../ActiveRoomObserver";
 import Modal from "../../Modal";
@@ -131,7 +131,7 @@ export class StopGapWidgetDriver extends WidgetDriver {
             }
         }
 
-        const allAllowed = new Set(iterableMerge(allowedSoFar, requested));
+        const allAllowed = new Set(iterableUnion(allowedSoFar, requested));
 
         if (rememberApproved) {
             setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allAllowed));

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -200,21 +200,21 @@ export function arrayDiff<T>(a: T[], b: T[]): { added: T[], removed: T[] } {
 }
 
 /**
- * Returns the union of two arrays.
+ * Returns the intersection of two arrays.
  * @param a The first array. Must be defined.
  * @param b The second array. Must be defined.
- * @returns The union of the arrays.
+ * @returns The intersection of the arrays.
  */
-export function arrayUnion<T>(a: T[], b: T[]): T[] {
+export function arrayIntersection<T>(a: T[], b: T[]): T[] {
     return a.filter(i => b.includes(i));
 }
 
 /**
- * Merges arrays, deduping contents using a Set.
+ * Unions arrays, deduping contents using a Set.
  * @param a The arrays to merge.
- * @returns The merged array.
+ * @returns The union of all given arrays.
  */
-export function arrayMerge<T>(...a: T[][]): T[] {
+export function arrayUnion<T>(...a: T[][]): T[] {
     return Array.from(a.reduce((c, v) => {
         v.forEach(i => c.add(i));
         return c;

--- a/src/utils/iterables.ts
+++ b/src/utils/iterables.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { arrayDiff, arrayMerge, arrayUnion } from "./arrays";
-
-export function iterableMerge<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
-    return arrayMerge(Array.from(a), Array.from(b));
-}
+import { arrayDiff, arrayUnion, arrayIntersection } from "./arrays";
 
 export function iterableUnion<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
     return arrayUnion(Array.from(a), Array.from(b));
+}
+
+export function iterableIntersection<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
+    return arrayIntersection(Array.from(a), Array.from(b));
 }
 
 export function iterableDiff<T>(a: Iterable<T>, b: Iterable<T>): { added: Iterable<T>, removed: Iterable<T> } {

--- a/src/utils/maps.ts
+++ b/src/utils/maps.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { arrayDiff, arrayMerge, arrayUnion } from "./arrays";
+import { arrayDiff, arrayUnion, arrayIntersection } from "./arrays";
 
 /**
  * Determines the keys added, changed, and removed between two Maps.
@@ -27,7 +27,7 @@ export function mapDiff<K, V>(a: Map<K, V>, b: Map<K, V>): { changed: K[], added
     const aKeys = [...a.keys()];
     const bKeys = [...b.keys()];
     const keyDiff = arrayDiff(aKeys, bKeys);
-    const possibleChanges = arrayUnion(aKeys, bKeys);
+    const possibleChanges = arrayIntersection(aKeys, bKeys);
     const changes = possibleChanges.filter(k => a.get(k) !== b.get(k));
 
     return { changed: changes, added: keyDiff.added, removed: keyDiff.removed };
@@ -42,7 +42,7 @@ export function mapDiff<K, V>(a: Map<K, V>, b: Map<K, V>): { changed: K[], added
  */
 export function mapKeyChanges<K, V>(a: Map<K, V>, b: Map<K, V>): K[] {
     const diff = mapDiff(a, b);
-    return arrayMerge(diff.removed, diff.added, diff.changed);
+    return arrayUnion(diff.removed, diff.added, diff.changed);
 }
 
 /**

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { arrayDiff, arrayMerge, arrayUnion } from "./arrays";
+import { arrayDiff, arrayUnion, arrayIntersection } from "./arrays";
 
 type ObjectExcluding<O extends {}, P extends (keyof O)[]> = {[k in Exclude<keyof O, P[number]>]: O[k]};
 
@@ -90,7 +90,7 @@ export function objectHasDiff<O extends {}>(a: O, b: O): boolean {
     const aKeys = Object.keys(a);
     const bKeys = Object.keys(b);
     if (aKeys.length !== bKeys.length) return true;
-    const possibleChanges = arrayUnion(aKeys, bKeys);
+    const possibleChanges = arrayIntersection(aKeys, bKeys);
     // if the amalgamation of both sets of keys has the a different length to the inputs then there must be a change
     if (possibleChanges.length !== aKeys.length) return true;
 
@@ -111,7 +111,7 @@ export function objectDiff<O extends {}>(a: O, b: O): Diff<keyof O> {
     const aKeys = Object.keys(a) as (keyof O)[];
     const bKeys = Object.keys(b) as (keyof O)[];
     const keyDiff = arrayDiff(aKeys, bKeys);
-    const possibleChanges = arrayUnion(aKeys, bKeys);
+    const possibleChanges = arrayIntersection(aKeys, bKeys);
     const changes = possibleChanges.filter(k => a[k] !== b[k]);
 
     return { changed: changes, added: keyDiff.added, removed: keyDiff.removed };
@@ -128,7 +128,7 @@ export function objectDiff<O extends {}>(a: O, b: O): Diff<keyof O> {
  */
 export function objectKeyChanges<O extends {}>(a: O, b: O): (keyof O)[] {
     const diff = objectDiff(a, b);
-    return arrayMerge(diff.removed, diff.added, diff.changed);
+    return arrayUnion(diff.removed, diff.added, diff.changed);
 }
 
 /**

--- a/test/utils/arrays-test.ts
+++ b/test/utils/arrays-test.ts
@@ -20,12 +20,12 @@ import {
     arrayFastResample,
     arrayHasDiff,
     arrayHasOrderChange,
-    arrayMerge,
+    arrayUnion,
     arrayRescale,
     arraySeed,
     arraySmoothingResample,
     arrayTrimFill,
-    arrayUnion,
+    arrayIntersection,
     ArrayUtil,
     GroupedArray,
 } from "../../src/utils/arrays";
@@ -276,11 +276,11 @@ describe('arrays', () => {
         });
     });
 
-    describe('arrayUnion', () => {
-        it('should return a union', () => {
+    describe('arrayIntersection', () => {
+        it('should return the intersection', () => {
             const a = [1, 2, 3];
             const b = [1, 2, 4]; // note diff
-            const result = arrayUnion(a, b);
+            const result = arrayIntersection(a, b);
             expect(result).toBeDefined();
             expect(result).toHaveLength(2);
             expect(result).toEqual([1, 2]);
@@ -289,18 +289,18 @@ describe('arrays', () => {
         it('should return an empty array on no matches', () => {
             const a = [1, 2, 3];
             const b = [4, 5, 6];
-            const result = arrayUnion(a, b);
+            const result = arrayIntersection(a, b);
             expect(result).toBeDefined();
             expect(result).toHaveLength(0);
         });
     });
 
-    describe('arrayMerge', () => {
-        it('should merge 3 arrays with deduplication', () => {
+    describe('arrayUnion', () => {
+        it('should union 3 arrays with deduplication', () => {
             const a = [1, 2, 3];
             const b = [1, 2, 4, 5]; // note missing 3
             const c = [6, 7, 8, 9];
-            const result = arrayMerge(a, b, c);
+            const result = arrayUnion(a, b, c);
             expect(result).toBeDefined();
             expect(result).toHaveLength(9);
             expect(result).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -308,9 +308,9 @@ describe('arrays', () => {
 
         it('should deduplicate a single array', () => {
             // dev note: this is technically an edge case, but it is described behaviour if the
-            // function is only provided one function (it'll merge the array against itself)
+            // function is only provided one array (it'll merge the array against itself)
             const a = [1, 1, 2, 2, 3, 3];
-            const result = arrayMerge(a);
+            const result = arrayUnion(a);
             expect(result).toBeDefined();
             expect(result).toHaveLength(3);
             expect(result).toEqual([1, 2, 3]);

--- a/test/utils/iterables-test.ts
+++ b/test/utils/iterables-test.ts
@@ -14,25 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { iterableDiff, iterableMerge, iterableUnion } from "../../src/utils/iterables";
+import { iterableDiff, iterableUnion, iterableIntersection } from "../../src/utils/iterables";
 
 describe('iterables', () => {
-    describe('iterableMerge', () => {
-        it('should return a merged array', () => {
+    describe('iterableUnion', () => {
+        it('should return the union array', () => {
             const a = [1, 2, 3];
             const b = [1, 2, 4]; // note diff
-            const result = iterableMerge(a, b);
+            const result = iterableUnion(a, b);
             expect(result).toBeDefined();
             expect(result).toHaveLength(4);
             expect(result).toEqual([1, 2, 3, 4]);
         });
     });
 
-    describe('iterableUnion', () => {
-        it('should return a union', () => {
+    describe('iterableIntersection', () => {
+        it('should return the intersection', () => {
             const a = [1, 2, 3];
             const b = [1, 2, 4]; // note diff
-            const result = iterableUnion(a, b);
+            const result = iterableIntersection(a, b);
             expect(result).toBeDefined();
             expect(result).toHaveLength(2);
             expect(result).toEqual([1, 2]);
@@ -41,7 +41,7 @@ describe('iterables', () => {
         it('should return an empty array on no matches', () => {
             const a = [1, 2, 3];
             const b = [4, 5, 6];
-            const result = iterableUnion(a, b);
+            const result = iterableIntersection(a, b);
             expect(result).toBeDefined();
             expect(result).toHaveLength(0);
         });


### PR DESCRIPTION
Builds on https://github.com/matrix-org/matrix-react-sdk/pull/7340 which fixed a bug caused by the misleading naming

merge -> union
union -> intersection

![image](https://user-images.githubusercontent.com/2403652/145798085-8ac7333b-a9ac-4b3c-811a-50d22a121c32.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b724348d16ffb35aa9924f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
