### PR TITLE
Changed MacOS hotkey for GoToHome view.

### DIFF
--- a/src/KeyBindingsDefaults.ts
+++ b/src/KeyBindingsDefaults.ts
@@ -373,7 +373,7 @@ const navigationBindings = (): KeyBinding<NavigationAction>[] => {
             action: NavigationAction.GoToHome,
             keyCombo: {
                 key: Key.H,
-                ctrlKey: true,
+                ctrlOrCmd: true,
                 altKey: !isMac,
                 shiftKey: isMac,
             },

--- a/src/accessibility/KeyboardShortcuts.ts
+++ b/src/accessibility/KeyboardShortcuts.ts
@@ -341,7 +341,8 @@ export const KEYBOARD_SHORTCUTS: { [setting: string]: ISetting } = {
     "KeyBinding.goToHomeView": {
         default: {
             ctrlOrCmdKey: true,
-            altKey: true,
+            altKey: !isMac,
+            shiftKey: isMac,
             key: Key.H,
         },
         displayName: _td("Go to Home View"),


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->
Fixes: [#19850](https://github.com/vector-im/element-web/issues/19850)
Type: Defect 
<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
Signed-off-by: Ajeya Bhat ajeybhat.off@gmail.com

Notes: 
changed the keybinding for the go-to home view to : `SHIFT + ⌘ + H` ( Mac)  and  `CTRL + ALT + H` (PC)
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
To suppress this:
Changes in this project generate changelog entries in element-web by default.
element-web notes: none
...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Changed MacOS hotkey for GoToHome view. ([\#7631](https://github.com/matrix-org/matrix-react-sdk/pull/7631)). Contributed by @aj-ya.<!-- CHANGELOG_PREVIEW_END -->