### PR TITLE
Tooltip on send button in forward dialog is redundant

### DIFF
--- a/src/components/views/dialogs/ForwardDialog.tsx
+++ b/src/components/views/dialogs/ForwardDialog.tsx
@@ -98,9 +98,7 @@ const Entry: React.FC<IEntryProps> = ({ room, event, matrixClient: cli, onFinish
     let icon;
     if (sendState === SendState.CanSend) {
         className = "mx_ForwardList_canSend";
-        if (room.maySendMessage()) {
-            title = _t("Send");
-        } else {
+        if (!room.maySendMessage()) {
             disabled = true;
             title = _t("You don't have permission to do this");
         }


### PR DESCRIPTION
Remove tooltip on the send button of the forward dialog
only in the specified case: the button and the tooltip
have the same text string "Send".

Fixes [element-web/issues/20630](https://github.com/vector-im/element-web/issues/20630)

Signed-off by: Ingrid Budau inigiri@posteo.jp

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->