### PR TITLE
runAllTimers -> runOnlyPendingTimers in SpaceStore-test

### DIFF
--- a/test/stores/SpaceStore-test.ts
+++ b/test/stores/SpaceStore-test.ts
@@ -98,19 +98,19 @@ describe("SpaceStore", () => {
         client.getRoom.mockImplementation(roomId => rooms.find(room => room.roomId === roomId));
         client.getRoomUpgradeHistory.mockImplementation(roomId => [rooms.find(room => room.roomId === roomId)]);
         await testUtils.setupAsyncStoreWithClient(store, client);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
     };
 
     const setShowAllRooms = async (value: boolean) => {
         if (store.allRoomsInHome === value) return;
         const emitProm = testUtils.emitPromise(store, UPDATE_HOME_BEHAVIOUR);
         await SettingsStore.setValue("Spaces.allRoomsInHome", null, SettingLevel.DEVICE, value);
-        jest.runAllTimers(); // run async dispatch
+        jest.runOnlyPendingTimers(); // run async dispatch
         await emitProm;
     };
 
     beforeEach(async () => {
-        jest.runAllTimers(); // run async dispatch
+        jest.runOnlyPendingTimers(); // run async dispatch
         client.getVisibleRooms.mockReturnValue(rooms = []);
 
         await SettingsStore.setValue("Spaces.enabledMetaSpaces", null, SettingLevel.DEVICE, {
@@ -692,7 +692,7 @@ describe("SpaceStore", () => {
         });
 
         const getCurrentRoom = () => {
-            jest.runAllTimers();
+            jest.runOnlyPendingTimers();
             return currentRoom;
         };
 
@@ -812,7 +812,7 @@ describe("SpaceStore", () => {
                 [MetaSpace.People]: false,
                 [MetaSpace.Orphans]: true,
             });
-            jest.runAllTimers();
+            jest.runOnlyPendingTimers();
             expect(store.activeSpace).toBe(MetaSpace.Orphans);
         });
 
@@ -885,14 +885,14 @@ describe("SpaceStore", () => {
         const rootSpace = mkSpace(space1, [room1, room2, space2]);
         rootSpace.getMyMembership.mockReturnValue("invite");
         client.emit("Room", rootSpace);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([rootSpace]);
         expect(SpaceStore.instance.spacePanelSpaces).toStrictEqual([]);
 
         // accept invite to space
         rootSpace.getMyMembership.mockReturnValue("join");
         client.emit("Room.myMembership", rootSpace, "join", "invite");
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([]);
         expect(SpaceStore.instance.spacePanelSpaces).toStrictEqual([rootSpace]);
 
@@ -901,7 +901,7 @@ describe("SpaceStore", () => {
         const rootSpaceRoom1 = mkRoom(room1);
         rootSpaceRoom1.getMyMembership.mockReturnValue("join");
         client.emit("Room", rootSpaceRoom1);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([]);
         expect(SpaceStore.instance.spacePanelSpaces).toStrictEqual([rootSpace]);
         expect(SpaceStore.instance.isRoomInSpace(space1, room1)).toBeTruthy();
@@ -915,7 +915,7 @@ describe("SpaceStore", () => {
         const rootSpaceRoom2 = mkRoom(room2);
         rootSpaceRoom2.getMyMembership.mockReturnValue("invite");
         client.emit("Room", rootSpaceRoom2);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([]);
         expect(SpaceStore.instance.spacePanelSpaces).toStrictEqual([rootSpace]);
         expect(SpaceStore.instance.isRoomInSpace(space1, room2)).toBeTruthy();
@@ -952,12 +952,12 @@ describe("SpaceStore", () => {
             user: dm1Partner.userId,
             room: space1,
         }));
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.getSpaceFilteredUserIds(space1).has(dm1Partner.userId)).toBeTruthy();
         const dm1Room = mkRoom(dm1);
         dm1Room.getMyMembership.mockReturnValue("join");
         client.emit("Room", dm1Room);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([]);
         expect(SpaceStore.instance.spacePanelSpaces).toStrictEqual([rootSpace]);
         expect(SpaceStore.instance.isRoomInSpace(space1, dm1)).toBeTruthy();
@@ -971,7 +971,7 @@ describe("SpaceStore", () => {
         subspace.getMyMembership.mockReturnValue("join");
         const prom = testUtils.emitPromise(SpaceStore.instance, space1);
         client.emit("Room", subspace);
-        jest.runAllTimers();
+        jest.runOnlyPendingTimers();
         expect(SpaceStore.instance.invitedSpaces).toStrictEqual([]);
         expect(SpaceStore.instance.spacePanelSpaces.map(r => r.roomId)).toStrictEqual([rootSpace.roomId]);
         await prom;

--- a/test/stores/SpaceStore-test.ts
+++ b/test/stores/SpaceStore-test.ts
@@ -812,7 +812,7 @@ describe("SpaceStore", () => {
                 [MetaSpace.People]: false,
                 [MetaSpace.Orphans]: true,
             });
-            jest.runOnlyPendingTimers();
+            jest.runAllTimers();
             expect(store.activeSpace).toBe(MetaSpace.Orphans);
         });
 


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Replace most `runAllTimers` with `runOnlyPendingTimers` in `SpaceStore-test`
`SpaceStore` unit tests have always failed for me locally because of infinite recursion running timers.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61f11ce02d8d556d9b67de0c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
