### PR TITLE
Add permission dropdown for sending reactions

### DIFF
--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -57,6 +57,7 @@ const plEventsToShow: Record<string, IEventShowOpts> = {
     [EventType.RoomEncryption]: { isState: true, hideForSpace: true },
     [EventType.RoomServerAcl]: { isState: true, hideForSpace: true },
     [EventType.RoomPinnedEvents]: { isState: true, hideForSpace: true },
+    [EventType.Reaction]: { isState: false, hideForSpace: true },
 
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
     "im.vector.modular.widgets": { isState: true, hideForSpace: true },
@@ -235,6 +236,7 @@ export default class RolesRoomSettingsTab extends React.Component<IProps> {
             [EventType.RoomTombstone]: _td("Upgrade the room"),
             [EventType.RoomEncryption]: _td("Enable room encryption"),
             [EventType.RoomServerAcl]: _td("Change server ACLs"),
+            [EventType.Reaction]: _td("Send reactions"),
 
             // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
             "im.vector.modular.widgets": isSpaceRoom ? null : _td("Modify widgets"),

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1555,6 +1555,7 @@
     "Upgrade the room": "Upgrade the room",
     "Enable room encryption": "Enable room encryption",
     "Change server ACLs": "Change server ACLs",
+    "Send reactions": "Send reactions",
     "Modify widgets": "Modify widgets",
     "Manage pinned events": "Manage pinned events",
     "Default role": "Default role",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20450

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add permission dropdown for sending reactions ([\#7492](https://github.com/matrix-org/matrix-react-sdk/pull/7492)). Fixes vector-im/element-web#20450.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61dc09f5d94b17a1bbc2fc9f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
