### PR TITLE
Don't include the accuracy parameter in location events if accuracy could not be determined.

### DIFF
--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -191,7 +191,7 @@ class LocationPicker extends React.Component<IProps, IState> {
                 ( position.coords.altitude !== undefined ?
                     `,${ position.coords.altitude }` : '' ) +
                 ( position.coords.accuracy !== undefined ?
-                    `;u=${ position.coords.accuracy }` : '' );
+                    `;u=${ position.coords.accuracy }` : '' ));
     };
 
     private onOk = () => {

--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -188,9 +188,9 @@ class LocationPicker extends React.Component<IProps, IState> {
     private getGeoUri = (position) => {
         return (`geo:${ position.coords.latitude },` +
                 position.coords.longitude +
-                ( position.coords.altitude != null ?
+                ( position.coords.altitude !== undefined ?
                     `,${ position.coords.altitude }` : '' ) +
-                ( position.coords.accuracy != null ?
+                ( position.coords.accuracy !== undefined ?
                     `;u=${ position.coords.accuracy }` : '' );
     };
 

--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -190,7 +190,8 @@ class LocationPicker extends React.Component<IProps, IState> {
                 position.coords.longitude +
                 ( position.coords.altitude != null ?
                     `,${ position.coords.altitude }` : '' ) +
-                `;u=${ position.coords.accuracy }`);
+                ( position.coords.accuracy != null ?
+                    `;u=${ position.coords.accuracy }` : '' );
     };
 
     private onOk = () => {


### PR DESCRIPTION
Fixes an issue where a uri would be rendered with `u` of undefined if not given, such as if manually selected in the client.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't include the accuracy parameter in location events if accuracy could not be determined. ([\#7375](https://github.com/matrix-org/matrix-react-sdk/pull/7375)). Contributed by @Half-Shot.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b9ceb001d254be18bc24e6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
