### PR TITLE
Fix excessive padding on inline images

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -471,9 +471,6 @@ $left-gutter: 64px;
 
     // selector wrongly applies to pill avatars but those have explicit width/height passed at a higher specificity
     &.markdown-body img {
-        // the image will have max-width and max-height applied during sanitization
-        width: 100%;
-        height: 100%;
         object-fit: contain;
         object-position: left top;
     }

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -209,11 +209,19 @@ const transformTags: IExtendedSanitizeOptions["transformTags"] = { // custom to 
             return { tagName, attribs: {} };
         }
 
-        const width = Math.min(Number(attribs.width) || 800, 800);
-        const height = Math.min(Number(attribs.height) || 600, 600);
+        const requestedWidth = Number(attribs.width);
+        const requestedHeight = Number(attribs.height);
+        const width = Math.min(requestedWidth || 800, 800);
+        const height = Math.min(requestedHeight || 600, 600);
         // specify width/height as max values instead of absolute ones to allow object-fit to do its thing
         // we only allow our own styles for this tag so overwrite the attribute
         attribs.style = `max-width: ${width}px; max-height: ${height}px;`;
+        if (requestedWidth) {
+            attribs.style += "width: 100%;";
+        }
+        if (requestedHeight) {
+            attribs.style += "height: 100%;";
+        }
 
         attribs.src = mediaFromMxc(src).getThumbnailOfSourceHttp(width, height);
         return { tagName, attribs };


### PR DESCRIPTION
Previously, if an inline image had a height specified but not a width (or vice versa), it would take up the maximum width of 800px regardless of its actual size. This was regressed by https://github.com/matrix-org/matrix-react-sdk/pull/7503.

Before:
![Screenshot 2022-01-22 at 12-03-32 Element general](https://user-images.githubusercontent.com/48614497/150648362-2d1be5cb-df9d-4eab-ba4c-9b382a019356.png)
After:
![Screenshot 2022-01-22 at 12-02-31 Element general](https://user-images.githubusercontent.com/48614497/150648361-d90cb5e9-fffb-4443-9434-bde9559e8952.png)

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix excessive padding on inline images ([\#7605](https://github.com/matrix-org/matrix-react-sdk/pull/7605)). Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->