### PR TITLE
Chat export parameter customisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "stylelint": "^13.9.0",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-scss": "^3.18.0",
+    "ts-jest": "^27.1.3",
     "typescript": "4.5.3",
     "walk": "^2.3.14"
   },

--- a/res/css/views/dialogs/_ExportDialog.scss
+++ b/res/css/views/dialogs/_ExportDialog.scss
@@ -89,3 +89,7 @@ limitations under the License.
         padding: 9px 10px;
     }
 }
+
+.mx_ExportDialog_attachments-checkbox {
+    margin-top: $spacing-16;
+}

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -39,40 +39,15 @@ import { useStateCallback } from "../../../hooks/useStateCallback";
 import Exporter from "../../../utils/exportUtils/Exporter";
 import Spinner from "../elements/Spinner";
 import InfoDialog from "./InfoDialog";
-import SettingsStore from "../../../settings/SettingsStore";
+import ChatExport from "../../../customisations/ChatExport";
 
 interface IProps extends IDialogProps {
     room: Room;
 }
-const isExportFormat = (config?: string): config is ExportFormat =>
-    config && Object.values(ExportFormat).includes(config as ExportFormat);
-
-const isExportType = (config?: string): config is ExportType =>
-    config && Object.values(ExportType).includes(config as ExportType);
 
 const validateNumberInRange = (min: number, max: number) => (value?: string | number) => {
     const parsedSize = parseInt(value as string, 10);
     return !(isNaN(parsedSize) || min > parsedSize || parsedSize > max);
-};
-
-// Sanitize setting values, exclude invalid or missing values
-export type ForceRoomExportParameters = {
-    format?: ExportFormat; range?: ExportType; numberOfMessages?: number; includeAttachments?: boolean; sizeMb?: number;
-};
-export const getSafeForceRoomExportParameters = (): ForceRoomExportParameters => {
-    const config = SettingsStore.getValue<ForceRoomExportParameters>("forceRoomExportParameters");
-    if (!config || typeof config !== "object") return {};
-
-    const { format, range, numberOfMessages, includeAttachments, sizeMb } = config;
-
-    return {
-        ...(isExportFormat(format) && { format }),
-        ...(isExportType(range) && { range }),
-        ...(validateNumberInRange(1, 10 ** 8)(numberOfMessages) && { numberOfMessages }),
-        // ~100GB limit
-        ...(validateNumberInRange(1, 100000)(sizeMb) && { sizeMb }),
-        ...(typeof includeAttachments === 'boolean' && { includeAttachments }),
-    };
 };
 
 interface ExportConfig {
@@ -94,7 +69,7 @@ interface ExportConfig {
  * Only return change handlers for editable values
  */
 const useExportFormState = (): ExportConfig => {
-    const config = getSafeForceRoomExportParameters();
+    const config = ChatExport.getForceChatExportParameters();
 
     const [exportFormat, setExportFormat] = useState(config.format || ExportFormat.Html);
     const [exportType, setExportType] = useState(config.range || ExportType.Timeline);

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -57,10 +57,11 @@ const validateNumberInRange = (min: number, max: number) => (value?: string | nu
 };
 
 // Sanitize setting values, exclude invalid or missing values
-export const getSafeForceRoomExportSettings = (): {
+export type ForceRoomExportSettings = {
     format?: ExportFormat; range?: ExportType; numberOfMessages?: number; includeAttachments?: boolean; sizeMb?: number;
-} => {
-    const config = SettingsStore.getValue(UIFeature.ForceRoomExportSettings);
+};
+export const getSafeForceRoomExportSettings = (): ForceRoomExportSettings => {
+    const config = SettingsStore.getValue<ForceRoomExportSettings>(UIFeature.ForceRoomExportSettings);
     if (!config || typeof config !== "object") return {};
 
     const { format, range, numberOfMessages, includeAttachments, sizeMb } = config;
@@ -87,6 +88,7 @@ interface ExportConfig {
     setNumberOfMessages?: Dispatch<SetStateAction<number>>;
     setSizeLimit?: Dispatch<SetStateAction<number>>;
 }
+
 /**
  * Set up form state using UIFeature.ForceRoomExportSettings or defaults
  * Form fields configured in ForceRoomExportSettings are not allowed to be edited

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -67,12 +67,12 @@ interface ExportConfig {
 const useExportFormState = (): ExportConfig => {
     const config = ChatExport.getForceChatExportParameters();
 
-    const [exportFormat, setExportFormat] = useState(config.format || ExportFormat.Html);
-    const [exportType, setExportType] = useState(config.range || ExportType.Timeline);
+    const [exportFormat, setExportFormat] = useState(config.format ?? ExportFormat.Html);
+    const [exportType, setExportType] = useState(config.range ?? ExportType.Timeline);
     const [includeAttachments, setAttachments] =
-        useState(config.includeAttachments !== undefined && config.includeAttachments);
-    const [numberOfMessages, setNumberOfMessages] = useState<number>(config.numberOfMessages || 100);
-    const [sizeLimit, setSizeLimit] = useState<number | null>(config.sizeMb || 8);
+        useState(config.includeAttachments ?? false);
+    const [numberOfMessages, setNumberOfMessages] = useState<number>(config.numberOfMessages ?? 100);
+    const [sizeLimit, setSizeLimit] = useState<number | null>(config.sizeMb ?? 8);
 
     return {
         exportFormat,

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -57,11 +57,11 @@ const validateNumberInRange = (min: number, max: number) => (value?: string | nu
 };
 
 // Sanitize setting values, exclude invalid or missing values
-export type ForceRoomExportSettings = {
+export type ForceRoomExportParameters = {
     format?: ExportFormat; range?: ExportType; numberOfMessages?: number; includeAttachments?: boolean; sizeMb?: number;
 };
-export const getSafeForceRoomExportSettings = (): ForceRoomExportSettings => {
-    const config = SettingsStore.getValue<ForceRoomExportSettings>(UIFeature.ForceRoomExportSettings);
+export const getSafeForceRoomExportParameters = (): ForceRoomExportParameters => {
+    const config = SettingsStore.getValue<ForceRoomExportParameters>(UIFeature.ForceRoomExportParameters);
     if (!config || typeof config !== "object") return {};
 
     const { format, range, numberOfMessages, includeAttachments, sizeMb } = config;
@@ -90,12 +90,12 @@ interface ExportConfig {
 }
 
 /**
- * Set up form state using UIFeature.ForceRoomExportSettings or defaults
- * Form fields configured in ForceRoomExportSettings are not allowed to be edited
+ * Set up form state using UIFeature.ForceRoomExportParameters or defaults
+ * Form fields configured in ForceRoomExportParameters are not allowed to be edited
  * Only return change handlers for editable values
  */
 const useExportFormState = (): ExportConfig => {
-    const config = getSafeForceRoomExportSettings();
+    const config = getSafeForceRoomExportParameters();
 
     const [exportFormat, setExportFormat] = useState(config.format || ExportFormat.Html);
     const [exportType, setExportType] = useState(config.range || ExportType.Timeline);

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -40,7 +40,6 @@ import Exporter from "../../../utils/exportUtils/Exporter";
 import Spinner from "../elements/Spinner";
 import InfoDialog from "./InfoDialog";
 import SettingsStore from "../../../settings/SettingsStore";
-import { UIFeature } from "../../../settings/UIFeature";
 
 interface IProps extends IDialogProps {
     room: Room;
@@ -61,7 +60,7 @@ export type ForceRoomExportParameters = {
     format?: ExportFormat; range?: ExportType; numberOfMessages?: number; includeAttachments?: boolean; sizeMb?: number;
 };
 export const getSafeForceRoomExportParameters = (): ForceRoomExportParameters => {
-    const config = SettingsStore.getValue<ForceRoomExportParameters>(UIFeature.ForceRoomExportParameters);
+    const config = SettingsStore.getValue<ForceRoomExportParameters>("forceRoomExportParameters");
     if (!config || typeof config !== "object") return {};
 
     const { format, range, numberOfMessages, includeAttachments, sizeMb } = config;
@@ -90,7 +89,7 @@ interface ExportConfig {
 }
 
 /**
- * Set up form state using UIFeature.ForceRoomExportParameters or defaults
+ * Set up form state using "forceRoomExportParameters" or defaults
  * Form fields configured in ForceRoomExportParameters are not allowed to be edited
  * Only return change handlers for editable values
  */

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -40,15 +40,11 @@ import Exporter from "../../../utils/exportUtils/Exporter";
 import Spinner from "../elements/Spinner";
 import InfoDialog from "./InfoDialog";
 import ChatExport from "../../../customisations/ChatExport";
+import { validateNumberInRange } from "../../../utils/validate";
 
 interface IProps extends IDialogProps {
     room: Room;
 }
-
-const validateNumberInRange = (min: number, max: number) => (value?: string | number) => {
-    const parsedSize = parseInt(value as string, 10);
-    return !(isNaN(parsedSize) || min > parsedSize || parsedSize > max);
-};
 
 interface ExportConfig {
     exportFormat: ExportFormat;
@@ -203,7 +199,10 @@ const ExportDialog: React.FC<IProps> = ({ room, onFinished }) => {
                 },
             }, {
                 key: "number",
-                test: ({ value }) => validateNumberInRange(1, 2000)(value),
+                test: ({ value }) => {
+                    const parsedSize = parseInt(value as string, 10);
+                    return validateNumberInRange(1, 2000)(parsedSize);
+                },
                 invalid: () => {
                     const min = 1;
                     const max = 2000;
@@ -238,7 +237,10 @@ const ExportDialog: React.FC<IProps> = ({ room, onFinished }) => {
                 },
             }, {
                 key: "number",
-                test: ({ value }) => validateNumberInRange(1, 10 ** 8)(value),
+                test: ({ value }) => {
+                    const parsedSize = parseInt(value as string, 10);
+                    return validateNumberInRange(1, 10 ** 8)(parsedSize);
+                },
                 invalid: () => {
                     const min = 1;
                     const max = 10 ** 8;

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -70,8 +70,8 @@ export const getSafeForceRoomExportParameters = (): ForceRoomExportParameters =>
         ...(isExportFormat(format) && { format }),
         ...(isExportType(range) && { range }),
         ...(validateNumberInRange(1, 10 ** 8)(numberOfMessages) && { numberOfMessages }),
-        // 100GB limit
-        ...(validateNumberInRange(1, 1024000)(sizeMb) && { sizeMb }),
+        // ~100GB limit
+        ...(validateNumberInRange(1, 100000)(sizeMb) && { sizeMb }),
         ...(typeof includeAttachments === 'boolean' && { includeAttachments }),
     };
 };

--- a/src/customisations/ChatExport.ts
+++ b/src/customisations/ChatExport.ts
@@ -25,7 +25,7 @@ export type ForceChatExportParameters = {
     numberOfMessages?: number;
     includeAttachments?: boolean;
     // maximum size of exported archive
-    // must be > 0 and < 100000
+    // must be > 0 and < 8000
     sizeMb?: number;
 };
 

--- a/src/customisations/ChatExport.ts
+++ b/src/customisations/ChatExport.ts
@@ -20,8 +20,11 @@ export type ForceChatExportParameters = {
     format?: ExportFormat;
     range?: ExportType;
     // must be < 10**8
+    // only used when range is 'LastNMessages'
+    // default is 100
     numberOfMessages?: number;
     includeAttachments?: boolean;
+    // maximum size of exported archive
     // must be > 0 and < 100000
     sizeMb?: number;
 };

--- a/src/customisations/ChatExport.ts
+++ b/src/customisations/ChatExport.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ExportFormat, ExportType } from "../utils/exportUtils/exportUtils";
+
+export type ForceChatExportParameters = {
+    format?: ExportFormat;
+    range?: ExportType;
+    // must be < 10**8
+    numberOfMessages?: number;
+    includeAttachments?: boolean;
+    // must be > 0 and < 100000
+    sizeMb?: number;
+};
+
+/**
+ * Force parameters in room chat export
+ * fields returned here are forced
+ * and not allowed to be edited in the chat export form
+ */
+const getForceChatExportParameters = (): ForceChatExportParameters => {
+    return {};
+};
+
+// This interface summarises all available customisation points and also marks
+// them all as optional. This allows customisers to only define and export the
+// customisations they need while still maintaining type safety.
+export interface IChatExportCustomisations {
+    getForceChatExportParameters?: typeof getForceChatExportParameters;
+}
+
+// A real customisation module will define and export one or more of the
+// customisation points that make up `IChatExportCustomisations`.
+export default {
+    getForceChatExportParameters,
+} as IChatExportCustomisations;

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -956,7 +956,7 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
     },
-    [UIFeature.ForceRoomExportSettings]: {
+    [UIFeature.ForceRoomExportParameters]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: {},
     },

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -883,6 +883,10 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: false,
         controller: new ReloadOnChangeController(),
     },
+    "forceRoomExportParameters": {
+        supportedLevels: LEVELS_UI_FEATURE,
+        default: {},
+    },
     [UIFeature.RoomHistorySettings]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
@@ -955,9 +959,5 @@ export const SETTINGS: {[setting: string]: ISetting} = {
     [UIFeature.TimelineEnableRelativeDates]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
-    },
-    [UIFeature.ForceRoomExportParameters]: {
-        supportedLevels: LEVELS_UI_FEATURE,
-        default: {},
     },
 };

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -956,4 +956,8 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
     },
+    [UIFeature.ForceRoomExportSettings]: {
+        supportedLevels: LEVELS_UI_FEATURE,
+        default: {},
+    },
 };

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -883,10 +883,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: false,
         controller: new ReloadOnChangeController(),
     },
-    "forceRoomExportParameters": {
-        supportedLevels: LEVELS_UI_FEATURE,
-        default: {},
-    },
     [UIFeature.RoomHistorySettings]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -33,7 +33,6 @@ export enum UIFeature {
     AdvancedSettings = "UIFeature.advancedSettings",
     RoomHistorySettings = "UIFeature.roomHistorySettings",
     TimelineEnableRelativeDates = "UIFeature.timelineEnableRelativeDates",
-    ForceRoomExportParameters = "UIFeature.ForceRoomExportParameters"
 }
 
 export enum UIComponent {

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -33,7 +33,7 @@ export enum UIFeature {
     AdvancedSettings = "UIFeature.advancedSettings",
     RoomHistorySettings = "UIFeature.roomHistorySettings",
     TimelineEnableRelativeDates = "UIFeature.timelineEnableRelativeDates",
-    ForceRoomExportSettings = "UIFeature.forceRoomExportSettings"
+    ForceRoomExportParameters = "UIFeature.ForceRoomExportParameters"
 }
 
 export enum UIComponent {

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -32,7 +32,8 @@ export enum UIFeature {
     Communities = "UIFeature.communities",
     AdvancedSettings = "UIFeature.advancedSettings",
     RoomHistorySettings = "UIFeature.roomHistorySettings",
-    TimelineEnableRelativeDates = "UIFeature.timelineEnableRelativeDates"
+    TimelineEnableRelativeDates = "UIFeature.timelineEnableRelativeDates",
+    ForceRoomExportSettings = "UIFeature.forceRoomExportSettings"
 }
 
 export enum UIComponent {

--- a/src/utils/exportUtils/Exporter.ts
+++ b/src/utils/exportUtils/Exporter.ts
@@ -48,7 +48,7 @@ export default abstract class Exporter {
         protected setProgressText: React.Dispatch<React.SetStateAction<string>>,
     ) {
         if (exportOptions.maxSize < 1 * 1024 * 1024|| // Less than 1 MB
-            exportOptions.maxSize > 1024000 * 1024 * 1024 || // More than 1000 GB
+            exportOptions.maxSize > 100000 * 1024 * 1024 || // More than 100 GB
             exportOptions.numberOfMessages > 10**8
         ) {
             throw new Error("Invalid export options");

--- a/src/utils/exportUtils/Exporter.ts
+++ b/src/utils/exportUtils/Exporter.ts
@@ -48,7 +48,7 @@ export default abstract class Exporter {
         protected setProgressText: React.Dispatch<React.SetStateAction<string>>,
     ) {
         if (exportOptions.maxSize < 1 * 1024 * 1024|| // Less than 1 MB
-            exportOptions.maxSize > 2000 * 1024 * 1024|| // More than ~ 2 GB
+            exportOptions.maxSize > 1024000 * 1024 * 1024 || // More than 1000 GB
             exportOptions.numberOfMessages > 10**8
         ) {
             throw new Error("Invalid export options");

--- a/src/utils/exportUtils/Exporter.ts
+++ b/src/utils/exportUtils/Exporter.ts
@@ -48,7 +48,7 @@ export default abstract class Exporter {
         protected setProgressText: React.Dispatch<React.SetStateAction<string>>,
     ) {
         if (exportOptions.maxSize < 1 * 1024 * 1024|| // Less than 1 MB
-            exportOptions.maxSize > 100000 * 1024 * 1024 || // More than 100 GB
+            exportOptions.maxSize > 8000 * 1024 * 1024 || // More than 8 GB
             exportOptions.numberOfMessages > 10**8
         ) {
             throw new Error("Invalid export options");

--- a/src/utils/validate/index.ts
+++ b/src/utils/validate/index.ts
@@ -1,0 +1,1 @@
+export * from "./numberInRange";

--- a/src/utils/validate/numberInRange.ts
+++ b/src/utils/validate/numberInRange.ts
@@ -1,0 +1,9 @@
+
+/**
+ * Validates that a value is
+ * - a number
+ * - in a provided range (inclusive)
+ */
+export const validateNumberInRange = (min: number, max: number) => (value?: number) => {
+    return typeof value === 'number' && !(isNaN(value) || min > value || value > max);
+};

--- a/test/components/views/dialogs/ExportDialog-test.tsx
+++ b/test/components/views/dialogs/ExportDialog-test.tsx
@@ -363,7 +363,7 @@ describe('<ExportDialog />', () => {
             ['numberOfMessages is valid', { numberOfMessages: 2000 }, { numberOfMessages: 2000 }],
             ['sizeMb is not a number', { sizeMb: 'test' }, {}],
             ['sizeMb is less than 1', { sizeMb: -1 }, {}],
-            ['sizeMb is more than 1024000', { sizeMb: Number.MAX_SAFE_INTEGER }, {}],
+            ['sizeMb is more than 100000', { sizeMb: Number.MAX_SAFE_INTEGER }, {}],
             ['sizeMb is valid', { sizeMb: 50000 }, { sizeMb: 50000 }],
             ['includeAttachments is not a boolean', { includeAttachments: 'yes' }, {}],
             ['includeAttachments is true', { includeAttachments: true }, { includeAttachments: true }],

--- a/test/components/views/dialogs/ExportDialog-test.tsx
+++ b/test/components/views/dialogs/ExportDialog-test.tsx
@@ -141,7 +141,7 @@ describe('<ExportDialog />', () => {
         ChatExportMock.getForceChatExportParameters.mockReturnValue({
             format: ExportFormat.PlainText,
             range: ExportType.Beginning,
-            sizeMb: 15000,
+            sizeMb: 7000,
             numberOfMessages: 30,
             includeAttachments: true,
         });
@@ -155,7 +155,7 @@ describe('<ExportDialog />', () => {
             ExportType.Beginning,
             {
                 attachmentsIncluded: true,
-                maxSize: 15000 * 1024 * 1024,
+                maxSize: 7000 * 1024 * 1024,
                 numberOfMessages: 30,
             },
         ]);

--- a/test/components/views/dialogs/ExportDialog-test.tsx
+++ b/test/components/views/dialogs/ExportDialog-test.tsx
@@ -22,7 +22,7 @@ import { act } from "react-dom/test-utils";
 import { Room } from 'matrix-js-sdk';
 
 import ExportDialog,
-{ getSafeForceRoomExportSettings, ForceRoomExportSettings }
+{ getSafeForceRoomExportParameters, ForceRoomExportParameters }
     from '../../../../src/components/views/dialogs/ExportDialog';
 import { ExportType, ExportFormat } from '../../../../src/utils/exportUtils/exportUtils';
 import { createTestClient, mkStubRoom } from '../../../test-utils';
@@ -140,7 +140,7 @@ describe('<ExportDialog />', () => {
         expect(htmlExporterInstance.export).toHaveBeenCalled();
     });
 
-    it('exports room using values set from ForceRoomExportSettings', async () => {
+    it('exports room using values set from ForceRoomExportParameters', async () => {
         SettingsStoreMock.getValue.mockReturnValue({
             format: ExportFormat.PlainText,
             range: ExportType.Beginning,
@@ -188,12 +188,12 @@ describe('<ExportDialog />', () => {
             expect(getExportFormatInput(component, ExportFormat.Html).props().checked).toBeFalsy();
         });
 
-        it('hides export format input when format is valid in ForceRoomExportSettings', () => {
+        it('hides export format input when format is valid in ForceRoomExportParameters', () => {
             const component = getComponent();
             expect(getExportFormatInput(component, ExportFormat.Html).props().checked).toBeTruthy();
         });
 
-        it('does not render export format when set in ForceRoomExportSettings', () => {
+        it('does not render export format when set in ForceRoomExportParameters', () => {
             SettingsStoreMock.getValue.mockReturnValue({
                 format: ExportFormat.PlainText,
             });
@@ -214,7 +214,7 @@ describe('<ExportDialog />', () => {
             expect(getExportTypeInput(component).props().value).toEqual(ExportType.Beginning);
         });
 
-        it('does not render export type when set in ForceRoomExportSettings', () => {
+        it('does not render export type when set in ForceRoomExportParameters', () => {
             SettingsStoreMock.getValue.mockReturnValue({
                 range: ExportType.Beginning,
             });
@@ -305,7 +305,7 @@ describe('<ExportDialog />', () => {
             expect(htmlExporterInstance.export).toHaveBeenCalled();
         });
 
-        it('does not render size limit input when set in ForceRoomExportSettings', () => {
+        it('does not render size limit input when set in ForceRoomExportParameters', () => {
             SettingsStoreMock.getValue.mockReturnValue({
                 sizeMb: 10000,
             });
@@ -316,7 +316,7 @@ describe('<ExportDialog />', () => {
         /**
          * 2000mb size limit does not apply when higher limit is configured in config
          */
-        it('exports when size limit set in ForceRoomExportSettings is larger than 2000', async () => {
+        it('exports when size limit set in ForceRoomExportParameters is larger than 2000', async () => {
             SettingsStoreMock.getValue.mockReturnValue({
                 sizeMb: 10000,
             });
@@ -339,7 +339,7 @@ describe('<ExportDialog />', () => {
             expect(getAttachmentsCheckbox(component).props().checked).toEqual(true);
         });
 
-        it('does not render input when set in ForceRoomExportSettings', () => {
+        it('does not render input when set in ForceRoomExportParameters', () => {
             SettingsStoreMock.getValue.mockReturnValue({
                 includeAttachments: false,
             });
@@ -348,8 +348,8 @@ describe('<ExportDialog />', () => {
         });
     });
 
-    describe('getSafeForceRoomExportSettings()', () => {
-        const testCases: [string, ForceRoomExportSettings, ForceRoomExportSettings][] = [
+    describe('getSafeForceRoomExportParameters()', () => {
+        const testCases: [string, ForceRoomExportParameters, ForceRoomExportParameters][] = [
             ['setting is falsy', undefined, {}],
             ['setting is configured to string', 'test' as unknown, {}],
             ['setting is empty', {}, {}],
@@ -373,7 +373,7 @@ describe('<ExportDialog />', () => {
         it.each(testCases)('sanitizes correctly when %s', (_d, setting, expected) => {
             SettingsStoreMock.getValue.mockReturnValue(setting);
 
-            expect(getSafeForceRoomExportSettings()).toEqual(expected);
+            expect(getSafeForceRoomExportParameters()).toEqual(expected);
         });
     });
 });

--- a/test/components/views/dialogs/__snapshots__/ExportDialog-test.tsx.snap
+++ b/test/components/views/dialogs/__snapshots__/ExportDialog-test.tsx.snap
@@ -105,14 +105,14 @@ Array [
               <p>
                 Select from the options below to export chats from your timeline
               </p>
-              <span
-                class="mx_ExportDialog_subheading"
-              >
-                Format
-              </span>
               <div
                 class="mx_ExportDialog_options"
               >
+                <span
+                  class="mx_ExportDialog_subheading"
+                >
+                  Format
+                </span>
                 <label
                   class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
                 >
@@ -235,7 +235,7 @@ Array [
                   </span>
                 </div>
                 <span
-                  class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                  class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
                 >
                   <input
                     id="include-attachments"
@@ -326,14 +326,14 @@ Array [
                 <p>
                   Select from the options below to export chats from your timeline
                 </p>
-                <span
-                  class="mx_ExportDialog_subheading"
-                >
-                  Format
-                </span>
                 <div
                   class="mx_ExportDialog_options"
                 >
+                  <span
+                    class="mx_ExportDialog_subheading"
+                  >
+                    Format
+                  </span>
                   <label
                     class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
                   >
@@ -456,7 +456,7 @@ Array [
                     </span>
                   </div>
                   <span
-                    class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                    class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
                   >
                     <input
                       id="include-attachments"
@@ -563,14 +563,14 @@ Array [
           <p>
             Select from the options below to export chats from your timeline
           </p>
-          <span
-            className="mx_ExportDialog_subheading"
-          >
-            Format
-          </span>
           <div
             className="mx_ExportDialog_options"
           >
+            <span
+              className="mx_ExportDialog_subheading"
+            >
+              Format
+            </span>
             <StyledRadioGroup
               definitions={
                 Array [
@@ -790,12 +790,12 @@ Array [
             </Field>
             <StyledCheckbox
               checked={false}
-              className=""
+              className="mx_ExportDialog_attachments-checkbox"
               id="include-attachments"
               onChange={[Function]}
             >
               <span
-                className="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                className="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
               >
                 <input
                   checked={false}
@@ -962,14 +962,14 @@ Array [
             <p>
               Select from the options below to export chats from your timeline
             </p>
-            <span
-              class="mx_ExportDialog_subheading"
-            >
-              Format
-            </span>
             <div
               class="mx_ExportDialog_options"
             >
+              <span
+                class="mx_ExportDialog_subheading"
+              >
+                Format
+              </span>
               <label
                 class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
               >
@@ -1092,7 +1092,7 @@ Array [
                 </span>
               </div>
               <span
-                class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
               >
                 <input
                   id="include-attachments"
@@ -1183,14 +1183,14 @@ Array [
               <p>
                 Select from the options below to export chats from your timeline
               </p>
-              <span
-                class="mx_ExportDialog_subheading"
-              >
-                Format
-              </span>
               <div
                 class="mx_ExportDialog_options"
               >
+                <span
+                  class="mx_ExportDialog_subheading"
+                >
+                  Format
+                </span>
                 <label
                   class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
                 >
@@ -1313,7 +1313,7 @@ Array [
                   </span>
                 </div>
                 <span
-                  class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                  class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
                 >
                   <input
                     id="include-attachments"
@@ -1420,14 +1420,14 @@ Array [
         <p>
           Select from the options below to export chats from your timeline
         </p>
-        <span
-          className="mx_ExportDialog_subheading"
-        >
-          Format
-        </span>
         <div
           className="mx_ExportDialog_options"
         >
+          <span
+            className="mx_ExportDialog_subheading"
+          >
+            Format
+          </span>
           <StyledRadioGroup
             definitions={
               Array [
@@ -1647,12 +1647,12 @@ Array [
           </Field>
           <StyledCheckbox
             checked={false}
-            className=""
+            className="mx_ExportDialog_attachments-checkbox"
             id="include-attachments"
             onChange={[Function]}
           >
             <span
-              className="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+              className="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
             >
               <input
                 checked={false}
@@ -1806,14 +1806,14 @@ Array [
           <p>
             Select from the options below to export chats from your timeline
           </p>
-          <span
-            class="mx_ExportDialog_subheading"
-          >
-            Format
-          </span>
           <div
             class="mx_ExportDialog_options"
           >
+            <span
+              class="mx_ExportDialog_subheading"
+            >
+              Format
+            </span>
             <label
               class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
             >
@@ -1936,7 +1936,7 @@ Array [
               </span>
             </div>
             <span
-              class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+              class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
             >
               <input
                 id="include-attachments"
@@ -2027,14 +2027,14 @@ Array [
             <p>
               Select from the options below to export chats from your timeline
             </p>
-            <span
-              class="mx_ExportDialog_subheading"
-            >
-              Format
-            </span>
             <div
               class="mx_ExportDialog_options"
             >
+              <span
+                class="mx_ExportDialog_subheading"
+              >
+                Format
+              </span>
               <label
                 class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
               >
@@ -2157,7 +2157,7 @@ Array [
                 </span>
               </div>
               <span
-                class="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+                class="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
               >
                 <input
                   id="include-attachments"
@@ -2264,14 +2264,14 @@ Array [
       <p>
         Select from the options below to export chats from your timeline
       </p>
-      <span
-        className="mx_ExportDialog_subheading"
-      >
-        Format
-      </span>
       <div
         className="mx_ExportDialog_options"
       >
+        <span
+          className="mx_ExportDialog_subheading"
+        >
+          Format
+        </span>
         <StyledRadioGroup
           definitions={
             Array [
@@ -2491,12 +2491,12 @@ Array [
         </Field>
         <StyledCheckbox
           checked={false}
-          className=""
+          className="mx_ExportDialog_attachments-checkbox"
           id="include-attachments"
           onChange={[Function]}
         >
           <span
-            className="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+            className="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
           >
             <input
               checked={false}
@@ -2613,14 +2613,14 @@ Array [
     <p>
       Select from the options below to export chats from your timeline
     </p>
-    <span
-      className="mx_ExportDialog_subheading"
-    >
-      Format
-    </span>
     <div
       className="mx_ExportDialog_options"
     >
+      <span
+        className="mx_ExportDialog_subheading"
+      >
+        Format
+      </span>
       <StyledRadioGroup
         definitions={
           Array [
@@ -2840,12 +2840,12 @@ Array [
       </Field>
       <StyledCheckbox
         checked={false}
-        className=""
+        className="mx_ExportDialog_attachments-checkbox"
         id="include-attachments"
         onChange={[Function]}
       >
         <span
-          className="mx_Checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+          className="mx_Checkbox mx_ExportDialog_attachments-checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
         >
           <input
             checked={false}

--- a/test/utils/export-test.tsx
+++ b/test/utils/export-test.tsx
@@ -194,7 +194,7 @@ describe('export', function() {
         ).toBeTruthy();
     });
 
-    const testCases: [string, IExportOptions][] = [
+    const invalidExportOptions: [string, IExportOptions][] = [
         ['numberOfMessages exceeds max', {
             numberOfMessages: 10 ** 9,
             maxSize: 1024 * 1024 * 1024,
@@ -211,7 +211,7 @@ describe('export', function() {
             attachmentsIncluded: false,
         }],
     ];
-    it.each(testCases)('%s', (_d, options) => {
+    it.each(invalidExportOptions)('%s', (_d, options) => {
         expect(
             () =>
                 new PlainTextExporter(mockRoom, ExportType.Beginning, options, null),

--- a/test/utils/export-test.tsx
+++ b/test/utils/export-test.tsx
@@ -50,24 +50,6 @@ describe('export', function() {
         attachmentsIncluded: false,
     };
 
-    const invalidExportOptions: IExportOptions[] = [
-        {
-            numberOfMessages: 10**9,
-            maxSize: 1024 * 1024 * 1024,
-            attachmentsIncluded: false,
-        },
-        {
-            numberOfMessages: -1,
-            maxSize: 4096 * 1024 * 1024,
-            attachmentsIncluded: false,
-        },
-        {
-            numberOfMessages: 0,
-            maxSize: 0,
-            attachmentsIncluded: false,
-        },
-    ];
-
     function createRoom() {
         const room = new Room(generateRoomId(), null, client.getUserId());
         return room;
@@ -212,13 +194,28 @@ describe('export', function() {
         ).toBeTruthy();
     });
 
-    it('checks if the export options are valid', function() {
-        for (const exportOption of invalidExportOptions) {
-            expect(
-                () =>
-                    new PlainTextExporter(mockRoom, ExportType.Beginning, exportOption, null),
-            ).toThrowError("Invalid export options");
-        }
+    const testCases: [string, IExportOptions][] = [
+        ['numberOfMessages exceeds max', {
+            numberOfMessages: 10 ** 9,
+            maxSize: 1024 * 1024 * 1024,
+            attachmentsIncluded: false,
+        }],
+        ['maxSize exceeds 1000GB', {
+            numberOfMessages: -1,
+            maxSize: 1024001 * 1024 * 1024,
+            attachmentsIncluded: false,
+        }],
+        ['maxSize is less than 1mb', {
+            numberOfMessages: 0,
+            maxSize: 0,
+            attachmentsIncluded: false,
+        }],
+    ];
+    it.each(testCases)('%s', (_d, options) => {
+        expect(
+            () =>
+                new PlainTextExporter(mockRoom, ExportType.Beginning, options, null),
+        ).toThrowError("Invalid export options");
     });
 
     it('tests the file extension splitter', function() {

--- a/test/utils/export-test.tsx
+++ b/test/utils/export-test.tsx
@@ -200,9 +200,9 @@ describe('export', function() {
             maxSize: 1024 * 1024 * 1024,
             attachmentsIncluded: false,
         }],
-        ['maxSize exceeds 1000GB', {
+        ['maxSize exceeds 100GB', {
             numberOfMessages: -1,
-            maxSize: 1024001 * 1024 * 1024,
+            maxSize: 100001 * 1024 * 1024,
             attachmentsIncluded: false,
         }],
         ['maxSize is less than 1mb', {

--- a/test/utils/export-test.tsx
+++ b/test/utils/export-test.tsx
@@ -200,9 +200,9 @@ describe('export', function() {
             maxSize: 1024 * 1024 * 1024,
             attachmentsIncluded: false,
         }],
-        ['maxSize exceeds 100GB', {
+        ['maxSize exceeds 8GB', {
             numberOfMessages: -1,
-            maxSize: 100001 * 1024 * 1024,
+            maxSize: 8001 * 1024 * 1024,
             attachmentsIncluded: false,
         }],
         ['maxSize is less than 1mb', {

--- a/test/utils/validate/numberInRange-test.ts
+++ b/test/utils/validate/numberInRange-test.ts
@@ -1,0 +1,26 @@
+import { validateNumberInRange } from '../../../src/utils/validate';
+
+describe('validateNumberInRange', () => {
+    const min = 1; const max = 10;
+    it('returns false when value is a not a number', () => {
+        expect(validateNumberInRange(min, max)('test' as unknown as number)).toEqual(false);
+    });
+    it('returns false when value is undefined', () => {
+        expect(validateNumberInRange(min, max)(undefined)).toEqual(false);
+    });
+    it('returns false when value is NaN', () => {
+        expect(validateNumberInRange(min, max)(NaN)).toEqual(false);
+    });
+    it('returns true when value is equal to min', () => {
+        expect(validateNumberInRange(min, max)(min)).toEqual(true);
+    });
+    it('returns true when value is equal to max', () => {
+        expect(validateNumberInRange(min, max)(max)).toEqual(true);
+    });
+    it('returns true when value is an int in range', () => {
+        expect(validateNumberInRange(min, max)(2)).toEqual(true);
+    });
+    it('returns true when value is a float in range', () => {
+        expect(validateNumberInRange(min, max)(2.2)).toEqual(true);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,6 +1334,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@mapbox/geojson-rewind@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz#adbe16dc683eb40e90934c51a5e28c7bbf44f4e1"
@@ -1980,6 +1991,13 @@
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2634,6 +2652,13 @@ browserslist@^4.12.0, browserslist@^4.17.5, browserslist@^4.19.1:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
@@ -2831,6 +2856,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
@@ -4079,7 +4109,7 @@ fast-glob@^3.2.5, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -5697,6 +5727,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
+  integrity sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.4"
+    picomatch "^2.2.3"
+
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -5843,19 +5885,19 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json5@2.x, json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -6028,6 +6070,11 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -6098,6 +6145,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -7787,17 +7839,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -8484,6 +8536,20 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-jest@^27.1.3:
+  version "27.1.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"
+  integrity sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 tsconfig-paths@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
@@ -9057,6 +9123,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yargs-parser@20.x, yargs-parser@^20.2.3:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
@@ -9072,11 +9143,6 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.3:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^21.0.0:
   version "21.0.0"


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Expose a customisation point to override and force chat export parameters.
https://element-io.atlassian.net/browse/PSE-334
https://element-io.atlassian.net/browse/PSE-335

documentation in eleweb: https://github.com/vector-im/element-web/pull/20777

Without config: (no change)

<img width="737" alt="Screenshot 2022-01-27 at 10 03 45" src="https://user-images.githubusercontent.com/3055605/151326701-46b44259-00eb-4ae1-ab34-47ba84c765d9.png">

With customisation:
<img width="750" alt="Screenshot 2022-01-27 at 10 03 07" src="https://user-images.githubusercontent.com/3055605/151326734-951ed48e-48ca-4e72-b97a-30be305e7ee0.png">
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Chat export parameter customisation ([\#7647](https://github.com/matrix-org/matrix-react-sdk/pull/7647)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->













<!-- Replace -->
Preview: https://61f3f81a714799df8bca3115--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
