### PR TITLE
Unify widget header actions with those in right panel

### DIFF
--- a/res/css/views/right_panel/_RoomSummaryCard.scss
+++ b/res/css/views/right_panel/_RoomSummaryCard.scss
@@ -133,8 +133,7 @@ limitations under the License.
             }
 
             .mx_RoomSummaryCard_app_pinToggle,
-            .mx_RoomSummaryCard_app_maximise,
-            .mx_RoomSummaryCard_app_minimise,
+            .mx_RoomSummaryCard_app_maximiseToggle,
             .mx_RoomSummaryCard_app_options {
                 position: absolute;
                 top: 0;
@@ -176,7 +175,7 @@ limitations under the License.
                     mask-image: url('$(res)/img/element-icons/room/pin-upright.svg');
                 }
             }
-            .mx_RoomSummaryCard_app_maximise {
+            .mx_RoomSummaryCard_app_maximiseToggle {
                 right: 32px; //24 + 8
 
                 &::before {
@@ -184,24 +183,13 @@ limitations under the License.
                     mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
                 }
             }
-            .mx_RoomSummaryCard_app_minimise {
-                right: 32px; //24 + 8
-                &::before {
-                    mask-size: 14px;
-                    mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
-                    background-color: $accent;
-                }
-            }
 
             .mx_RoomSummaryCard_app_options {
-                right: 32px; //24 + 8
+                right: 56px; //2*24 + 8
                 display: none;
 
                 &::before {
                     mask-image: url('$(res)/img/element-icons/room/ellipsis.svg');
-                }
-                &.mx_RoomSummaryCard_maximised_widget {
-                    right: 56px; //2*24 + 8
                 }
             }
 
@@ -211,6 +199,16 @@ limitations under the License.
                 }
 
                 .mx_RoomSummaryCard_app_pinToggle::before {
+                    background-color: $accent;
+                }
+            }
+
+            &.mx_RoomSummaryCard_Button_maximised {
+                &::after {
+                    opacity: 0.2;
+                }
+
+                .mx_RoomSummaryCard_app_maximiseToggle::before {
                     background-color: $accent;
                 }
             }

--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -231,14 +231,24 @@ $MinWidth: 240px;
     background-color: $topleftmenu-color;
     margin: 0 5px;
 
