### PR TITLE
Add config option to autorageshake when key backup is not enabled

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -243,6 +243,7 @@ export default class DeviceListener {
             ) {
                 // Cross-signing on account but this device doesn't trust the master key (verify this session)
                 showSetupEncryptionToast(SetupKind.VERIFY_THIS_SESSION);
+                this.checkKeyBackupStatus();
             } else {
                 const backupInfo = await this.getKeyBackupInfo();
                 if (backupInfo) {
@@ -325,8 +326,9 @@ export default class DeviceListener {
         // returns null when key backup status hasn't finished being checked
         const isKeyBackupEnabled = MatrixClientPeg.get().getKeyBackupEnabled();
         this.keyBackupStatusChecked = isKeyBackupEnabled !== null;
+
         if (isKeyBackupEnabled === false) {
             dis.dispatch({ action: Action.ReportKeyBackupNotEnabled });
         }
-    }
+    };
 }

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -36,6 +36,7 @@ import { isSecretStorageBeingAccessed, accessSecretStorage } from "./SecurityMan
 import { isSecureBackupRequired } from './utils/WellKnownUtils';
 import { isLoggedIn } from './components/structures/MatrixChat';
 import { ActionPayload } from "./dispatcher/payloads";
+import { Action } from "./dispatcher/actions";
 
 const KEY_BACKUP_POLL_INTERVAL = 5 * 60 * 1000;
 
@@ -48,6 +49,7 @@ export default class DeviceListener {
     // cache of the key backup info
     private keyBackupInfo: object = null;
     private keyBackupFetchedAt: number = null;
+    private keyBackupStatusChecked = false;
     // We keep a list of our own device IDs so we can batch ones that were already
     // there the last time the app launched into a single toast, but display new
     // ones in their own toasts.
@@ -92,6 +94,7 @@ export default class DeviceListener {
         this.dismissedThisDeviceToast = false;
         this.keyBackupInfo = null;
         this.keyBackupFetchedAt = null;
+        this.keyBackupStatusChecked = false;
         this.ourDeviceIdsAtStart = null;
         this.displayingToastsForDeviceIds = new Set();
     }
@@ -227,6 +230,8 @@ export default class DeviceListener {
 
         if (this.dismissedThisDeviceToast || allSystemsReady) {
             hideSetupEncryptionToast();
+
+            this.checkKeyBackupStatus();
         } else if (this.shouldShowSetupEncryptionToast()) {
             // make sure our keys are finished downloading
             await cli.downloadKeys([cli.getUserId()]);
@@ -311,5 +316,17 @@ export default class DeviceListener {
         }
 
         this.displayingToastsForDeviceIds = newUnverifiedDeviceIds;
+    }
+
+    private checkKeyBackupStatus = async () => {
+        if (this.keyBackupStatusChecked) {
+            return;
+        }
+        // returns null when key backup status hasn't finished being checked
+        const isKeyBackupEnabled = MatrixClientPeg.get().getKeyBackupEnabled();
+        this.keyBackupStatusChecked = isKeyBackupEnabled !== null;
+        if (isKeyBackupEnabled === false) {
+            dis.dispatch({ action: Action.ReportKeyBackupNotEnabled });
+        }
     }
 }

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -218,4 +218,9 @@ export enum Action {
      * Payload: none
      */
     AnonymousAnalyticsReject = "anonymous_analytics_reject",
+
+    /**
+     * Fires when
+     */
+    ReportKeyBackupNotEnabled = "report_key_backup_not_enabled",
 }

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -220,7 +220,8 @@ export enum Action {
     AnonymousAnalyticsReject = "anonymous_analytics_reject",
 
     /**
-     * Fires when
+     * Fires after crypto is setup if key backup is not enabled
+     * Used to trigger auto rageshakes when configured
      */
     ReportKeyBackupNotEnabled = "report_key_backup_not_enabled",
 }

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -870,6 +870,12 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: false,
         controller: new ReloadOnChangeController(),
     },
