### PR TITLE
Add tooltips to emoji in messages

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -391,10 +391,9 @@ $left-gutter: 64px;
     position: absolute;
 }
 
-/* HACK to override line-height which is already marked important elsewhere */
-.mx_EventTile_bigEmoji.mx_EventTile_bigEmoji {
+.mx_EventTile_bigEmoji .mx_EventTile_Emoji {
     font-size: 48px !important;
-    line-height: 57px !important;
+    line-height: 57px;
 }
 
 .mx_EventTile_content .mx_EventTile_edited {


### PR DESCRIPTION
This adds a tooltip to emoji to view their shortcode, and also incidentally fixes compound emojis being broken.

Examples:

(with big emoji)
![tooltip1](https://user-images.githubusercontent.com/48614497/150475077-0df94cd2-0e53-4b4c-8832-fe34549d9533.png)
(with compound emoji)
![tooltip2](https://user-images.githubusercontent.com/48614497/150475079-80b87bea-db50-43c3-aab1-2f5ada53e002.png)

Type: enhancement

Closes https://github.com/vector-im/element-web/issues/9911.
Closes https://github.com/vector-im/element-web/issues/20661.

Signed-off-by: Robin Townsend <robin@robin.town>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add tooltips to emoji in messages ([\#7592](https://github.com/matrix-org/matrix-react-sdk/pull/7592)). Fixes vector-im/element-web#9911 and vector-im/element-web#20661. Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->