### PR TITLE
Load icons using @svgr

### DIFF
--- a/docs/icons.md
+++ b/docs/icons.md
@@ -1,0 +1,44 @@
+# Icons
+
+Icons are loaded using [@svgr/webpack](https://www.npmjs.com/package/@svgr/webpack). This is configured in [element-web](https://github.com/vector-im/element-web/blob/develop/webpack.config.js#L458)
+
+Each .svg exports a `ReactComponent` at the named export `Icon`.
+Icons have `role="presentation"` and `aria-hidden` automatically applied. These can be overriden by passing props to the icon component.
+
+eg
+```
+import { Icon as FavoriteIcon } from 'res/img/element-icons/favorite.svg';
+
+const MyComponent = () => {
+    return <>
+        <FavoriteIcon>
+        <FavoriteIcon className="mx_MyComponent-icon" role="img" aria-hidden="false">
+    </>;
+}
+```
+
+## Styling
+
+Icon components are svg elements and can be styled as usual.
+
+```
+// _MyComponents.scss
+.mx_MyComponent-icon {
+    height: 20px;
+    width: 20px;
+
+    * {
+        fill: $accent;
+    }
+}
+
+// MyComponent.tsx
+import { Icon as FavoriteIcon } from 'res/img/element-icons/favorite.svg';
+
+const MyComponent = () => {
+    return <>
+        <FavoriteIcon>
+        <FavoriteIcon className="mx_MyComponent-icon" role="img" aria-hidden="false">
+    </>;
+}
+```

--- a/res/css/structures/_QuickSettingsButton.scss
+++ b/res/css/structures/_QuickSettingsButton.scss
@@ -100,7 +100,6 @@ limitations under the License.
         }
     }
 
-
     .mx_QuickSettingsButton_moreOptionsButton {
         padding-left: 22px;
         margin-left: 22px;
@@ -114,7 +113,7 @@ limitations under the License.
 
 .mx_QuickSettingsButton_icon {
     * {
-        fill:  $secondary-content;
+        fill: $secondary-content;
     }
     width: 16px;
     height: 16px;

--- a/res/css/structures/_QuickSettingsButton.scss
+++ b/res/css/structures/_QuickSettingsButton.scss
@@ -82,21 +82,6 @@ limitations under the License.
     .mx_QuickSettingsButton_pinToSidebarHeading {
         padding-left: 24px;
         position: relative;
-
-        &::before {
-            background-color: $secondary-content;
-            content: "";
-            mask-repeat: no-repeat;
-            mask-position: center;
-            mask-size: contain;
-            mask-image: url('$(res)/img/element-icons/room/pin-upright.svg');
-            width: 16px;
-            height: 16px;
-            position: absolute;
-            left: 0;
-            top: 50%;
-            transform: translateY(-50%);
-        }
     }
 
     .mx_Checkbox {
@@ -112,30 +97,9 @@ limitations under the License.
             font-size: $font-15px;
             line-height: $font-24px;
             color: $secondary-content;
-
-            &::before {
-                background-color: $secondary-content;
-                content: "";
-                mask-repeat: no-repeat;
-                mask-position: center;
-                mask-size: contain;
-                width: 16px;
-                height: 16px;
-                position: absolute;
-                left: 0;
-                top: 50%;
-                transform: translateY(-50%);
-            }
         }
     }
 
-    .mx_QuickSettingsButton_favouritesCheckbox .mx_Checkbox_background + div::before {
-        mask-image: url('$(res)/img/element-icons/roomlist/favorite.svg');
-    }
-
-    .mx_QuickSettingsButton_peopleCheckbox .mx_Checkbox_background + div::before {
-        mask-image: url('$(res)/img/element-icons/room/members.svg');
-    }
 
     .mx_QuickSettingsButton_moreOptionsButton {
         padding-left: 22px;
@@ -145,20 +109,17 @@ limitations under the License.
         color: $secondary-content;
         position: relative;
         margin-bottom: 16px;
-
-        &::before {
-            background-color: $secondary-content;
-            content: "";
-            mask-repeat: no-repeat;
-            mask-position: center;
-            mask-size: contain;
-            width: 16px;
-            height: 16px;
-            position: absolute;
-            left: 0;
-            top: 50%;
-            transform: translateY(-50%);
-            mask-image: url('$(res)/img/element-icons/room/ellipsis.svg');
-        }
     }
+}
+
+.mx_QuickSettingsButton_icon {
+    * {
+        fill:  $secondary-content;
+    }
+    width: 16px;
+    height: 16px;
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
 }

