### PR TITLE
fix color of location share caret

### DIFF
--- a/res/css/views/location/_LocationPicker.scss
+++ b/res/css/views/location/_LocationPicker.scss
@@ -58,7 +58,22 @@ limitations under the License.
         .mx_MLocationBody_pointer {
             position: absolute;
             bottom: -3px;
-            left: 12px;
+            left: 11px;
+            width: 9px;
+            height: 5px;
+
+            &::before {
+                mask-image: url('$(res)/img/location/pointer.svg');
+                mask-position: center;
+                mask-repeat: no-repeat;
+                mask-size: 9px;
+                content: '';
+                display: inline-block;
+                width: 9px;
+                height: 5px;
+                position: absolute;
+                background-color: $accent;
+            }
         }
     }
 

--- a/res/css/views/messages/_MLocationBody.scss
+++ b/res/css/views/messages/_MLocationBody.scss
@@ -38,7 +38,22 @@ limitations under the License.
     .mx_MLocationBody_pointer {
         position: absolute;
         bottom: -3px;
-        left: 12px;
+        left: 11px;
+        width: 9px;
+        height: 5px;
+
+        &::before {
+            mask-image: url('$(res)/img/location/pointer.svg');
+            mask-position: center;
+            mask-repeat: no-repeat;
+            mask-size: 9px;
+            content: '';
+            display: inline-block;
+            width: 9px;
+            height: 5px;
+            position: absolute;
+            background-color: $accent;
+        }
     }
 
     .mx_MLocationBody_markerContents {

--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -197,11 +197,8 @@ class LocationPicker extends React.Component<IProps, IState> {
                             viewUserOnClick={false}
                         />
                     </div>
-                    <img
+                    <div
                         className="mx_MLocationBody_pointer"
-                        src={require("../../../../res/img/location/pointer.svg")}
-                        width="9"
-                        height="5"
                     />
                 </div>
             </div>

--- a/src/components/views/messages/MLocationBody.tsx
+++ b/src/components/views/messages/MLocationBody.tsx
@@ -188,11 +188,8 @@ export function LocationBodyContent(props: ILocationBodyContentProps):
             <div className="mx_MLocationBody_markerBorder">
                 { markerContents }
             </div>
-            <img
+            <div
                 className="mx_MLocationBody_pointer"
-                src={require("../../../../res/img/location/pointer.svg")}
-                width="9"
-                height="5"
             />
         </div>
         {


### PR DESCRIPTION
non-high contrast theme
<img width="150" alt="Screenshot 2022-02-28 at 17 28 01" src="https://user-images.githubusercontent.com/3055605/156020918-996173c5-23e0-4e0e-94fc-9ef098df5146.png">

high contrast theme:
<img width="132" alt="Screenshot 2022-02-28 at 17 27 34" src="https://user-images.githubusercontent.com/3055605/156020923-21b8742a-fa0f-4d20-b9a1-bcd385104f46.png">

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * fix color of location share caret ([\#7917](https://github.com/matrix-org/matrix-react-sdk/pull/7917)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7917--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
