### PR TITLE
Consider continuations when resolving whether a tile is last in section

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -727,12 +727,14 @@ export default class MessagePanel extends React.Component<IProps, IState> {
             ret.push(dateSeparator);
         }
 
-        let willWantDateSeparator = false;
         let lastInSection = true;
         if (nextEventWithTile) {
-            willWantDateSeparator = this.wantsDateSeparator(mxEv, nextEventWithTile.getDate() || new Date());
-            lastInSection = willWantDateSeparator || mxEv.getSender() !== nextEventWithTile.getSender() ||
-                getEventDisplayInfo(nextEventWithTile).isInfoMessage;
+            const nextEv = nextEventWithTile;
+            const willWantDateSeparator = this.wantsDateSeparator(mxEv, nextEv.getDate() || new Date());
+            lastInSection = willWantDateSeparator ||
+                mxEv.getSender() !== nextEv.getSender() ||
+                getEventDisplayInfo(nextEv).isInfoMessage ||
+                !shouldFormContinuation(mxEv, nextEv, this.showHiddenEvents, this.context.timelineRenderingType);
         }
 
         // is this a continuation of the previous message?


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20368
Fixes https://github.com/vector-im/element-web/issues/20369

![image](https://user-images.githubusercontent.com/2403652/148092308-510bb7de-08e3-4733-a544-93c77d5e2eaf.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Consider continuations when resolving whether a tile is last in section ([\#7461](https://github.com/matrix-org/matrix-react-sdk/pull/7461)). Fixes vector-im/element-web#20368 and vector-im/element-web#20369.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61d478857035493ef210d12c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
