### PR TITLE
Put call on hold when transfer dialog is opened

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -39,6 +39,7 @@ import { WidgetType } from "./widgets/WidgetType";
 import { SettingLevel } from "./settings/SettingLevel";
 import QuestionDialog from "./components/views/dialogs/QuestionDialog";
 import ErrorDialog from "./components/views/dialogs/ErrorDialog";
+import InviteDialog, { KIND_CALL_TRANSFER } from "./components/views/dialogs/InviteDialog";
 import WidgetStore from "./stores/WidgetStore";
 import { WidgetMessagingStore } from "./stores/widgets/WidgetMessagingStore";
 import { ElementWidgetActions } from "./stores/widgets/ElementWidgetActions";
@@ -1097,6 +1098,23 @@ export default class CallHandler extends EventEmitter {
             if (!messaging) return; // more "should never happen" words
 
             messaging.transport.send(ElementWidgetActions.HangupCall, {});
+        });
+    }
+
+    /*
+     * Shows the transfer dialog for a call, signalling to the other end that
+     * a transfer is about to happen
+     */
+    public showTransferDialog(call: MatrixCall): void {
+        call.setRemoteOnHold(true);
+        const { finished } = Modal.createTrackedDialog(
+            'Transfer Call', '', InviteDialog, { kind: KIND_CALL_TRANSFER, call },
+            /*className=*/"mx_InviteDialog_transferWrapper", /*isPriority=*/false, /*isStatic=*/true,
+        );
+        finished.then((results: boolean[]) => {
+            if (results.length === 0 || results[0] === false) {
+                call.setRemoteOnHold(false);
+            }
         });
     }
 

--- a/src/components/views/context_menus/CallContextMenu.tsx
+++ b/src/components/views/context_menus/CallContextMenu.tsx
@@ -21,8 +21,6 @@ import { MatrixCall } from 'matrix-js-sdk/src/webrtc/call';
 import { _t } from '../../../languageHandler';
 import ContextMenu, { IProps as IContextMenuProps, MenuItem } from '../../structures/ContextMenu';
 import CallHandler from '../../../CallHandler';
-import InviteDialog, { KIND_CALL_TRANSFER } from '../dialogs/InviteDialog';
-import Modal from '../../../Modal';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 
 interface IProps extends IContextMenuProps {
@@ -52,10 +50,7 @@ export default class CallContextMenu extends React.Component<IProps> {
     };
 
     onTransferClick = () => {
-        Modal.createTrackedDialog(
-            'Transfer Call', '', InviteDialog, { kind: KIND_CALL_TRANSFER, call: this.props.call },
-            /*className=*/"mx_InviteDialog_transferWrapper", /*isPriority=*/false, /*isStatic=*/true,
-        );
+        CallHandler.instance.showTransferDialog(this.props.call);
         this.props.onFinished();
     };
 

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -352,8 +352,10 @@ class DMRoomTile extends React.PureComponent<IDMRoomTileProps> {
 }
 
 interface IInviteDialogProps {
-    // Takes an array of user IDs/emails to invite.
-    onFinished: (toInvite?: string[]) => void;
+    // Takes a boolean which is true if a user / users were invited /
+    // a call transfer was initiated or false if the dialog was cancelled
+    // with no action taken.
+    onFinished: (success: boolean) => void;
 
     // The kind of invite being performed. Assumed to be KIND_DM if
     // not provided.
@@ -685,7 +687,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                 should_peek: false,
                 joining: false,
             });
-            this.props.onFinished();
+            this.props.onFinished(true);
             return;
         }
 
@@ -732,7 +734,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
             }
 
             await createRoom(createRoomOptions);
-            this.props.onFinished();
+            this.props.onFinished(true);
         } catch (err) {
             logger.error(err);
             this.setState({
@@ -764,7 +766,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
             const result = await inviteMultipleToRoom(this.props.roomId, targetIds, true);
             CountlyAnalytics.instance.trackSendInvite(startTime, this.props.roomId, targetIds.length);
             if (!this.shouldAbortAfterInviteError(result, room)) { // handles setting error message too
-                this.props.onFinished();
+                this.props.onFinished(true);
             }
         } catch (err) {
             logger.error(err);
@@ -801,7 +803,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                 this.state.consultFirst,
             );
         }
-        this.props.onFinished();
+        this.props.onFinished(true);
     };
 
     private onKeyDown = (e) => {
@@ -824,7 +826,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
     };
 
     private onCancel = () => {
-        this.props.onFinished([]);
+        this.props.onFinished(false);
     };
 
     private updateSuggestions = async (term) => {
@@ -1086,11 +1088,11 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
     private onManageSettingsClick = (e) => {
         e.preventDefault();
         dis.fire(Action.ViewUserSettings);
-        this.props.onFinished();
+        this.props.onFinished(false);
     };
 
     private onCommunityInviteClick = (e) => {
-        this.props.onFinished();
+        this.props.onFinished(false);
         showCommunityInviteDialog(CommunityPrototypeStore.instance.getSelectedCommunityId());
     };
 


### PR DESCRIPTION
And take it off hold if the dialog is cancelled.

Also changes the onFinished signature of invitedialog which claimed
to return an array of strings but never did, so now it just returns
a boolean.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Put call on hold when transfer dialog is opened ([\#7669](https://github.com/matrix-org/matrix-react-sdk/pull/7669)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61f416e8b9b09ff2e2330ccd--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
