### PR TITLE
Fix vertical spacing in `compact` `<ContextMenu>`

### DIFF
--- a/res/css/views/context_menus/_IconizedContextMenu.scss
+++ b/res/css/views/context_menus/_IconizedContextMenu.scss
@@ -50,21 +50,21 @@ limitations under the License.
         }
 
         // round the top corners of the top button for the hover effect to be bounded
-        &:first-child .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind):first-child {
+        &:first-child .mx_IconizedContextMenu_item:first-child {
             border-radius: 8px 8px 0 0; // radius matches .mx_ContextualMenu
         }
 
         // round the bottom corners of the bottom button for the hover effect to be bounded
-        &:last-child .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind):last-child {
+        &:last-child .mx_IconizedContextMenu_item:last-child {
             border-radius: 0 0 8px 8px; // radius matches .mx_ContextualMenu
         }
 
         // round all corners of the only button for the hover effect to be bounded
-        &:first-child:last-child .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind):first-child:last-child {
+        &:first-child:last-child .mx_IconizedContextMenu_item:first-child:last-child {
             border-radius: 8px; // radius matches .mx_ContextualMenu
         }
 
-        .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind) {
+        .mx_IconizedContextMenu_item {
             // pad the inside of the button so that the hover background is padded too
             padding-top: 12px;
             padding-bottom: 12px;
@@ -130,7 +130,7 @@ limitations under the License.
     }
 
     .mx_IconizedContextMenu_optionList_red {
-        .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind) {
+        .mx_IconizedContextMenu_item {
             color: $alert !important;
         }
 
@@ -148,7 +148,7 @@ limitations under the License.
     }
 
     .mx_IconizedContextMenu_active {
-        &.mx_AccessibleButton:not(.mx_AccessibleButton_hasKind), .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind) {
+        &.mx_IconizedContextMenu_item, .mx_IconizedContextMenu_item {
             color: $accent !important;
         }
 

--- a/res/css/views/messages/_JumpToDatePicker.scss
+++ b/res/css/views/messages/_JumpToDatePicker.scss
@@ -16,6 +16,8 @@ limitations under the License.
 
 .mx_JumpToDatePicker_form {
     display: flex;
+    padding-top: 12px;
+    padding-bottom: 12px;
 }
 
 .mx_JumpToDatePicker_label {

--- a/res/css/views/messages/_JumpToDatePicker.scss
+++ b/res/css/views/messages/_JumpToDatePicker.scss
@@ -16,6 +16,8 @@ limitations under the License.
 
 .mx_JumpToDatePicker_form {
     display: flex;
+    // This matches the default padding of IconizedContextMenuOption
+    // (see context_menus/_IconizedContextMenu.scss)
     padding-top: 12px;
     padding-bottom: 12px;
 }

--- a/src/components/views/context_menus/IconizedContextMenu.tsx
+++ b/src/components/views/context_menus/IconizedContextMenu.tsx
@@ -59,6 +59,7 @@ export const IconizedContextMenuRadio: React.FC<IRadioProps> = ({
     return <MenuItemRadio
         {...props}
         className={classNames(className, {
+            "mx_IconizedContextMenu_item": true,
             mx_IconizedContextMenu_active: active,
         })}
         active={active}
@@ -93,6 +94,7 @@ export const IconizedContextMenuCheckbox: React.FC<ICheckboxProps> = ({
     return <MenuItemCheckbox
         {...props}
         className={classNames(className, {
+            "mx_IconizedContextMenu_item": true,
             mx_IconizedContextMenu_active: active,
         })}
         active={active}
@@ -105,7 +107,7 @@ export const IconizedContextMenuCheckbox: React.FC<ICheckboxProps> = ({
 };
 
 export const IconizedContextMenuOption: React.FC<IOptionProps> = ({ label, iconClassName, children, ...props }) => {
-    return <MenuItem {...props} label={label}>
+    return <MenuItem {...props} className="mx_IconizedContextMenu_item" label={label}>
         { iconClassName && <span className={classNames("mx_IconizedContextMenu_icon", iconClassName)} /> }
         <span className="mx_IconizedContextMenu_label">{ label }</span>
         { children }

--- a/src/components/views/context_menus/IconizedContextMenu.tsx
+++ b/src/components/views/context_menus/IconizedContextMenu.tsx
@@ -59,7 +59,7 @@ export const IconizedContextMenuRadio: React.FC<IRadioProps> = ({
     return <MenuItemRadio
         {...props}
         className={classNames(className, {
-            "mx_IconizedContextMenu_item": true,
+            mx_IconizedContextMenu_item: true,
             mx_IconizedContextMenu_active: active,
         })}
         active={active}
@@ -94,7 +94,7 @@ export const IconizedContextMenuCheckbox: React.FC<ICheckboxProps> = ({
     return <MenuItemCheckbox
         {...props}
         className={classNames(className, {
-            "mx_IconizedContextMenu_item": true,
+            mx_IconizedContextMenu_item: true,
             mx_IconizedContextMenu_active: active,
         })}
         active={active}
@@ -106,11 +106,17 @@ export const IconizedContextMenuCheckbox: React.FC<ICheckboxProps> = ({
     </MenuItemCheckbox>;
 };
 
-export const IconizedContextMenuOption: React.FC<IOptionProps> = ({ label, className, iconClassName, children, ...props }) => {
+export const IconizedContextMenuOption: React.FC<IOptionProps> = ({
+    label,
+    className,
+    iconClassName,
+    children,
+    ...props
+}) => {
     return <MenuItem
         {...props}
         className={classNames(className, {
-            "mx_IconizedContextMenu_item": true,
+            mx_IconizedContextMenu_item: true,
         })}
         label={label}
     >

--- a/src/components/views/context_menus/IconizedContextMenu.tsx
+++ b/src/components/views/context_menus/IconizedContextMenu.tsx
@@ -106,8 +106,14 @@ export const IconizedContextMenuCheckbox: React.FC<ICheckboxProps> = ({
     </MenuItemCheckbox>;
 };
 
-export const IconizedContextMenuOption: React.FC<IOptionProps> = ({ label, iconClassName, children, ...props }) => {
-    return <MenuItem {...props} className="mx_IconizedContextMenu_item" label={label}>
+export const IconizedContextMenuOption: React.FC<IOptionProps> = ({ label, className, iconClassName, children, ...props }) => {
+    return <MenuItem
+        {...props}
+        className={classNames(className, {
+            "mx_IconizedContextMenu_item": true,
+        })}
+        label={label}
+    >
         { iconClassName && <span className={classNames("mx_IconizedContextMenu_icon", iconClassName)} /> }
         <span className="mx_IconizedContextMenu_label">{ label }</span>
         { children }

--- a/src/components/views/messages/DateSeparator.tsx
+++ b/src/components/views/messages/DateSeparator.tsx
@@ -193,7 +193,6 @@ export default class DateSeparator extends React.Component<IProps, IState> {
         if (this.state.contextMenuPosition) {
             contextMenu = <IconizedContextMenu
                 {...contextMenuBelow(this.state.contextMenuPosition)}
-                compact
                 onFinished={this.onContextMenuCloseClick}
             >
                 <IconizedContextMenuOptionList first>


### PR DESCRIPTION
Fix vertical spacing in `compact` `<ContextMenu>`

Fix https://github.com/vector-im/element-web/issues/20801

Regressed in https://github.com/matrix-org/matrix-react-sdk/pull/7339

Relevant styles were first added in https://github.com/matrix-org/matrix-react-sdk/pull/4858
(context behind why the original styles were added)


On `develop` (broken) | On `app.element.io` (expected) | This PR (fixed)
--- | --- | ---
<img width="318" alt="" src="https://user-images.githubusercontent.com/558581/151896583-0e97c619-8fbb-4449-8f68-03eb93ca6a5f.png"> | <img width="325" alt="" src="https://user-images.githubusercontent.com/558581/151896717-4b605d07-b0ce-41fe-be7a-8379233641fa.png"> | <img width="344" alt="" src="https://user-images.githubusercontent.com/558581/151896429-5a40ec62-d4eb-49d1-ad7e-bad504fce2d9.png">
<img width="347" alt="" src="https://user-images.githubusercontent.com/558581/151896587-0e87deb2-5b44-4027-8444-c350bd4e2399.png"> | <img width="333" alt="" src="https://user-images.githubusercontent.com/558581/151896719-47ad2bc9-5435-4caf-bae2-5a99db880988.png"> | <img width="365" alt="" src="https://user-images.githubusercontent.com/558581/151896431-75d63e4b-1809-4d83-80d8-d809edb0ecac.png">


And general screenshots of before/after this PR. You won't notice any changes with the `<ContextMenu>` using the default styles but the `compact` ones will be compact again!

Before | After
--- | ---
<img width="417" alt="" src="https://user-images.githubusercontent.com/558581/151897420-90129790-4002-4957-8eba-aab7d163bb1a.png"> | <img width="414" alt="" src="https://user-images.githubusercontent.com/558581/151897083-ed927838-3cff-4816-b81f-db4fe07b7aaf.png">
<img width="218" alt="" src="https://user-images.githubusercontent.com/558581/151897421-cbd2ba54-e71b-4399-89e5-4a786c408b12.png"> | <img width="226" alt="" src="https://user-images.githubusercontent.com/558581/151897085-66f3ad3d-64aa-43b2-848d-303c12dd94a3.png">
<img width="331" alt="" src="https://user-images.githubusercontent.com/558581/151897422-1e289d69-b934-4d90-8827-46da63498b44.png"> | <img width="333" alt="" src="https://user-images.githubusercontent.com/558581/151897090-b492ec18-39e1-4504-8791-c0edb1586edc.png">
<img width="230" alt="" src="https://user-images.githubusercontent.com/558581/151897423-0b71c4c3-8eeb-48ac-88e2-40d6e4184040.png"> | <img width="227" alt="" src="https://user-images.githubusercontent.com/558581/151897089-16f35846-09d4-4719-bcab-9eb6060c22b8.png">
<img width="433" alt="" src="https://user-images.githubusercontent.com/558581/151897424-0c551eed-a839-4582-bdb9-f22ae9b0ede5.png"> | <img width="434" alt="" src="https://user-images.githubusercontent.com/558581/151898207-7a31d77e-21c8-4458-abf2-76f79e041fd4.png">
<img width="316" alt="" src="https://user-images.githubusercontent.com/558581/151897427-e5df2712-4e91-47ec-a477-b556fa7224b9.png"> | <img width="323" alt="" src="https://user-images.githubusercontent.com/558581/151898204-4b50d5fa-8407-470f-92cf-35e3ef4c1f57.png">


## Cause

Battling CSS specificity between the default and compact styles, https://specificity.keegan.st/

Known good (On `app.element.io` (expected)):
```css
// 0 3 0
.mx_IconizedContextMenu .mx_IconizedContextMenu_optionList .mx_AccessibleButton {
    padding-top: 12px;
    padding-bottom: 12px;
}

// Compact styles override our default rules because they come
// after the other styles (source order) and have the same specificity
// 0 3 0
.mx_IconizedContextMenu.mx_IconizedContextMenu_compact .mx_IconizedContextMenu_optionList > * {
    padding: 8px 16px 8px 11px;
}
```

Bad (On `develop` (broken)):
```css
// Default rules always override because they have higher specificity.
// The `:not()` selector doesn't add any extra specificity but the selectors inside the `:not(...)` do.
// 0 4 0
.mx_IconizedContextMenu .mx_IconizedContextMenu_optionList .mx_AccessibleButton:not(.mx_AccessibleButton_hasKind) {
    padding-top: 12px;
    padding-bottom: 12px;
}

// 0 3 0
.mx_IconizedContextMenu.mx_IconizedContextMenu_compact .mx_IconizedContextMenu_optionList > * {
    padding: 8px 16px 8px 11px;
}
```





<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix vertical spacing in `compact` `<ContextMenu>` ([\#7684](https://github.com/matrix-org/matrix-react-sdk/pull/7684)). Fixes vector-im/element-web#20801. Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://61f88c7a026b0e4ba9a68188--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