--- a/src/@types/svg.d.ts
+++ b/src/@types/svg.d.ts
@@ -1,5 +1,6 @@
 /*
 Copyright 2021 Šimon Brandner <simon.bra.ag@gmail.com>
+Copyright 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/@types/svg.d.ts
+++ b/src/@types/svg.d.ts
@@ -16,5 +16,6 @@ limitations under the License.
 
 declare module "*.svg" {
     const path: string;
+    export const Icon: React.FC<React.SVGProps<SVGSVGElement>>;
     export default path;
 }

--- a/src/components/views/spaces/QuickSettingsButton.tsx
+++ b/src/components/views/spaces/QuickSettingsButton.tsx
@@ -29,6 +29,10 @@ import defaultDispatcher from "../../../dispatcher/dispatcher";
 import { Action } from "../../../dispatcher/actions";
 import { UserTab } from "../dialogs/UserSettingsDialog";
 import QuickThemeSwitcher from "./QuickThemeSwitcher";
+import { Icon as PinUprightIcon } from '../../../../res/img/element-icons/room/pin-upright.svg';
+import { Icon as EllipsisIcon } from '../../../../res/img/element-icons/room/ellipsis.svg';
+import { Icon as MembersIcon } from '../../../../res/img/element-icons/room/members.svg';
+import { Icon as FavoriteIcon } from '../../../../res/img/element-icons/roomlist/favorite.svg';
 
 const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
     const [menuDisplayed, handle, openMenu, closeMenu] = useContextMenu<HTMLDivElement>();
@@ -59,13 +63,17 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                 { _t("All settings") }
             </AccessibleButton>
 
-            <h4 className="mx_QuickSettingsButton_pinToSidebarHeading">{ _t("Pin to sidebar") }</h4>
+            <h4 className="mx_QuickSettingsButton_pinToSidebarHeading">
+                <PinUprightIcon aria-hidden className="mx_QuickSettingsButton_icon" />
+                { _t("Pin to sidebar") }
+            </h4>
 
             <StyledCheckbox
                 className="mx_QuickSettingsButton_favouritesCheckbox"
                 checked={!!favouritesEnabled}
                 onChange={onMetaSpaceChangeFactory(MetaSpace.Favourites, "WebQuickSettingsPinToSidebarCheckbox")}
             >
+                <FavoriteIcon className="mx_QuickSettingsButton_icon" aria-hidden />
                 { _t("Favourites") }
             </StyledCheckbox>
             <StyledCheckbox
@@ -73,6 +81,8 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                 checked={!!peopleEnabled}
                 onChange={onMetaSpaceChangeFactory(MetaSpace.People, "WebQuickSettingsPinToSidebarCheckbox")}
             >
+
+                <MembersIcon className="mx_QuickSettingsButton_icon" aria-hidden />
                 { _t("People") }
             </StyledCheckbox>
             <AccessibleButton
@@ -85,6 +95,7 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                     });
                 }}
             >
+                <EllipsisIcon aria-hidden className="mx_QuickSettingsButton_icon" />
                 { _t("More options") }
             </AccessibleButton>
 

--- a/src/components/views/spaces/QuickSettingsButton.tsx
+++ b/src/components/views/spaces/QuickSettingsButton.tsx
@@ -64,7 +64,7 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
             </AccessibleButton>
 
             <h4 className="mx_QuickSettingsButton_pinToSidebarHeading">
-                <PinUprightIcon aria-hidden className="mx_QuickSettingsButton_icon" />
+                <PinUprightIcon className="mx_QuickSettingsButton_icon" />
                 { _t("Pin to sidebar") }
             </h4>
 
@@ -73,7 +73,7 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                 checked={!!favouritesEnabled}
                 onChange={onMetaSpaceChangeFactory(MetaSpace.Favourites, "WebQuickSettingsPinToSidebarCheckbox")}
             >
-                <FavoriteIcon className="mx_QuickSettingsButton_icon" aria-hidden />
+                <FavoriteIcon className="mx_QuickSettingsButton_icon" />
                 { _t("Favourites") }
             </StyledCheckbox>
             <StyledCheckbox
@@ -82,7 +82,7 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                 onChange={onMetaSpaceChangeFactory(MetaSpace.People, "WebQuickSettingsPinToSidebarCheckbox")}
             >
 
-                <MembersIcon className="mx_QuickSettingsButton_icon" aria-hidden />
+                <MembersIcon className="mx_QuickSettingsButton_icon" />
                 { _t("People") }
             </StyledCheckbox>
             <AccessibleButton
@@ -95,7 +95,7 @@ const QuickSettingsButton = ({ isPanelCollapsed = false }) => {
                     });
                 }}
             >
-                <EllipsisIcon aria-hidden className="mx_QuickSettingsButton_icon" />
+                <EllipsisIcon className="mx_QuickSettingsButton_icon" />
                 { _t("More options") }
             </AccessibleButton>
 


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Changes in element-web: https://github.com/vector-im/element-web/pull/21248

Current icon situation is a mixture of two approaches -
- using svgs in css as `mask-image`, can control colour, expensive for css evaluation, fussy, heaps of duplication of styles
- loading svgs as images, can't control colour

This PR extends the .svg modules types and adds a POC in `QuickSettingsButton`
Loader changes in element-web https://github.com/vector-im/element-web/pull/21248
@svgr automatically applies `role="img"` and `aria-hidden` to generated svg components.

Further improvements:
- groom svgs to set `fill: currentColor` so most of the time icons will not need any particular styling

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr7928--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
