### PR TITLE
Show error if could not load space hierarchy

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3075,6 +3075,7 @@
     "Removing...": "Removing...",
     "Mark as not suggested": "Mark as not suggested",
     "Mark as suggested": "Mark as suggested",
+    "Failed to load list of rooms.": "Failed to load list of rooms.",
     "Your server does not support showing space hierarchies.": "Your server does not support showing space hierarchies.",
     "No results found": "No results found",
     "You may want to try a different search or check for typos.": "You may want to try a different search or check for typos.",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20221

Previously an error was only shown if the server didn't support the API, now also show one if it failed to respond with a different error

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Show error if could not load space hierarchy ([\#7399](https://github.com/matrix-org/matrix-react-sdk/pull/7399)). Fixes vector-im/element-web#20221.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61bc5a2479c1bc22f3505dc6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
