### PR TITLE
Limit max-width for bubble layout to 1200px

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_RoomView_body[data-layout=bubble] {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
 .mx_EventTile[data-layout=bubble],
 .mx_EventListSummary[data-layout=bubble] {
     --avatarSize: 32px;

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2227,7 +2227,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                             excludedRightPanelPhaseButtons={excludedRightPanelPhaseButtons}
                         />
                         <MainSplit panel={rightPanel} resizeNotifier={this.props.resizeNotifier}>
-                            <div className="mx_RoomView_body">
+                            <div className="mx_RoomView_body" data-layout={this.state.layout}>
                                 { mainSplitBody }
                             </div>
                         </MainSplit>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18072

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Limit max-width for bubble layout to 1200px ([\#7458](https://github.com/matrix-org/matrix-react-sdk/pull/7458)). Fixes vector-im/element-web#18072.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61d427c6d676bab99b76bb56--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
