### PR TITLE
Fix composer format buttons on WebKit

### DIFF
--- a/res/css/views/rooms/_MessageComposerFormatBar.scss
+++ b/res/css/views/rooms/_MessageComposerFormatBar.scss
@@ -37,12 +37,6 @@ limitations under the License.
         display: inline-block;
         position: relative;
         margin: 2px;
-
-        &:hover {
-            background: $panel-actions;
-            border-radius: 6px;
-            z-index: 1;
-        }
     }
 
     .mx_MessageComposerFormatBar_button {
@@ -50,6 +44,14 @@ limitations under the License.
         height: 28px;
         box-sizing: border-box;
         vertical-align: middle;
+        background: none;
+        border: none;
+
+        &:hover {
+            background: $panel-actions;
+            border-radius: 6px;
+            z-index: 1;
+        }
     }
 
     .mx_MessageComposerFormatBar_button::after {

--- a/src/components/views/rooms/MessageComposerFormatBar.tsx
+++ b/src/components/views/rooms/MessageComposerFormatBar.tsx
@@ -103,8 +103,12 @@ class FormatButton extends React.PureComponent<IFormatButtonProps> {
             </div>
         </div>;
 
+        // element="button" and type="button" are necessary for the buttons to work on WebKit,
+        // otherwise the text is deselected before onClick can ever be called
         return (
             <AccessibleTooltipButton
+                element="button"
+                type="button"
                 onClick={this.props.onClick}
                 title={this.props.label}
                 tooltip={tooltip}


### PR DESCRIPTION
Needs someone with access to Safari to confirm this works again.

Type: defect

Closes https://github.com/vector-im/element-web/issues/20868.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix composer format buttons on WebKit ([\#7898](https://github.com/matrix-org/matrix-react-sdk/pull/7898)). Fixes vector-im/element-web#20868.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr7898--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
