### PR TITLE
Fix desktop notifications for invites showing user IDs instead of displaynames

### DIFF
--- a/src/TextForEvent.tsx
+++ b/src/TextForEvent.tsx
@@ -51,6 +51,13 @@ export function getSenderName(event: MatrixEvent): string {
     return event.sender?.name ?? event.getSender() ?? _t("Someone");
 }
 
+function getRoomMemberDisplayname(event: MatrixEvent, userId = event.getSender()): string {
+    const client = MatrixClientPeg.get();
+    const roomId = event.getRoomId();
+    const member = client.getRoom(roomId)?.getMember(userId);
+    return member?.rawDisplayName || userId || _t("Someone");
+}
+
 // These functions are frequently used just to check whether an event has
 // any text to display at all. For this reason they return deferred values
 // to avoid the expense of looking up translations when they're not needed.
@@ -77,8 +84,8 @@ function textForCallInviteEvent(event: MatrixEvent): () => string | null {
 
 function textForMemberEvent(ev: MatrixEvent, allowJSX: boolean, showHiddenEvents?: boolean): () => string | null {
     // XXX: SYJS-16 "sender is sometimes null for join messages"
-    const senderName = getSenderName(ev);
-    const targetName = ev.target ? ev.target.name : ev.getStateKey();
+    const senderName = ev.sender?.name || getRoomMemberDisplayname(ev);
+    const targetName = ev.target?.name || getRoomMemberDisplayname(ev, ev.getStateKey());
     const prevContent = ev.getPrevContent();
     const content = ev.getContent();
     const reason = content.reason;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21022
Probably not the cleanest way... but it works

Type: defect

Signed-off-by: Charlie Calendre [c-cal@watcha.fr](mailto:c-cal@watcha.fr)




<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix desktop notifications for invites showing user IDs instead of displaynames ([\#7780](https://github.com/matrix-org/matrix-react-sdk/pull/7780)). Fixes vector-im/element-web#21022. Contributed by @c-cal.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr7780--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
