### PR TITLE
Unhide display names when switching back to modern layout

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -289,6 +289,10 @@ export default class MessagePanel extends React.Component<IProps, IState> {
     }
 
     componentDidUpdate(prevProps, prevState) {
+        if (prevProps.layout !== this.props.layout) {
+            this.calculateRoomMembersCount();
+        }
+
         if (prevProps.readMarkerVisible && this.props.readMarkerEventId !== prevProps.readMarkerEventId) {
             const ghostReadMarkers = this.state.ghostReadMarkers;
             ghostReadMarkers.push(prevProps.readMarkerEventId);


### PR DESCRIPTION
Type: defect

Closes https://github.com/vector-im/element-web/issues/20676.

Signed-off-by: Robin Townsend <robin@robin.town>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Unhide display names when switching back to modern layout ([\#7601](https://github.com/matrix-org/matrix-react-sdk/pull/7601)). Fixes vector-im/element-web#20676. Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->