### PR TITLE
Fix space member list right panel state

### DIFF
--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -287,11 +287,6 @@ export default class RightPanelStore extends ReadyWatchingStore {
                     console.warn("removed card from right panel because of missing member in card state");
                 }
                 return !!card.state.member;
-            case RightPanelPhases.SpaceMemberList:
-                if (!card.state.spaceId) {
-                    console.warn("removed card from right panel because of missing spaceId in card state");
-                }
-                return !!card.state.spaceId;
             case RightPanelPhases.Room3pidMemberInfo:
             case RightPanelPhases.Space3pidMemberInfo:
                 if (!card.state.memberInfoEvent) {


### PR DESCRIPTION
The right panel card validation was expecting a space ID and rejecting cards without it, but this is not actually needed for correct functionality.

Fixes https://github.com/vector-im/element-web/issues/20716

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix space member list right panel state ([\#7617](https://github.com/matrix-org/matrix-react-sdk/pull/7617)). Fixes vector-im/element-web#20716.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61eed72f804f6a3b2d163c84--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
