### PR TITLE
Have LocalEchoWrapper emit updates so the app can react faster

### DIFF
--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -28,7 +28,7 @@ import { _t } from '../languageHandler';
 import dis from '../dispatcher/dispatcher';
 import { IFeature, ISetting, LabGroup, SETTINGS } from "./Settings";
 import LocalEchoWrapper from "./handlers/LocalEchoWrapper";
-import { WatchManager, CallbackFn as WatchCallbackFn } from "./WatchManager";
+import { CallbackFn as WatchCallbackFn, WatchManager } from "./WatchManager";
 import { SettingLevel } from "./SettingLevel";
 import SettingsHandler from "./handlers/SettingsHandler";
 import { SettingUpdatedPayload } from "../dispatcher/payloads/SettingUpdatedPayload";
@@ -50,20 +50,19 @@ for (const key of Object.keys(SETTINGS)) {
     }
 }
 
+// Only wrap the handlers with async setters in a local echo wrapper
 const LEVEL_HANDLERS = {
     [SettingLevel.DEVICE]: new DeviceSettingsHandler(featureNames, defaultWatchManager),
     [SettingLevel.ROOM_DEVICE]: new RoomDeviceSettingsHandler(defaultWatchManager),
-    [SettingLevel.ROOM_ACCOUNT]: new RoomAccountSettingsHandler(defaultWatchManager),
-    [SettingLevel.ACCOUNT]: new AccountSettingsHandler(defaultWatchManager),
-    [SettingLevel.ROOM]: new RoomSettingsHandler(defaultWatchManager),
+    [SettingLevel.ROOM_ACCOUNT]: new LocalEchoWrapper(
+        new RoomAccountSettingsHandler(defaultWatchManager),
+        SettingLevel.ROOM_ACCOUNT,
+    ),
+    [SettingLevel.ACCOUNT]: new LocalEchoWrapper(new AccountSettingsHandler(defaultWatchManager), SettingLevel.ACCOUNT),
+    [SettingLevel.ROOM]: new LocalEchoWrapper(new RoomSettingsHandler(defaultWatchManager), SettingLevel.ROOM),
     [SettingLevel.CONFIG]: new ConfigSettingsHandler(featureNames),
     [SettingLevel.DEFAULT]: new DefaultSettingsHandler(defaultSettings, invertedDefaultSettings),
 };
-
-// Wrap all the handlers with local echo
-for (const key of Object.keys(LEVEL_HANDLERS)) {
-    LEVEL_HANDLERS[key] = new LocalEchoWrapper(LEVEL_HANDLERS[key]);
-}
 
 export const LEVEL_ORDER = [
     SettingLevel.DEVICE,

--- a/src/settings/handlers/AccountSettingsHandler.ts
+++ b/src/settings/handlers/AccountSettingsHandler.ts
@@ -36,8 +36,12 @@ const ANALYTICS_EVENT_TYPE = "im.vector.analytics";
  * This handler does not make use of the roomId parameter.
  */
 export default class AccountSettingsHandler extends MatrixClientBackedSettingsHandler {
-    constructor(private watchers: WatchManager) {
+    constructor(public readonly watchers: WatchManager) {
         super();
+    }
+
+    public get level(): SettingLevel {
+        return SettingLevel.ACCOUNT;
     }
 
     public initMatrixClient(oldClient: MatrixClient, newClient: MatrixClient) {

--- a/src/settings/handlers/DeviceSettingsHandler.ts
+++ b/src/settings/handlers/DeviceSettingsHandler.ts
@@ -33,7 +33,7 @@ export default class DeviceSettingsHandler extends SettingsHandler {
      * @param {string[]} featureNames The names of known features.
      * @param {WatchManager} watchers The watch manager to notify updates to
      */
-    constructor(private featureNames: string[], private watchers: WatchManager) {
+    constructor(private featureNames: string[], public readonly watchers: WatchManager) {
         super();
     }
 

--- a/src/settings/handlers/RoomAccountSettingsHandler.ts
+++ b/src/settings/handlers/RoomAccountSettingsHandler.ts
@@ -31,7 +31,7 @@ const ALLOWED_WIDGETS_EVENT_TYPE = "im.vector.setting.allowed_widgets";
  * Gets and sets settings at the "room-account" level for the current user.
  */
 export default class RoomAccountSettingsHandler extends MatrixClientBackedSettingsHandler {
-    constructor(private watchers: WatchManager) {
+    constructor(public readonly watchers: WatchManager) {
         super();
     }
 

--- a/src/settings/handlers/RoomDeviceSettingsHandler.ts
+++ b/src/settings/handlers/RoomDeviceSettingsHandler.ts
@@ -24,7 +24,7 @@ import { WatchManager } from "../WatchManager";
  * room.
  */
 export default class RoomDeviceSettingsHandler extends SettingsHandler {
-    constructor(private watchers: WatchManager) {
+    constructor(public readonly watchers: WatchManager) {
         super();
     }
 

--- a/src/settings/handlers/RoomSettingsHandler.ts
+++ b/src/settings/handlers/RoomSettingsHandler.ts
@@ -29,7 +29,7 @@ import { WatchManager } from "../WatchManager";
  * Gets and sets settings at the "room" level.
  */
 export default class RoomSettingsHandler extends MatrixClientBackedSettingsHandler {
-    constructor(private watchers: WatchManager) {
+    constructor(public readonly watchers: WatchManager) {
         super();
     }
 

--- a/src/settings/handlers/SettingsHandler.ts
+++ b/src/settings/handlers/SettingsHandler.ts
@@ -15,11 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { WatchManager } from "../WatchManager";
+
 /**
  * Represents the base class for all level handlers. This class performs no logic
  * and should be overridden.
  */
 export default abstract class SettingsHandler {
+    public readonly watchers?: WatchManager;
+
     /**
      * Gets the value for a particular setting at this level for a particular room.
      * If no room is applicable, the roomId may be null. The roomId may not be


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19749 and probably more

Previously the app wouldn't react to the setting change until the remote echo came down /sync
Requesting review from Travis as this might break some edge case assumptions
Skips the local echo wrapper on handlers which are `canSetValue===false` and those which `notifyUpdate` in the synchronous phase of `setValue`  

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Have LocalEchoWrapper emit updates so the app can react faster ([\#7358](https://github.com/matrix-org/matrix-react-sdk/pull/7358)). Fixes vector-im/element-web#19749.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b894b0106a4516965105f4--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
