### PR TITLE
Only return the approved widget capabilities instead of accepting all requested capabilities

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -34,7 +34,7 @@ import { IContent, IEvent, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { logger } from "matrix-js-sdk/src/logger";
 
-import { iterableDiff, iterableUnion } from "../../utils/iterables";
+import { iterableDiff } from "../../utils/iterables";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import ActiveRoomObserver from "../../ActiveRoomObserver";
 import Modal from "../../Modal";
@@ -131,13 +131,11 @@ export class StopGapWidgetDriver extends WidgetDriver {
             }
         }
 
-        const allAllowed = new Set(iterableUnion(allowedSoFar, requested));
-
         if (rememberApproved) {
-            setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allAllowed));
+            setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allowedSoFar));
         }
 
-        return allAllowed;
+        return allowedSoFar;
     }
 
     public async sendEvent(

--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -34,7 +34,7 @@ import { IContent, IEvent, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { logger } from "matrix-js-sdk/src/logger";
 
-import { iterableDiff } from "../../utils/iterables";
+import { iterableDiff, iterableIntersection } from "../../utils/iterables";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import ActiveRoomObserver from "../../ActiveRoomObserver";
 import Modal from "../../Modal";
@@ -131,11 +131,15 @@ export class StopGapWidgetDriver extends WidgetDriver {
             }
         }
 
+        // discard all previously allowed capabilities if they are not requested
+        // TODO: this results in an unexpected behavior when this function is called during the capabilities renegotiation of MSC2974 that will be resolved later.
+        const allAllowed = new Set(iterableIntersection(allowedSoFar, requested));
+
         if (rememberApproved) {
-            setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allowedSoFar));
+            setRememberedCapabilitiesForWidget(this.forWidget, Array.from(allAllowed));
         }
 
-        return allowedSoFar;
+        return allAllowed;
     }
 
     public async sendEvent(


### PR DESCRIPTION
This is a follow-up to #7340 and #7343. All capabilities are now persisted correctly, however, it seems like the function permits the widget to use _all_ the requested capabilities, even though the user rejects some or all. The old code was a bit misleading and fixing the set-theory terminology introduced a bug there.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://61d55c64e9cb5af06d26b712--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
