### PR TITLE
Prevent event tiles being shrunk/collapsed by flexbox

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -36,7 +36,6 @@ limitations under the License.
     margin-top: var(--gutterSize);
     margin-left: 49px;
     font-size: $font-14px;
-    flex-shrink: 0;
 
     .mx_ThreadInfo {
         clear: both;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -18,6 +18,8 @@ limitations under the License.
 $left-gutter: 64px;
 
 .mx_EventTile {
+    flex-shrink: 0;
+
     .mx_EventTile_receiptSent,
     .mx_EventTile_receiptSending {
         // Give it some dimensions so the tooltip can position properly


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21269

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent event tiles being shrunk/collapsed by flexbox ([\#7942](https://github.com/matrix-org/matrix-react-sdk/pull/7942)). Fixes vector-im/element-web#21269.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7942--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
