### PR TITLE
Fix the colour of the map attribution text in dark theme

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -182,6 +182,13 @@ $call-view-button-off-background: $primary-content;
 $video-feed-secondary-background: $system;
 // ********************
 
+// Location sharing
+// ********************
+.maplibregl-ctrl-attrib-button {
+    color: $background;
+}
+// ********************
+
 // One-off colors
 // ********************
 $progressbar-bg-color: $system;


### PR DESCRIPTION
After:
![image](https://user-images.githubusercontent.com/76812/149546515-e04796ae-8886-4b96-86fa-a564b667b258.png)

Before:
![image](https://user-images.githubusercontent.com/76812/149546535-b7b4deb3-1e72-41c9-b3f5-cb7a8de9752f.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e19fb84e6274317332de7d--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
