### PR TITLE
fix fallback for pluralized strings

### DIFF
--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -2,6 +2,7 @@ const en = require("../src/i18n/strings/en_EN");
 const de = require("../src/i18n/strings/de_DE");
 const lv = {
     "Save": "Saglabāt",
+    "Uploading %(filename)s and %(count)s others|one": "Качване на %(filename)s и %(count)s друг",
 };
 
 // Mock the browser-request for the languageHandler tests to return

--- a/src/languageHandler.tsx
+++ b/src/languageHandler.tsx
@@ -85,7 +85,7 @@ export function _td(s: string): string { // eslint-disable-line @typescript-esli
 const translateWithFallback = (text: string, options?: object): { translated?: string, isFallback?: boolean } => {
     const translated = counterpart.translate(text, options);
     if (/^missing translation:/.test(translated)) {
-        const fallbackTranslated = counterpart.translate(text, { ...options, fallbackLocale: FALLBACK_LOCALE });
+        const fallbackTranslated = counterpart.translate(text, { ...options, locale: FALLBACK_LOCALE });
         return { translated: fallbackTranslated, isFallback: true };
     }
     return { translated };
@@ -168,7 +168,6 @@ export function _t(text: string, variables: IVariables, tags: Tags): React.React
 export function _t(text: string, variables?: IVariables, tags?: Tags): TranslatedString {
     // The translation returns text so there's no XSS vector here (no unsafe HTML, no code execution)
     const { translated } = safeCounterpartTranslate(text, variables);
-
     const substituted = substitute(translated, variables, tags);
 
     return annotateStrings(substituted, text);

--- a/test/i18n-test/languageHandler-test.tsx
+++ b/test/i18n-test/languageHandler-test.tsx
@@ -21,6 +21,13 @@ describe('languageHandler', function() {
     const testCasesEn: TestCase[] = [
         ['translates a basic string', basicString, {}, undefined, 'Rooms'],
         [
+            'handles plurals when count is 0',
+            plurals,
+            { count: 0 },
+            undefined,
+            'and 0 others...',
+        ],
+        [
             'handles plurals when count is 1',
             plurals,
             { count: 1 },

--- a/test/i18n-test/languageHandler-test.tsx
+++ b/test/i18n-test/languageHandler-test.tsx
@@ -130,8 +130,19 @@ describe('languageHandler', function() {
             setMissingEntryGenerator(counterpartDefaultMissingEntryGen);
         });
 
+        const lvExistingPlural = 'Uploading %(filename)s and %(count)s others';
+
+        // lv does not have a pluralizer function
+        const noPluralizerCase = [
+            'handles plural strings when no pluralizer exists for language',
+            lvExistingPlural,
+            { count: 1, filename: 'test.txt' },
+            undefined,
+            'Uploading test.txt and 1 other',
+        ] as TestCase;
+
         describe('_t', () => {
-            it.each(testCasesEn)(
+            it.each([...testCasesEn, noPluralizerCase])(
                 "%s and translates with fallback locale",
                 async (_d, translationString, variables, tags, result) => {
                     expect(_t(translationString, variables, tags)).toEqual(result);
@@ -140,7 +151,7 @@ describe('languageHandler', function() {
         });
 
         describe('_tDom()', () => {
-            it.each(testCasesEn)(
+            it.each([...testCasesEn, noPluralizerCase])(
                 "%s and translates with fallback locale, attributes fallback locale",
                 async (_d, translationString, variables, tags, result) => {
                     expect(_tDom(translationString, variables, tags)).toEqual(<span lang="en">{ result }</span>);


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>


Fixes: vector-im/element-web#20426


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
<img width="749" alt="Screenshot 2022-01-07 at 16 15 08" src="https://user-images.githubusercontent.com/3055605/148564377-c4a69eaf-d567-4e03-9426-798d8a6e997e.png">



<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * fix fallback for pluralized strings ([\#7480](https://github.com/matrix-org/matrix-react-sdk/pull/7480)). Fixes vector-im/element-web#20426. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61d856981f96251d670592e5--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