+    "automaticKeyBackNotEnabledReporting": {
+        displayName: _td("Automatically send debug logs when key backup is not functioning"),
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
+        default: false,
+        controller: new ReloadOnChangeController(),
+    },
     [UIFeature.RoomHistorySettings]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,

--- a/src/stores/AutoRageshakeStore.ts
+++ b/src/stores/AutoRageshakeStore.ts
@@ -24,6 +24,7 @@ import defaultDispatcher from '../dispatcher/dispatcher';
 import { AsyncStoreWithClient } from './AsyncStoreWithClient';
 import { ActionPayload } from '../dispatcher/payloads';
 import SettingsStore from "../settings/SettingsStore";
+import { Action } from "../dispatcher/actions";
 
 // Minimum interval of 1 minute between reports
 const RAGESHAKE_INTERVAL = 60000;
@@ -63,6 +64,12 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
 
     protected async onAction(payload: ActionPayload) {
         // we don't actually do anything here
+        console.log('HHH', 'payload.action', payload.action);
+
+        switch (payload.action) {
+            case Action.ReportKeyBackupNotEnabled:
+                this.onReportKeyBackupNotEnabled()
+        }
     }
 
     protected async onReady() {
@@ -151,6 +158,20 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
                 },
             });
         }
+    }
+
+    private async onReportKeyBackupNotEnabled(): Promise<void> {
+        if (!SettingsStore.getValue("automaticReportKeyBackupNotEnabled")) return;
+        await sendBugReport(SdkConfig.get().bug_report_endpoint_url, {
+            userText: `Auto-reporting key backup not enabled`,
+            sendLogs: false,
+            labels: ["Z-UISI", "web", "uisi-sender"],
+            customApp: SdkConfig.get().uisi_autorageshake_app,
+            customFields: {
+                "recipient_rageshake": recipientRageshake,
+                "auto_uisi": JSON.stringify(messageContent),
+            },
+        });
     }
 }
 

--- a/src/stores/AutoRageshakeStore.ts
+++ b/src/stores/AutoRageshakeStore.ts
@@ -158,8 +158,6 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
     }
 
     private async onReportKeyBackupNotEnabled(): Promise<void> {
-        console.log('HHH', 'onReportKeyBackupNotEnabled', SdkConfig.get().bug_report_endpoint_url);
-
         if (!SettingsStore.getValue("automaticKeyBackNotEnabledReporting")) return;
 
         await sendBugReport(SdkConfig.get().bug_report_endpoint_url, {

--- a/src/stores/AutoRageshakeStore.ts
+++ b/src/stores/AutoRageshakeStore.ts
@@ -63,12 +63,9 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
     }
 
     protected async onAction(payload: ActionPayload) {
-        // we don't actually do anything here
-        console.log('HHH', 'payload.action', payload.action);
-
         switch (payload.action) {
             case Action.ReportKeyBackupNotEnabled:
-                this.onReportKeyBackupNotEnabled()
+                this.onReportKeyBackupNotEnabled();
         }
     }
 
@@ -161,16 +158,14 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
     }
 
     private async onReportKeyBackupNotEnabled(): Promise<void> {
-        if (!SettingsStore.getValue("automaticReportKeyBackupNotEnabled")) return;
+        console.log('HHH', 'onReportKeyBackupNotEnabled', SdkConfig.get().bug_report_endpoint_url);
+
+        if (!SettingsStore.getValue("automaticKeyBackNotEnabledReporting")) return;
+
         await sendBugReport(SdkConfig.get().bug_report_endpoint_url, {
             userText: `Auto-reporting key backup not enabled`,
             sendLogs: false,
-            labels: ["Z-UISI", "web", "uisi-sender"],
-            customApp: SdkConfig.get().uisi_autorageshake_app,
-            customFields: {
-                "recipient_rageshake": recipientRageshake,
-                "auto_uisi": JSON.stringify(messageContent),
-            },
+            labels: ["web", Action.ReportKeyBackupNotEnabled],
         });
     }
 }


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

https://element-io.atlassian.net/browse/PSE-327

Example report: https://github.com/matrix-org/element-web-rageshakes/issues/10530

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
