### PR TITLE
Fix wrongly wrapping code blocks, breaking line numbers

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -483,8 +483,17 @@ $left-gutter: 64px;
         background-color: $codeblock-background-color;
     }
 
-    pre code > * {
-        display: inline;
+    // this selector wrongly applies to code blocks too but we will unset it in the next one
+    code {
+        white-space: pre-wrap; // don't collapse spaces in inline code blocks
+    }
+
+    pre code {
+        white-space: pre; // we want code blocks to be scrollable and not wrap
+
+        > * {
+            display: inline;
+        }
     }
 
     pre {
@@ -497,10 +506,6 @@ $left-gutter: 64px;
         &::-webkit-scrollbar-corner {
             background: transparent;
         }
-    }
-
-    code {
-        white-space: pre-wrap; // don't collapse spaces in inline code blocks
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20316

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrongly wrapping code blocks, breaking line numbers ([\#7507](https://github.com/matrix-org/matrix-react-sdk/pull/7507)). Fixes vector-im/element-web#20316.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61dd5d57fa9237e2056cb01f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
