### PR TITLE
Always show right panel after setting a card

### DIFF
--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -154,12 +154,13 @@ export default class RightPanelStore extends ReadyWatchingStore {
             hist[hist.length - 1].state = cardState;
             this.emitAndUpdateSettings();
             return;
-        }
-
-        if (targetPhase !== this.currentCard?.phase) {
+        } else if (targetPhase !== this.currentCard?.phase) {
             // Set right panel and erase history.
             this.show();
             this.setRightPanelCache({ phase: targetPhase, state: cardState ?? {} }, rId);
+        } else {
+            this.show();
+            this.emitAndUpdateSettings();
         }
     }
 

--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -177,7 +177,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
         allowClose = true,
         roomId: string = null,
     ) {
-        // This function appends a card to the history and shows the right panel (if now already visible)
+        // This function appends a card to the history and shows the right panel if now already visible.
         const rId = roomId ?? this.viewedRoomId;
         const redirect = this.getVerificationRedirect(card);
         const targetPhase = redirect?.phase ?? card.phase;

--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -140,6 +140,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
         // This function behaves as following:
         // Update state: if the same phase is send but with a state
         // Set right panel and erase history: if a "different to the current" phase is send (with or without a state)
+        // If the right panel is set, this function also shows the right panel.
         const redirect = this.getVerificationRedirect(card);
         const targetPhase = redirect?.phase ?? card.phase;
         const cardState = redirect?.state ?? (Object.keys(card.state ?? {}).length === 0 ? null : card.state);
@@ -157,14 +158,17 @@ export default class RightPanelStore extends ReadyWatchingStore {
 
         if (targetPhase !== this.currentCard?.phase) {
             // Set right panel and erase history.
+            this.show();
             this.setRightPanelCache({ phase: targetPhase, state: cardState ?? {} }, rId);
         }
     }
 
     public setCards(cards: IRightPanelCard[], allowClose = true, roomId: string = null) {
+        // This function sets the history of the right panel and shows the right panel if not already visible.
         const rId = roomId ?? this.viewedRoomId;
         const history = cards.map(c => ({ phase: c.phase, state: c.state ?? {} }));
         this.byRoom[rId] = { history, isOpen: true };
+        this.show();
         this.emitAndUpdateSettings();
     }
 
@@ -173,6 +177,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
         allowClose = true,
         roomId: string = null,
     ) {
+        // This function appends a card to the history and shows the right panel (if now already visible)
         const rId = roomId ?? this.viewedRoomId;
         const redirect = this.getVerificationRedirect(card);
         const targetPhase = redirect?.phase ?? card.phase;
@@ -194,7 +199,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
                 isOpen: !allowClose,
             };
         }
-
+        this.show();
         this.emitAndUpdateSettings();
     }
 
@@ -213,6 +218,18 @@ export default class RightPanelStore extends ReadyWatchingStore {
 
         this.byRoom[rId].isOpen = !this.byRoom[rId].isOpen;
         this.emitAndUpdateSettings();
+    }
+
+    public show() {
+        if (!this.isOpenForRoom) {
+            this.togglePanel();
+        }
+    }
+
+    public hide() {
+        if (this.isOpenForRoom) {
+            this.togglePanel();
+        }
     }
 
     // Private


### PR DESCRIPTION
This changes that the right panel is always shown if a new card is set,
if the desired behavior is to only update the panel without showing,
hide needs to be called after setCard/s.

Fixes:
>  
>   1. On develop.element.io
>   2. With the right panel being closed
>   3. Try clicking on the Threads icon on the room header
>   4. The thread panel is not shown, the button does nothing. It only works if there was a panel open already (e.g. the room info panel)



<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Always show right panel after setting a card ([\#7544](https://github.com/matrix-org/matrix-react-sdk/pull/7544)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61e1851aff0c520df185b8cb--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
