### PR TITLE
Start a conference in a room with 2 people + invitee rather than a 1:1 call

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -809,12 +809,13 @@ export default class CallHandler extends EventEmitter {
         // We leave the check for whether there's already a call in this room until later,
         // otherwise it can race.
 
-        const members = room.getJoinedMembers();
-        if (members.length <= 1) {
+        const joinedMemberCount = room.getJoinedMemberCount();
+        const invitedAndJoinedMemberCount = room.getInvitedAndJoinedMemberCount();
+        if (joinedMemberCount <= 1) {
             Modal.createTrackedDialog('Call Handler', 'Cannot place call with self', ErrorDialog, {
                 description: _t('You cannot place a call with yourself.'),
             });
-        } else if (members.length === 2) {
+        } else if (invitedAndJoinedMemberCount === 2) {
             logger.info(`Place ${type} call in ${roomId}`);
 
             this.placeMatrixCall(roomId, type, transferee);

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -54,6 +54,8 @@ function mkStubDM(roomId, userId) {
             getMxcAvatarUrl: () => 'mxc://avatar.url/image.png',
         },
     ]);
+    room.getJoinedMemberCount = jest.fn().mockReturnValue(room.getJoinedMembers().length);
+    room.getInvitedAndJoinedMemberCount = jest.fn().mockReturnValue(room.getJoinedMembers().length);
     room.currentState.getMembers = room.getJoinedMembers;
 
     return room;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/1202
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Start a conference in a room with 2 people + invitee rather than a 1:1 call ([\#7557](https://github.com/matrix-org/matrix-react-sdk/pull/7557)). Fixes vector-im/element-web#1202. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61e56ebbfe272fbf25a3afdd--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
