### PR TITLE
Use semantic heading on dialog component

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -376,7 +376,7 @@ legend {
 }
 
 .mx_Dialog_header.mx_Dialog_headerWithButton > .mx_Dialog_title {
-    justify-content: center;
+    text-align: center;
 }
 .mx_Dialog_header.mx_Dialog_headerWithCancel {
     padding-right: 20px; // leave space for the 'X' cancel button

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -355,6 +355,7 @@ legend {
 
 .mx_Dialog_header {
     position: relative;
+    padding: 3px 0;
     margin-bottom: 10px;
 }
 
@@ -367,17 +368,17 @@ legend {
 }
 
 .mx_Dialog_title {
-    font-size: $font-22px;
-    font-weight: $font-semi-bold;
-    line-height: $font-36px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     color: $dialog-title-fg-color;
 }
 
 .mx_Dialog_header.mx_Dialog_headerWithButton > .mx_Dialog_title {
-    text-align: center;
+    justify-content: center;
 }
-.mx_Dialog_header.mx_Dialog_headerWithCancel > .mx_Dialog_title {
-    margin-right: 20px; // leave space for the 'X' cancel button
+.mx_Dialog_header.mx_Dialog_headerWithCancel {
+    padding-right: 20px; // leave space for the 'X' cancel button
 }
 
 .mx_Dialog_title.danger {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -365,13 +365,14 @@ legend {
     height: 25px;
     margin-left: -2px;
     margin-right: 4px;
+    margin-bottom: 2px;
 }
 
 .mx_Dialog_title {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
     color: $dialog-title-fg-color;
+    display: inline-block;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .mx_Dialog_header.mx_Dialog_headerWithButton > .mx_Dialog_title {

--- a/res/css/views/dialogs/_SettingsDialog.scss
+++ b/res/css/views/dialogs/_SettingsDialog.scss
@@ -36,8 +36,4 @@ limitations under the License.
         // colliding harshly with the dialog when scrolled down.
         padding-bottom: 100px;
     }
-
-    .mx_Dialog_title {
-        margin-bottom: 24px;
-    }
 }

--- a/src/components/views/dialogs/BaseDialog.tsx
+++ b/src/components/views/dialogs/BaseDialog.tsx
@@ -28,6 +28,7 @@ import { _t } from "../../../languageHandler";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { IDialogProps } from "./IDialogProps";
+import Heading from '../typography/Heading';
 
 interface IProps extends IDialogProps {
     // Whether the dialog should have a 'close' button that will
@@ -141,10 +142,10 @@ export default class BaseDialog extends React.Component<IProps> {
                         'mx_Dialog_headerWithButton': !!this.props.headerButton,
                         'mx_Dialog_headerWithCancel': !!cancelButton,
                     })}>
-                        <div className={classNames('mx_Dialog_title', this.props.titleClass)} id='mx_BaseDialog_title'>
+                        <Heading size='h2' className={classNames('mx_Dialog_title', this.props.titleClass)} id='mx_BaseDialog_title'>
                             { headerImage }
                             { this.props.title }
-                        </div>
+                        </Heading>
                         { this.props.headerButton }
                         { cancelButton }
                     </div>

--- a/src/components/views/dialogs/BaseDialog.tsx
+++ b/src/components/views/dialogs/BaseDialog.tsx
@@ -27,8 +27,8 @@ import { MatrixClientPeg } from '../../../MatrixClientPeg';
 import { _t } from "../../../languageHandler";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
-import { IDialogProps } from "./IDialogProps";
 import Heading from '../typography/Heading';
+import { IDialogProps } from "./IDialogProps";
 
 interface IProps extends IDialogProps {
     // Whether the dialog should have a 'close' button that will


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

https://element-io.atlassian.net/browse/PSE-117?filter=-1

Use semantic heading elements to improve screen reader experience

Before:
<img width="769" alt="Screenshot 2021-12-15 at 15 27 56" src="https://user-images.githubusercontent.com/3055605/146204933-86fcfbb0-d4f6-47b9-8d43-7417ef41eb3a.png">
<img width="1063" alt="Screenshot 2021-12-15 at 15 27 46" src="https://user-images.githubusercontent.com/3055605/146204940-51a86867-b8a4-486c-b90e-f3a10b9465a7.png">


After:
<img width="1066" alt="Screenshot 2021-12-15 at 15 25 25" src="https://user-images.githubusercontent.com/3055605/146204968-57d0808c-d9e1-4ed1-9cbb-17c42226aa5b.png">
<img width="774" alt="Screenshot 2021-12-15 at 15 22 59" src="https://user-images.githubusercontent.com/3055605/146204980-959b0907-69ef-49ef-a16d-04c1f3a89beb.png">

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use semantic heading on dialog component ([\#7383](https://github.com/matrix-org/matrix-react-sdk/pull/7383)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61b9fd848d5b43190caaf8c9--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
