### PR TITLE
Use PR number directly in netlify github action

### DIFF
--- a/.github/workflows/layered-build.yaml
+++ b/.github/workflows/layered-build.yaml
@@ -17,16 +17,4 @@ jobs:
                   path: element-web/webapp
                   # We'll only use this in a triggered job, then we're done with it
                   retention-days: 1
-            - uses: actions/github-script@v3.1.0
-              with:
-                script: |
-                    var fs = require('fs');
-                    fs.writeFileSync('${{github.workspace}}/pr.json', JSON.stringify(context.payload.pull_request));
-            - name: Upload PR Info
-              uses: actions/upload-artifact@v2
-              with:
-                  name: pr.json
-                  path: pr.json
-                  # We'll only use this in a triggered job, then we're done with it
-                  retention-days: 1
 

--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -33,28 +33,8 @@ jobs:
                   });
                   var fs = require('fs');
                   fs.writeFileSync('${{github.workspace}}/previewbuild.zip', Buffer.from(download.data));
-
-                  var prInfoArtifact = artifacts.data.artifacts.filter((artifact) => {
-                    return artifact.name == "pr.json"
-                  })[0];
-                  var download = await github.actions.downloadArtifact({
-                     owner: context.repo.owner,
-                     repo: context.repo.repo,
-                     artifact_id: prInfoArtifact.id,
-                     archive_format: 'zip',
-                  });
-                  var fs = require('fs');
-                  fs.writeFileSync('${{github.workspace}}/pr.json.zip', Buffer.from(download.data));
             - name: Extract Artifacts
-              run: unzip -d webapp previewbuild.zip && rm previewbuild.zip && unzip pr.json.zip && rm pr.json.zip
-            - name: 'Read PR Info'
-              id: readctx
-              uses: actions/github-script@v3.1.0
-              with:
-                script: |
-                    var fs = require('fs');
-                    var pr = JSON.parse(fs.readFileSync('${{github.workspace}}/pr.json'));
-                    console.log(`::set-output name=prnumber::${pr.number}`);
+              run: unzip -d webapp previewbuild.zip && rm previewbuild.zip
             - name: Deploy to Netlify
               id: netlify
               uses: nwtgck/actions-netlify@v1.2
@@ -73,7 +53,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  pull-request-number: ${{ steps.readctx.outputs.prnumber }}
+                  pull-request-number: ${{github.event.workflow_run.pull_requests[0].number}}
                   description-message: |
                       Preview: ${{ steps.netlify.outputs.deploy-url }}
                       ⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.


### PR DESCRIPTION
Looks like we can get the PR number for the workflow run that triggered
the workflow_run event, so there's no need for the massive faff we were
doing here.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e5ad24c5b566a2d07d3c5e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
