### PR TITLE
Add `#/dm` command to be used as a link in custom `home.html`

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -677,6 +677,9 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             }
             case 'view_create_room':
                 this.createRoom(payload.public, payload.defaultName);
+
+                // View the welcome or home page if we need something to look at
+                this.viewSomethingBehindModal();
                 break;
             case 'view_create_group': {
                 const prototype = SettingsStore.getValue("feature_communities_v2_prototypes");
@@ -714,6 +717,9 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 break;
             case 'view_create_chat':
                 showStartChatInviteDialog(payload.initialText || "");
+
+                // View the welcome or home page if we need something to look at
+                this.viewSomethingBehindModal();
                 break;
             case 'view_invite': {
                 const room = MatrixClientPeg.get().getRoom(payload.roomId);

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1707,6 +1707,10 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             dis.dispatch({
                 action: 'view_create_room',
             });
+        } else if (screen === 'dm') {
+            dis.dispatch({
+                action: 'view_create_chat',
+            });
         } else if (screen === 'settings') {
             dis.fire(Action.ViewUserSettings);
         } else if (screen === 'welcome') {


### PR DESCRIPTION
A custom home.html configured via `embeddedPages->homeUrl` can include links to `#/directory` and `#/new` which result in showing the "Explore Rooms" and "Create a private room" dialogs.
The "Direct Messages" dialog can not yet be shown through such a link.

The first commit establishes `#/dm` to show the "Direct Rooms" dialog.

The second commit fixes the problem that `#/new` and `#/dm` can not be triggered twice when clicking the "x" button and uses the same approach as already present for `#/directory` and `#/settings`.

Notes: A link to `#/dm` in a custom home.html will open the "Direct Messages" dialog.

Signed-off-by: Johannes Krude <johannes.krude@comsys.rwth-aachen.de>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * A link to `#/dm` in a custom home.html will open the "Direct Messages" dialog. ([\#7783](https://github.com/matrix-org/matrix-react-sdk/pull/7783)). Contributed by @johannes-krude.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7783--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
