### PR TITLE
Standardise on top margin for settings tabs

### DIFF
--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -13,7 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+.mx_SettingsTab{
+    margin-top: 10px;
+ }
+ 
 .mx_AppearanceUserSettingsTab .mx_Field {
     width: 256px;
 }

--- a/res/css/views/settings/tabs/user/_GeneralUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_GeneralUserSettingsTab.scss
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+
+.mx_SettingsTab{
+    margin-top: 10px;
+}
+
+
 .mx_GeneralUserSettingsTab_changePassword .mx_Field {
     @mixin mx_Settings_fullWidthField;
 }

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -14,6 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+.mx_SettingsTab{
+    margin-top: 10px;
+ }
 
 .mx_HelpUserSettingsTab_debugButton {
     margin-bottom: 5px;

--- a/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
@@ -14,6 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+.mx_SettingsTab{
+    margin-top: 10px;
+ }
 
 .mx_KeyboardUserSettingsTab .mx_SettingsTab_section {
     .mx_KeyboardShortcut_shortcutRow {

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+
 .mx_LabsUserSettingsTab {
     .mx_SettingsTab_section {
         margin-top: 32px;

--- a/res/css/views/settings/tabs/user/_NotificationUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_NotificationUserSettingsTab.scss
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+.mx_SettingsTab{
+   margin-top: 10px;
+}
 
 .mx_NotificationUserSettingsTab .mx_SettingsTab_heading {
     margin-bottom: 10px; // Give some spacing between the title and the first elements

--- a/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+.mx_SettingsTab{
+    margin-top: 10px;
+ }
 
 .mx_SecurityUserSettingsTab_bulkOptions .mx_AccessibleButton {
     margin-right: 10px;

--- a/res/css/views/settings/tabs/user/_VoiceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_VoiceUserSettingsTab.scss
@@ -13,7 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+.mx_SettingsTab{
+    margin-top: 10px;
+ }
+ 
 .mx_VoiceUserSettingsTab .mx_Field {
     @mixin mx_Settings_fullWidthField;
 }


### PR DESCRIPTION
Fixes vector-im/element-web#20767

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
Signed-off-by: Sahil saini <sohil170246@gmail.com.example.org>
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: changes top margin in settings tab.

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * changes top margin in settings tab. ([\#7727](https://github.com/matrix-org/matrix-react-sdk/pull/7727)). Fixes vector-im/element-web#20767. Contributed by @sahilsaini110.<!-- CHANGELOG_PREVIEW_END -->