### PR TITLE
Update and expand ways to access pinned messages

### DIFF
--- a/res/css/views/right_panel/_RoomSummaryCard.scss
+++ b/res/css/views/right_panel/_RoomSummaryCard.scss
@@ -251,6 +251,10 @@ limitations under the License.
     mask-image: url('$(res)/img/element-icons/room/files.svg');
 }
 
+.mx_RoomSummaryCard_icon_pins::before {
+    mask-image: url('$(res)/img/element-icons/room/pin-upright.svg');
+}
+
 .mx_RoomSummaryCard_icon_threads::before {
     mask-image: url('$(res)/img/element-icons/message/thread.svg');
 }

--- a/res/css/views/rooms/_RoomTile.scss
+++ b/res/css/views/rooms/_RoomTile.scss
@@ -213,6 +213,10 @@ limitations under the License.
         mask-image: url('$(res)/img/element-icons/room/files.svg');
     }
 
+    .mx_RoomTile_iconPins::before {
+        mask-image: url('$(res)/img/element-icons/room/pin-upright.svg');
+    }
+
     .mx_RoomTile_iconWidgets::before {
         mask-image: url('$(res)/img/element-icons/room/apps.svg');
     }

--- a/src/components/views/context_menus/RoomContextMenu.tsx
+++ b/src/components/views/context_menus/RoomContextMenu.tsx
@@ -36,6 +36,8 @@ import { EchoChamber } from "../../../stores/local-echo/EchoChamber";
 import { RoomNotifState } from "../../../RoomNotifs";
 import Modal from "../../../Modal";
 import ExportDialog from "../dialogs/ExportDialog";
+import { useSettingValue } from "../../../hooks/useSettings";
+import { usePinnedEvents } from "../right_panel/PinnedMessagesCard";
 import RoomViewStore from "../../../stores/RoomViewStore";
 import { RightPanelPhases } from '../../../stores/right-panel/RightPanelStorePhases';
 import { ROOM_NOTIFICATIONS_TAB } from "../dialogs/RoomSettingsDialog";
@@ -228,6 +230,29 @@ const RoomContextMenu = ({ room, onFinished, ...props }: IProps) => {
         />;
     }
 
