### PR TITLE
Fix room list being laggy while scrolling 🐌

### DIFF
--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -160,7 +160,7 @@ export default class Tooltip extends React.Component<ITooltipProps> {
         let style: CSSProperties = {};
         // When the tooltip is hidden, no need to thrash the DOM with `style`
         // attribute updates (performance)
-        if(this.props.visible) {
+        if (this.props.visible) {
             style = this.updatePosition({});
         }
         // Hide the entire container when not visible. This prevents flashing of the tooltip

--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -98,6 +98,8 @@ export default class Tooltip extends React.Component<ITooltipProps> {
         });
     }
 
+    // Add the parent's position to the tooltips, so it's correctly
+    // positioned, also taking into account any window zoom
     private updatePosition(style: CSSProperties) {
         const parentBox = this.parent.getBoundingClientRect();
         let offset = 0;
@@ -155,11 +157,10 @@ export default class Tooltip extends React.Component<ITooltipProps> {
     }
 
     private renderTooltip = () => {
-        // Add the parent's position to the tooltips, so it's correctly
-        // positioned, also taking into account any window zoom
-        // NOTE: The additional 6 pixels for the left position, is to take account of the
-        // tooltips chevron
-        const style = this.updatePosition({});
+        let style: CSSProperties = {};
+        if(this.props.visible) {
+            style = this.updatePosition({});
+        }
         // Hide the entire container when not visible. This prevents flashing of the tooltip
         // if it is not meant to be visible on first mount.
         style.display = this.props.visible ? "block" : "none";

--- a/src/components/views/elements/Tooltip.tsx
+++ b/src/components/views/elements/Tooltip.tsx
@@ -158,6 +158,8 @@ export default class Tooltip extends React.Component<ITooltipProps> {
 
     private renderTooltip = () => {
         let style: CSSProperties = {};
+        // When the tooltip is hidden, no need to thrash the DOM with `style`
+        // attribute updates (performance)
         if(this.props.visible) {
             style = this.updatePosition({});
         }

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -44,6 +44,17 @@ const TooltipTarget: React.FC<IProps> = ({
     const show = () => setIsVisible(true);
     const hide = () => setIsVisible(false);
 
+    const tooltip = isVisible && <Tooltip
+        id={id}
+        className={className}
+        tooltipClassName={tooltipClassName}
+        label={label}
+        yOffset={yOffset}
+        alignment={alignment}
+        visible={isVisible}
+        maxParentWidth={maxParentWidth}
+    />;
+
     return (
         <div
             tabIndex={0}
@@ -56,16 +67,7 @@ const TooltipTarget: React.FC<IProps> = ({
             {...rest}
         >
             { children }
-            <Tooltip
-                id={id}
-                className={className}
-                tooltipClassName={tooltipClassName}
-                label={label}
-                yOffset={yOffset}
-                alignment={alignment}
-                visible={isVisible}
-                maxParentWidth={maxParentWidth}
-            />
+            { tooltip }
         </div>
     );
 };

--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -44,6 +44,8 @@ const TooltipTarget: React.FC<IProps> = ({
     const show = () => setIsVisible(true);
     const hide = () => setIsVisible(false);
 
+    // No need to fill up the DOM with hidden tooltip elements. Only add the
+    // tooltip when we're hovering over the item (performance)
     const tooltip = isVisible && <Tooltip
         id={id}
         className={className}

--- a/test/components/views/elements/TooltipTarget-test.tsx
+++ b/test/components/views/elements/TooltipTarget-test.tsx
@@ -39,7 +39,9 @@ describe('<TooltipTarget />', () => {
     afterEach(() => {
         // clean up visible tooltips
         const tooltipWrapper = document.querySelector('.mx_Tooltip_wrapper');
-        document.body.removeChild(tooltipWrapper);
+        if(tooltipWrapper) {
+            document.body.removeChild(tooltipWrapper);
+        }
     });
 
     it('renders container', () => {

--- a/test/components/views/elements/TooltipTarget-test.tsx
+++ b/test/components/views/elements/TooltipTarget-test.tsx
@@ -39,7 +39,7 @@ describe('<TooltipTarget />', () => {
     afterEach(() => {
         // clean up visible tooltips
         const tooltipWrapper = document.querySelector('.mx_Tooltip_wrapper');
-        if(tooltipWrapper) {
+        if (tooltipWrapper) {
             document.body.removeChild(tooltipWrapper);
         }
     });

--- a/test/components/views/elements/__snapshots__/TooltipTarget-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/TooltipTarget-test.tsx.snap
@@ -22,8 +22,5 @@ exports[`<TooltipTarget /> renders container 1`] = `
   <span>
     child
   </span>
-  <div
-    class="test className"
-  />
 </div>
 `;


### PR DESCRIPTION
Fix room list being laggy while scrolling 🐌

Fix https://github.com/vector-im/element-web/issues/21262

Optimizations:

 1. Don't update the `style` (positioning) of hidden tooltips
 1. Don't add DOM elements to the page for hidden tooltips


Huge difference even on my local dev instance with 21 rooms:

Before | After
--- | ---
[Chrome performance profile](https://gist.githubusercontent.com/MadLittleMods/cd1805f4fc43641dc4803bd300fc85f3/raw/825473bbc6a07a8554898ed842aff886a4650532/profile-before.json) <img width="474" alt="" src="https://user-images.githubusercontent.com/558581/156286188-0bc09428-2a49-4f67-8303-c7d0aa7c8275.png"> | [Chrome performance profile](https://gist.githubusercontent.com/MadLittleMods/cd1805f4fc43641dc4803bd300fc85f3/raw/825473bbc6a07a8554898ed842aff886a4650532/profile-after.json) <img width="331" alt="" src="https://user-images.githubusercontent.com/558581/156286185-31507984-9548-4173-b53c-d149c15aecd5.png">


> ## Performance problems broken down
>
>
> ### Hidden tooltips rendering on `scroll`
>
> You can see that the Tooltip render is attached to the `scroll` event  at [`src/components/views/elements/Tooltip.tsx#L78-L81`](https://github.com/matrix-org/matrix-react-sdk/blob/31f0a37ca2eeba6a6296787f2fcb33c4b26efebc/src/components/views/elements/Tooltip.tsx#L78-L81)
>
> The rendering calls [`src/components/views/elements/Tooltip.tsx#L101` -> `updatePosition`](https://github.com/matrix-org/matrix-react-sdk/blob/36adba101caf58afd280e6eedad003b38165be4f/src/components/views/elements/Tooltip.tsx#L101) which ends up as an expensive "Recalculate Style" because it uses [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect). This happens many many times within a single `scroll` event. Probably once for each tooltip within the room list **even though no tooltips are even visible as I scroll**. I can see that we're just updating the `style` attribute for a bunch of `.mx_Tooltip_invisible` elements at the end of the document.
>
> Each one of the purple spans below the `scroll` span ends up as a call to `updatePosition`. And a `scroll` event takes 35ms to 60ms to complete which is way over the 16.6ms 60 FPS budget (on a powerful desktop PC), granted these times are with the performance profiling running. This is without the Passbolt extension explained below.
>
> And the room list contains about 141 rooms (`document.querySelectorAll('.mx_RoomTile').length`):
>
> ![](https://user-images.githubusercontent.com/558581/156273551-e744d3d6-93c6-4b07-bb12-6aad361f96a2.png)
>
>
>
> ### Passbolt Chrome browser extension exacerbates the problem
>
> In order to login to Passbolt, it requires a browser extension which defaults to mucking up all pages:
>
> <img src="https://user-images.githubusercontent.com/558581/156275644-bc26b1f5-5d99-4eae-b74b-c2028f2f1baf.png" width="300">
>
>
> The extension source seems to be available: https://github.com/passbolt/passbolt_browser_extension
>
> The Passbolt Chrome extension has a `MutationObserver` listening to all attribute and element changes to the whole `<body>` of the `document` so it can `findAndSetAuthenticationFields` (find form elements and autofill).
>
>
> [`passbolt/passbolt_styleguide` -> `src/react-web-integration/lib/InForm/InFormManager.js#L143`](https://github.com/passbolt/passbolt_styleguide/blob/1c5eddc9102c7cd1029d10dc6836af4722cdba61/src/react-web-integration/lib/InForm/InFormManager.js#L143)
> ```js
> this.mutationObserver.observe(document.body, { attributes: true, childList: true, subtree: true });
> ```
>
> This causes a bunch of `Forced reflow` because the Tooltip `updatePosition` is mutating the element `style` attribute and Passbolt `MutationObserver` callbacks are querying the whole DOM looking for form elements all in the same frame.
>
> Under the `scroll` event, all of the little spans are the `MutationObserver` -> `findAndSetAuthenticationFields`. With the Passbolt extension, scrolling is verrrrry crunchy and bad.
>
> ![](https://user-images.githubusercontent.com/558581/156144998-8cf7686f-3c7b-42f8-8d81-ff780bae0ab5.png)
>
>
> #### Workaround
>
> Instead of running Passbolt on all sites, we can enable the extension to only run on the domain for Passbolt instance itself. I'm guessing the Passbolt extension also does autofill stuff on sites but I always login manually to the Passbolt instance so this solution works for me �
>
> **Extensions** -> **Passbolt** -> **Details** -> Change **Site access** to `On specific sites` -> Enter in your Passbolt instance `https://passbolt.example.com/`
>
> ![](https://user-images.githubusercontent.com/558581/156275630-a53ef6a1-c058-4ac9-aa08-ae50b90e72c9.png)
>
> *-- https://github.com/vector-im/element-web/issues/21262*

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix room list being laggy while scrolling 🐌 ([\#7939](https://github.com/matrix-org/matrix-react-sdk/pull/7939)). Fixes vector-im/element-web#21262. Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://pr7939--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
