### PR TITLE
Enlarge emoji in bubble layout

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -86,6 +86,11 @@ a.mx_Pill {
     margin-right: 0.24rem;
 }
 
+.mx_Emoji {
+    font-size: 1.8rem;
+    vertical-align: bottom;
+}
+
 .mx_Markdown_BOLD {
     font-weight: bold;
 }

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -88,6 +88,8 @@ limitations under the License.
     .mx_EventTile_line {
         width: fit-content;
         max-width: 70%;
+        // fixed line height to prevent emoji from being taller than text
+        line-height: $font-18px;
     }
 
     > .mx_SenderProfile {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -386,12 +386,7 @@ $left-gutter: 64px;
     position: absolute;
 }
 
-.mx_EventTile_Emoji {
-    font-size: 1.8rem;
-    vertical-align: bottom;
-}
-
-.mx_EventTile_bigEmoji .mx_EventTile_Emoji {
+.mx_EventTile_bigEmoji .mx_Emoji {
     font-size: 48px !important;
     line-height: 57px;
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -233,11 +233,6 @@ $left-gutter: 64px;
         overflow-y: hidden;
     }
 
-    .mx_EventTile_Emoji {
-        font-size: 1.8rem;
-        vertical-align: bottom;
-    }
-
     &.mx_EventTile_selected .mx_EventTile_line,
     &:hover .mx_EventTile_line {
         border-top-left-radius: 4px;
@@ -389,6 +384,11 @@ $left-gutter: 64px;
     color: $event-timestamp-color;
     font-size: $font-11px;
     position: absolute;
+}
+
+.mx_EventTile_Emoji {
+    font-size: 1.8rem;
+    vertical-align: bottom;
 }
 
 /* HACK to override line-height which is already marked important elsewhere */

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -404,9 +404,9 @@ export interface IOptsReturnString extends IOpts {
 }
 
 const emojiToHtmlSpan = (emoji: string) =>
-    `<span class='mx_EventTile_Emoji' title='${unicodeToShortcode(emoji)}'>${emoji}</span>`;
+    `<span class='mx_Emoji' title='${unicodeToShortcode(emoji)}'>${emoji}</span>`;
 const emojiToJsxSpan = (emoji: string, key: number) =>
-    <span key={key} className='mx_EventTile_Emoji' title={unicodeToShortcode(emoji)}>{ emoji }</span>;
+    <span key={key} className='mx_Emoji' title={unicodeToShortcode(emoji)}>{ emoji }</span>;
 
 /**
  * Wraps emojis in <span> to style them separately from the rest of message. Consecutive emojis (and modifiers) are wrapped


### PR DESCRIPTION
Example:
![Screenshot 2022-01-21 at 21-41-51 Element #element-dev matrix org](https://user-images.githubusercontent.com/48614497/150622051-94358fd8-9ce9-4f24-b689-3a3f73781495.png)

Type: defect

element-web notes: none

Closes https://github.com/vector-im/element-web/issues/20660.

Signed-off-by: Robin Townsend <robin@robin.town>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Enlarge emoji in bubble layout ([\#7593](https://github.com/matrix-org/matrix-react-sdk/pull/7593)). Fixes vector-im/element-web#20660. Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->