### PR TITLE
Fix shift-enter repeating last character

### DIFF
--- a/src/KeyBindingsDefaults.ts
+++ b/src/KeyBindingsDefaults.ts
@@ -140,6 +140,13 @@ const messageComposerBindings = (): KeyBinding<MessageComposerAction>[] => {
                 key: Key.ENTER,
             },
         });
+        bindings.push({
+            action: MessageComposerAction.NewLine,
+            keyCombo: {
+                key: Key.ENTER,
+                shiftKey: true,
+            },
+        });
     } else {
         bindings.push({
             action: MessageComposerAction.Send,


### PR DESCRIPTION
Type: defect
Fixes https://github.com/vector-im/element-web/issues/17215
Closes https://github.com/matrix-org/matrix-react-sdk/pull/6038

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix shift-enter repeating last character ([\#7665](https://github.com/matrix-org/matrix-react-sdk/pull/7665)). Fixes vector-im/element-web#17215. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->