### PR TITLE
Avoid double dialog after clicking to remove a public room

### DIFF
--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -611,21 +611,14 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
                 onMouseDown={(ev) => this.onRoomClicked(room, ev)}
                 className="mx_RoomDirectory_roomDescription"
             >
-                <div
-                    className="mx_RoomDirectory_name"
-                    onMouseDown={(ev) => this.onRoomClicked(room, ev)}
-                >
+                <div className="mx_RoomDirectory_name">
                     { name }
                 </div>&nbsp;
                 <div
                     className="mx_RoomDirectory_topic"
-                    onMouseDown={(ev) => this.onRoomClicked(room, ev)}
                     dangerouslySetInnerHTML={{ __html: topic }}
                 />
-                <div
-                    className="mx_RoomDirectory_alias"
-                    onMouseDown={(ev) => this.onRoomClicked(room, ev)}
-                >
+                <div className="mx_RoomDirectory_alias">
                     { getDisplayAliasForRoom(room) }
                 </div>
             </div>
@@ -637,7 +630,6 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
             </div>
             <div
                 onMouseDown={(ev) => this.onRoomClicked(room, ev)}
-                // cancel onMouseDown otherwise shift-clicking highlights text
                 className="mx_RoomDirectory_preview"
             >
                 { previewButton }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20681

Signed-off-by: Charlie Calendre c-cal@watcha.fr

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Avoid double dialog after clicking to remove a public room ([\#7604](https://github.com/matrix-org/matrix-react-sdk/pull/7604)). Fixes vector-im/element-web#20681. Contributed by @c-cal.<!-- CHANGELOG_PREVIEW_END -->