### PR TITLE
Fix legacy breadcrumbs wrongly showing up

### DIFF
--- a/src/components/structures/LeftPanel.tsx
+++ b/src/components/structures/LeftPanel.tsx
@@ -84,7 +84,7 @@ export default class LeftPanel extends React.Component<IProps, IState> {
     }
 
     private static get breadcrumbsMode(): BreadcrumbsMode {
-        if (!SettingsStore.getValue("breadcrumbs")) return BreadcrumbsMode.Disabled;
+        if (!BreadcrumbsStore.instance.visible) return BreadcrumbsMode.Disabled;
         return SettingsStore.getValue("feature_breadcrumbs_v2") ? BreadcrumbsMode.Labs : BreadcrumbsMode.Legacy;
     }
 


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix legacy breadcrumbs wrongly showing up ([\#7425](https://github.com/matrix-org/matrix-react-sdk/pull/7425)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61c1c4a22d054052fded1049--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
