### PR TITLE
a11y - wrap notification level radios in fieldsets

### DIFF
--- a/res/css/views/settings/_Notifications.scss
+++ b/res/css/views/settings/_Notifications.scss
@@ -37,7 +37,7 @@ limitations under the License.
 }
 
 .mx_UserNotifSettings_gridRowContainer {
-    display: contents
+    display: contents;
 }
 
 .mx_UserNotifSettings_gridRow {

--- a/res/css/views/settings/_Notifications.scss
+++ b/res/css/views/settings/_Notifications.scss
@@ -14,53 +14,56 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_UserNotifSettings {
-    color: $primary-content; // override from default settings page styles
+.mx_UserNotifSettings_grid {
+    width: calc(100% + 12px); // +12px to line up center of 'Noisy' column with toggle switches
+    display: grid;
+    grid-template-columns: auto repeat(3, 62px);
+    place-items: center center;
+    grid-gap: 8px;
+    margin-top: $spacing-40;
 
-    .mx_UserNotifSettings_pushRulesTable {
-        width: calc(100% + 12px); // +12px to line up center of 'Noisy' column with toggle switches
-        table-layout: fixed;
-        border-collapse: collapse;
-        border-spacing: 0;
-        margin-top: 40px;
+    // Override StyledRadioButton default styles
+    .mx_StyledRadioButton {
+        justify-content: center;
 
-        tr > th {
-            font-weight: $font-semi-bold;
+        .mx_StyledRadioButton_content {
+            display: none;
         }
 
-        tr > th:first-child {
-            text-align: left;
-            font-size: $font-18px;
-        }
-
-        tr > th:nth-child(n + 2) {
-            color: $secondary-content;
-            font-size: $font-12px;
-            vertical-align: middle;
-            width: 66px;
-        }
-
-        tr > td:nth-child(n + 2) {
-            text-align: center;
-        }
-
-        tr > td {
-            padding-top: 8px;
-        }
-
-        // Override StyledRadioButton default styles
-        .mx_StyledRadioButton {
-            justify-content: center;
-
-            .mx_StyledRadioButton_content {
-                display: none;
-            }
-
-            .mx_StyledRadioButton_spacer {
-                display: none;
-            }
+        .mx_StyledRadioButton_spacer {
+            display: none;
         }
     }
+}
+
+.mx_UserNotifSettings_gridRowContainer {
+    display: contents
+}
+
+.mx_UserNotifSettings_gridRow {
+    display: contents;
+}
+
+.mx_UserNotifSettings_gridRowLabel {
+    justify-self: start;
+    // <legend> does not accept
+    // display: inline | inline-block
+    // force it inline using float
+    float: left;
+}
+.mx_UserNotifSettings_gridRowHeading {
+    font-size: $font-18px;
+    font-weight: $font-semi-bold;
+}
+
+.mx_UserNotifSettings_gridColumnLabel {
+    color: $secondary-content;
+    font-size: $font-12px;
+    font-weight: $font-semi-bold;
+}
+
+.mx_UserNotifSettings {
+    color: $primary-content; // override from default settings page styles
 
     .mx_UserNotifSettings_floatingSection {
         margin-top: 40px;

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -572,10 +572,9 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
 
         const makeRadio = (r: IVectorPushRule, s: VectorState) => (
             <StyledRadioButton
-                key={r.ruleId}
+                key={r.ruleId + s}
                 name={r.ruleId}
                 checked={r.vectorState === s}
-                aria-label={VectorStateToLabel[r.vectorState]}
                 onChange={this.onRadioChecked.bind(this, r, s)}
                 disabled={this.state.phase === Phase.Persisting}
                 aria-label={VectorStateToLabel[s]}

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -575,6 +575,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
                 key={r.ruleId}
                 name={r.ruleId}
                 checked={r.vectorState === s}
+                aria-label={VectorStateToLabel[r.vectorState]}
                 onChange={this.onRadioChecked.bind(this, r, s)}
                 disabled={this.state.phase === Phase.Persisting}
                 aria-label={VectorStateToLabel[s]}
@@ -613,9 +614,9 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
         return <>
             <div data-test-id={`notif-section-${category}`} className='mx_UserNotifSettings_grid'>
                 <span className='mx_UserNotifSettings_gridRowLabel mx_UserNotifSettings_gridRowHeading'>{ sectionName }</span>
-                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("Off") }</span>
-                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("On") }</span>
-                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("Noisy") }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ VectorStateToLabel[VectorState.Off] }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ VectorStateToLabel[VectorState.On] }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ VectorStateToLabel[VectorState.Loud] }</span>
                 { fieldsetRows }
             </div>
             { clearNotifsButton }

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -581,15 +581,19 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
             />
         );
 
-        const rows = this.state.vectorPushRules[category].map(r => <tr
-            data-test-id={category + r.ruleId}
-            key={category + r.ruleId}
-        >
-            <td>{ r.description }</td>
-            <td>{ makeRadio(r, VectorState.Off) }</td>
-            <td>{ makeRadio(r, VectorState.On) }</td>
-            <td>{ makeRadio(r, VectorState.Loud) }</td>
-        </tr>);
+        const fieldsetRows = this.state.vectorPushRules[category].map(r =>
+            <fieldset
+                key={category + r.ruleId}
+                data-test-id={category + r.ruleId}
+                className='mx_UserNotifSettings_gridRowContainer'>
+                { /* fieldset is not styled sanely, needs div wrapper */ }
+
+                <div className='mx_UserNotifSettings_gridRow'>
+                    <legend className='mx_UserNotifSettings_gridRowLabel'>{ r.description }</legend>
+                    { makeRadio(r, VectorState.Off) }
+                    { makeRadio(r, VectorState.On) }
+                    { makeRadio(r, VectorState.Loud) }
+                </div></fieldset>);
 
         let sectionName: TranslatedString;
         switch (category) {
@@ -607,19 +611,13 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
         }
 
         return <>
-            <table data-test-id={`notif-section-${category}`} className='mx_UserNotifSettings_pushRulesTable'>
-                <thead>
-                    <tr>
-                        <th>{ sectionName }</th>
-                        <th>{ VectorStateToLabel[VectorState.Off] }</th>
-                        <th>{ VectorStateToLabel[VectorState.On] }</th>
-                        <th>{ VectorStateToLabel[VectorState.Loud] }</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    { rows }
-                </tbody>
-            </table>
+            <div data-test-id={`notif-section-${category}`} className='mx_UserNotifSettings_grid'>
+                <span className='mx_UserNotifSettings_gridRowLabel mx_UserNotifSettings_gridRowHeading'>{ sectionName }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("Off") }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("On") }</span>
+                <span className='mx_UserNotifSettings_gridColumnLabel'>{ _t("Noisy") }</span>
+                { fieldsetRows }
+            </div>
             { clearNotifsButton }
             { keywordComposer }
         </>;

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -585,15 +585,13 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
             <fieldset
                 key={category + r.ruleId}
                 data-test-id={category + r.ruleId}
