### PR TITLE
Make thread event timestamp work with AM/PM

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -979,7 +979,9 @@ $left-gutter: 64px;
 
         .mx_MessageTimestamp {
             top: 2px !important;
-            width: auto;
+            left: -11px;
+            width: 49px;
+            text-align: center;
         }
 
         .mx_EventTile_senderDetails {


### PR DESCRIPTION
<img width="366" alt="Screen Shot 2022-02-17 at 11 09 59" src="https://user-images.githubusercontent.com/769871/154469486-b5af294e-40a1-4b75-953d-0d4552cc28a8.png">


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7827--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
