### PR TITLE
Set header buttons to no phase when right panel is closed

### DIFF
--- a/src/components/views/right_panel/HeaderButtons.tsx
+++ b/src/components/views/right_panel/HeaderButtons.tsx
@@ -80,7 +80,8 @@ export default abstract class HeaderButtons<P = {}> extends React.Component<IPro
         }
     }
 
-    public isPhase(phases: string | string[]) {
+    public isPhase(phases: string | string[]): boolean {
+        if (!RightPanelStore.instance.isOpenForRoom) return false;
         if (Array.isArray(phases)) {
             return phases.includes(this.state.phase);
         } else {


### PR DESCRIPTION
Various cases could cause the room header buttons to be confused into highlighted as if their info is being displayed when it is not because the right panel is closed. For example, if you have a maximised widget and chat is closed, leaving and returning to the room would highlight the chat button incorrectly.

With this fix, we always check first whether the right panel is open before checking the phase.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set header buttons to no phase when right panel is closed ([\#7506](https://github.com/matrix-org/matrix-react-sdk/pull/7506)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61dc7505cb050c007a5b620f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
