### PR TITLE
Make widgets and calls span across the whole room width when using bubble layout

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -15,8 +15,11 @@ limitations under the License.
 */
 
 .mx_RoomView_body[data-layout=bubble] {
-    max-width: 1200px;
-    margin: 0 auto;
+    .mx_RoomView_timeline, .mx_RoomView_statusArea, .mx_MessageComposer {
+        width: 100%;
+        max-width: 1200px;
+        margin: 0 auto;
+    }
 }
 
 .mx_EventTile[data-layout=bubble],


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20560
Type: defect

<hr>

![2022-01-16_17-25](https://user-images.githubusercontent.com/25768714/149668577-7a05c83e-35ef-44b3-a090-2c2e3eba6533.png)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make widgets and calls span across the whole room width when using bubble layout ([\#7553](https://github.com/matrix-org/matrix-react-sdk/pull/7553)). Fixes vector-im/element-web#20560. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e447828eef0b0fd1256f40--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
