### PR TITLE
fallback properly with pluralized strings

### DIFF
--- a/src/languageHandler.tsx
+++ b/src/languageHandler.tsx
@@ -41,6 +41,7 @@ counterpart.setSeparator('|');
 
 // see `translateWithFallback` for an explanation of fallback handling
 const FALLBACK_LOCALE = 'en';
+counterpart.setFallbackLocale(FALLBACK_LOCALE);
 
 interface ITranslatableError extends Error {
     translatedMessage: string;
@@ -79,12 +80,12 @@ export function _td(s: string): string { // eslint-disable-line @typescript-esli
  * should be wrapped with an appropriate `lang='en'` attribute
  * counterpart's `translate` doesn't expose a way to determine if the resulting translation
  * is in the target locale or a fallback locale
- * for this reason, we do not set a fallback via `counterpart.setFallbackLocale`
+ * for this reason, force fallbackLocale === locale in the first call to translate
  * and fallback 'manually' so we can mark fallback strings appropriately
  * */
 const translateWithFallback = (text: string, options?: object): { translated?: string, isFallback?: boolean } => {
-    const translated = counterpart.translate(text, options);
-    if (/^missing translation:/.test(translated)) {
+    const translated = counterpart.translate(text, { ...options, fallbackLocale: counterpart.getLocale() });
+    if (!translated || /^missing translation:/.test(translated)) {
         const fallbackTranslated = counterpart.translate(text, { ...options, locale: FALLBACK_LOCALE });
         return { translated: fallbackTranslated, isFallback: true };
     }


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Fixes: https://github.com/vector-im/element-web/issues/20455

Before:
App in German, pluralized 'Uploading..' string in English
<img width="775" alt="Screenshot 2022-01-10 at 12 07 26" src="https://user-images.githubusercontent.com/3055605/148757481-1928300c-7ed7-4e31-878e-f7a0bcede4ce.png">

After:
App in German, pluralized uploading string in German:
<img width="1006" alt="Screenshot 2022-01-10 at 12 15 09" src="https://user-images.githubusercontent.com/3055605/148757603-dd1d4d22-b596-462f-b169-452c97f07de7.png">
<img width="1086" alt="Screenshot 2022-01-10 at 12 14 57" src="https://user-images.githubusercontent.com/3055605/148757608-563049d6-1f2a-4478-b565-6726fe132132.png">

Fall back still working (app in Latvian, lv has many missing translations):
<img width="1073" alt="Screenshot 2022-01-10 at 12 13 20" src="https://user-images.githubusercontent.com/3055605/148757726-fb18e011-bd2f-423b-b9a9-b653252c403d.png">



<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61dc1715827e3a7e3f1193bf--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
