### PR TITLE
Don't pillify code blocks

### DIFF
--- a/src/utils/pillify.tsx
+++ b/src/utils/pillify.tsx
@@ -44,7 +44,11 @@ export function pillifyLinks(nodes: ArrayLike<Element>, mxEvent: MatrixEvent, pi
     while (node) {
         let pillified = false;
 
-        if (node.tagName === "A" && node.getAttribute("href")) {
+        if (node.tagName === "PRE" || node.tagName === "CODE") {
+            // Skip code blocks
+            node = node.nextSibling as Element;
+            continue;
+        } else if (node.tagName === "A" && node.getAttribute("href")) {
             const href = node.getAttribute("href");
             const parts = parsePermalink(href);
             // If the link is a (localised) matrix.to link, replace it with a pill

--- a/test/components/views/messages/TextualBody-test.js
+++ b/test/components/views/messages/TextualBody-test.js
@@ -239,15 +239,7 @@ describe("<TextualBody />", () => {
             const wrapper = mount(<TextualBody mxEvent={ev} />);
             expect(wrapper.text()).toBe("@room\n1@room\n\n");
             const content = wrapper.find(".mx_EventTile_body");
-            expect(content.html()).toBe(
-                '<span class="mx_EventTile_body markdown-body" dir="auto">' +
-                '<p><code>@room</code></p>\n' +
-                '<div class="mx_EventTile_pre_container">' +
-                '<pre class="mx_EventTile_collapsedCodeBlock">' +
-                '<span class="mx_EventTile_lineNumbers"><span>1</span></span>' +
-                '<code>@room\n</code><span></span></pre>' +
-                '<span class="mx_EventTile_button mx_EventTile_copyButton "></span></div>\n</span>',
-            );
+            expect(content.html()).toMatchSnapshot();
         });
 
         it("pills do not appear for event permalinks", () => {

--- a/test/components/views/messages/TextualBody-test.js
+++ b/test/components/views/messages/TextualBody-test.js
@@ -222,6 +222,34 @@ describe("<TextualBody />", () => {
                 '</span></span>');
         });
 
+        it("pills do not appear in code blocks", () => {
+            const ev = mkEvent({
+                type: "m.room.message",
+                room: "room_id",
+                user: "sender",
+                content: {
+                    body: "`@room`\n```\n@room\n```",
+                    msgtype: "m.text",
+                    format: "org.matrix.custom.html",
+                    formatted_body: "<p><code>@room</code></p>\n<pre><code>@room\n</code></pre>\n",
+                },
+                event: true,
+            });
+
+            const wrapper = mount(<TextualBody mxEvent={ev} />);
+            expect(wrapper.text()).toBe("@room\n1@room\n\n");
+            const content = wrapper.find(".mx_EventTile_body");
+            expect(content.html()).toBe(
+                '<span class="mx_EventTile_body markdown-body" dir="auto">' +
+                '<p><code>@room</code></p>\n' +
+                '<div class="mx_EventTile_pre_container">' +
+                '<pre class="mx_EventTile_collapsedCodeBlock">' +
+                '<span class="mx_EventTile_lineNumbers"><span>1</span></span>' +
+                '<code>@room\n</code><span></span></pre>' +
+                '<span class="mx_EventTile_button mx_EventTile_copyButton "></span></div>\n</span>',
+            );
+        });
+
         it("pills do not appear for event permalinks", () => {
             const ev = mkEvent({
                 type: "m.room.message",

--- a/test/components/views/messages/__snapshots__/TextualBody-test.js.snap
+++ b/test/components/views/messages/__snapshots__/TextualBody-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TextualBody /> renders formatted m.text correctly pills do not appear in code blocks 1`] = `
+"<span class=\\"mx_EventTile_body markdown-body\\" dir=\\"auto\\"><p><code>@room</code></p>
+<div class=\\"mx_EventTile_pre_container\\"><pre class=\\"mx_EventTile_collapsedCodeBlock\\"><span class=\\"mx_EventTile_lineNumbers\\"><span>1</span></span><code>@room
+</code><span></span></pre><span class=\\"mx_EventTile_button mx_EventTile_copyButton \\"></span></div>
+</span>"
+`;


### PR DESCRIPTION
Type: defect

Closes https://github.com/vector-im/element-web/issues/20851.
Closes https://github.com/vector-im/element-web/issues/18687.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't pillify code blocks ([\#7861](https://github.com/matrix-org/matrix-react-sdk/pull/7861)). Fixes vector-im/element-web#20851 and vector-im/element-web#18687. Contributed by @robintown.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr7861--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
