### PR TITLE
Fix sort order for facepiles which was exactly reverse

### DIFF
--- a/src/components/views/elements/FacePile.tsx
+++ b/src/components/views/elements/FacePile.tsx
@@ -43,12 +43,12 @@ const FacePile = ({ room, onlyKnownUsers = true, numShown = DEFAULT_NUM_FACES, .
     const count = members.length;
 
     // sort users with an explicit avatar first
-    const iteratees = [member => !!member.getMxcAvatarUrl()];
+    const iteratees = [member => member.getMxcAvatarUrl() ? 0 : 1];
     if (onlyKnownUsers) {
         members = members.filter(isKnownMember);
     } else {
         // sort known users first
-        iteratees.unshift(member => isKnownMember(member));
+        iteratees.unshift(member => isKnownMember(member) ? 0 : 1);
     }
 
     // exclude ourselves from the shown members list


### PR DESCRIPTION
<img width="566" alt="image" src="https://user-images.githubusercontent.com/2403652/153236101-79c70584-bc0c-40bf-9a36-a9867876c74f.png">
