### PR TITLE
Render image data in reactions

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -102,7 +102,7 @@ function mightContainEmoji(str: string): boolean {
  */
 export function unicodeToShortcode(char: string): string {
     const shortcodes = getEmojiFromUnicode(char)?.shortcodes;
-    return shortcodes?.length ? `:${shortcodes[0]}:` : '';
+    return shortcodes?.length ? `:${shortcodes[0]}:` : char;
 }
 
 export function processHtmlForSending(html: string): string {

--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -139,7 +139,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         }
     };
 
-    private isGif = (): boolean => {
+    protected isGif = (): boolean => {
         const content = this.props.mxEvent.getContent();
         return content.info?.mimetype === "image/gif";
     };

--- a/src/components/views/messages/ReactionImage.tsx
+++ b/src/components/views/messages/ReactionImage.tsx
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+
+import MImageBody from './MImageBody';
+import { replaceableComponent } from "../../../utils/replaceableComponent";
+import { BLURHASH_FIELD } from "../../../ContentMessages";
+import { IMediaEventContent } from '../../../customisations/models/IMediaEventContent';
+import SettingsStore from '../../../settings/SettingsStore';
+
+const FORCED_IMAGE_HEIGHT = 20;
+
+@replaceableComponent("views.messages.ReactionImage")
+export default class ReactionImage extends MImageBody {
+    public onClick = (ev: React.MouseEvent): void => {
+        ev.preventDefault();
+    };
+
+    protected wrapImage(contentUrl: string, children: JSX.Element): JSX.Element {
+        return children;
+    }
+
+    protected getPlaceholder(width: number, height: number): JSX.Element {
+        if (this.props.mxEvent.getContent().info?.[BLURHASH_FIELD]) return super.getPlaceholder(width, height);
+        return <img src={require("../../../../res/img/icons-show-stickers.svg")} width="14" height="20" />;
+    }
+
+    // Tooltip to show on mouse over
+    protected getTooltip(): JSX.Element {
+        return null;
+    }
+
+    // Don't show "Download this_file.png ..."
+    protected getFileBody() {
+        return null;
+    }
+
+    render() {
+        const contentUrl = this.getContentUrl();
+        const content = this.props.mxEvent.getContent<IMediaEventContent>();
+        let thumbUrl;
+        if (this.props.forExport || (this.isGif() && SettingsStore.getValue("autoplayGifs"))) {
+            thumbUrl = contentUrl;
+        } else {
+            thumbUrl = this.getThumbUrl();
+        }
+        const thumbnail = this.messageContent(contentUrl, thumbUrl, content, FORCED_IMAGE_HEIGHT);
+        return thumbnail;
+    }
+}

--- a/src/utils/MediaEventHelper.ts
+++ b/src/utils/MediaEventHelper.ts
@@ -105,7 +105,7 @@ export class MediaEventHelper implements IDestroyable {
         if (!event) return false;
         if (event.isRedacted()) return false;
         if (event.getType() === EventType.Sticker) return true;
-        if (event.getType() !== EventType.RoomMessage) return false;
+        if (event.getType() !== EventType.RoomMessage && event.getType() !== EventType.Reaction) return false;
 
         const content = event.getContent();
         const mediaMsgTypes: string[] = [


### PR DESCRIPTION
Many messaging services such as Slack and Discord allow for custom
images for reacts, rather than only standard emoji. Currently Element
will only show the plain text of the reaction key.

This PR updates element to render the media content from reaction
events. This does not add a way for users to add custom reactions yet.

This can be useful in the case of bots and bridges, which will be able
to immediately use this functionality.  A picker for Element users will
be added in the future.

This is a solution to vector-im/element-meta#339

Similarly to stickers, the event type should simply be sent with an image content, and it will be displayed appropriately.  For example
```json
 "content": {
    "body": "parrot.gif",
    "info": {
      "size": 15010,
      "mimetype": "image/gif",
      "w": 128,
      "h": 128,
      "xyz.amorgan.blurhash": "UKFg2,Ef0f-V0es:}tR*wf$*xZNH$*NaI:bH"
    },
    "url": "mxc://localhost:8008/zyCSlBnBTQCxhTFDEDNpNobe",
    "m.relates_to": {
      "rel_type": "m.annotation",
      "event_id": "$FqS1dRW7gMe_JhXNSBUy2ApAQNMQ4IL-vywYNqbXRlA",
      "key": ":partyparrot:"
    }
  },
```

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Signed-off-by: Andrew Ryan [andrewryanchama@clover.club](mailto:andrewryanchama@clover.club)
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


Original behavior / fallback:
<img width="297" alt="Screen Shot 2022-02-25 at 12 03 45 PM" src="https://user-images.githubusercontent.com/89478935/155788683-6bf94dfb-c39b-422b-bf63-7e47d7ce6d8f.png">
Updated to display image:
<img width="297" alt="Screen Shot 2022-02-25 at 11 54 12 AM" src="https://user-images.githubusercontent.com/89478935/155789028-ac6d6a23-2ba6-4888-8de5-72bd8f26c7a7.png">


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Render image data in reactions ([\#7903](https://github.com/matrix-org/matrix-react-sdk/pull/7903)). Contributed by @AndrewRyanChama.<!-- CHANGELOG_PREVIEW_END -->