### PR TITLE
Full page spinner has no padding

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -493,7 +493,7 @@ legend {
 .mx_Dialog_wrapper.mx_Dialog_spinner .mx_Dialog {
     width: auto;
     border-radius: 8px;
-    padding: 0px;
+    padding: 8px;
     box-shadow: none;
 
     /* Don't show scroll-bars on spinner dialogs */


### PR DESCRIPTION
**Description:**
Adds padding to full page spinner (e.g. when creating a room),
which otherwise looks awkward on the grey background.
Before:
![spinner-before1](https://user-images.githubusercontent.com/36052282/146356873-20dfcefa-1c22-4bf5-aad0-f467b6adda99.png)

After:
![spinner-after2](https://user-images.githubusercontent.com/36052282/146357004-36a27f7c-18fa-4b9d-9088-7a2aa8286053.png)

Fixes [element-web/issues/20001](https://github.com/vector-im/element-web/issues/20001)

Signed-off-by: Ingrid Budau inigiri@posteo.jp

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61bb19682eb271343d43a1a1--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
