### PR TITLE
Fix positioning of the thread context menu

### DIFF
--- a/src/components/structures/ContextMenu.tsx
+++ b/src/components/structures/ContextMenu.tsx
@@ -260,10 +260,11 @@ export default class ContextMenu extends React.PureComponent<IProps, IState> {
         const { windowWidth, windowHeight } = UIStore.instance;
         if (contextMenuRect) {
             if (position.top !== undefined) {
-                position.top = Math.min(
-                    position.top,
-                    windowHeight - contextMenuRect.height - WINDOW_PADDING,
-                );
+                let maxTop = windowHeight - WINDOW_PADDING;
+                if (!this.props.bottomAligned) {
+                    maxTop -= contextMenuRect.height;
+                }
+                position.top = Math.min(position.top, maxTop);
                 // Adjust the chevron if necessary
                 if (chevronOffset.top !== undefined) {
                     chevronOffset.top = props.chevronOffset + props.top - position.top;
@@ -271,17 +272,18 @@ export default class ContextMenu extends React.PureComponent<IProps, IState> {
             } else if (position.bottom !== undefined) {
                 position.bottom = Math.min(
                     position.bottom,
-                    windowHeight - WINDOW_PADDING, // positioning is based on top-right corner so width is irrelevant
+                    windowHeight - contextMenuRect.height - WINDOW_PADDING,
                 );
                 if (chevronOffset.top !== undefined) {
                     chevronOffset.top = props.chevronOffset + position.bottom - props.bottom;
                 }
             }
             if (position.left !== undefined) {
-                position.left = Math.min(
-                    position.left,
-                    windowWidth - WINDOW_PADDING, // positioning is based on top-right corner so width is irrelevant
-                );
+                let maxLeft = windowWidth - WINDOW_PADDING;
+                if (!this.props.rightAligned) {
+                    maxLeft -= contextMenuRect.width;
+                }
+                position.left = Math.min(position.left, maxLeft);
                 if (chevronOffset.left !== undefined) {
                     chevronOffset.left = props.chevronOffset + props.left - position.left;
                 }

--- a/src/components/structures/ContextMenu.tsx
+++ b/src/components/structures/ContextMenu.tsx
@@ -271,7 +271,7 @@ export default class ContextMenu extends React.PureComponent<IProps, IState> {
             } else if (position.bottom !== undefined) {
                 position.bottom = Math.min(
                     position.bottom,
-                    windowHeight - contextMenuRect.height - WINDOW_PADDING,
+                    windowHeight - WINDOW_PADDING, // positioning is based on top-right corner so width is irrelevant
                 );
                 if (chevronOffset.top !== undefined) {
                     chevronOffset.top = props.chevronOffset + position.bottom - props.bottom;
@@ -280,7 +280,7 @@ export default class ContextMenu extends React.PureComponent<IProps, IState> {
             if (position.left !== undefined) {
                 position.left = Math.min(
                     position.left,
-                    windowWidth - contextMenuRect.width - WINDOW_PADDING,
+                    windowWidth - WINDOW_PADDING, // positioning is based on top-right corner so width is irrelevant
                 );
                 if (chevronOffset.left !== undefined) {
                     chevronOffset.left = props.chevronOffset + props.left - position.left;

--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -27,7 +27,6 @@ import { _t } from "../../../languageHandler";
 import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOptionList } from "./IconizedContextMenu";
 import { WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
-import { useRovingTabIndex } from "../../../accessibility/RovingTabIndex";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 
 interface IProps {
@@ -49,17 +48,6 @@ const contextMenuBelow = (elementRect: DOMRect) => {
     const top = elementRect.bottom + window.pageYOffset;
     const chevronFace = ChevronFace.None;
     return { left, top, chevronFace };
-};
-
-export const RovingThreadListContextMenu: React.FC<IProps> = (props) => {
-    const [onFocus, isActive, ref] = useRovingTabIndex();
-
-    return <ThreadListContextMenu
-        {...props}
-        onFocus={onFocus}
-        tabIndex={isActive ? 0 : -1}
-        inputRef={ref}
-    />;
 };
 
 const ThreadListContextMenu: React.FC<IExtendedProps> = ({

--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -28,7 +28,6 @@ import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOpti
 import { WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
-import UIStore from "../../../stores/UIStore";
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -38,10 +37,10 @@ interface IProps {
 
 const contextMenuBelow = (elementRect: DOMRect) => {
     // align the context menu's icons with the icon which opened the context menu
-    const right = UIStore.instance.windowWidth - elementRect.right + window.pageXOffset;
+    const left = elementRect.left + window.pageXOffset + elementRect.width;
     const top = elementRect.bottom + window.pageYOffset;
     const chevronFace = ChevronFace.None;
-    return { right, top, chevronFace };
+    return { left, top, chevronFace };
 };
 
 const ThreadListContextMenu: React.FC<IProps> = ({

--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -38,7 +38,6 @@ interface IProps {
 interface IExtendedProps extends IProps {
     // Props for making the button into a roving one
     tabIndex?: number;
-    inputRef?: RefObject<HTMLElement>;
     onFocus?(): void;
 }
 
@@ -55,11 +54,9 @@ const ThreadListContextMenu: React.FC<IExtendedProps> = ({
     permalinkCreator,
     onMenuToggle,
     onFocus,
-    inputRef,
     ...props
 }) => {
-    const [menuDisplayed, _ref, openMenu, closeThreadOptions] = useContextMenu();
-    const button = inputRef ?? _ref; // prefer the ref we receive via props in case we are being controlled
+    const [menuDisplayed, button, openMenu, closeThreadOptions] = useContextMenu();
 
     const viewInRoom = useCallback((evt: ButtonEvent): void => {
         evt.preventDefault();

--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { RefObject, useCallback, useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { MatrixEvent } from "matrix-js-sdk/src";
 
 import { ButtonEvent } from "../elements/AccessibleButton";
@@ -28,6 +28,7 @@ import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOpti
 import { WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
+import UIStore from "../../../stores/UIStore";
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -35,25 +36,18 @@ interface IProps {
     onMenuToggle?: (open: boolean) => void;
 }
 
-interface IExtendedProps extends IProps {
-    // Props for making the button into a roving one
-    tabIndex?: number;
-    onFocus?(): void;
-}
-
 const contextMenuBelow = (elementRect: DOMRect) => {
     // align the context menu's icons with the icon which opened the context menu
-    const left = elementRect.left + window.pageXOffset + elementRect.width;
+    const right = UIStore.instance.windowWidth - elementRect.right + window.pageXOffset;
     const top = elementRect.bottom + window.pageYOffset;
     const chevronFace = ChevronFace.None;
-    return { left, top, chevronFace };
+    return { right, top, chevronFace };
 };
 
-const ThreadListContextMenu: React.FC<IExtendedProps> = ({
+const ThreadListContextMenu: React.FC<IProps> = ({
     mxEvent,
     permalinkCreator,
     onMenuToggle,
-    onFocus,
     ...props
 }) => {
     const [menuDisplayed, button, openMenu, closeThreadOptions] = useContextMenu();
@@ -80,11 +74,8 @@ const ThreadListContextMenu: React.FC<IExtendedProps> = ({
     }, [mxEvent, closeThreadOptions, permalinkCreator]);
 
     useEffect(() => {
-        if (onMenuToggle) {
-            onMenuToggle(menuDisplayed);
-        }
-        onFocus?.();
-    }, [menuDisplayed, onMenuToggle, onFocus]);
+        onMenuToggle?.(menuDisplayed);
+    }, [menuDisplayed, onMenuToggle]);
 
     const isMainSplitTimelineShown = !WidgetLayoutStore.instance.hasMaximisedWidget(
         MatrixClientPeg.get().getRoom(mxEvent.getRoomId()),


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21236

![image](https://user-images.githubusercontent.com/2403652/156027671-052fc8b4-822b-4f4d-b00f-439b2d0c3c36.png)


Positioning of the mx_ContextualMenu is based on the top-right corner of its wrapper 
![image](https://user-images.githubusercontent.com/2403652/156025858-37b8fe67-4bd6-4760-b430-1008fe385568.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix positioning of the thread context menu ([\#7918](https://github.com/matrix-org/matrix-react-sdk/pull/7918)). Fixes vector-im/element-web#21236.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr7918--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
