### PR TITLE
 Improve taken username warning in registration for when request fails

### DIFF
--- a/src/components/views/elements/Validation.tsx
+++ b/src/components/views/elements/Validation.tsx
@@ -92,7 +92,7 @@ export default function withValidation<T = undefined, D = void>({
         }
 
         const data = { value, allowEmpty };
-        const derivedData = deriveData ? await deriveData(data) : undefined;
+        const derivedData: D | undefined = deriveData ? await deriveData.call(this, data) : undefined;
 
         const results: IResult[] = [];
         let valid = true;
@@ -106,13 +106,13 @@ export default function withValidation<T = undefined, D = void>({
                     continue;
                 }
 
-                if (rule.skip && rule.skip.call(this, data, derivedData)) {
+                if (rule.skip?.call(this, data, derivedData)) {
                     continue;
                 }
 
                 // We're setting `this` to whichever component holds the validation
                 // function. That allows rules to access the state of the component.
-                const ruleValid = await rule.test.call(this, data, derivedData);
+                const ruleValid: boolean = await rule.test.call(this, data, derivedData);
                 valid = valid && ruleValid;
                 if (ruleValid && rule.valid) {
                     // If the rule's result is valid and has text to show for

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2941,6 +2941,7 @@
     "Other users can invite you to rooms using your contact details": "Other users can invite you to rooms using your contact details",
     "Enter phone number (required on this homeserver)": "Enter phone number (required on this homeserver)",
     "Use lowercase letters, numbers, dashes and underscores only": "Use lowercase letters, numbers, dashes and underscores only",
+    "Unable to check if username has been taken. Try again later.": "Unable to check if username has been taken. Try again later.",
     "Someone already has that username. Try another or if it is you, sign in below.": "Someone already has that username. Try another or if it is you, sign in below.",
     "Phone (optional)": "Phone (optional)",
     "Register": "Register",


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2130

![image](https://user-images.githubusercontent.com/2403652/150955615-2133cf09-0be3-4e99-96fd-46d177d0591b.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 *  Improve taken username warning in registration for when request fails ([\#7621](https://github.com/matrix-org/matrix-react-sdk/pull/7621)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61efccf7827564d4d16eacea--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
