### PR TITLE
Increase gap between ELS and the subsequent event to prevent overlap

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -392,6 +392,11 @@ limitations under the License.
     padding: 0 49px;
 }
 
+// increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
+.mx_EventListSummary[data-layout=bubble][data-expanded=false] + .mx_EventTile[data-layout=bubble][data-self=true] {
+    margin-top: 20px;
+}
+
 /* events that do not require bubble layout */
 .mx_EventListSummary[data-layout=bubble],
 .mx_EventTile.mx_EventTile_bad[data-layout=bubble] {

--- a/src/components/views/elements/MemberEventListSummary.tsx
+++ b/src/components/views/elements/MemberEventListSummary.tsx
@@ -90,14 +90,15 @@ export default class MemberEventListSummary extends React.Component<IProps> {
         layout: Layout.Group,
     };
 
-    shouldComponentUpdate(nextProps) {
+    shouldComponentUpdate(nextProps: IProps): boolean {
         // Update if
         //  - The number of summarised events has changed
         //  - or if the summary is about to toggle to become collapsed
         //  - or if there are fewEvents, meaning the child eventTiles are shown as-is
         return (
             nextProps.events.length !== this.props.events.length ||
-            nextProps.events.length < this.props.threshold
+            nextProps.events.length < this.props.threshold ||
+            nextProps.layout !== this.props.layout
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18319

Before
![image](https://user-images.githubusercontent.com/2403652/146358079-fb8eead1-ec0a-4eff-a985-e17a3175887a.png)


After
![image](https://user-images.githubusercontent.com/2403652/146357935-4d81d327-4eb8-4169-9632-f90f32ba092c.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Increase gap between ELS and the subsequent event to prevent overlap ([\#7391](https://github.com/matrix-org/matrix-react-sdk/pull/7391)). Fixes vector-im/element-web#18319.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://61bc5781d375d918f9bae919--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
