### PR TITLE
Add a developer mode 'view source' button to crashed event tiles

### DIFF
--- a/src/components/views/messages/TileErrorBoundary.tsx
+++ b/src/components/views/messages/TileErrorBoundary.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import SdkConfig from "../../../SdkConfig";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import BugReportDialog from '../dialogs/BugReportDialog';
 import AccessibleButton from '../elements/AccessibleButton';
+import SettingsStore from "../../../settings/SettingsStore";
+import ViewSource from "../../structures/ViewSource";
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -56,6 +58,12 @@ export default class TileErrorBoundary extends React.Component<IProps, IState> {
         });
     };
 
+    private onViewSource = (): void => {
+        Modal.createTrackedDialog('View Event Source', 'from crash', ViewSource, {
+            mxEvent: this.props.mxEvent,
+        }, 'mx_Dialog_viewsource');
+    };
+
     render() {
         if (this.state.error) {
             const { mxEvent } = this.props;
@@ -73,12 +81,20 @@ export default class TileErrorBoundary extends React.Component<IProps, IState> {
                 </AccessibleButton>;
             }
 
+            let viewSourceButton;
+            if (mxEvent && SettingsStore.getValue("developerMode")) {
+                viewSourceButton = <AccessibleButton onClick={this.onViewSource} kind="link_inline">
+                    { _t("View Source") }
+                </AccessibleButton>
+            }
+
             return (<div className={classNames(classes)}>
                 <div className="mx_EventTile_line">
                     <span>
                         { _t("Can't load this message") }
                         { mxEvent && ` (${mxEvent.getType()})` }
                         { submitLogsButton }
+                        { viewSourceButton }
                     </span>
                 </div>
             </div>);

--- a/src/components/views/messages/TileErrorBoundary.tsx
+++ b/src/components/views/messages/TileErrorBoundary.tsx
@@ -85,7 +85,7 @@ export default class TileErrorBoundary extends React.Component<IProps, IState> {
             if (mxEvent && SettingsStore.getValue("developerMode")) {
                 viewSourceButton = <AccessibleButton onClick={this.onViewSource} kind="link_inline">
                     { _t("View Source") }
-                </AccessibleButton>
+                </AccessibleButton>;
             }
 
             return (<div className={classNames(classes)}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1190097/149412175-dfa38419-8d98-4521-95b6-e4f244c066ff.png)

This is to allow developers to inspect the event that caused the crash as stacktraces might not always be clear.

The button is ugly, but hopefully fine enough for developers.

element-web notes: None

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a developer mode 'view source' button to crashed event tiles ([\#7537](https://github.com/matrix-org/matrix-react-sdk/pull/7537)).<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61e09baca841ca1254730294--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
