### PR TITLE
Mandate use of js-sdk/src/matrix import over js-sdk/src

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,19 @@ module.exports = {
 
         // Ban matrix-js-sdk/src imports in favour of matrix-js-sdk/src/matrix imports to prevent unleashing hell.
         "no-restricted-imports": ["error", {
+            "name": "matrix-js-sdk",
+            "message": "Please use matrix-js-sdk/src/matrix instead",
+        }, {
+            "name": "matrix-js-sdk/",
+            "message": "Please use matrix-js-sdk/src/matrix instead",
+        }, {
             "name": "matrix-js-sdk/src",
+            "message": "Please use matrix-js-sdk/src/matrix instead",
+        }, {
+            "name": "matrix-js-sdk/src/",
+            "message": "Please use matrix-js-sdk/src/matrix instead",
+        }, {
+            "name": "matrix-js-sdk/src/index",
             "message": "Please use matrix-js-sdk/src/matrix instead",
         }],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,12 @@ module.exports = {
             ),
         ],
 
+        // Ban matrix-js-sdk/src imports in favour of matrix-js-sdk/src/matrix imports to prevent unleashing hell.
+        "no-restricted-imports": ["error", {
+            "name": "matrix-js-sdk/src",
+            "message": "Please use matrix-js-sdk/src/matrix instead",
+        }],
+
         // There are too many a11y violations to fix at once
         // Turn violated rules off until they are fixed
         "jsx-a11y/alt-text": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,20 +42,32 @@ module.exports = {
 
         // Ban matrix-js-sdk/src imports in favour of matrix-js-sdk/src/matrix imports to prevent unleashing hell.
         "no-restricted-imports": ["error", {
-            "name": "matrix-js-sdk",
-            "message": "Please use matrix-js-sdk/src/matrix instead",
-        }, {
-            "name": "matrix-js-sdk/",
-            "message": "Please use matrix-js-sdk/src/matrix instead",
-        }, {
-            "name": "matrix-js-sdk/src",
-            "message": "Please use matrix-js-sdk/src/matrix instead",
-        }, {
-            "name": "matrix-js-sdk/src/",
-            "message": "Please use matrix-js-sdk/src/matrix instead",
-        }, {
-            "name": "matrix-js-sdk/src/index",
-            "message": "Please use matrix-js-sdk/src/matrix instead",
+            "paths": [{
+                "name": "matrix-js-sdk",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src/",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src/index",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-react-sdk",
+                "message": "Please use matrix-react-sdk/src/index instead",
+            }, {
+                "name": "matrix-react-sdk/",
+                "message": "Please use matrix-react-sdk/src/index instead",
+            }],
+            "patterns": [{
+                "group": ["matrix-js-sdk/lib", "matrix-js-sdk/lib/", "matrix-js-sdk/lib/**"],
+                "message": "Please use matrix-js-sdk/src/* instead",
+            }],
         }],
 
         // There are too many a11y violations to fix at once

--- a/src/AddThreepid.ts
+++ b/src/AddThreepid.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IRequestMsisdnTokenResponse, IRequestTokenResponse } from "matrix-js-sdk/src";
+import { IRequestMsisdnTokenResponse, IRequestTokenResponse } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from './MatrixClientPeg';
 import Modal from './Modal';

--- a/src/ContentMessages.tsx
+++ b/src/ContentMessages.tsx
@@ -24,7 +24,7 @@ import encrypt from "browser-encrypt-attachment";
 import extractPngChunks from "png-chunks-extract";
 import { IAbortablePromise, IImageInfo } from "matrix-js-sdk/src/@types/partials";
 import { logger } from "matrix-js-sdk/src/logger";
-import { IEventRelation, ISendEventResponse } from "matrix-js-sdk/src";
+import { IEventRelation, ISendEventResponse } from "matrix-js-sdk/src/matrix";
 
 import { IEncryptedFile, IMediaEventInfo } from "./customisations/models/IMediaEventContent";
 import dis from './dispatcher/dispatcher';

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -20,7 +20,7 @@ import FileSaver from 'file-saver';
 import { logger } from "matrix-js-sdk/src/logger";
 import { IKeyBackupInfo } from "matrix-js-sdk/src/crypto/keybackup";
 import { TrustInfo } from "matrix-js-sdk/src/crypto/backup";
