### PR TITLE
Trim spurious whitespace of "Explore rooms" menu input

### DIFF
--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -393,7 +393,7 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
 
     private onFilterChange = (alias: string) => {
         this.setState({
-            filterString: alias.trim() || "",
+            filterString: alias?.trim() || "",
         });
 
         // don't send the request for a little bit,

--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -393,7 +393,7 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
 
     private onFilterChange = (alias: string) => {
         this.setState({
-            filterString: alias || "",
+            filterString: alias.trim() || "",
         });
 
         // don't send the request for a little bit,


### PR DESCRIPTION
Trims the whitespace around the input string in order to
 still show relevant room suggestions and the "Join" button.

Before:
![trim-before1](https://user-images.githubusercontent.com/36052282/146950954-43a5c060-62a6-4102-b0a4-d7e6b301045c.png)
After:
![trim-after1](https://user-images.githubusercontent.com/36052282/146951049-87dca936-35ed-43d1-ab45-c7759930e93e.png)


Fixes [element-web/issues/19728](https://github.com/vector-im/element-web/issues/19728)

Signed-off by: Ingrid Budau inigiri@posteo.jp



<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61c2fe1a94e23b5283c661d6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
