### PR TITLE
Disable location sharing button on Desktop

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -284,7 +284,10 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             isMenuOpen: false,
             showStickers: false,
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
-            showLocationButton: SettingsStore.getValue("MessageComposerInput.showLocationButton"),
+            showLocationButton: (
+                !window.electron &&
+                SettingsStore.getValue("MessageComposerInput.showLocationButton")
+            ),
         };
 
         this.instanceId = instanceCount++;
@@ -340,8 +343,10 @@ export default class MessageComposer extends React.Component<IProps, IState> {
 
                     case "MessageComposerInput.showLocationButton":
                     case "feature_location_share": {
-                        const showLocationButton = SettingsStore.getValue(
-                            "MessageComposerInput.showLocationButton");
+                        const showLocationButton = (
+                            !window.electron &&
+                            SettingsStore.getValue("MessageComposerInput.showLocationButton")
+                        );
 
                         if (this.state.showLocationButton !== showLocationButton) {
                             this.setState({ showLocationButton });

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -307,7 +307,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
     getShowLocationIfEnabled(): string[] {
         // TODO: when location sharing is out of labs, this can be deleted and
         //       we can just add this to COMPOSER_SETTINGS
-        if (SettingsStore.getValue("feature_location_share")) {
+        if (!window.electron && SettingsStore.getValue("feature_location_share")) {
             return ['MessageComposerInput.showLocationButton'];
         } else {
             return [];


### PR DESCRIPTION
Getting the user's location in Element Desktop (Electron app) is much trickier than getting it on Web.  We have agreed to remove the feature from Desktop for now.

This change removes the "Share location" button from the composer (when running in Electron), and removes the config setting that allows manually removing that button (when running in Electron).

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Disable location sharing button on Desktop ([\#7590](https://github.com/matrix-org/matrix-react-sdk/pull/7590)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61e996b92dcce44f2d431cee--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
