### PR TITLE
Do not assume unread state if read receipt comes from a thread

### DIFF
--- a/src/Unread.ts
+++ b/src/Unread.ts
@@ -67,6 +67,15 @@ export function doesRoomHaveUnreadMessages(room: Room): boolean {
         return false;
     }
 
+    // if the read receipt relates to an event is that part of a thread
+    // we consider that there are no unread messages
+    // This might be a false negative, but probably the best we can do until
+    // the read receipts have evolved to cater for threads
+    const event = room.findEventById(readUpToId);
+    if (event?.getThread()) {
+        return false;
+    }
+
     // this just looks at whatever history we have, which if we've only just started
     // up probably won't be very much, so if the last couple of events are ones that
     // don't count, we don't know if there are any events that do count between where


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20052

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b8cb706a007b12d65d3456--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
