### PR TITLE
Fix emojis getting cropped in irc & bubble layouts by anti-zalgo

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -279,7 +279,7 @@ limitations under the License.
     }
 
     &:not(.mx_EventTile_noBubble) .mx_EventTile_line:not(.mx_EventTile_mediaLine) {
-        // make the top and bottom padding 1px smaller so that we can pad  .mx_EventTile_content by 1px
+        // make the top and bottom padding 1px smaller so that we can pad .mx_EventTile_content by 1px
         // to avoid anti-zalgo cutting off our larger than text emojis.
         padding: calc(var(--gutterSize) - 1px);
         padding-right: 60px; // space for the timestamp

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -279,9 +279,15 @@ limitations under the License.
     }
 
     &:not(.mx_EventTile_noBubble) .mx_EventTile_line:not(.mx_EventTile_mediaLine) {
-        padding: var(--gutterSize);
+        // make the top and bottom padding 1px smaller so that we can pad  .mx_EventTile_content by 1px
+        // to avoid anti-zalgo cutting off our larger than text emojis.
+        padding: calc(var(--gutterSize) - 1px);
         padding-right: 60px; // space for the timestamp
         background: var(--backgroundColor);
+
+        .mx_EventTile_content {
+            padding: 1px;
+        }
     }
 
     &.mx_EventTile_continuation[data-self=false] .mx_EventTile_line {

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -25,7 +25,6 @@ $irc-line-height: $font-18px;
     line-height: $irc-line-height !important;
 
     .mx_EventTile {
-
         // timestamps are links which shouldn't be underlined
         > a {
             text-decoration: none;
@@ -111,6 +110,8 @@ $irc-line-height: $font-18px;
             .mx_TextualEvent,
             .mx_MTextBody {
                 display: inline-block;
+                // add a 1px padding top and bottom because our larger emoji font otherwise gets cropped by anti-zalgo
+                padding: 1px 0;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20744

Tested at normal font-size, 13px font-size and 20px font-size (min and max)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix emojis getting cropped in irc & bubble layouts by anti-zalgo ([\#7637](https://github.com/matrix-org/matrix-react-sdk/pull/7637)). Fixes vector-im/element-web#20744.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://61f26928b1774f954cc64c4e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
