### PR TITLE
Make the close button of the location share dialog visible in high-contrast theme

### DIFF
--- a/res/themes/light-high-contrast/css/_light-high-contrast.scss
+++ b/res/themes/light-high-contrast/css/_light-high-contrast.scss
@@ -125,3 +125,7 @@ $roomtopic-color: $secondary-content;
         }
     }
 }
+
+.mx_Dialog_buttons button.mx_LocationPicker_cancelButton::before {
+    background-color: $background !important;
+}


### PR DESCRIPTION
After:
![image](https://user-images.githubusercontent.com/76812/150551060-df361320-c5d3-4b27-b068-1a63ad06e8d9.png)

Before:
![image](https://user-images.githubusercontent.com/76812/150551148-21e18357-4e76-472d-aa80-c75ac28a9c52.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make the close button of the location share dialog visible in high-contrast theme ([\#7597](https://github.com/matrix-org/matrix-react-sdk/pull/7597)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61eace3804a67f10d8a5de3c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
