### PR TITLE
Remove light weight font rendering

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -294,7 +294,6 @@ legend {
     background-color: $background;
     color: $light-fg-color;
     z-index: 4012;
-    font-weight: 300;
     font-size: $font-15px;
     position: relative;
     padding: 24px;

--- a/res/css/structures/_CreateRoom.scss
+++ b/res/css/structures/_CreateRoom.scss
@@ -25,7 +25,6 @@ limitations under the License.
 .mx_CreateRoom textarea {
     border-radius: 3px;
     border: 1px solid $strong-input-border-color;
-    font-weight: 300;
     font-size: $font-13px;
     padding: 9px;
     margin-top: 6px;

--- a/res/css/structures/_GroupView.scss
+++ b/res/css/structures/_GroupView.scss
@@ -147,7 +147,6 @@ limitations under the License.
     float: left;
     max-height: 42px;
     color: $settings-grey-fg-color;
-    font-weight: 300;
     font-size: $font-13px;
     padding-left: 19px;
     margin-right: 16px;


### PR DESCRIPTION
Specifying the font-weight here is harmful when using fonts that support
Light or variable weights.

Signed-off-by: glob <byron@glob.com.au>

Notes: Remove light weight font rendering

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7880--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
