### PR TITLE
Fix room_id check when adding user widgets

### DIFF
--- a/src/ScalarMessaging.ts
+++ b/src/ScalarMessaging.ts
@@ -250,7 +250,6 @@ import { objectClone } from "./utils/objects";
 enum Action {
     CloseScalar = "close_scalar",
     GetWidgets = "get_widgets",
-    SetWidgets = "set_widgets",
     SetWidget = "set_widget",
     JoinRulesState = "join_rules_state",
     SetPlumbingState = "set_plumbing_state",
@@ -630,7 +629,7 @@ const onMessage = function(event: MessageEvent<any>): void {
         if (event.data.action === Action.GetWidgets) {
             getWidgets(event, null);
             return;
-        } else if (event.data.action === Action.SetWidgets) {
+        } else if (event.data.action === Action.SetWidget) {
             setWidget(event, null);
             return;
         } else {


### PR DESCRIPTION
Fixes: vector-im/element-web#19382

Currently the "set_widget" action always requires a room_id to be set and will throw an error otherwise. This makes it impossible to add widgets that do not require a room_id, like stickers. This fix changes the logic to check for "set_widget" instead of "set_widgets". I assume that this was just a typo that happened during a refactoring (#6869), since the logic before used "set_widget".

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix room_id check when adding user widgets ([\#7448](https://github.com/matrix-org/matrix-react-sdk/pull/7448)). Fixes vector-im/element-web#19382. Contributed by @bink.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61cb144886686a5e352e662f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
