### PR TITLE
Bypass rageshake when warning about devtools

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -527,7 +527,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             "and contribute!",
         );
 
-        console.log(
+        global.mx_rage_logger.bypassRageshake(
+            "log",
             `%c${waitText}\n%c${scamText}\n%c${devText}`,
             `font-size:${largeFontSize}; color:blue;`,
             `font-size:${normalFontSize}; color:red;`,

--- a/src/rageshake/rageshake.ts
+++ b/src/rageshake/rageshake.ts
@@ -45,10 +45,13 @@ const FLUSH_RATE_MS = 30 * 1000;
 // the length of log data we keep in indexeddb (and include in the reports)
 const MAX_LOG_SIZE = 1024 * 1024 * 5; // 5 MB
 
+type LogFunction = (...args: (Error | DOMException | object | string)[]) => void;
+type LogFunctionName = "log" | "info" | "warn" | "error";
+
 // A class which monkey-patches the global console and stores log lines.
 export class ConsoleLogger {
     private logs = "";
-    private originalFunctions = {};
+    private originalFunctions: {[key in LogFunctionName]?: LogFunction} = {};
 
     public monkeyPatch(consoleObj: Console): void {
         // Monkey-patch console logging
@@ -70,7 +73,7 @@ export class ConsoleLogger {
     }
 
     public bypassRageshake(
-        fnName: "log" | "info" | "warn" | "error",
+        fnName: LogFunctionName,
         ...args: (Error | DOMException | object | string)[]
     ): void {
         this.originalFunctions[fnName](...args);

--- a/src/rageshake/rageshake.ts
+++ b/src/rageshake/rageshake.ts
@@ -71,10 +71,9 @@ export class ConsoleLogger {
 
     public bypassRageshake(
         fnName: "log" | "info" | "warn" | "error",
-        level: string,
         ...args: (Error | DOMException | object | string)[]
     ): void {
-        this.originalFunctions[fnName](level, ...args);
+        this.originalFunctions[fnName](...args);
     }
 
     private log(level: string, ...args: (Error | DOMException | object | string)[]): void {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20885
Type: defect
Notes: none

<hr>

There quite possibly might be a better way to do this? Let me know if a different approach would be better

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->