### PR TITLE
Fix warning image overflow in space hierarchy

### DIFF
--- a/res/css/structures/_SpaceHierarchy.scss
+++ b/res/css/structures/_SpaceHierarchy.scss
@@ -84,6 +84,8 @@ limitations under the License.
             width: 16px;
             left: 0;
             background-image: url("$(res)/img/element-icons/warning-badge.svg");
+            background-size: cover;
+            background-repeat: no-repeat;
         }
     }
 


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/32841439/151913634-b6095447-0cc9-49b9-83d3-a5f5f62b83e3.png)

after
![image](https://user-images.githubusercontent.com/32841439/151913665-679313f4-22b7-4807-b177-6801521e14c3.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->