### PR TITLE
Update lastReply to filter out local event ID from thread fallback

### DIFF
--- a/src/components/structures/ThreadPanel.tsx
+++ b/src/components/structures/ThreadPanel.tsx
@@ -88,7 +88,7 @@ async function getThreadTimelineSet(
         const timelineSet = new EventTimelineSet(room, {});
 
         Array.from(room.threads)
-            .sort(([, threadA], [, threadB]) => threadA.lastReply.getTs() - threadB.lastReply.getTs())
+            .sort(([, threadA], [, threadB]) => threadA.lastReply().getTs() - threadB.lastReply().getTs())
             .forEach(([, thread]) => {
                 const isOwnEvent = thread.rootEvent.getSender() === client.getUserId();
                 if (filterType !== ThreadFilterType.My || isOwnEvent) {

--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -166,7 +166,9 @@ export default class ThreadView extends React.Component<IProps, IState> {
         if (thread && this.state.thread !== thread) {
             this.setState({
                 thread,
-                lastThreadReply: thread.lastReply,
+                lastThreadReply: thread.lastReply((ev: MatrixEvent) => {
+                    return !ev.status;
+                }),
             }, () => {
                 thread.emit(ThreadEvent.ViewThread);
                 this.timelinePanelRef.current?.refreshTimeline();
@@ -177,7 +179,9 @@ export default class ThreadView extends React.Component<IProps, IState> {
     private updateLastThreadReply = () => {
         if (this.state.thread) {
             this.setState({
-                lastThreadReply: this.state.thread.lastReply,
+                lastThreadReply: this.state.thread.lastReply((ev: MatrixEvent) => {
+                    return !ev.status;
+                }),
             });
         }
     };

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -402,7 +402,7 @@ export default class EventTile extends React.Component<IProps, IState> {
 
             thread,
             threadReplyCount: thread?.length,
-            threadLastReply: thread?.lastReply,
+            threadLastReply: thread?.lastReply(),
         };
 
         // don't do RR animations until we are mounted
@@ -556,7 +556,7 @@ export default class EventTile extends React.Component<IProps, IState> {
         }
 
         this.setState({
-            threadLastReply: thread?.lastReply,
+            threadLastReply: thread?.lastReply(),
             threadReplyCount: thread?.length,
             thread,
         });
@@ -1271,7 +1271,7 @@ export default class EventTile extends React.Component<IProps, IState> {
         // Thread panel shows the timestamp of the last reply in that thread
         const ts = this.props.tileShape !== TileShape.ThreadPanel
             ? this.props.mxEvent.getTs()
-            : thread?.lastReply.getTs();
+            : thread?.lastReply().getTs();
 
         const timestamp = showTimestamp && ts ?
             <MessageTimestamp


### PR DESCRIPTION
Fixes vector-im/element-web#20644
Related to https://github.com/matrix-org/matrix-js-sdk/pull/2129

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61efbeb6d5a539cad7b743b3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
