### PR TITLE
Fix bubble radius wrong when followed by a state event from same user

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -50,6 +50,7 @@ import TileErrorBoundary from '../views/messages/TileErrorBoundary';
 import { RoomPermalinkCreator } from "../../utils/permalinks/Permalinks";
 import EditorStateTransfer from "../../utils/EditorStateTransfer";
 import { Action } from '../../dispatcher/actions';
+import { getEventDisplayInfo } from "../../utils/EventUtils";
 
 const CONTINUATION_MAX_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const continuedTypes = [EventType.Sticker, EventType.RoomMessage];
@@ -724,7 +725,8 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         let lastInSection = true;
         if (nextEventWithTile) {
             willWantDateSeparator = this.wantsDateSeparator(mxEv, nextEventWithTile.getDate() || new Date());
-            lastInSection = willWantDateSeparator || mxEv.getSender() !== nextEventWithTile.getSender();
+            lastInSection = willWantDateSeparator || mxEv.getSender() !== nextEventWithTile.getSender() ||
+                getEventDisplayInfo(nextEventWithTile).isInfoMessage;
         }
 
         // is this a continuation of the previous message?


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18982

Before
![image](https://user-images.githubusercontent.com/2403652/146367373-cf289c9d-bd08-484f-8217-fca02bdef957.png)

After
![image](https://user-images.githubusercontent.com/2403652/146367322-1bcb8be2-df71-4b71-b985-67279b53c3d4.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix bubble radius wrong when followed by a state event from same user ([\#7393](https://github.com/matrix-org/matrix-react-sdk/pull/7393)). Fixes vector-im/element-web#18982.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61bb2a57e9ea256749f4b3c5--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
