### PR TITLE
Prevent escape to cancel edit from also scrolling to bottom

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -160,9 +160,11 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
         switch (action) {
             case MessageComposerAction.Send:
                 this.sendEdit();
+                event.stopPropagation();
                 event.preventDefault();
                 break;
             case MessageComposerAction.CancelEditing:
+                event.stopPropagation();
                 this.cancelEdit();
                 break;
             case MessageComposerAction.EditPrevMessage: {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20182

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent escape to cancel edit from also scrolling to bottom ([\#7380](https://github.com/matrix-org/matrix-react-sdk/pull/7380)). Fixes vector-im/element-web#20182.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61b9f3698b0c0f0c4a0f23b0--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
