### PR TITLE
Use IncompatibleController to disable showLocation via labs flag

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -286,10 +286,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             showStickers: false,
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
             showPollsButton: SettingsStore.getValue("feature_polls"),
-            showLocationButton: (
-                SettingsStore.getValue("feature_location_share") &&
-                SettingsStore.getValue("MessageComposerInput.showLocationButton")
-            ),
+            showLocationButton: SettingsStore.getValue("MessageComposerInput.showLocationButton"),
         };
 
         this.instanceId = instanceCount++;
@@ -354,12 +351,9 @@ export default class MessageComposer extends React.Component<IProps, IState> {
 
                     case "MessageComposerInput.showLocationButton":
                     case "feature_location_share": {
-                        const showLocationButton = (
-                            SettingsStore.getValue("feature_location_share") &&
-                            SettingsStore.getValue(
-                                "MessageComposerInput.showLocationButton",
-                            )
-                        );
+                        const showLocationButton = SettingsStore.getValue(
+                            "MessageComposerInput.showLocationButton");
+
                         if (this.state.showLocationButton !== showLocationButton) {
                             this.setState({ showLocationButton });
                         }

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -418,7 +418,7 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td('Enable location sharing'),
         default: true,
-        controller: new UIFeatureController(UIFeature.Widgets, false),
+        controller: new IncompatibleController("feature_location_share", false, false),
     },
     // TODO: Wire up appropriately to UI (FTUE notifications)
     "Notifications.alwaysShowBadgeCounts": {


### PR DESCRIPTION
As suggested by @t3chguy in #7547 use the IncompatibleController to automate disabling location sharing when the labs flag is disabled.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e697cc910579678812d446--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
