### PR TITLE
Fix incorrect sizing of DecoratedRoomAvatar in RoomHeader

### DIFF
--- a/res/css/views/avatars/_DecoratedRoomAvatar.scss
+++ b/res/css/views/avatars/_DecoratedRoomAvatar.scss
@@ -27,18 +27,19 @@ limitations under the License.
 
     .mx_DecoratedRoomAvatar_icon {
         position: absolute;
-        bottom: -2px;
-        right: -2px;
-        margin: 4px;
-        width: 8px;
-        height: 8px;
+        // the following percentage based sizings are to match the scalable svg mask for the cutout
+        bottom: -6.25%;
+        right: -6.25%;
+        margin: 12.5%;
+        width: 25%;
+        height: 25%;
         border-radius: 50%;
     }
 
     .mx_DecoratedRoomAvatar_icon::before {
         content: '';
-        width: 8px;
-        height: 8px;
+        width: 100%;
+        height: 100%;
         right: 0;
         position: absolute;
         border-radius: 8px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20090

Before
![image](https://user-images.githubusercontent.com/2403652/152009491-f1872852-fedf-4f3b-9070-d81872d436ae.png)

After
![image](https://user-images.githubusercontent.com/2403652/152010714-ebfd0ac1-08f8-4828-b8a4-88ce63e95fcb.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect sizing of DecoratedRoomAvatar in RoomHeader ([\#7697](https://github.com/matrix-org/matrix-react-sdk/pull/7697)). Fixes vector-im/element-web#20090.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://61f963253dbfcb275eaaed27--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
