### PR TITLE
Wait for initial profile load before displaying widget

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -89,8 +89,8 @@ interface IState {
     // Assume that widget has permission to load if we are the user who
     // added it to the room, or if explicitly granted by the user
     hasPermissionToLoad: boolean;
-    //
-    isUserReady: boolean;
+    // Wait for user profile load to display correct name
+    isUserProfileReady: boolean;
     error: Error;
     menuDisplayed: boolean;
     widgetPageTitle: string;
@@ -148,7 +148,7 @@ export default class AppTile extends React.Component<IProps, IState> {
 
     private onUserReady = (): void => {
         if (OwnProfileStore.instance.profileInfoFetchedAt) {
-            this.setState({ isUserReady: true });
+            this.setState({ isUserProfileReady: true });
             OwnProfileStore.instance.removeListener(UPDATE_EVENT, this.onUserReady);
         }
     };
@@ -179,7 +179,7 @@ export default class AppTile extends React.Component<IProps, IState> {
             // Assume that widget has permission to load if we are the user who
             // added it to the room, or if explicitly granted by the user
             hasPermissionToLoad: this.hasPermissionToLoad(newProps),
-            isUserReady: !!OwnProfileStore.instance.profileInfoFetchedAt,
+            isUserProfileReady: !!OwnProfileStore.instance.profileInfoFetchedAt,
             error: null,
             menuDisplayed: false,
             widgetPageTitle: this.props.widgetPageTitle,
@@ -494,7 +494,7 @@ export default class AppTile extends React.Component<IProps, IState> {
                     />
                 </div>
             );
-        } else if (this.state.initialising || !this.state.isUserReady) {
+        } else if (this.state.initialising || !this.state.isUserProfileReady) {
             appTileBody = (
                 <div className={appTileBodyClass + (this.state.loading ? 'mx_AppLoading' : '')} style={appTileBodyStyles}>
                     { loadingElement }

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -147,9 +147,7 @@ export default class AppTile extends React.Component<IProps, IState> {
     };
 
     private onUserReady = (): void => {
-        if (OwnProfileStore.instance.isProfileInfoFetched) {
-            this.setState({ isUserProfileReady: true });
-        }
+        this.setState({ isUserProfileReady: true });
     };
 
     // This is a function to make the impact of calling SettingsStore slightly less

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -143,13 +143,12 @@ export default class AppTile extends React.Component<IProps, IState> {
         if (OwnProfileStore.instance.isProfileInfoFetched) {
             return;
         }
-        OwnProfileStore.instance.on(UPDATE_EVENT, this.onUserReady);
+        OwnProfileStore.instance.once(UPDATE_EVENT, this.onUserReady);
     };
 
     private onUserReady = (): void => {
         if (OwnProfileStore.instance.isProfileInfoFetched) {
             this.setState({ isUserProfileReady: true });
-            OwnProfileStore.instance.removeListener(UPDATE_EVENT, this.onUserReady);
         }
     };
 

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -140,14 +140,14 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private watchUserReady = () => {
-        if (!!OwnProfileStore.instance.profileInfoFetchedAt) {
+        if (OwnProfileStore.instance.isProfileInfoFetched) {
             return;
         }
         OwnProfileStore.instance.on(UPDATE_EVENT, this.onUserReady);
     };
 
     private onUserReady = (): void => {
-        if (OwnProfileStore.instance.profileInfoFetchedAt) {
+        if (OwnProfileStore.instance.isProfileInfoFetched) {
             this.setState({ isUserProfileReady: true });
             OwnProfileStore.instance.removeListener(UPDATE_EVENT, this.onUserReady);
         }
@@ -179,7 +179,7 @@ export default class AppTile extends React.Component<IProps, IState> {
             // Assume that widget has permission to load if we are the user who
             // added it to the room, or if explicitly granted by the user
             hasPermissionToLoad: this.hasPermissionToLoad(newProps),
-            isUserProfileReady: !!OwnProfileStore.instance.profileInfoFetchedAt,
+            isUserProfileReady: OwnProfileStore.instance.isProfileInfoFetched,
             error: null,
             menuDisplayed: false,
             widgetPageTitle: this.props.widgetPageTitle,

--- a/src/stores/OwnProfileStore.ts
+++ b/src/stores/OwnProfileStore.ts
@@ -28,6 +28,7 @@ import { mediaFromMxc } from "../customisations/Media";
 interface IState {
     displayName?: string;
     avatarUrl?: string;
+    fetchedAt?: number;
 }
 
 const KEY_DISPLAY_NAME = "mx_profile_displayname";
@@ -65,6 +66,10 @@ export class OwnProfileStore extends AsyncStoreWithClient<IState> {
         } else {
             return this.matrixClient.getUserId();
         }
+    }
+
+    public get profileInfoFetchedAt(): number | undefined {
+        return this.state.fetchedAt;
     }
 
     /**
@@ -135,7 +140,12 @@ export class OwnProfileStore extends AsyncStoreWithClient<IState> {
         } else {
             window.localStorage.removeItem(KEY_AVATAR_URL);
         }
-        await this.updateState({ displayName: profileInfo.displayname, avatarUrl: profileInfo.avatar_url });
+
+        await this.updateState({
+            displayName: profileInfo.displayname,
+            avatarUrl: profileInfo.avatar_url,
+            fetchedAt: Date.now(),
+        });
     };
 
     private onStateEvents = throttle(async (ev: MatrixEvent) => {

--- a/src/stores/OwnProfileStore.ts
+++ b/src/stores/OwnProfileStore.ts
@@ -68,8 +68,8 @@ export class OwnProfileStore extends AsyncStoreWithClient<IState> {
         }
     }
 
-    public get profileInfoFetchedAt(): number | undefined {
-        return this.state.fetchedAt;
+    public get isProfileInfoFetched(): boolean {
+        return !!this.state.fetchedAt;
     }
 
     /**


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

https://element-io.atlassian.net/browse/PSE-271
When refreshing a room with a jitsi conference the widget url builder does not wait for profile info load. This sometimes sets the jitsi default user name to the mxid, when it should be the display name.

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Wait for initial profile load before displaying widget ([\#7556](https://github.com/matrix-org/matrix-react-sdk/pull/7556)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://61e5725b2224afb9fefda950--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
