### PR TITLE
Enable the polls feature

### DIFF
--- a/src/components/views/messages/MessageEvent.tsx
+++ b/src/components/views/messages/MessageEvent.tsx
@@ -125,13 +125,9 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
                 BodyType = UnknownBody;
             }
 
+            // TODO: this can be done in eventTypes when Polls stabilise
             if (M_POLL_START.matches(type)) {
-                // TODO: this can all disappear when Polls comes out of labs -
-                // instead, add something like this into this.evTypes:
-                // [EventType.Poll]: "messages.MPollBody"
-                if (SettingsStore.getValue("feature_polls")) {
-                    BodyType = sdk.getComponent('messages.MPollBody');
-                }
+                BodyType = sdk.getComponent('messages.MPollBody');
             }
 
             if (

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -178,13 +178,6 @@ export function getHandlerTile(ev: MatrixEvent): string {
         }
     }
 
-    if (
-        M_POLL_START.matches(type) &&
-        !SettingsStore.getValue("feature_polls")
-    ) {
-        return undefined;
-    }
-
     if (ev.isState()) {
         if (stateEventSingular.has(type) && ev.getStateKey() !== "") return undefined;
         return stateEventTileTypes[type];

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -253,7 +253,6 @@ interface IState {
     isMenuOpen: boolean;
     showStickers: boolean;
     showStickersButton: boolean;
-    showPollsButton: boolean;
     showLocationButton: boolean;
 }
 
@@ -285,7 +284,6 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             isMenuOpen: false,
             showStickers: false,
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
-            showPollsButton: SettingsStore.getValue("feature_polls"),
             showLocationButton: SettingsStore.getValue("MessageComposerInput.showLocationButton"),
         };
 
@@ -293,7 +291,6 @@ export default class MessageComposer extends React.Component<IProps, IState> {
 
         SettingsStore.monitorSetting("MessageComposerInput.showStickersButton", null);
         SettingsStore.monitorSetting("MessageComposerInput.showLocationButton", null);
-        SettingsStore.monitorSetting("feature_polls", null);
         SettingsStore.monitorSetting("feature_location_share", null);
     }
 
@@ -337,14 +334,6 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                         const showStickersButton = SettingsStore.getValue("MessageComposerInput.showStickersButton");
                         if (this.state.showStickersButton !== showStickersButton) {
                             this.setState({ showStickersButton });
-                        }
-                        break;
-                    }
-
-                    case "feature_polls": {
-                        const showPollsButton = SettingsStore.getValue("feature_polls");
-                        if (this.state.showPollsButton !== showPollsButton) {
-                            this.setState({ showPollsButton });
                         }
                         break;
                     }
@@ -519,11 +508,13 @@ export default class MessageComposer extends React.Component<IProps, IState> {
         let uploadButtonIndex = 0;
         const buttons: JSX.Element[] = [];
         if (!this.state.haveRecording) {
-            if (this.state.showPollsButton) {
-                buttons.push(
-                    <PollButton key="polls" room={this.props.room} narrowMode={this.state.narrowMode} />,
-                );
-            }
+            buttons.push(
+                <PollButton
+                    key="polls"
+                    room={this.props.room}
+                    narrowMode={this.state.narrowMode}
+                />,
+            );
             uploadButtonIndex = buttons.length;
             buttons.push(
                 <UploadButton key="controls_upload" roomId={this.props.room.roomId} relation={this.props.relation} />,

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -883,7 +883,6 @@
     "Show message previews for reactions in all rooms": "Show message previews for reactions in all rooms",
     "Offline encrypted messaging using dehydrated devices": "Offline encrypted messaging using dehydrated devices",
     "Show extensible event representation of events": "Show extensible event representation of events",
-    "Polls (under active development)": "Polls (under active development)",
     "Location sharing (under active development)": "Location sharing (under active development)",
     "Show info about bridges in room settings": "Show info about bridges in room settings",
     "New layout switcher (with message bubbles)": "New layout switcher (with message bubbles)",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -306,13 +306,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         displayName: _td("Show extensible event representation of events"),
         default: false,
     },
-    "feature_polls": {
-        isFeature: true,
-        labsGroup: LabGroup.Messaging,
-        supportedLevels: LEVELS_FEATURE,
-        displayName: _td("Polls (under active development)"),
-        default: false,
-    },
     "feature_location_share": {
         isFeature: true,
         labsGroup: LabGroup.Messaging,

--- a/src/stores/room-list/MessagePreviewStore.ts
+++ b/src/stores/room-list/MessagePreviewStore.ts
@@ -31,7 +31,6 @@ import { CallHangupEvent } from "./previews/CallHangupEvent";
 import { StickerEventPreview } from "./previews/StickerEventPreview";
 import { ReactionEventPreview } from "./previews/ReactionEventPreview";
 import { UPDATE_EVENT } from "../AsyncStore";
-import SettingsStore from "../../settings/SettingsStore";
 
 // Emitted event for when a room's preview has changed. First argument will the room for which
 // the change happened.
@@ -62,26 +61,15 @@ const PREVIEWS = {
         isState: false,
         previewer: new ReactionEventPreview(),
     },
+    [M_POLL_START.name]: {
+        isState: false,
+        previewer: new PollStartEventPreview(),
+    },
+    [M_POLL_START.altName]: {
+        isState: false,
+        previewer: new PollStartEventPreview(),
+    },
 };
-
-function previews(): Object {
-    // TODO: when polls comes out of labs, add this to PREVIEWS
-    if (SettingsStore.getValue("feature_polls")) {
-        return {
-            [M_POLL_START.name]: {
-                isState: false,
-                previewer: new PollStartEventPreview(),
-            },
-            [M_POLL_START.altName]: {
-                isState: false,
-                previewer: new PollStartEventPreview(),
-            },
-            ...PREVIEWS,
-        };
-    } else {
-        return PREVIEWS;
-    }
-}
 
 // The maximum number of events we're willing to look back on to get a preview.
 const MAX_EVENTS_BACKWARDS = 50;
@@ -133,7 +121,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
     }
 
     public generatePreviewForEvent(event: MatrixEvent): string {
-        const previewDef = previews()[event.getType()];
+        const previewDef = PREVIEWS[event.getType()];
         // TODO: Handle case where we don't have
         if (!previewDef) return '';
         const previewText = previewDef.previewer.getTextFor(event, null, true);
@@ -165,7 +153,7 @@ export class MessagePreviewStore extends AsyncStoreWithClient<IState> {
 
             await this.matrixClient.decryptEventIfNeeded(event);
 
-            const previewDef = previews()[event.getType()];
+            const previewDef = PREVIEWS[event.getType()];
             if (!previewDef) continue;
             if (previewDef.isState && isNullOrUndefined(event.getStateKey())) continue;
 


### PR DESCRIPTION
This change removes the Polls labs flag, making the Create Poll button visible in the composer, and making existing polls visible in the timeline.

It does not change the fact that polls events still use an unstable prefix.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Enable the polls feature ([\#7581](https://github.com/matrix-org/matrix-react-sdk/pull/7581)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61e81b7a1fe03b15d1cadf14--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
