### PR TITLE
Fix soft-crash when hanging up Jitsi via PIP

### DIFF
--- a/src/components/views/voip/CallView/CallViewHeader.tsx
+++ b/src/components/views/voip/CallView/CallViewHeader.tsx
@@ -75,8 +75,7 @@ const CallViewHeader: React.FC<CallViewHeaderProps> = ({
     onPipMouseDown,
 }) => {
     const [callRoom, onHoldCallRoom] = callRooms;
-    const callRoomName = callRoom.name;
-    const { roomId } = callRoom;
+    const { roomId, name: callRoomName } = callRoom;
 
     if (!pipMode) {
         return <div className="mx_CallViewHeader">


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20766

`showWidgetInPip` going to false was lagging behind a render cycle whilst `persistentWidgetId` already went to null and caused a split-brain

<!-- Replace -->
Preview: https://61f167ad191c14e12bcc3401--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
