### PR TITLE
Fix composer localStorage key for draft event in a thread

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -451,9 +451,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
 
     private get editorStateKey() {
         let key = `mx_cider_state_${this.props.room.roomId}`;
-        const thread = this.props.replyToEvent?.getThread();
-        if (thread) {
-            key += `_${thread.id}`;
+        if (this.props.relation?.rel_type === RelationType.Thread) {
+            key += `_${this.props.relation.event_id}`;
         }
         return key;
     }

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -291,13 +291,6 @@ describe('<SendMessageComposer/>', () => {
         });
 
         it('correctly sets the editorStateKey for threads', () => {
-            const mockThread ={
-                getThread: () => {
-                    return {
-                        id: 'myFakeThreadId',
-                    };
-                },
-            } as any;
             const wrapper = mount(<MatrixClientContext.Provider value={mockClient}>
                 <RoomContext.Provider value={roomContext}>
 

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { act } from "react-dom/test-utils";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { mount } from 'enzyme';
+import { RelationType } from 'matrix-js-sdk/src/@types/event';
 
 import SendMessageComposer, {
     createMessageContent,
@@ -304,14 +305,15 @@ describe('<SendMessageComposer/>', () => {
                         room={mockRoom as any}
                         placeholder=""
                         permalinkCreator={new SpecPermalinkConstructor() as any}
-                        replyToEvent={mockThread}
+                        relation={{
+                            rel_type: RelationType.Thread,
+                            event_id: "myFakeThreadId",
+                        }}
                     />
                 </RoomContext.Provider>
             </MatrixClientContext.Provider>);
-
             const instance = wrapper.find(SendMessageComposerClass).instance();
             const key = instance.editorStateKey;
-
             expect(key).toEqual('mx_cider_state_myfakeroom_myFakeThreadId');
         });
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20306

A regression that was created when we moved from `replyToEvent` to a relation prop on the composer component

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://61df0b8d9c4b9d0a2de77fc1--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