-import { CrossSigningKeys } from "matrix-js-sdk/src";
+import { CrossSigningKeys } from "matrix-js-sdk/src/matrix";
 import { IRecoveryKey } from "matrix-js-sdk/src/crypto/api";
 import { CryptoEvent } from "matrix-js-sdk/src/crypto";
 

--- a/src/components/structures/UploadBar.tsx
+++ b/src/components/structures/UploadBar.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import { Room } from "matrix-js-sdk/src/models/room";
 import filesize from "filesize";
-import { IEventRelation } from 'matrix-js-sdk/src';
+import { IEventRelation } from 'matrix-js-sdk/src/matrix';
 
 import ContentMessages from '../../ContentMessages';
 import dis from "../../dispatcher/dispatcher";

--- a/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { useCallback, useEffect } from "react";
-import { MatrixEvent } from "matrix-js-sdk/src";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import { ButtonEvent } from "../elements/AccessibleButton";
 import dis from '../../../dispatcher/dispatcher';

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { useRef, useState, Dispatch, SetStateAction } from "react";
-import { Room } from "matrix-js-sdk/src";
+import { Room } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { _t } from "../../../languageHandler";

--- a/src/components/views/messages/DownloadActionButton.tsx
+++ b/src/components/views/messages/DownloadActionButton.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "matrix-js-sdk/src";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 import React from "react";
 import classNames from "classnames";
 

--- a/src/components/views/messages/MKeyVerificationRequest.tsx
+++ b/src/components/views/messages/MKeyVerificationRequest.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { MatrixEvent } from 'matrix-js-sdk/src';
+import { MatrixEvent } from 'matrix-js-sdk/src/matrix';
 import { logger } from "matrix-js-sdk/src/logger";
 import { VerificationRequestEvent } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
 

--- a/src/components/views/messages/UnknownBody.tsx
+++ b/src/components/views/messages/UnknownBody.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import React, { forwardRef } from "react";
-import { MatrixEvent } from "matrix-js-sdk/src";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 interface IProps {
     mxEvent: MatrixEvent;

--- a/src/components/views/messages/ViewSourceEvent.tsx
+++ b/src/components/views/messages/ViewSourceEvent.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { MatrixEvent, MatrixEventEvent } from 'matrix-js-sdk/src';
+import { MatrixEvent, MatrixEventEvent } from 'matrix-js-sdk/src/matrix';
 import classNames from 'classnames';
 
 import { replaceableComponent } from "../../../utils/replaceableComponent";

--- a/src/components/views/rooms/RoomDetailList.tsx
+++ b/src/components/views/rooms/RoomDetailList.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Room } from 'matrix-js-sdk/src';
+import { Room } from 'matrix-js-sdk/src/matrix';
 import classNames from 'classnames';
 
 import dis from '../../../dispatcher/dispatcher';

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 import React from 'react';
 import classNames from 'classnames';
 import { throttle } from 'lodash';
-import { MatrixEvent, Room, RoomStateEvent } from 'matrix-js-sdk/src';
+import { MatrixEvent, Room, RoomStateEvent } from 'matrix-js-sdk/src/matrix';
 import { CallType } from "matrix-js-sdk/src/webrtc/call";
 
 import { _t } from '../../../languageHandler';

--- a/src/components/views/settings/CrossSigningPanel.tsx
+++ b/src/components/views/settings/CrossSigningPanel.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { ClientEvent, MatrixEvent } from 'matrix-js-sdk/src';
+import { ClientEvent, MatrixEvent } from 'matrix-js-sdk/src/matrix';
 import { logger } from "matrix-js-sdk/src/logger";
 import { CryptoEvent } from "matrix-js-sdk/src/crypto";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import Skinner, { ISkinObject } from './Skinner';
 
 // Import the js-sdk so the proper `request` object can be set. This does some
 // magic with the browser injection to make all subsequent imports work fine.
