### PR TITLE
Restore ability to click to lightbox image in bubble layout

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -203,6 +203,7 @@ limitations under the License.
                 bottom: 0;
                 left: 0;
                 right: 0;
+                pointer-events: none;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20526

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e003014ff34f0358143e62--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
