### PR TITLE
Fix padding inside the labels on Settings

### DIFF
--- a/res/css/structures/_TabbedView.scss
+++ b/res/css/structures/_TabbedView.scss
@@ -55,7 +55,6 @@ limitations under the License.
     .mx_TabbedView_maskedIcon {
         width: 16px;
         height: 16px;
-        margin-left: 8px;
         margin-right: 16px;
     }
 
@@ -122,7 +121,7 @@ limitations under the License.
     align-items: center;
     vertical-align: text-top;
     cursor: pointer;
-    padding: 8px 0;
+    padding: 8px;
     border-radius: 8px;
     font-size: $font-13px;
     position: relative;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21232

This commit fixes padding space inside the labels on Settings. It sets the padding space on the right and left side of the labels, removing the margin-left property from the icon, and enables proper word-breaking which does not depend on whitespace characters.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Notes: Fix padding inside the labels on Settings
element-web notes: none

**Before:**

![before](https://user-images.githubusercontent.com/3362943/155951053-433ed0c5-a7ed-4985-aff2-db310978d430.png)![before-css](https://user-images.githubusercontent.com/3362943/155951078-6955016a-f0cf-4963-b153-7e3eca67ccb2.png)

**After:**

![after](https://user-images.githubusercontent.com/3362943/155951141-b00d5320-464d-42a7-87da-b012e2044b8d.png)![after-css](https://user-images.githubusercontent.com/3362943/155951150-d8385d74-40aa-4ac9-b165-d1afc92a9426.png)

<!-- To specify text for the changelog entry (otherwise the PR title will be used):


Changes in this project generate changelog entries in element-web by default.
To suppress this:



...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7912--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
