### PR TITLE
Remove log line to try to fix freeze on answering VoIP call

### DIFF
--- a/src/components/views/voip/VideoFeed.tsx
+++ b/src/components/views/voip/VideoFeed.tsx
@@ -137,7 +137,6 @@ export default class VideoFeed extends React.PureComponent<IProps, IState> {
             // them with another load() which will cancel the pending one, but since we don't call
             // load() explicitly, it shouldn't be a problem. - Dave
             await element.play();
-            logger.debug((this.props.feed.isLocal ? "Local" : "Remote") + " video feed play() completed");
         } catch (e) {
             logger.info("Failed to play media element with feed", this.props.feed, e);
         }


### PR DESCRIPTION
The profiles point to some huge object being logged in VideoFeed's
playMedia() method, but this is the only log line added recently.
I can't see how this could possibly log anything huge, but not
sure what else to try, so let's try removing this as an experiment.
The bug it was added to diagnose seems to be fixed now anyway.

For https://github.com/vector-im/element-web/issues/21181

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove log line to try to fix freeze on answering VoIP call ([\#7883](https://github.com/matrix-org/matrix-react-sdk/pull/7883)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7883--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
