### PR TITLE
Fix zIndex of peristent apps in miniMode

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -508,7 +508,7 @@ export default class AppTile extends React.Component<IProps, IState> {
                     // Also wrap the PersistedElement in a div to fix the height, otherwise
                     // AppTile's border is in the wrong place
                     appTileBody = <div className="mx_AppTile_persistedWrapper">
-                        <PersistedElement persistKey={this.persistKey}>
+                        <PersistedElement zIndex={this.props.miniMode ? 10 : 9}persistKey={this.persistKey}>
                             { appTileBody }
                         </PersistedElement>
                     </div>;


### PR DESCRIPTION
If there is a jitsy meeting from another room and a widget in the maximised or pinned container, they both use the zIndex: 9.
This fixes so that miniMode widget (floating ones) have a zIndex of 10 to be drawn on top of the widgets that are not floating.

The Issue in pictures:
![image](https://user-images.githubusercontent.com/16718859/146948196-dc9502be-07a0-4d0b-8b7c-8f82b30a4ec5.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix zIndex of peristent app in miniMode vs maximised ([\#7429](https://github.com/matrix-org/matrix-react-sdk/pull/7429)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61c1e8c1194fe10d1127b407--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
