### PR TITLE
Fix offscreen canvas breaking with split-brained firefox support

### DIFF
--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -127,15 +127,18 @@ async function createThumbnail(
     }
 
     let canvas: HTMLCanvasElement | OffscreenCanvas;
-    if (window.OffscreenCanvas) {
+    let context: CanvasRenderingContext2D;
+    try {
         canvas = new window.OffscreenCanvas(targetWidth, targetHeight);
-    } else {
+        context = canvas.getContext("2d");
+    } catch (e) {
+        // Fallback support for other browsers (Safari and Firefox for now)
         canvas = document.createElement("canvas");
         (canvas as HTMLCanvasElement).width = targetWidth;
         (canvas as HTMLCanvasElement).height = targetHeight;
+        context = canvas.getContext("2d");
     }
 
-    const context = canvas.getContext("2d");
     context.drawImage(element, 0, 0, targetWidth, targetHeight);
 
     let thumbnailPromise: Promise<Blob>;


### PR DESCRIPTION
Firefox added partial OffscreenCanvas support, missing 2d contexts.
Only impacts users who opt in to the new API using `gfx.offscreencanvas.enabled` which is off by default until the current Nightly channel it seems.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix offscreen canvas breaking with split-brained firefox support ([\#7440](https://github.com/matrix-org/matrix-react-sdk/pull/7440)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61c351494bd53f4ecb189bd8--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
