### PR TITLE
Remove `autoplayGifsAndVideos` workaround

### DIFF
--- a/src/settings/handlers/AccountSettingsHandler.ts
+++ b/src/settings/handlers/AccountSettingsHandler.ts
@@ -116,23 +116,6 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
             return content ? content['enabled'] : null;
         }
 
-        // Special case for autoplaying videos and GIFs
-        if (["autoplayGifs", "autoplayVideo"].includes(settingName)) {
-            const settings = this.getSettings() || {};
-            const value = settings[settingName];
-            // Fallback to old combined setting
-            if (value === null || value === undefined) {
-                const oldCombinedValue = settings["autoplayGifsAndVideos"];
-                // Write, so that we can remove this in the future
-                if (oldCombinedValue !== null && oldCombinedValue !== undefined) {
-                    this.setValue("autoplayGifs", roomId, oldCombinedValue);
-                    this.setValue("autoplayVideo", roomId, oldCombinedValue);
-                }
-                return oldCombinedValue;
-            }
-            return value;
-        }
-
         if (settingName === "pseudonymousAnalyticsOptIn") {
             const content = this.getSettings(ANALYTICS_EVENT_TYPE) || {};
             // Check to make sure that we actually got a boolean


### PR DESCRIPTION
Type: task

<hr>

Removes the workaround introduced in https://github.com/matrix-org/matrix-react-sdk/pull/6726 as it's been more than 6 months now

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7852--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
