### PR TITLE
Inject sender into pinned messages

### DIFF
--- a/src/components/views/right_panel/PinnedMessagesCard.tsx
+++ b/src/components/views/right_panel/PinnedMessagesCard.tsx
@@ -108,6 +108,8 @@ const PinnedMessagesCard = ({ room, onClose }: IProps) => {
                     await cli.decryptEventIfNeeded(event); // TODO await?
                 }
                 if (event && PinningUtils.isPinnable(event)) {
+                    // Inject sender information
+                    event.sender = room.getMember(event.getSender());
                     return event;
                 }
             } catch (err) {

--- a/src/components/views/rooms/PinnedEventTile.tsx
+++ b/src/components/views/rooms/PinnedEventTile.tsx
@@ -56,7 +56,6 @@ export default class PinnedEventTile extends React.Component<IProps> {
 
     render() {
         const sender = this.props.event.getSender();
-        const senderProfile = this.props.room.getMember(sender);
 
         let unpinButton = null;
         if (this.props.onUnpinClicked) {
@@ -72,14 +71,14 @@ export default class PinnedEventTile extends React.Component<IProps> {
         return <div className="mx_PinnedEventTile">
             <MemberAvatar
                 className="mx_PinnedEventTile_senderAvatar"
-                member={senderProfile}
+                member={this.props.event.sender}
                 width={AVATAR_SIZE}
                 height={AVATAR_SIZE}
                 fallbackUserId={sender}
             />
 
             <span className={"mx_PinnedEventTile_sender " + getUserNameColorClass(sender)}>
-                { senderProfile?.name || sender }
+                { this.props.event.sender?.name || sender }
             </span>
 
             { unpinButton }


### PR DESCRIPTION
Sender information is needed for the rendering of certain events, like locations.

Type: defect

Closes https://github.com/vector-im/element-web/issues/20314.