### PR TITLE
Only update tooltip position when it is visible

### DIFF
--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -87,7 +87,9 @@ export default class Tooltip extends React.Component<ITooltipProps> {
     }
 
     public componentDidUpdate() {
-        this.renderTooltip();
+        if (this.props.visible) {
+            this.renderTooltip();
+        }
     }
 
     // Remove the wrapper element, as the tooltip has finished using it


### PR DESCRIPTION
Attempt to address https://github.com/vector-im/element-web/issues/20884

We should not need to update the tooltip position if it isn't visible

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
