### PR TITLE
Truncate long server names on login/register screen

### DIFF
--- a/res/css/views/elements/_ServerPicker.scss
+++ b/res/css/views/elements/_ServerPicker.scss
@@ -62,6 +62,8 @@ limitations under the License.
         color: $authpage-primary-color;
         grid-column: 1;
         grid-row: 2;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .mx_ServerPicker_change {

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -86,7 +86,7 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
     return <div className="mx_ServerPicker">
         <h3>{ title || _t("Homeserver") }</h3>
         { !disableCustomUrls ? <AccessibleButton className="mx_ServerPicker_help" onClick={onHelpClick} /> : null }
-        <span className="mx_ServerPicker_server">{ serverName }</span>
+        <span className="mx_ServerPicker_server" title={serverName}>{ serverName }</span>
         { editBtn }
         { desc }
     </div>;

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -70,8 +70,8 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
     }
 
     const serverName: JSX.Element = <TextWithTooltip
-                    class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""}
-                    tooltip={serverConfig.hsUrl}>
+        class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""}
+        tooltip={serverConfig.hsUrl}>
         { serverConfig.hsName }
     </TextWithTooltip>;
 

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -69,8 +69,7 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
         </AccessibleButton>;
     }
 
-    let serverName: React.ReactNode = serverConfig.isNameResolvable ? serverConfig.hsName : serverConfig.hsUrl;
-    serverName = <TextWithTooltip
+    const serverName: JSX.Element = <TextWithTooltip
                     class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""}
                     tooltip={serverConfig.hsUrl}>
         { serverConfig.hsName }

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -70,7 +70,9 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
     }
 
     let serverName: React.ReactNode = serverConfig.isNameResolvable ? serverConfig.hsName : serverConfig.hsUrl;
-    serverName = <TextWithTooltip class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""} tooltip={serverConfig.hsUrl}>
+    serverName = <TextWithTooltip
+                    class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""}
+                    tooltip={serverConfig.hsUrl}>
         { serverConfig.hsName }
     </TextWithTooltip>;
 

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -70,11 +70,9 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
     }
 
     let serverName: React.ReactNode = serverConfig.isNameResolvable ? serverConfig.hsName : serverConfig.hsUrl;
-    if (serverConfig.hsNameIsDifferent) {
-        serverName = <TextWithTooltip class="mx_Login_underlinedServerName" tooltip={serverConfig.hsUrl}>
-            { serverConfig.hsName }
-        </TextWithTooltip>;
-    }
+    serverName = <TextWithTooltip class={serverConfig.hsNameIsDifferent ? "mx_Login_underlinedServerName" : ""} tooltip={serverConfig.hsUrl}>
+        { serverConfig.hsName }
+    </TextWithTooltip>;
 
     let desc;
     if (serverConfig.hsName === "matrix.org") {
@@ -86,7 +84,7 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
     return <div className="mx_ServerPicker">
         <h3>{ title || _t("Homeserver") }</h3>
         { !disableCustomUrls ? <AccessibleButton className="mx_ServerPicker_help" onClick={onHelpClick} /> : null }
-        <span className="mx_ServerPicker_server" title={serverName}>{ serverName }</span>
+        <span className="mx_ServerPicker_server">{ serverName }</span>
         { editBtn }
         { desc }
     </div>;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18452

Before:
<img width="797" src="https://user-images.githubusercontent.com/5855073/148767523-926602f0-b77c-489c-b48c-e3c16148b9f0.png">

After:
<img width="943" src="https://user-images.githubusercontent.com/5855073/148767472-28a0e256-24ce-4e75-9448-d61d579cee2b.png">


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Truncate long server names on login/register screen ([\#7498](https://github.com/matrix-org/matrix-react-sdk/pull/7498)). Fixes vector-im/element-web#18452. Contributed by @aaronraimist.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://61dc3a5abb5c3dbba7154468--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
