### PR TITLE
Fix state events being wrongly hidden when redacted

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1642,11 +1642,12 @@ function isMessageEvent(ev: MatrixEvent): boolean {
 }
 
 export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean): boolean {
-    // Only show "Message deleted" tile for message or encrypted events
-    if (e.isRedacted() && !e.isEncrypted() && !isMessageEvent(e)) return false;
+    // Only show "Message deleted" tile for plain message events, encrypted events,
+    // and state events as they'll likely still contain enough keys to be relevant.
+    if (e.isRedacted() && !e.isEncrypted() && !isMessageEvent(e) && !e.isState()) return false;
 
     // No tile for replacement events since they update the original tile
-    if (e.isRelation("m.replace")) return false;
+    if (e.isRelation(RelationType.Replace)) return false;
 
     const handler = getHandlerTile(e);
     if (handler === undefined) return false;

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1636,9 +1636,9 @@ export default class EventTile extends React.Component<IProps, IState> {
 }
 
 // XXX this'll eventually be dynamic based on the fields once we have extensible event types
-const messageTypes = ['m.room.message', 'm.sticker'];
+const messageTypes = [EventType.RoomMessage, EventType.Sticker];
 function isMessageEvent(ev: MatrixEvent): boolean {
-    return (messageTypes.includes(ev.getType()));
+    return (messageTypes.includes(ev.getType() as EventType));
 }
 
 export function haveTileForEvent(e: MatrixEvent, showHiddenEvents?: boolean): boolean {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20959

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix state events being wrongly hidden when redacted ([\#7768](https://github.com/matrix-org/matrix-react-sdk/pull/7768)). Fixes vector-im/element-web#20959.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://6203d503713d9b6417e57f92--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
