### PR TITLE
Add `jest-mock` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "jest-canvas-mock": "^2.3.0",
     "jest-environment-jsdom": "^27.0.6",
     "jest-fetch-mock": "^3.0.3",
+    "jest-mock": "^27.5.1",
     "jest-raw-loader": "^1.0.1",
     "matrix-mock-request": "^1.2.3",
     "matrix-react-test-utils": "^0.2.3",


### PR DESCRIPTION
It's being used by the chat export test, but is not listed as a dependency.

If we rely on it, we should rely on it.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7800--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
