### PR TITLE
Add labs flag for default open right panel

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -889,6 +889,7 @@
     "Meta Spaces": "Meta Spaces",
     "Use new room breadcrumbs": "Use new room breadcrumbs",
     "New spotlight search experience": "New spotlight search experience",
+    "Right panel stays open (defaults to room member list)": "Right panel stays open (defaults to room member list)",
     "Jump to date (adds /jumptodate)": "Jump to date (adds /jumptodate)",
     "Don't send read receipts": "Don't send read receipts",
     "Font size": "Font size",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -366,6 +366,13 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         displayName: _td("New spotlight search experience"),
         default: false,
     },
+    "feature_right_panel_default_open": {
+        isFeature: true,
+        labsGroup: LabGroup.Rooms,
+        supportedLevels: LEVELS_FEATURE,
+        displayName: _td("Right panel stays open (defaults to room member list)"),
+        default: false,
+    },
     "feature_jump_to_date": {
         // We purposely leave out `isFeature: true` so it doesn't show in Labs
         // by default. We will conditionally show it depending on whether we can

--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -368,6 +368,21 @@ export default class RightPanelStore extends ReadyWatchingStore {
         this.isViewingRoom = true; // Is viewing room will of course be removed when removing groups
         // load values from byRoomCache with the viewedRoomId.
         this.loadCacheFromSettings();
+        // If the right panel stays open mode is used, and the panel was either
+        // closed or never shown for that room, then force it open and display
+        // the room member list.
+        if (
+            SettingsStore.getValue("feature_right_panel_default_open") &&
+            !this.byRoom[this.viewedRoomId]?.isOpen
+        ) {
+            this.byRoom[this.viewedRoomId] = {
+                isOpen: true,
+                history: [
+                    { phase: RightPanelPhases.RoomSummary },
+                    { phase: RightPanelPhases.RoomMemberList },
+                ],
+            };
+        }
         this.emitAndUpdateSettings();
     };
 


### PR DESCRIPTION
This adds an experimental default open right panel mode as a quick fix for those
who prefer to have the right panel open consistently across rooms.

If no right panel state is known for the room or it was closed on the last room
visit, it will default to the room member list. Otherwise, the saved card last
used in that room is shown.

Fixes https://github.com/vector-im/element-web/issues/20666
Docs in https://github.com/vector-im/element-web/pull/20722

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add labs flag for default open right panel ([\#7618](https://github.com/matrix-org/matrix-react-sdk/pull/7618)). Fixes vector-im/element-web#20666.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61eee28c2e53e9489eb02525--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
