### PR TITLE
Prevent pills from being split by formatting actions

### DIFF
--- a/res/css/views/rooms/_BasicMessageComposer.scss
+++ b/res/css/views/rooms/_BasicMessageComposer.scss
@@ -47,6 +47,7 @@ limitations under the License.
         &.mx_BasicMessageComposer_input_shouldShowPillAvatar {
             span.mx_UserPill, span.mx_RoomPill {
                 position: relative;
+                user-select: all;
 
                 // avatar psuedo element
                 &::before {


### PR DESCRIPTION
This forces pills in the composer to be selected as a whole if the user tries to select them at all, to prevent weird results like the following where the user selects a pill halfway and then toggles formatting:

https://user-images.githubusercontent.com/48614497/150655115-54a24593-660e-47ac-b0a5-682c677be802.mp4

(ignore the graphical glitches, that's just Firefox's buggy webrender compositor)

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent pills from being split by formatting actions ([\#7606](https://github.com/matrix-org/matrix-react-sdk/pull/7606)). Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->