### PR TITLE
Fix left panel widgets causing app-wide crash

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -243,7 +243,11 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
         this.watchUserReady();
 
-        WidgetLayoutStore.instance.on(WidgetLayoutStore.emissionForRoom(this.props.room), this.onWidgetLayoutChange);
+        if (this.props.room) {
+            const emitEvent = WidgetLayoutStore.emissionForRoom(this.props.room);
+            WidgetLayoutStore.instance.on(emitEvent, this.onWidgetLayoutChange);
+        }
+
         this.roomStoreToken = RoomViewStore.addListener(this.onRoomViewStoreUpdate);
         this.allowedWidgetsWatchRef = SettingsStore.watchSetting("allowedWidgets", null, this.onAllowedWidgetsChange);
         // Widget action listeners
@@ -254,7 +258,11 @@ export default class AppTile extends React.Component<IProps, IState> {
         // Widget action listeners
         if (this.dispatcherRef) dis.unregister(this.dispatcherRef);
 
-        WidgetLayoutStore.instance.off(WidgetLayoutStore.emissionForRoom(this.props.room), this.onWidgetLayoutChange);
+        if (this.props.room) {
+            const emitEvent = WidgetLayoutStore.emissionForRoom(this.props.room);
+            WidgetLayoutStore.instance.off(emitEvent, this.onWidgetLayoutChange);
+        }
+
         this.roomStoreToken?.remove();
         SettingsStore.unwatchSetting(this.allowedWidgetsWatchRef);
         OwnProfileStore.instance.removeListener(UPDATE_EVENT, this.onUserReady);


### PR DESCRIPTION
Left panel widgets don't have an associated room.

Notes: none

(changelog disabled because it'll be included in a different release)

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61f30a1b560341449de7cc9e--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
