### PR TITLE
Revert "Start a conference in a room with 2 people + invitee rather than a 1:1 call"

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -822,13 +822,12 @@ export default class CallHandler extends EventEmitter {
         // We leave the check for whether there's already a call in this room until later,
         // otherwise it can race.
 
-        const joinedMemberCount = room.getJoinedMemberCount();
-        const invitedAndJoinedMemberCount = room.getInvitedAndJoinedMemberCount();
-        if (joinedMemberCount <= 1) {
+        const members = room.getJoinedMembers();
+        if (members.length <= 1) {
             Modal.createTrackedDialog('Call Handler', 'Cannot place call with self', ErrorDialog, {
                 description: _t('You cannot place a call with yourself.'),
             });
-        } else if (invitedAndJoinedMemberCount === 2) {
+        } else if (members.length === 2) {
             logger.info(`Place ${type} call in ${roomId}`);
 
             this.placeMatrixCall(roomId, type, transferee);

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -54,8 +54,6 @@ function mkStubDM(roomId, userId) {
             getMxcAvatarUrl: () => 'mxc://avatar.url/image.png',
         },
     ]);
-    room.getJoinedMemberCount = jest.fn().mockReturnValue(room.getJoinedMembers().length);
-    room.getInvitedAndJoinedMemberCount = jest.fn().mockReturnValue(room.getJoinedMembers().length);
     room.currentState.getMembers = room.getJoinedMembers;
 
     return room;


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#7557

It seems `summaryInvitedMemberCount` is unreliable and affects the invited + joined member count which this relies on, so I'm reverting this for now to fix https://github.com/vector-im/element-web/issues/20753.

Reintroduce this once https://github.com/matrix-org/matrix-js-sdk/issues/2133 is fixed.

Will re-open https://github.com/vector-im/element-web/issues/1202

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Start a conference in a room with 2 people + invitee rather than a 1:1 call" ([\#7641](https://github.com/matrix-org/matrix-react-sdk/pull/7641)). Fixes vector-im/element-web#20753.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61f1469fe43c3eba86158f5c--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
