### PR TITLE
Inhibit tooltip on timeline pill avatars, the whole pill has its own

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -84,6 +84,7 @@ a.mx_Pill {
     align-items: center;
     border-radius: 10rem;
     margin-right: 0.24rem;
+    pointer-events: none;
 }
 
 .mx_Emoji {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21135

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Inhibit tooltip on timeline pill avatars, the whole pill has its own ([\#7854](https://github.com/matrix-org/matrix-react-sdk/pull/7854)). Fixes vector-im/element-web#21135.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7854--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