-    &.mx_AppTileMenuBar_iconButton_minWidget {
-        mask-size: auto 10px;
-        mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
-    }
-
-    &.mx_AppTileMenuBar_iconButton_maxWidget {
+    &.mx_AppTileMenuBar_iconButton_close {
         mask-size: auto 10px;
         mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
+        background-color: $accent;
+    }
+
+    &.mx_AppTileMenuBar_iconButton_maximise {
+        mask-size: auto 10px;
+        mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
+    }
+
+    &.mx_AppTileMenuBar_iconButton_unpin {
+        mask-image: url("$(res)/img/element-icons/room/pin-upright.svg");
+        background-color: $accent;
+    }
+
+    &.mx_AppTileMenuBar_iconButton_pin {
+        mask-image: url("$(res)/img/element-icons/room/pin-upright.svg");
     }
 
     &.mx_AppTileMenuBar_iconButton_popout {

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -83,7 +83,7 @@ interface IProps {
     // sets the pointer-events property on the iframe
     pointerEvents?: string;
     widgetPageTitle?: string;
-    hideMaximiseButton?: boolean;
+    showLayoutButtons?: boolean;
 }
 
 interface IState {
@@ -115,6 +115,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         userWidget: false,
         miniMode: false,
         threadId: null,
+        showLayoutButtons: true,
     };
 
     private contextMenuButton = createRef<any>();
@@ -648,7 +649,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
 
         let maxMinButton;
-        if (!this.props.hideMaximiseButton) {
+        if (this.props.showLayoutButtons) {
             const widgetIsMaximised = WidgetLayoutStore.instance.
                 isInContainer(this.props.room, this.props.app, Container.Center);
             const className = classNames({

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -508,11 +508,19 @@ export default class AppTile extends React.Component<IProps, IState> {
             { target: '_blank', href: this.sgWidget.popoutUrl, rel: 'noreferrer noopener' }).click();
     };
 
-    private onMaxMinWidgetClick = (): void => {
+    private onToggleMaximisedClick = (): void => {
         const targetContainer =
             WidgetLayoutStore.instance.isInContainer(this.props.room, this.props.app, Container.Center)
                 ? Container.Right
                 : Container.Center;
+        WidgetLayoutStore.instance.moveToContainer(this.props.room, this.props.app, targetContainer);
+    };
+
+    private onTogglePinnedClick = (): void => {
+        const targetContainer =
+            WidgetLayoutStore.instance.isInContainer(this.props.room, this.props.app, Container.Top)
+                ? Container.Right
+                : Container.Top;
         WidgetLayoutStore.instance.moveToContainer(this.props.room, this.props.app, targetContainer);
     };
 
@@ -648,22 +656,37 @@ export default class AppTile extends React.Component<IProps, IState> {
             );
         }
 
-        let maxMinButton;
+        const layoutButtons: React.ReactNodeArray = [];
         if (this.props.showLayoutButtons) {
-            const widgetIsMaximised = WidgetLayoutStore.instance.
+            const isMaximised = WidgetLayoutStore.instance.
                 isInContainer(this.props.room, this.props.app, Container.Center);
-            const className = classNames({
+            const maximisedClasses = classNames({
                 "mx_AppTileMenuBar_iconButton": true,
-                "mx_AppTileMenuBar_iconButton_minWidget": widgetIsMaximised,
-                "mx_AppTileMenuBar_iconButton_maxWidget": !widgetIsMaximised,
+                "mx_AppTileMenuBar_iconButton_close": isMaximised,
+                "mx_AppTileMenuBar_iconButton_maximise": !isMaximised,
             });
-            maxMinButton = <AccessibleButton
-                className={className}
+            layoutButtons.push(<AccessibleButton
+                className={maximisedClasses}
                 title={
-                    widgetIsMaximised ? _t('Close') : _t('Maximise widget')
+                    isMaximised ? _t("Close") : _t("Maximise")
                 }
-                onClick={this.onMaxMinWidgetClick}
-            />;
+                onClick={this.onToggleMaximisedClick}
+            />);
+
+            const isPinned = WidgetLayoutStore.instance.
+                isInContainer(this.props.room, this.props.app, Container.Top);
+            const pinnedClasses = classNames({
+                "mx_AppTileMenuBar_iconButton": true,
+                "mx_AppTileMenuBar_iconButton_unpin": isPinned,
+                "mx_AppTileMenuBar_iconButton_pin": !isPinned,
+            });
+            layoutButtons.push(<AccessibleButton
+                className={pinnedClasses}
+                title={
+                    isPinned ? _t("Unpin") : _t("Pin")
+                }
+                onClick={this.onTogglePinnedClick}
+            />);
         }
 
         return <React.Fragment>
@@ -674,7 +697,7 @@ export default class AppTile extends React.Component<IProps, IState> {
                             { this.props.showTitle && this.getTileTitle() }
                         </span>
                         <span className="mx_AppTileMenuBarWidgets">
-                            { maxMinButton }
+                            { layoutButtons }
                             { (this.props.showPopout && !this.state.requiresClient) && <AccessibleButton
                                 className="mx_AppTileMenuBar_iconButton mx_AppTileMenuBar_iconButton_popout"
                                 title={_t('Popout widget')}

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -170,7 +170,7 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
         </AccessibleTooltipButton>
 
         { canModifyWidget && <ContextMenuTooltipButton
-            className="mx_RoomSummaryCard_app_options mx_RoomSummaryCard_maximised_widget"
+            className="mx_RoomSummaryCard_app_options"
             isExpanded={menuDisplayed}
             onClick={openMenu}
             title={_t("Options")}

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -135,16 +135,12 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
         pinTitle = isPinned ? _t("Unpin") : _t("Pin");
     }
 
-    const classes = classNames("mx_BaseCard_Button mx_RoomSummaryCard_Button", {
-        mx_RoomSummaryCard_Button_pinned: isPinned,
-    });
-
     const isMaximised = WidgetLayoutStore.instance.isInContainer(room, app, Container.Center);
     const toggleMaximised = isMaximised
         ? () => { WidgetLayoutStore.instance.moveToContainer(room, app, Container.Right); }
         : () => { WidgetLayoutStore.instance.moveToContainer(room, app, Container.Center); };
 
-    const maximiseTitle = isMaximised ? _t("Close") : _t("Maximise widget");
+    const maximiseTitle = isMaximised ? _t("Close") : _t("Maximise");
 
     let openTitle = "";
     if (isPinned) {
@@ -152,6 +148,11 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
     } else if (isMaximised) {
         openTitle =_t("Close this widget to view it in this panel");
     }
+
+    const classes = classNames("mx_BaseCard_Button mx_RoomSummaryCard_Button", {
+        mx_RoomSummaryCard_Button_pinned: isPinned,
+        mx_RoomSummaryCard_Button_maximised: isMaximised,
+    });
 
     return <div className={classes} ref={handle}>
         <AccessibleTooltipButton
@@ -184,7 +185,7 @@ const AppRow: React.FC<IAppRowProps> = ({ app, room }) => {
             yOffset={-24}
         />
         <AccessibleTooltipButton
-            className={isMaximised ? "mx_RoomSummaryCard_app_minimise" : "mx_RoomSummaryCard_app_maximise"}
+            className="mx_RoomSummaryCard_app_maximiseToggle"
             onClick={toggleMaximised}
             title={maximiseTitle}
             yOffset={-24}

--- a/src/components/views/rooms/Stickerpicker.tsx
+++ b/src/components/views/rooms/Stickerpicker.tsx
@@ -304,7 +304,7 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
                                 showPopout={false}
                                 handleMinimisePointerEvents={true}
                                 userWidget={true}
-                                hideMaximiseButton={true}
+                                showLayoutButtons={false}
                             />
                         </PersistedElement>
                     </div>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1938,7 +1938,7 @@
     "Chat": "Chat",
     "Room Info": "Room Info",
     "You can only pin up to %(count)s widgets|other": "You can only pin up to %(count)s widgets",
-    "Maximise widget": "Maximise widget",
+    "Maximise": "Maximise",
     "Unpin this widget to view it in this panel": "Unpin this widget to view it in this panel",
     "Close this widget to view it in this panel": "Close this widget to view it in this panel",
     "Set my room layout for everyone": "Set my room layout for everyone",


### PR DESCRIPTION
This exposes both maximised and pinned toggle on the widget header, matching what is shown on the right panel. Maximised is changed to use a single icon for both states and instead uses highlighting to indicate it is active, matching the existing behaviour of pinned.

Hopefully helps with https://github.com/vector-im/element-web/issues/20506

https://user-images.githubusercontent.com/279572/152844705-0a48f0cf-7346-4c67-979e-251f5a805bf9.mov

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Unify widget header actions with those in right panel ([\#7734](https://github.com/matrix-org/matrix-react-sdk/pull/7734)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6202565e8880bfbf80f693d3--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
