### PR TITLE
Fix `/jumptodate` using wrong MSC feature flag

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -334,7 +334,7 @@ export const Commands = [
                     );
                     dis.dispatch({
                         action: Action.ViewRoom,
-                        eventId,
+                        event_id: eventId,
                         highlighted: true,
                         room_id: roomId,
                     });

--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
@@ -61,7 +61,7 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
             this.setState({ showHiddenReadReceipts });
         });
 
-        MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc2716").then((showJumpToDate) => {
+        MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc3030").then((showJumpToDate) => {
             this.setState({ showJumpToDate });
         });
 


### PR DESCRIPTION
Fix `/jumptodate` using wrong MSC feature flag. Also fixes camelCase typo causing the slash command not to navigate anywhere.

As reported by @turt2live, https://matrix.to/#/!EMAlzkQQlZGEVTkDnD:matrix.org/$gnoVWQnIkYYL1i1cL8A4qRKJCFpNtq0Oj5khpzOq1mQ?via=half-shot.uk&via=matrix.org&via=element.io


Original PR where we introduced `/jumptodate`, https://github.com/matrix-org/matrix-react-sdk/pull/7372


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix `/jumptodate` using wrong MSC feature flag ([\#7563](https://github.com/matrix-org/matrix-react-sdk/pull/7563)). Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e66801d5eabe70cf996931--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
