### PR TITLE
Set initial zoom level to 1 to make zooming to location faster

### DIFF
--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -74,7 +74,7 @@ class LocationPicker extends React.Component<IProps, IState> {
             container: 'mx_LocationPicker_map',
             style: config.map_style_url,
             center: [0, 0],
-            zoom: 15,
+            zoom: 1,
         });
 
         try {


### PR DESCRIPTION
After: 
![fast_zoom](https://user-images.githubusercontent.com/76812/149512781-0d2a74ef-bc1d-4226-a205-efe797292890.gif)

Before:
![slow-zoom](https://user-images.githubusercontent.com/76812/149512791-ee368ba7-abb5-4321-b7e4-943cac5cafae.gif)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set initial zoom level to 1 to make zooming to location faster ([\#7541](https://github.com/matrix-org/matrix-react-sdk/pull/7541)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e167a788d11b09d69f8a69--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