+    const pinningEnabled = useSettingValue("feature_pinning");
+    const pinCount = usePinnedEvents(pinningEnabled && room)?.length;
+
+    let pinsOption: JSX.Element;
+    if (pinningEnabled) {
+        pinsOption = <IconizedContextMenuOption
+            onClick={(ev: ButtonEvent) => {
+                ev.preventDefault();
+                ev.stopPropagation();
+
+                ensureViewingRoom(ev);
+                RightPanelStore.instance.pushCard({ phase: RightPanelPhases.PinnedMessages }, false);
+                onFinished();
+            }}
+            label={_t("Pinned")}
+            iconClassName="mx_RoomTile_iconPins"
+        >
+            { pinCount > 0 && <span className="mx_IconizedContextMenu_sublabel">
+                { pinCount }
+            </span> }
+        </IconizedContextMenuOption>;
+    }
+
     const onTagRoom = (ev: ButtonEvent, tagId: TagID) => {
         ev.preventDefault();
         ev.stopPropagation();
@@ -277,6 +302,8 @@ const RoomContextMenu = ({ room, onFinished, ...props }: IProps) => {
                 label={_t("Files")}
                 iconClassName="mx_RoomTile_iconFiles"
             />
+
+            { pinsOption }
 
             <IconizedContextMenuOption
                 onClick={(ev: ButtonEvent) => {

--- a/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -80,7 +80,7 @@ const PinnedMessagesHeaderButton = ({ room, isHighlighted, onClick }: IHeaderBut
     const pinningEnabled = useSettingValue("feature_pinning");
     const pinnedEvents = usePinnedEvents(pinningEnabled && room);
     const readPinnedEvents = useReadPinnedEvents(pinningEnabled && room);
-    if (!pinningEnabled) return null;
+    if (!(pinningEnabled && pinnedEvents.length)) return null;
 
     let unreadIndicator;
     if (pinnedEvents.some(id => !readPinnedEvents.has(id))) {

--- a/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -80,7 +80,7 @@ const PinnedMessagesHeaderButton = ({ room, isHighlighted, onClick }: IHeaderBut
     const pinningEnabled = useSettingValue("feature_pinning");
     const pinnedEvents = usePinnedEvents(pinningEnabled && room);
     const readPinnedEvents = useReadPinnedEvents(pinningEnabled && room);
-    if (!(pinningEnabled && pinnedEvents.length)) return null;
+    if (!pinnedEvents?.length) return null;
 
     let unreadIndicator;
     if (pinnedEvents.some(id => !readPinnedEvents.has(id))) {

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -42,6 +42,8 @@ import { UIFeature } from "../../../settings/UIFeature";
 import { ChevronFace, ContextMenuTooltipButton, useContextMenu } from "../../structures/ContextMenu";
 import WidgetContextMenu from "../context_menus/WidgetContextMenu";
 import { useRoomMemberCount } from "../../../hooks/useRoomMembers";
+import { useSettingValue } from "../../../hooks/useSettings";
+import { usePinnedEvents } from "./PinnedMessagesCard";
 import { Container, MAX_PINNED, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import RoomName from "../elements/RoomName";
 import UIStore from "../../../stores/UIStore";
@@ -239,6 +241,10 @@ const onRoomFilesClick = () => {
     RightPanelStore.instance.pushCard({ phase: RightPanelPhases.FilePanel }, true);
 };
 
+const onRoomPinsClick = () => {
+    RightPanelStore.instance.pushCard({ phase: RightPanelPhases.PinnedMessages }, true);
+};
+
 const onRoomSettingsClick = (ev: ButtonEvent) => {
     defaultDispatcher.dispatch({ action: "open_room_settings" });
     PosthogTrackers.trackInteraction("WebRightPanelRoomInfoSettingsButton", ev);
@@ -290,6 +296,8 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, onClose }) => {
     </React.Fragment>;
 
     const memberCount = useRoomMemberCount(room);
+    const pinningEnabled = useSettingValue("feature_pinning");
+    const pinCount = usePinnedEvents(pinningEnabled && room)?.length;
 
     return <BaseCard header={header} className="mx_RoomSummaryCard" onClose={onClose}>
         <Group title={_t("About")} className="mx_RoomSummaryCard_aboutGroup">
@@ -302,6 +310,12 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, onClose }) => {
             <Button className="mx_RoomSummaryCard_icon_files" onClick={onRoomFilesClick}>
                 { _t("Files") }
             </Button>
+            { pinningEnabled && <Button className="mx_RoomSummaryCard_icon_pins" onClick={onRoomPinsClick}>
+                { _t("Pinned") }
+                { pinCount > 0 && <span className="mx_BaseCard_Button_sublabel">
+                    { pinCount }
+                </span> }
+            </Button> }
             <Button className="mx_RoomSummaryCard_icon_export" onClick={onRoomExportClick}>
                 { _t("Export chat") }
             </Button>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1960,6 +1960,7 @@
     "Not encrypted": "Not encrypted",
     "About": "About",
     "Files": "Files",
+    "Pinned": "Pinned",
     "Export chat": "Export chat",
     "Share room": "Share room",
     "Room settings": "Room settings",


### PR DESCRIPTION
This adds options to view pinned messages to the room info panel and room header menu, and hides the room header button if nothing is pinned, as per the designs.

![Screenshot 2022-02-25 at 17-57-55 Element Test room](https://user-images.githubusercontent.com/48614497/155814280-1a8d760b-f985-4a80-bbf4-04328f55e4d4.png)
![menu](https://user-images.githubusercontent.com/48614497/155814271-cf1edcdf-9a94-4324-97e8-6b89a8c4e06b.png)

Since this is still in labs, it shouldn't need a design review.

Type: enhancement

Closes https://github.com/vector-im/element-web/issues/21209.
Closes https://github.com/vector-im/element-web/issues/21211.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Update and expand ways to access pinned messages ([\#7906](https://github.com/matrix-org/matrix-react-sdk/pull/7906)). Fixes vector-im/element-web#21209 and vector-im/element-web#21211.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr7906--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
