### PR TITLE
Allow downloads from widgets

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -435,7 +435,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         // hosted on the same origin as the client will get the same access as if you clicked
         // a link to it.
         const sandboxFlags = "allow-forms allow-popups allow-popups-to-escape-sandbox " +
-            "allow-same-origin allow-scripts allow-presentation";
+            "allow-same-origin allow-scripts allow-presentation allow-downloads";
 
         // Additional iframe feature pemissions
         // (see - https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes and https://wicg.github.io/feature-policy/)


### PR DESCRIPTION
Notes: Allow downloads from widgets.

We are working on a widget that allows the user to download a file (a ICS calendar entry). Right now the sandbox of the widget iframe doesn't allow downloading. Instead, the following error is displayed in the console (for Google Chrome):

```
Download is disallowed. The frame initiating or instantiating the download is sandboxed, but the flag ‘allow-downloads’ is not set. See https://www.chromestatus.com/feature/5706745674465280 for more details.
```

Therefore this PR adds `allow-downloads` to the sandbox capabilities.

Steps to reproduce:
1. Create a simple widget with an `index.html` file like, e.g.
   ```
     <a href="index.html" download>Download</a>
   ```
2. Host the widget somewhere, add it to the room and open the widget
3. Click on the download button
    * Without the fix: Nothing happens, there is a warning in the console (see above)
    * With the fix: The file is downloaded

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow downloads from widgets. ([\#7502](https://github.com/matrix-org/matrix-react-sdk/pull/7502)). Contributed by @Fox32.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61df3c0a9c4b9d4623e77899--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
