### PR TITLE
Fix font size of spaces between big emoji

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -386,9 +386,13 @@ $left-gutter: 64px;
     position: absolute;
 }
 
-.mx_EventTile_bigEmoji .mx_Emoji {
-    font-size: 48px !important;
+.mx_EventTile_bigEmoji {
+    font-size: 48px;
     line-height: 57px;
+
+    .mx_Emoji {
+        font-size: inherit !important;
+    }
 }
 
 .mx_EventTile_content .mx_EventTile_edited {


### PR DESCRIPTION
Fixes a regression from https://github.com/matrix-org/matrix-react-sdk/pull/7602 where the font size applied to big emoji no longer applied to spaces between them.

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix font size of spaces between big emoji ([\#7675](https://github.com/matrix-org/matrix-react-sdk/pull/7675)). Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->