### PR TITLE
Improved way to retrieve event sender for thread summary

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -360,6 +360,7 @@ interface IState {
     thread: Thread;
     threadReplyCount: number;
     threadLastReply: MatrixEvent;
+    threadLastSender: RoomMember | null;
     threadNotification?: NotificationCountType;
 }
 
@@ -408,6 +409,7 @@ export default class EventTile extends React.Component<IProps, IState> {
             thread,
             threadReplyCount: thread?.length,
             threadLastReply: thread?.replyToEvent,
+            threadLastSender: thread?.replyToEvent.sender,
         };
 
         // don't do RR animations until we are mounted
@@ -562,6 +564,7 @@ export default class EventTile extends React.Component<IProps, IState> {
 
         this.setState({
             threadLastReply: thread?.replyToEvent,
+            threadLastSender: thread?.replyToEvent?.sender,
             threadReplyCount: thread?.length,
             thread,
         });
@@ -663,9 +666,13 @@ export default class EventTile extends React.Component<IProps, IState> {
 
         const sender = this.thread.roomState.getSentinelMember(threadLastReply.getSender());
         return <>
-            { sender && (
-                <MemberAvatar member={sender} width={24} height={24} className="mx_ThreadInfo_avatar" />
-            ) }
+            <MemberAvatar
+                member={null}
+                fallbackUserId={threadLastReply.getSender()}
+                width={24}
+                height={24}
+                className="mx_ThreadInfo_avatar"
+            />
             { threadMessagePreview && (
                 <div className="mx_ThreadInfo_content">
                     <span className="mx_ThreadInfo_message-preview">

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -667,7 +667,7 @@ export default class EventTile extends React.Component<IProps, IState> {
         const sender = this.thread.roomState.getSentinelMember(threadLastReply.getSender());
         return <>
             <MemberAvatar
-                member={null}
+                member={sender}
                 fallbackUserId={threadLastReply.getSender()}
                 width={24}
                 height={24}

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -659,23 +659,20 @@ export default class EventTile extends React.Component<IProps, IState> {
 
     private renderThreadLastMessagePreview(): JSX.Element | null {
         const { threadLastReply } = this.state;
-        if (!threadLastReply) {
-            return null;
-        }
-
         const threadMessagePreview = MessagePreviewStore.instance.generatePreviewForEvent(threadLastReply);
 
-        if (!threadMessagePreview || !threadLastReply.sender) {
-            return null;
-        }
-
+        const sender = this.thread.roomState.getSentinelMember(threadLastReply.getSender());
         return <>
-            <MemberAvatar member={threadLastReply.sender} width={24} height={24} className="mx_ThreadInfo_avatar" />
-            <div className="mx_ThreadInfo_content">
-                <span className="mx_ThreadInfo_message-preview">
-                    { threadMessagePreview }
-                </span>
-            </div>
+            { sender && (
+                <MemberAvatar member={sender} width={24} height={24} className="mx_ThreadInfo_avatar" />
+            ) }
+            { threadMessagePreview && (
+                <div className="mx_ThreadInfo_content">
+                    <span className="mx_ThreadInfo_message-preview">
+                        { threadMessagePreview }
+                    </span>
+                </div>
+            ) }
         </>;
     }
 


### PR DESCRIPTION
It appears that `sender` can be `null` and this seems to be a more fool-proof solution to this problem

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://620158b3a28a7a2a67a95e6d--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
