### PR TITLE
Re-renable Share option for location messages

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -378,27 +378,25 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
 
         let permalink: string | null = null;
         let permalinkButton: ReactElement | null = null;
-        if (canShare(mxEvent)) {
-            if (this.props.permalinkCreator) {
-                permalink = this.props.permalinkCreator.forEvent(this.props.mxEvent.getId());
-            }
-            permalinkButton = (
-                <IconizedContextMenuOption
-                    iconClassName="mx_MessageContextMenu_iconPermalink"
-                    onClick={this.onPermalinkClick}
-                    label={_t('Share')}
-                    element="a"
-                    {
-                        // XXX: Typescript signature for AccessibleButton doesn't work properly for non-inputs like `a`
-                        ...{
-                            href: permalink,
-                            target: "_blank",
-                            rel: "noreferrer noopener",
-                        }
-                    }
-                />
-            );
+        if (this.props.permalinkCreator) {
+            permalink = this.props.permalinkCreator.forEvent(this.props.mxEvent.getId());
         }
+        permalinkButton = (
+            <IconizedContextMenuOption
+                iconClassName="mx_MessageContextMenu_iconPermalink"
+                onClick={this.onPermalinkClick}
+                label={_t('Share')}
+                element="a"
+                {
+                    // XXX: Typescript signature for AccessibleButton doesn't work properly for non-inputs like `a`
+                    ...{
+                        href: permalink,
+                        target: "_blank",
+                        rel: "noreferrer noopener",
+                    }
+                }
+            />
+        );
 
         if (this.canEndPoll(mxEvent)) {
             endPollButton = (
@@ -516,10 +514,6 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
 }
 
 function canForward(event: MatrixEvent): boolean {
-    return !isLocationEvent(event);
-}
-
-function canShare(event: MatrixEvent): boolean {
     return !isLocationEvent(event);
 }
 


### PR DESCRIPTION
After discussion, we agreed that it is fine to allow sharing a permalink to someone's location-sharing message, so reversing part of https://github.com/matrix-org/matrix-react-sdk/pull/7423/files to allow that.

![image](https://user-images.githubusercontent.com/76812/150547984-7219d5e2-1f53-4bc9-bb1f-cf3df86f75ff.png)

(Forwarding is still not allowed, partly because we don't yet support sharing a location other than your own location.  This will be revisited when we do allow "pin drops".)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Re-renable Share option for location messages ([\#7596](https://github.com/matrix-org/matrix-react-sdk/pull/7596)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61eaca2604a67f0c66a5dce1--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
