### PR TITLE
Improve responsiveness of the layout switcher

### DIFF
--- a/res/css/views/settings/_LayoutSwitcher.scss
+++ b/res/css/views/settings/_LayoutSwitcher.scss
@@ -30,6 +30,7 @@ limitations under the License.
             flex-direction: column;
 
             width: 300px;
+            min-width: 0;
 
             border: 1px solid $appearance-tab-border-color;
             border-radius: 10px;
@@ -81,6 +82,7 @@ limitations under the License.
             margin: 0;
             &[data-layout=bubble] {
                 margin-right: 40px;
+                flex-shrink: 1;
             }
             &[data-layout=irc] {
                 > a {


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/2403652/152847393-a525e949-025c-4647-922b-b3bd65345ae7.png)

After
<img width="572" alt="image" src="https://user-images.githubusercontent.com/2403652/152847248-e119bd61-2025-4741-a78b-5714d389bd2d.png">

Any better than this and the layout becomes really quite complicated unfortunately, many many things in Element break down at narrow widths, this is one of the less awful ones tbh

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve responsiveness of the layout switcher ([\#7736](https://github.com/matrix-org/matrix-react-sdk/pull/7736)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://620162dd42ef9731422c99db--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
