### PR TITLE
Fix wrong icon being used for appearance tab in space preferences dialog

### DIFF
--- a/res/css/views/dialogs/_SpacePreferencesDialog.scss
+++ b/res/css/views/dialogs/_SpacePreferencesDialog.scss
@@ -44,3 +44,7 @@ limitations under the License.
         }
     }
 }
+
+.mx_SpacePreferencesDialog_appearanceIcon::before {
+    mask-image: url('$(res)/img/element-icons/settings/appearance.svg');
+}

--- a/src/components/views/dialogs/SpacePreferencesDialog.tsx
+++ b/src/components/views/dialogs/SpacePreferencesDialog.tsx
@@ -73,7 +73,7 @@ const SpacePreferencesDialog: React.FC<IProps> = ({ space, initialTabId, onFinis
         new Tab(
             SpacePreferenceTab.Appearance,
             _td("Appearance"),
-            "mx_RoomSettingsDialog_notificationsIcon",
+            "mx_SpacePreferencesDialog_appearanceIcon",
             <SpacePreferencesAppearanceTab space={space} />,
         ),
     ];


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20608

![image](https://user-images.githubusercontent.com/2403652/149939275-0b2f5f20-264a-4fa7-afdf-ba8b628510f2.png)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrong icon being used for appearance tab in space preferences dialog ([\#7570](https://github.com/matrix-org/matrix-react-sdk/pull/7570)). Fixes vector-im/element-web#20608.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e6b66c20b5dc182690835a--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