-import "matrix-js-sdk";
+import "matrix-js-sdk/src/browser-index";
 
 export function loadSkin(skinObject: ISkinObject): void {
     Skinner.load(skinObject);

--- a/src/indexing/BaseEventIndexManager.ts
+++ b/src/indexing/BaseEventIndexManager.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { IMatrixProfile, IEventWithRoomId as IMatrixEvent, IResultRoomEvents } from "matrix-js-sdk/src/@types/search";
-import { Direction } from "matrix-js-sdk/src";
+import { Direction } from "matrix-js-sdk/src/matrix";
 
 // The following interfaces take their names and member names from seshat and the spec
 /* eslint-disable camelcase */

--- a/src/models/IUpload.ts
+++ b/src/models/IUpload.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IEventRelation } from "matrix-js-sdk/src";
+import { IEventRelation } from "matrix-js-sdk/src/matrix";
 import { IAbortablePromise } from "matrix-js-sdk/src/@types/partials";
 
 export interface IUpload {

--- a/src/sendTimePerformanceMetrics.ts
+++ b/src/sendTimePerformanceMetrics.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "matrix-js-sdk/src";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 /**
  * Decorates the given event content object with the "send start time". The

--- a/src/stores/ActiveWidgetStore.ts
+++ b/src/stores/ActiveWidgetStore.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import EventEmitter from 'events';
-import { MatrixEvent, RoomStateEvent } from "matrix-js-sdk/src";
+import { MatrixEvent, RoomStateEvent } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from '../MatrixClientPeg';
 import { WidgetMessagingStore } from "./widgets/WidgetMessagingStore";

--- a/src/stores/AutoRageshakeStore.ts
+++ b/src/stores/AutoRageshakeStore.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ClientEvent, MatrixEvent, MatrixEventEvent } from "matrix-js-sdk/src";
+import { ClientEvent, MatrixEvent, MatrixEventEvent } from "matrix-js-sdk/src/matrix";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { ISyncStateData, SyncState } from "matrix-js-sdk/src/sync";
 

--- a/src/utils/MediaEventHelper.ts
+++ b/src/utils/MediaEventHelper.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "matrix-js-sdk/src";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
 import { logger } from "matrix-js-sdk/src/logger";
 

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import './skinned-sdk';
 
-import { IProtocol } from 'matrix-js-sdk/src';
+import { IProtocol } from 'matrix-js-sdk/src/matrix';
 import { CallEvent, CallState, CallType } from 'matrix-js-sdk/src/webrtc/call';
 import EventEmitter from 'events';
 

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from 'matrix-js-sdk';
+import { MatrixEvent } from 'matrix-js-sdk/src/matrix';
 
 import './skinned-sdk'; // Must be first for skinning to work
 import { DecryptionFailureTracker } from '../src/DecryptionFailureTracker';

--- a/test/DeviceListener-test.ts
+++ b/test/DeviceListener-test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 
 import { EventEmitter } from "events";
 import { mocked } from "jest-mock";
-import { Room } from "matrix-js-sdk";
+import { Room } from "matrix-js-sdk/src/matrix";
 
 import './skinned-sdk';
 import DeviceListener from "../src/DeviceListener";

--- a/test/Terms-test.js
+++ b/test/Terms-test.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as Matrix from 'matrix-js-sdk';
+import * as Matrix from 'matrix-js-sdk/src/matrix';
 
 import { startTermsFlow, Service } from '../src/Terms';
 import { stubClient } from './test-utils';

--- a/test/TextForEvent-test.ts
+++ b/test/TextForEvent-test.ts
@@ -1,6 +1,6 @@
 import './skinned-sdk';
 
-import { EventType, MatrixEvent } from "matrix-js-sdk";
+import { EventType, MatrixEvent } from "matrix-js-sdk/src/matrix";
 import TestRenderer from 'react-test-renderer';
 
 import { getSenderName, textForEvent } from "../src/TextForEvent";

--- a/test/components/structures/CallEventGrouper-test.ts
+++ b/test/components/structures/CallEventGrouper-test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import "../../skinned-sdk";
-import { MatrixClient } from 'matrix-js-sdk';
+import { MatrixClient } from 'matrix-js-sdk/src/matrix';
 import { EventType } from "matrix-js-sdk/src/@types/event";
 import { CallState } from "matrix-js-sdk/src/webrtc/call";
 

--- a/test/components/structures/GroupView-test.js
+++ b/test/components/structures/GroupView-test.js
@@ -18,7 +18,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import MockHttpBackend from 'matrix-mock-request';
-import Matrix from 'matrix-js-sdk/src/matrix';
+import * as Matrix from 'matrix-js-sdk/src/matrix';
 
 import { MatrixClientPeg } from '../../../src/MatrixClientPeg';
 import sdk from '../../skinned-sdk';

--- a/test/components/structures/GroupView-test.js
+++ b/test/components/structures/GroupView-test.js
@@ -18,7 +18,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import MockHttpBackend from 'matrix-mock-request';
-import Matrix from 'matrix-js-sdk';
+import Matrix from 'matrix-js-sdk/src/matrix';
 
 import { MatrixClientPeg } from '../../../src/MatrixClientPeg';
 import sdk from '../../skinned-sdk';

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 import React from 'react';
 import ReactDOM from "react-dom";
 import { EventEmitter } from "events";
-import Matrix from 'matrix-js-sdk/src/matrix';
+import * as Matrix from 'matrix-js-sdk/src/matrix';
 import FakeTimers from '@sinonjs/fake-timers';
 import { mount } from "enzyme";
 

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 import React from 'react';
 import ReactDOM from "react-dom";
 import { EventEmitter } from "events";
-import Matrix from 'matrix-js-sdk';
+import Matrix from 'matrix-js-sdk/src/matrix';
 import FakeTimers from '@sinonjs/fake-timers';
 import { mount } from "enzyme";
 

--- a/test/components/structures/ThreadPanel-test.tsx
+++ b/test/components/structures/ThreadPanel-test.tsx
@@ -22,7 +22,7 @@ import {
     Room,
     UNSTABLE_FILTER_RELATION_SENDERS,
     UNSTABLE_FILTER_RELATION_TYPES,
-} from 'matrix-js-sdk';
+} from 'matrix-js-sdk/src/matrix';
 import { mocked } from 'jest-mock';
 import '../../skinned-sdk';
 

--- a/test/components/views/context_menus/SpaceContextMenu-test.tsx
+++ b/test/components/views/context_menus/SpaceContextMenu-test.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { Room } from 'matrix-js-sdk';
+import { Room } from 'matrix-js-sdk/src/matrix';
 import { mocked } from 'jest-mock';
 import { act } from 'react-dom/test-utils';
 

--- a/test/components/views/dialogs/ExportDialog-test.tsx
+++ b/test/components/views/dialogs/ExportDialog-test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { mocked } from 'jest-mock';
 import { act } from "react-dom/test-utils";
-import { Room } from 'matrix-js-sdk';
+import { Room } from 'matrix-js-sdk/src/matrix';
 
 import '../../../skinned-sdk';
 import ExportDialog from '../../../../src/components/views/dialogs/ExportDialog';

--- a/test/components/views/groups/GroupMemberList-test.js
+++ b/test/components/views/groups/GroupMemberList-test.js
@@ -18,7 +18,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import ReactTestUtils from "react-dom/test-utils";
 import MockHttpBackend from "matrix-mock-request";
-import Matrix from "matrix-js-sdk";
+import Matrix from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import sdk from "../../../skinned-sdk";

--- a/test/components/views/groups/GroupMemberList-test.js
+++ b/test/components/views/groups/GroupMemberList-test.js
@@ -18,7 +18,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import ReactTestUtils from "react-dom/test-utils";
 import MockHttpBackend from "matrix-mock-request";
-import Matrix from "matrix-js-sdk/src/matrix";
+import * as Matrix from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import sdk from "../../../skinned-sdk";

--- a/test/components/views/messages/MKeyVerificationConclusion-test.js
+++ b/test/components/views/messages/MKeyVerificationConclusion-test.js
@@ -2,7 +2,7 @@ import '../../../skinned-sdk'; // Must be first for skinning to work
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { EventEmitter } from 'events';
-import { MatrixEvent } from 'matrix-js-sdk';
+import { MatrixEvent } from 'matrix-js-sdk/src/matrix';
 
 import * as TestUtils from '../../../test-utils';
 import { MatrixClientPeg } from '../../../../src/MatrixClientPeg';

--- a/test/components/views/messages/MPollBody-test.tsx
+++ b/test/components/views/messages/MPollBody-test.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from "react";
 import { mount, ReactWrapper } from "enzyme";
-import { Callback, IContent, MatrixClient, MatrixEvent, Room } from "matrix-js-sdk";
+import { Callback, IContent, MatrixClient, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 import { Relations } from "matrix-js-sdk/src/models/relations";
 import { RelatedRelations } from "matrix-js-sdk/src/models/related-relations";

--- a/test/components/views/right_panel/UserInfo-test.tsx
+++ b/test/components/views/right_panel/UserInfo-test.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from "react-dom/test-utils";
-import { Room, User } from 'matrix-js-sdk';
+import { Room, User } from 'matrix-js-sdk/src/matrix';
 import { Phase, VerificationRequest } from 'matrix-js-sdk/src/crypto/verification/request/VerificationRequest';
 
 import "../../../skinned-sdk";

--- a/test/components/views/rooms/RoomHeader-test.tsx
+++ b/test/components/views/rooms/RoomHeader-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Room, PendingEventOrdering, MatrixEvent, MatrixClient } from 'matrix-js-sdk';
+import { Room, PendingEventOrdering, MatrixEvent, MatrixClient } from 'matrix-js-sdk/src/matrix';
 
 import "../../../skinned-sdk";
 import * as TestUtils from '../../../test-utils';

--- a/test/components/views/rooms/RoomList-test.js
+++ b/test/components/views/rooms/RoomList-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
-import { MatrixClient, Room, RoomMember } from 'matrix-js-sdk';
+import { MatrixClient, Room, RoomMember } from 'matrix-js-sdk/src/matrix';
 
 import * as TestUtils from '../../../test-utils';
 import { MatrixClientPeg } from '../../../../src/MatrixClientPeg';

--- a/test/components/views/rooms/RoomPreviewBar-test.tsx
+++ b/test/components/views/rooms/RoomPreviewBar-test.tsx
@@ -21,7 +21,7 @@ import {
     findRenderedDOMComponentWithClass,
     act,
 } from 'react-dom/test-utils';
-import { Room, RoomMember, MatrixError, IContent } from 'matrix-js-sdk';
+import { Room, RoomMember, MatrixError, IContent } from 'matrix-js-sdk/src/matrix';
 
 import "../../../skinned-sdk";
 import { stubClient } from '../../../test-utils';

--- a/test/components/views/settings/CryptographyPanel-test.tsx
+++ b/test/components/views/settings/CryptographyPanel-test.tsx
@@ -2,7 +2,7 @@ import '../../../skinned-sdk';
 
 import React, { ReactElement } from 'react';
 import ReactDOM from 'react-dom';
-import { MatrixClient } from 'matrix-js-sdk';
+import { MatrixClient } from 'matrix-js-sdk/src/matrix';
 
 import { MatrixClientPeg } from '../../../../src/MatrixClientPeg';
 import * as TestUtils from '../../../test-utils';

--- a/test/components/views/settings/Notifications-test.tsx
+++ b/test/components/views/settings/Notifications-test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 import React from 'react';
 import { mount } from 'enzyme';
 import '../../../skinned-sdk';
-import { IPushRule, IPushRules, RuleId } from 'matrix-js-sdk';
+import { IPushRule, IPushRules, RuleId } from 'matrix-js-sdk/src/matrix';
 import { ThreepidMedium } from 'matrix-js-sdk/src/@types/threepids';
 import { act } from 'react-dom/test-utils';
 

--- a/test/components/views/spaces/SpacePanel-test.tsx
+++ b/test/components/views/spaces/SpacePanel-test.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import React from 'react';
 import { mount } from 'enzyme';
 import { mocked } from 'jest-mock';
-import { MatrixClient } from 'matrix-js-sdk';
+import { MatrixClient } from 'matrix-js-sdk/src/matrix';
 import { act } from "react-dom/test-utils";
 
 import '../../../skinned-sdk';

--- a/test/components/views/spaces/SpaceSettingsVisibilityTab-test.tsx
+++ b/test/components/views/spaces/SpaceSettingsVisibilityTab-test.tsx
@@ -6,7 +6,7 @@ import {
     Simulate,
 } from 'react-dom/test-utils';
 import { act } from "react-dom/test-utils";
-import { EventType, MatrixClient, Room } from 'matrix-js-sdk';
+import { EventType, MatrixClient, Room } from 'matrix-js-sdk/src/matrix';
 import { GuestAccess, HistoryVisibility, JoinRule } from 'matrix-js-sdk/src/@types/partials';
 
 import _SpaceSettingsVisibilityTab from "../../../../src/components/views/spaces/SpaceSettingsVisibilityTab";

--- a/test/stores/VoiceRecordingStore-test.ts
+++ b/test/stores/VoiceRecordingStore-test.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import "../skinned-sdk"; // Must be first for skinning to work
 import { VoiceRecording } from '../../src/audio/VoiceRecording';

--- a/test/stores/WidgetLayoutStore-test.ts
+++ b/test/stores/WidgetLayoutStore-test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import "../skinned-sdk"; // Must be first for skinning to work
-import { Room } from "matrix-js-sdk";
+import { Room } from "matrix-js-sdk/src/matrix";
 
 import WidgetStore, { IApp } from "../../src/stores/WidgetStore";
 import { Container, WidgetLayoutStore } from "../../src/stores/widgets/WidgetLayoutStore";

--- a/test/stores/room-list/previews/PollStartEventPreview-test.ts
+++ b/test/stores/room-list/previews/PollStartEventPreview-test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "matrix-js-sdk";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { POLL_ANSWER, M_TEXT, M_POLL_KIND_DISCLOSED, M_POLL_START } from "matrix-events-sdk";
 
 import { PollStartEventPreview } from "../../../../src/stores/room-list/previews/PollStartEventPreview";

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -13,7 +13,7 @@ import {
     RoomState,
     EventType,
     IEventRelation,
-} from 'matrix-js-sdk';
+} from 'matrix-js-sdk/src/matrix';
 
 import { MatrixClientPeg as peg } from '../../src/MatrixClientPeg';
 import dis from '../../src/dispatcher/dispatcher';

--- a/test/test-utils/threads.ts
+++ b/test/test-utils/threads.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient, MatrixEvent, RelationType, Room } from "matrix-js-sdk";
+import { MatrixClient, MatrixEvent, RelationType, Room } from "matrix-js-sdk/src/matrix";
 import { Thread } from "matrix-js-sdk/src/models/thread";
 
 import { mkMessage, MessageEventProps } from "./test-utils";

--- a/test/test-utils/wrappers.tsx
+++ b/test/test-utils/wrappers.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { RefCallback } from "react";
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg as peg } from '../../src/MatrixClientPeg';
 import MatrixClientContext from "../../src/contexts/MatrixClientContext";

--- a/test/utils/export-test.tsx
+++ b/test/utils/export-test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { renderToString } from "react-dom/server";
-import { IContent, MatrixClient, MatrixEvent, Room } from "matrix-js-sdk";
+import { IContent, MatrixClient, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
 import { IExportOptions, ExportType, ExportFormat } from "../../src/utils/exportUtils/exportUtils";


### PR DESCRIPTION
See https://github.com/vector-im/element-web/issues/21253#issuecomment-1055716419 for some context
`/src/index` is the node entrypoint which a webapp should not be using.

Fixes https://github.com/vector-im/element-web/issues/21253
Paired with https://github.com/matrix-org/matrix-js-sdk/pull/2211

![image](https://user-images.githubusercontent.com/2403652/156225152-4259c6cd-572f-4dbf-bb10-f88468e1eb5b.png)

Also makes the bundle size smaller

Before
![image](https://user-images.githubusercontent.com/2403652/156225096-72293cd7-fc09-4ae1-9585-656929db34c0.png)

After
![image](https://user-images.githubusercontent.com/2403652/156225109-2147c889-5dc4-4719-963d-b3e7f3d7a750.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Mandate use of js-sdk/src/matrix import over js-sdk/src ([\#7933](https://github.com/matrix-org/matrix-react-sdk/pull/7933)). Fixes vector-im/element-web#21253.<!-- CHANGELOG_PREVIEW_END -->
















<!-- Replace -->
Preview: https://pr7933--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
