### PR TITLE
Space Panel use SettingsStore instead of SpaceStore as source of truth

### DIFF
--- a/src/components/views/spaces/SpacePanel.tsx
+++ b/src/components/views/spaces/SpacePanel.tsx
@@ -97,9 +97,7 @@ export const HomeButtonContextMenu = ({
     hideHeader,
     ...props
 }: ComponentProps<typeof SpaceContextMenu>) => {
-    const allRoomsInHome = useEventEmitterState(SpaceStore.instance, UPDATE_HOME_BEHAVIOUR, () => {
-        return SpaceStore.instance.allRoomsInHome;
-    });
+    const allRoomsInHome = useSettingValue<boolean>("Spaces.allRoomsInHome");
 
     return <IconizedContextMenu
         {...props}

--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -109,8 +109,9 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
     private _invitedSpaces = new Set<Room>();
     private spaceOrderLocalEchoMap = new Map<string, string>();
     private _restrictedJoinRuleSupport?: IRoomCapability;
-    private _allRoomsInHome: boolean = SettingsStore.getValue("Spaces.allRoomsInHome");
-    private _enabledMetaSpaces: MetaSpace[] = []; // set by onReady
+    // The following properties are set by onReady as they live in account_data
+    private _allRoomsInHome = false;
+    private _enabledMetaSpaces: MetaSpace[] = [];
 
     constructor() {
         super(defaultDispatcher, {});
@@ -1041,6 +1042,8 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
 
         const enabledMetaSpaces = SettingsStore.getValue("Spaces.enabledMetaSpaces");
         this._enabledMetaSpaces = metaSpaceOrder.filter(k => enabledMetaSpaces[k]) as MetaSpace[];
+
+        this._allRoomsInHome = SettingsStore.getValue("Spaces.allRoomsInHome");
 
         this.rebuildSpaceHierarchy(); // trigger an initial update
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20250

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Space Panel use SettingsStore instead of SpaceStore as source of truth ([\#7404](https://github.com/matrix-org/matrix-react-sdk/pull/7404)). Fixes vector-im/element-web#20250.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61bcaa9bc00bce3e6bd8e63f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