-                className='mx_UserNotifSettings_gridRowContainer'>
-                { /* fieldset is not styled sanely, needs div wrapper */ }
-
-                <div className='mx_UserNotifSettings_gridRow'>
-                    <legend className='mx_UserNotifSettings_gridRowLabel'>{ r.description }</legend>
-                    { makeRadio(r, VectorState.Off) }
-                    { makeRadio(r, VectorState.On) }
-                    { makeRadio(r, VectorState.Loud) }
-                </div></fieldset>);
+                className='mx_UserNotifSettings_gridRowContainer'
+            >
+                <legend className='mx_UserNotifSettings_gridRowLabel'>{ r.description }</legend>
+                { makeRadio(r, VectorState.Off) }
+                { makeRadio(r, VectorState.On) }
+                { makeRadio(r, VectorState.Loud) }
+            </fieldset>);
 
         let sectionName: TranslatedString;
         switch (category) {

--- a/test/components/views/settings/Notifications-test.tsx
+++ b/test/components/views/settings/Notifications-test.tsx
@@ -245,8 +245,8 @@ describe('<Notifications />', () => {
             const section = 'vector_global';
 
             const globalSection = findByTestId(component, `notif-section-${section}`);
-            // 16 notification rules with class 'global'
-            expect(globalSection.find('td').length).toEqual(16);
+            // 4 notification rules with class 'global'
+            expect(globalSection.find('fieldset').length).toEqual(4);
             // oneToOneRule is set to 'on'
             const oneToOneRuleElement = findByTestId(component, section + oneToOneRule.rule_id);
             expect(getCheckedRadioForRule(oneToOneRuleElement)).toEqual('On');


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Group sets of radio buttons into `fieldset`s to improve screen reader experience

<img width="1296" alt="Screenshot 2022-01-06 at 11 06 39" src="https://user-images.githubusercontent.com/3055605/148391159-664e09ad-a014-459e-9e5e-56b7acc632ec.png">


Before:
https://user-images.githubusercontent.com/3055605/148390568-2ea92ead-1995-4798-a475-f02357bc8333.mov

After:
https://user-images.githubusercontent.com/3055605/148390622-c0307e03-c5f6-47db-85ac-e0c1c3b0eb7e.mov



<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * a11y - wrap notification level radios in fieldsets ([\#7471](https://github.com/matrix-org/matrix-react-sdk/pull/7471)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61d6f0fc8eb1c2261146bde6--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
