### PR TITLE
Add setting for enabling location sharing

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -286,12 +286,16 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             showStickers: false,
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
             showPollsButton: SettingsStore.getValue("feature_polls"),
-            showLocationButton: SettingsStore.getValue("feature_location_share"),
+            showLocationButton: (
+                SettingsStore.getValue("feature_location_share") &&
+                SettingsStore.getValue("MessageComposerInput.showLocationButton")
+            ),
         };
 
         this.instanceId = instanceCount++;
 
         SettingsStore.monitorSetting("MessageComposerInput.showStickersButton", null);
+        SettingsStore.monitorSetting("MessageComposerInput.showLocationButton", null);
         SettingsStore.monitorSetting("feature_polls", null);
         SettingsStore.monitorSetting("feature_location_share", null);
     }
@@ -348,9 +352,14 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                         break;
                     }
 
+                    case "MessageComposerInput.showLocationButton":
                     case "feature_location_share": {
-                        const showLocationButton = SettingsStore.getValue(
-                            "feature_location_share");
+                        const showLocationButton = (
+                            SettingsStore.getValue("feature_location_share") &&
+                            SettingsStore.getValue(
+                                "MessageComposerInput.showLocationButton",
+                            )
+                        );
                         if (this.state.showLocationButton !== showLocationButton) {
                             this.setState({ showLocationButton });
                         }
@@ -525,7 +534,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             buttons.push(
                 <UploadButton key="controls_upload" roomId={this.props.room.roomId} relation={this.props.relation} />,
             );
-            if (SettingsStore.getValue("feature_location_share")) {
+            if (this.state.showLocationButton) {
                 const sender = this.props.room.getMember(
                     MatrixClientPeg.get().getUserId(),
                 );

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -296,6 +296,16 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         });
     }
 
+    getShowLocationIfEnabled(): string[] {
+        // TODO: when location sharing is out of labs, this can be deleted and
+        //       we can just add this to COMPOSER_SETTINGS
+        if (SettingsStore.getValue("feature_location_share")) {
+            return ['MessageComposerInput.showLocationButton'];
+        } else {
+            return [];
+        }
+    }
+
     render() {
         let autoLaunchOption = null;
         if (this.state.autoLaunchSupported) {
@@ -377,7 +387,10 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
 
                 <div className="mx_SettingsTab_section">
                     <span className="mx_SettingsTab_subheading">{ _t("Composer") }</span>
-                    { this.renderGroup(PreferencesUserSettingsTab.COMPOSER_SETTINGS) }
+                    { this.renderGroup([
+                        ...PreferencesUserSettingsTab.COMPOSER_SETTINGS,
+                        ...this.getShowLocationIfEnabled(),
+                    ]) }
                 </div>
 
                 <div className="mx_SettingsTab_section">

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -892,6 +892,7 @@
     "Use custom size": "Use custom size",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",
     "Show stickers button": "Show stickers button",
+    "Enable location sharing": "Enable location sharing",
     "Use a more compact 'Modern' layout": "Use a more compact 'Modern' layout",
     "Show a placeholder for removed messages": "Show a placeholder for removed messages",
     "Show join/leave messages (invites/removes/bans unaffected)": "Show join/leave messages (invites/removes/bans unaffected)",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -407,6 +407,12 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: true,
         controller: new UIFeatureController(UIFeature.Widgets, false),
     },
+    "MessageComposerInput.showLocationButton": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td('Enable location sharing'),
+        default: true,
+        controller: new UIFeatureController(UIFeature.Widgets, false),
+    },
     // TODO: Wire up appropriately to UI (FTUE notifications)
     "Notifications.alwaysShowBadgeCounts": {
         supportedLevels: LEVELS_ROOM_OR_ACCOUNT,


### PR DESCRIPTION
This is slightly complicated by the presence of a labs flag too.

When the labs flag is ON:
- this setting appears
- locations appear in the timeline

When this setting AND the labs flag are BOTH ON:
- the location sharing button appears in composer

![rec-2022-01-14_14 52 30](https://user-images.githubusercontent.com/76812/149537514-c7d123b4-219a-4c44-a75e-f3c70647aec6.gif)

If there is a better way of dynamically controlling which settings appear based on labs flags, please let me know.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e193080fa20c1d3e0f0e0f--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
