### PR TITLE
Fix vanishing recently viewed menu

### DIFF
--- a/src/components/views/elements/InteractiveTooltip.tsx
+++ b/src/components/views/elements/InteractiveTooltip.tsx
@@ -357,7 +357,7 @@ export default class InteractiveTooltip extends React.Component<IProps, IState> 
         } else {
             const targetRight = targetRect.right + window.pageXOffset;
             const spaceOnRight = UIStore.instance.windowWidth - targetRight;
-            return !contentRect || (spaceOnRight - contentRect.width < MIN_SAFE_DISTANCE_TO_WINDOW_EDGE);
+            return contentRect && (spaceOnRight - contentRect.width < MIN_SAFE_DISTANCE_TO_WINDOW_EDGE);
         }
     }
 
@@ -371,7 +371,7 @@ export default class InteractiveTooltip extends React.Component<IProps, IState> 
         } else {
             const targetBottom = targetRect.bottom + window.pageYOffset;
             const spaceBelow = UIStore.instance.windowHeight - targetBottom;
-            return !contentRect || (spaceBelow - contentRect.height < MIN_SAFE_DISTANCE_TO_WINDOW_EDGE);
+            return contentRect && (spaceBelow - contentRect.height < MIN_SAFE_DISTANCE_TO_WINDOW_EDGE);
         }
     }
 


### PR DESCRIPTION
Whenever the recently viewed menu appears for the first time, it starts out with `contentRect` set to `null` until its actual dimensions can be determined. The logic in these two functions was then mistakenly causing the menu to act as if it were on the left and subsequently disappear, even though the menu was specifically requested to appear on the right.

Type: defect

Closes https://github.com/vector-im/element-web/issues/20827.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix vanishing recently viewed menu ([\#7887](https://github.com/matrix-org/matrix-react-sdk/pull/7887)). Fixes vector-im/element-web#20827.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7887--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
