### PR TITLE
Tweak info message padding in right panel timeline

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -90,7 +90,8 @@ limitations under the License.
         margin-right: 2px;
     }
 
-    .mx_EventListSummary:not([data-layout=bubble]) .mx_EventTile_line {
+    .mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line,
+    .mx_GenericEventListSummary:not([data-layout=bubble]) > ol > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
         padding-left: 36px;
     }
 

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -91,7 +91,7 @@ limitations under the License.
     }
 
     .mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line,
-    .mx_GenericEventListSummary:not([data-layout=bubble]) > ol > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
+    .mx_GenericEventListSummary:not([data-layout=bubble]) > .mx_GenericEventListSummary_unstyledList > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
         padding-left: 36px;
     }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -285,7 +285,7 @@ $left-gutter: 64px;
 }
 
 .mx_EventTile:not([data-layout=bubble]).mx_EventTile_info .mx_EventTile_line,
-.mx_GenericEventListSummary:not([data-layout=bubble]) > ol > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
+.mx_GenericEventListSummary:not([data-layout=bubble]) > .mx_GenericEventListSummary_unstyledList > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
     padding-left: calc($left-gutter + 20px); // override padding-left $left-gutter
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -280,14 +280,13 @@ $left-gutter: 64px;
     }
 }
 
-.mx_EventTile:not([data-layout=bubble]).mx_EventTile_info .mx_EventTile_line,
-.mx_GenericEventListSummary:not([data-layout=bubble]) > ol > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
-    padding-left: calc($left-gutter + 20px) !important; // override padding-left $left-gutter
+.mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line {
+    padding-left: $left-gutter;
 }
 
 .mx_EventTile:not([data-layout=bubble]).mx_EventTile_info .mx_EventTile_line,
-.mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line {
-    padding-left: $left-gutter;
+.mx_GenericEventListSummary:not([data-layout=bubble]) > ol > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
+    padding-left: calc($left-gutter + 20px); // override padding-left $left-gutter
 }
 
 /* all the overflow-y: hidden; are to trap Zalgos -


### PR DESCRIPTION
Main timeline, group collapsed:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/279572/155761577-ec928523-33aa-4bb1-92fa-c60cee1f4187.png">

Main timeline, group expanded:

<img width="506" alt="image" src="https://user-images.githubusercontent.com/279572/155761631-a106acc1-cff1-4f55-822b-cc3066615493.png">

Right panel timeline, group collapsed (the group's avatar position is a separate non-regression issue):

<img width="324" alt="image" src="https://user-images.githubusercontent.com/279572/155761885-c8ed822a-2e9b-4322-a4bc-03a817e03438.png">

Right panel timeline, group expanded:

<img width="325" alt="image" src="https://user-images.githubusercontent.com/279572/155762011-6316eb99-e2b2-4359-9855-45a9fae2dba2.png">

Fixes https://github.com/vector-im/element-web/issues/21212

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Tweak info message padding in right panel timeline ([\#7901](https://github.com/matrix-org/matrix-react-sdk/pull/7901)). Fixes vector-im/element-web#21212.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr7901--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
