### PR TITLE
truncate room name on pip header

### DIFF
--- a/res/css/views/voip/_CallViewHeader.scss
+++ b/res/css/views/voip/_CallViewHeader.scss
@@ -75,6 +75,7 @@ limitations under the License.
 .mx_CallViewHeader_callInfo {
     margin-left: 12px;
     margin-right: 16px;
+    overflow: hidden;
 }
 
 .mx_CallViewHeader_roomName {
@@ -82,6 +83,10 @@ limitations under the License.
     font-size: 12px;
     line-height: initial;
     height: 15px;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .mx_CallView_secondaryCall_roomName {

--- a/src/components/views/voip/CallView/CallViewHeader.tsx
+++ b/src/components/views/voip/CallView/CallViewHeader.tsx
@@ -111,7 +111,7 @@ const CallViewHeader: React.FC<CallViewHeaderProps> = ({
         >
             <RoomAvatar room={callRoom} height={32} width={32} />
             <div className="mx_CallViewHeader_callInfo">
-                <div className="mx_CallViewHeader_roomName" title={callRoomName}>{callRoomName}</div>
+                <div className="mx_CallViewHeader_roomName" title={callRoomName}>{ callRoomName }</div>
                 <div className="mx_CallViewHeader_callTypeSmall">
                     { callTypeText }
                     { onHoldCallRoom && <SecondaryCallInfo callRoom={onHoldCallRoom} /> }

--- a/src/components/views/voip/CallView/CallViewHeader.tsx
+++ b/src/components/views/voip/CallView/CallViewHeader.tsx
@@ -111,7 +111,7 @@ const CallViewHeader: React.FC<CallViewHeaderProps> = ({
         >
             <RoomAvatar room={callRoom} height={32} width={32} />
             <div className="mx_CallViewHeader_callInfo">
-                <div className="mx_CallViewHeader_roomName">{ callRoomName }</div>
+                <div className="mx_CallViewHeader_roomName" title={callRoomName}>{callRoomName}</div>
                 <div className="mx_CallViewHeader_callTypeSmall">
                     { callTypeText }
                     { onHoldCallRoom && <SecondaryCallInfo callRoom={onHoldCallRoom} /> }


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

https://github.com/vector-im/element-web/issues/20551

Before:
<img width="355" alt="Screenshot 2022-01-14 at 10 52 26" src="https://user-images.githubusercontent.com/3055605/149499171-6cc36521-db00-4b64-881f-b576c3ce7ab7.png">


After:
<img width="354" alt="Screenshot 2022-01-14 at 11 05 22" src="https://user-images.githubusercontent.com/3055605/149499140-87450f53-d91a-495a-8ada-a26e5d6cb191.png">
<img width="350" alt="Screenshot 2022-01-14 at 11 05 10" src="https://user-images.githubusercontent.com/3055605/149499144-4a4c18e9-d3a3-42c5-8d3f-5e15af430ddf.png">


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * truncate room name on pip header ([\#7538](https://github.com/matrix-org/matrix-react-sdk/pull/7538)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61e1517bfc35a3ea41ddcb67--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
