### PR TITLE
Upgrade linkifyjs to fix schemes as domain prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/runtime": "^7.12.5",
     "@matrix-org/linkify-element": "^4.0.0-rc.5",
     "@matrix-org/linkify-string": "^4.0.0-rc.5",
-    "@matrix-org/linkifyjs": "^4.0.0-rc.5",
+    "@matrix-org/linkifyjs": "^4.0.0-rc.6",
     "@sentry/browser": "^6.11.0",
     "@sentry/tracing": "^6.11.0",
     "@types/geojson": "^7946.0.8",

--- a/src/linkify-matrix.ts
+++ b/src/linkify-matrix.ts
@@ -245,7 +245,7 @@ export const options = {
 // Run the plugins
 registerPlugin(Type.RoomAlias, ({ scanner, parser, utils }) => {
     const token = scanner.tokens.POUND as '#';
-    return matrixOpaqueIdLinkifyParser({
+    matrixOpaqueIdLinkifyParser({
         scanner,
         parser,
         utils,
@@ -256,7 +256,7 @@ registerPlugin(Type.RoomAlias, ({ scanner, parser, utils }) => {
 
 registerPlugin(Type.GroupId, ({ scanner, parser, utils }) => {
     const token = scanner.tokens.PLUS as '+';
-    return matrixOpaqueIdLinkifyParser({
+    matrixOpaqueIdLinkifyParser({
         scanner,
         parser,
         utils,
@@ -267,7 +267,7 @@ registerPlugin(Type.GroupId, ({ scanner, parser, utils }) => {
 
 registerPlugin(Type.UserId, ({ scanner, parser, utils }) => {
     const token = scanner.tokens.AT as '@';
-    return matrixOpaqueIdLinkifyParser({
+    matrixOpaqueIdLinkifyParser({
         scanner,
         parser,
         utils,

--- a/test/linkify-matrix-test.ts
+++ b/test/linkify-matrix-test.ts
@@ -278,7 +278,7 @@ describe('linkify-matrix', () => {
     });
 
     describe('matrix uri', () => {
-        const AcceptedMatrixUris = [
+        const acceptedMatrixUris = [
             'matrix:u/foo_bar:server.uk',
             'matrix:r/foo-bar:server.uk',
             'matrix:roomid/somewhere:example.org?via=elsewhere.ca',
@@ -287,7 +287,7 @@ describe('linkify-matrix', () => {
             'matrix:roomid/somewhere:example.org/e/event?via=elsewhere.ca',
             'matrix:u/alice:example.org?action=chat',
         ];
-        for (const matrixUri of AcceptedMatrixUris) {
+        for (const matrixUri of acceptedMatrixUris) {
             it('accepts ' + matrixUri, () => {
                 const test = matrixUri;
                 const found = linkify.find(test);
@@ -296,6 +296,29 @@ describe('linkify-matrix', () => {
                     type: Type.URL,
                     value: matrixUri,
                     end: matrixUri.length,
+                    start: 0,
+                    isLink: true,
+                }]));
+            });
+        }
+    });
+
+    describe("matrix-prefixed domains", () => {
+        const acceptedDomains = [
+            'matrix.org',
+            'matrix.to',
+            'matrix-help.org',
+            'matrix123.org',
+        ];
+        for (const domain of acceptedDomains) {
+            it('accepts ' + domain, () => {
+                const test = domain;
+                const found = linkify.find(test);
+                expect(found).toEqual(([{
+                    href: `http://${domain}`,
+                    type: Type.URL,
+                    value: domain,
+                    end: domain.length,
                     start: 0,
                     isLink: true,
                 }]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,10 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/linkify-string/-/linkify-string-4.0.0-rc.5.tgz#139ba23c70a4f5b531656365a6109c122177b132"
   integrity sha512-WFyu6+kVEPJsDwZwgCSrtUDeIMDdWIFzRRq5z+MLYHiO3J8G19jvRjRnNm4dwjDUqROWhvWS9b8JG7rbuwjkLQ==
 
-"@matrix-org/linkifyjs@^4.0.0-rc.5":
-  version "4.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@matrix-org/linkifyjs/-/linkifyjs-4.0.0-rc.5.tgz#3a2885754a8de51164a30e6e09909173e348d6bb"
-  integrity sha512-HGmEZuUzCOzdsUFM5dQK2R2KhBFnxRfye5CYJhM2EpRTO4t5aTcR6Ey09HuJ/DZevQ9GTFUjkuKAKurQhnAfOA==
+"@matrix-org/linkifyjs@^4.0.0-rc.6":
+  version "4.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@matrix-org/linkifyjs/-/linkifyjs-4.0.0-rc.6.tgz#62bce99272e0b2a78896b01651d8b26602247f32"
+  integrity sha512-RoBejrxlv8jJjaZ9itTx0+JW8ECNEvj7iJzbD1rGhToLZjRZ5qXexWIa3+Vu4qmm+Yic+ETPCSH7odYWSYj/fA==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz":
   version "3.2.8"


### PR DESCRIPTION
This pulls in matrix-org/linkifyjs@7a723dc so that schemes are allowed to appear as the prefix of a domain.

Fixes vector-im/element-web#20720

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Upgrade linkifyjs to fix schemes as domain prefixes ([\#7628](https://github.com/matrix-org/matrix-react-sdk/pull/7628)). Fixes vector-im/element-web#20720.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61f03360998e715728429cfb--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
