### PR TITLE
Override hide redaction preference for thread root

### DIFF
--- a/src/shouldHideEvent.ts
+++ b/src/shouldHideEvent.ts
@@ -62,7 +62,9 @@ export default function shouldHideEvent(ev: MatrixEvent, ctx?: IRoomState): bool
         name => SettingsStore.getValue(name, ev.getRoomId());
 
     // Hide redacted events
-    if (ev.isRedacted() && !isEnabled('showRedactions')) return true;
+    // Deleted events with a thread are always shown regardless of user preference
+    // to make sure that a thread can be accessible even if the root message is deleted
+    if (ev.isRedacted() && !isEnabled('showRedactions') && !ev.getThread()) return true;
 
     // Hide replacement events since they update the original tile (if enabled)
     if (ev.isRelation("m.replace")) return true;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20558

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e18a81f4eb710a6e432d82--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
