### PR TITLE
replace all require(.svg) with esm import

### DIFF
--- a/src/components/structures/FileDropTarget.tsx
+++ b/src/components/structures/FileDropTarget.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React, { useEffect, useState } from "react";
 
 import { _t } from "../../languageHandler";
+import FileDropSvg from '../../../res/img/upload-big.svg';
 
 interface IProps {
     parent: HTMLElement;
@@ -109,7 +110,7 @@ const FileDropTarget: React.FC<IProps> = ({ parent, onFileDrop }) => {
 
     if (state.dragging) {
         return <div className="mx_FileDropTarget">
-            <img src={require("../../../res/img/upload-big.svg")} className="mx_FileDropTarget_image" alt="" />
+            <img src={FileDropSvg} className="mx_FileDropTarget_image" alt="" />
             { _t("Drop file here to upload") }
         </div>;
     }

--- a/src/components/structures/GroupView.js
+++ b/src/components/structures/GroupView.js
@@ -46,6 +46,12 @@ import { createSpaceFromCommunity } from "../../utils/space";
 import { Action } from "../../dispatcher/actions";
 import { RightPanelPhases } from "../../stores/right-panel/RightPanelStorePhases";
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
+import CreateRoomSvg from '../../../res/img/icons-create-room.svg';
+import CancelSmallSvg from '../../../res/img/cancel-small.svg';
+import CancelSvg from '../../../res/img/cancel.svg';
+import ExternalLinkSvg from '../../../res/img/external-link.svg';
+import AddRoomSvg from '../../../res/img/icons-room-add.svg';
+import CameraSvg from '../../../res/img/camera.svg';
 
 const LONG_DESC_PLACEHOLDER = _td(
     `<h1>HTML for your community's page</h1>
@@ -135,7 +141,7 @@ class CategoryRoomList extends React.Component {
             (<AccessibleButton className="mx_GroupView_featuredThings_addButton"
                 onClick={this.onAddRoomsToSummaryClicked}
             >
-                <img src={require("../../../res/img/icons-create-room.svg")} width="64" height="64" />
+                <img src={CreateRoomSvg} width="64" height="64" />
                 <div className="mx_GroupView_featuredThings_addButton_label">
                     { _t('Add a Room') }
                 </div>
@@ -235,7 +241,7 @@ class FeaturedRoom extends React.Component {
         const deleteButton = this.props.editing ?
             <img
                 className="mx_GroupView_featuredThing_deleteButton"
-                src={require("../../../res/img/cancel-small.svg")}
+                src={CancelSmallSvg}
                 width="14"
                 height="14"
                 alt="Delete"
@@ -306,7 +312,7 @@ class RoleUserList extends React.Component {
     render() {
         const addButton = this.props.editing ?
             (<AccessibleButton className="mx_GroupView_featuredThings_addButton" onClick={this.onAddUsersClicked}>
-                <img src={require("../../../res/img/icons-create-room.svg")} width="64" height="64" />
+                <img src={CreateRoomSvg} width="64" height="64" />
                 <div className="mx_GroupView_featuredThings_addButton_label">
                     { _t('Add a User') }
                 </div>
@@ -386,7 +392,7 @@ class FeaturedUser extends React.Component {
         const deleteButton = this.props.editing ?
             <img
                 className="mx_GroupView_featuredThing_deleteButton"
-                src={require("../../../res/img/cancel-small.svg")}
+                src={CancelSmallSvg}
                 width="14"
                 height="14"
                 alt="Delete"
@@ -844,7 +850,7 @@ export default class GroupView extends React.Component {
                     },
                 ) }
                 <a href={hostingSignupLink} target="_blank" rel="noreferrer noopener">
-                    <img src={require("../../../res/img/external-link.svg")} width="11" height="10" alt='' />
+                    <img src={ExternalLinkSvg} width="11" height="10" alt='' />
                 </a>
             </div>;
         }
@@ -925,7 +931,7 @@ export default class GroupView extends React.Component {
                 onClick={this._onAddRoomsClick}
             >
                 <div className="mx_GroupView_rooms_header_addRow_button">
-                    <img src={require("../../../res/img/icons-room-add.svg")} width="24" height="24" />
+                    <img src={AddRoomSvg} width="24" height="24" />
                 </div>
                 <div className="mx_GroupView_rooms_header_addRow_label">
                     { _t('Add rooms to this community') }
@@ -1257,7 +1263,7 @@ export default class GroupView extends React.Component {
                         <div className="mx_GroupView_avatarPicker_edit">
                             <label htmlFor="avatarInput" className="mx_GroupView_avatarPicker_label">
                                 <img
-                                    src={require("../../../res/img/camera.svg")}
+                                    src={CameraSvg}
                                     alt={_t("Upload avatar")}
                                     title={_t("Upload avatar")}
                                     width="17"
@@ -1331,7 +1337,7 @@ export default class GroupView extends React.Component {
                         onClick={this._onCancelClick}
                     >
                         <img
-                            src={require("../../../res/img/cancel.svg")}
+                            src={CancelSvg}
                             className="mx_filterFlipColor"
                             width="18"
                             height="18"

--- a/src/components/structures/MyGroups.js
+++ b/src/components/structures/MyGroups.js
@@ -26,6 +26,7 @@ import AccessibleButton from '../views/elements/AccessibleButton';
 import MatrixClientContext from "../../contexts/MatrixClientContext";
 import AutoHideScrollbar from "./AutoHideScrollbar";
 import { replaceableComponent } from "../../utils/replaceableComponent";
+import GroupsSvg from '../../../res/img/icons-groups.svg';
 
 @replaceableComponent("structures.MyGroups")
 export default class MyGroups extends React.Component {
@@ -106,7 +107,7 @@ export default class MyGroups extends React.Component {
         }
 
         return <div className="mx_MyGroups">
-            <SimpleRoomHeader title={_t("Communities")} icon={require("../../../res/img/icons-groups.svg")} />
+            <SimpleRoomHeader title={_t("Communities")} icon={GroupsSvg} />
             <div className='mx_MyGroups_header'>
                 <div className="mx_MyGroups_headerCard">
                     <AccessibleButton className='mx_MyGroups_headerCard_button' onClick={this._onCreateGroupClick} />

--- a/src/components/structures/RoomStatusBar.tsx
+++ b/src/components/structures/RoomStatusBar.tsx
@@ -30,6 +30,7 @@ import { StaticNotificationState } from "../../stores/notifications/StaticNotifi
 import AccessibleButton from "../views/elements/AccessibleButton";
 import InlineSpinner from "../views/elements/InlineSpinner";
 import MatrixClientContext from "../../contexts/MatrixClientContext";
+import WarningTriangleSvg from '../../../res/img/feather-customised/warning-triangle.svg';
 
 const STATUS_BAR_HIDDEN = 0;
 const STATUS_BAR_EXPANDED = 1;
@@ -285,7 +286,7 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
                     <div role="alert">
                         <div className="mx_RoomStatusBar_connectionLostBar">
                             <img
-                                src={require("../../../res/img/feather-customised/warning-triangle.svg")}
+                                src={WarningTriangleSvg}
                                 width="24"
                                 height="24"
                                 title="/!\ "

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -62,6 +62,7 @@ import { SettingUpdatedPayload } from "../../dispatcher/payloads/SettingUpdatedP
 import UserIdentifierCustomisations from "../../customisations/UserIdentifier";
 import PosthogTrackers from "../../PosthogTrackers";
 import { ViewHomePagePayload } from "../../dispatcher/payloads/ViewHomePagePayload";
+import SwitchThemeSvg from '../../../res/img/element-icons/roomlist/dark-light-mode.svg';
 
 const CustomStatusSection = () => {
     const cli = useContext(MatrixClientContext);
@@ -515,7 +516,7 @@ export default class UserMenu extends React.Component<IProps, IState> {
                     title={this.state.isDarkTheme ? _t("Switch to light mode") : _t("Switch to dark mode")}
                 >
                     <img
-                        src={require("../../../res/img/element-icons/roomlist/dark-light-mode.svg")}
+                        src={SwitchThemeSvg}
                         alt={_t("Switch theme")}
                         width={16}
                     />

--- a/src/components/views/avatars/WidgetAvatar.tsx
+++ b/src/components/views/avatars/WidgetAvatar.tsx
@@ -20,22 +20,27 @@ import classNames from 'classnames';
 import { IApp } from "../../../stores/WidgetStore";
 import BaseAvatar, { BaseAvatarType } from "./BaseAvatar";
 import { mediaFromMxc } from "../../../customisations/Media";
+import DefaultAppSvg from '../../../../res/img/element-icons/room/default_app.svg';
+import DefaultVideoSvg from '../../../../res/img/element-icons/room/default_video.svg';
+import DefaultCalSvg from '../../../../res/img/element-icons/room/default_cal.svg';
+import DefaultDocSvg from '../../../../res/img/element-icons/room/default_doc.svg';
+import DefaultClockSvg from '../../../../res/img/element-icons/room/default_clock.svg';
 
 interface IProps extends Omit<ComponentProps<BaseAvatarType>, "name" | "url" | "urls"> {
     app: IApp;
 }
 
 const WidgetAvatar: React.FC<IProps> = ({ app, className, width = 20, height = 20, ...props }) => {
-    let iconUrls = [require("../../../../res/img/element-icons/room/default_app.svg")];
+    let iconUrls = [DefaultAppSvg];
     // heuristics for some better icons until Widgets support their own icons
     if (app.type.includes("jitsi")) {
-        iconUrls = [require("../../../../res/img/element-icons/room/default_video.svg")];
+        iconUrls = [DefaultVideoSvg];
     } else if (app.type.includes("meeting") || app.type.includes("calendar")) {
-        iconUrls = [require("../../../../res/img/element-icons/room/default_cal.svg")];
+        iconUrls = [DefaultCalSvg];
     } else if (app.type.includes("pad") || app.type.includes("doc") || app.type.includes("calc")) {
-        iconUrls = [require("../../../../res/img/element-icons/room/default_doc.svg")];
+        iconUrls = [DefaultDocSvg];
     } else if (app.type.includes("clock")) {
-        iconUrls = [require("../../../../res/img/element-icons/room/default_clock.svg")];
+        iconUrls = [DefaultClockSvg];
     }
 
     return (

--- a/src/components/views/context_menus/GroupInviteTileContextMenu.js
+++ b/src/components/views/context_menus/GroupInviteTileContextMenu.js
@@ -26,6 +26,7 @@ import Modal from '../../../Modal';
 import GroupStore from "../../../stores/GroupStore";
 import { MenuItem } from "../../structures/ContextMenu";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
+import ContextDeleteSvg from '../../../../res/img/icon_context_delete.svg';
 
 @replaceableComponent("views.context_menus.GroupInviteTileContextMenu")
 export default class GroupInviteTileContextMenu extends React.Component {
@@ -85,7 +86,7 @@ export default class GroupInviteTileContextMenu extends React.Component {
     render() {
         return <div>
             <MenuItem className="mx_RoomTileContextMenu_leave" onClick={this._onClickReject}>
-                <img className="mx_RoomTileContextMenu_tag_icon" src={require("../../../../res/img/icon_context_delete.svg")} width="15" height="15" alt="" />
+                <img className="mx_RoomTileContextMenu_tag_icon" src={ContextDeleteSvg} width="15" height="15" alt="" />
                 { _t('Reject') }
             </MenuItem>
         </div>;

--- a/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
+++ b/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
@@ -39,6 +39,7 @@ import ProgressBar from "../elements/ProgressBar";
 import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar";
 import QueryMatcher from "../../../autocomplete/QueryMatcher";
 import LazyRenderList from "../elements/LazyRenderList";
+import WarningBadgeSvg from '../../../../res/img/element-icons/warning-badge.svg';
 
 // These values match CSS
 const ROW_HEIGHT = 32 + 12;
@@ -213,7 +214,7 @@ export const AddExistingToSpace: React.FC<IAddExistingToSpaceProps> = ({
     if (error) {
         footer = <>
             <img
-                src={require("../../../../res/img/element-icons/warning-badge.svg")}
+                src={WarningBadgeSvg}
                 height="24"
                 width="24"
                 alt=""

--- a/src/components/views/dialogs/CreateSpaceFromCommunityDialog.tsx
+++ b/src/components/views/dialogs/CreateSpaceFromCommunityDialog.tsx
@@ -44,6 +44,7 @@ import { inviteUsersToRoom } from "../../../RoomInvite";
 import ProgressBar from "../elements/ProgressBar";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { CreateEventField, IGroupRoom, IGroupSummary } from "../../../@types/groups";
+import WarningBadgeSvg from '../../../../res/img/element-icons/warning-badge.svg';
 
 interface IProps {
     matrixClient: MatrixClient;
@@ -241,7 +242,7 @@ const CreateSpaceFromCommunityDialog: React.FC<IProps> = ({ matrixClient: cli, g
     let footer;
     if (error) {
         footer = <>
-            <img src={require("../../../../res/img/element-icons/warning-badge.svg")} height="24" width="24" alt="" />
+            <img src={WarningBadgeSvg} height="24" width="24" alt="" />
 
             <span className="mx_CreateSpaceFromCommunityDialog_error">
                 <div className="mx_CreateSpaceFromCommunityDialog_errorHeading">{ _t("Failed to migrate community") }</div>

--- a/src/components/views/dialogs/ForwardDialog.tsx
+++ b/src/components/views/dialogs/ForwardDialog.tsx
@@ -48,6 +48,7 @@ import { roomContextDetailsText } from "../../../Rooms";
 import { Action } from "../../../dispatcher/actions";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { ButtonEvent } from "../elements/AccessibleButton";
+import EllipsisSvg from '../../../../res/img/ellipsis.svg';
 
 const AVATAR_SIZE = 30;
 
@@ -216,7 +217,7 @@ const ForwardDialog: React.FC<IProps> = ({ matrixClient: cli, event, permalinkCr
             <EntityTile
                 className="mx_EntityTile_ellipsis"
                 avatarJsx={
-                    <BaseAvatar url={require("../../../../res/img/ellipsis.svg")} name="..." width={36} height={36} />
+                    <BaseAvatar url={EllipsisSvg} name="..." width={36} height={36} />
                 }
                 name={text}
                 presenceState="online"

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -72,6 +72,9 @@ import { ScreenName } from '../../../PosthogTrackers';
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { getKeyBindingsManager } from "../../../KeyBindingsManager";
+import EmailPillSvg from '../../../../res/img/icon-email-pill-avatar.svg';
+import PillRemoveSvg from '../../../../res/img/icon-pill-remove.svg';
+import InfoSvg from '../../../../res/img/element-icons/info.svg';
 
 // we have a number of types defined from the Matrix spec which can't reasonably be altered here.
 /* eslint-disable camelcase */
@@ -195,7 +198,7 @@ class DMUserTile extends React.PureComponent<IDMUserTileProps> {
         const avatar = (this.props.member as ThreepidMember).isEmail
             ? <img
                 className='mx_InviteDialog_userTile_avatar mx_InviteDialog_userTile_threepidAvatar'
-                src={require("../../../../res/img/icon-email-pill-avatar.svg")}
+                src={EmailPillSvg}
                 width={avatarSize}
                 height={avatarSize}
             />
@@ -217,7 +220,7 @@ class DMUserTile extends React.PureComponent<IDMUserTileProps> {
                     onClick={this.onRemove}
                 >
                     <img
-                        src={require("../../../../res/img/icon-pill-remove.svg")}
+                        src={PillRemoveSvg}
                         alt={_t('Remove')}
                         width={8}
                         height={8}
@@ -301,7 +304,7 @@ class DMRoomTile extends React.PureComponent<IDMRoomTileProps> {
         const avatarSize = 36;
         const avatar = (this.props.member as ThreepidMember).isEmail
             ? <img
-                src={require("../../../../res/img/icon-email-pill-avatar.svg")}
+                src={EmailPillSvg}
                 width={avatarSize}
                 height={avatarSize}
             />
@@ -1472,7 +1475,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
                     keySharingWarning =
                         <p className='mx_InviteDialog_helpText'>
                             <img
-                                src={require("../../../../res/img/element-icons/info.svg")}
+                                src={InfoSvg}
                                 width={14}
                                 height={14} />
                             { " " + _t("Invited people will be able to read old messages.") }

--- a/src/components/views/dialogs/ModalWidgetDialog.tsx
+++ b/src/components/views/dialogs/ModalWidgetDialog.tsx
@@ -42,7 +42,7 @@ import { ElementWidget } from "../../../stores/widgets/StopGapWidget";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { ELEMENT_CLIENT_ID } from "../../../identifiers";
 import SettingsStore from "../../../settings/SettingsStore";
-
+import WarningBadgeSvg from '../../../../res/img/element-icons/warning-badge.svg';
 interface IProps {
     widgetDefinition: IModalWidgetOpenRequestData;
     widgetRoomId?: string;
@@ -187,7 +187,7 @@ export default class ModalWidgetDialog extends React.PureComponent<IProps, IStat
         >
             <div className="mx_ModalWidgetDialog_warning">
                 <img
-                    src={require("../../../../res/img/element-icons/warning-badge.svg")}
+                    src={WarningBadgeSvg}
                     height="16"
                     width="16"
                     alt=""

--- a/src/components/views/dialogs/UploadConfirmDialog.tsx
+++ b/src/components/views/dialogs/UploadConfirmDialog.tsx
@@ -23,6 +23,7 @@ import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { getBlobSafeMimeType } from '../../../utils/blobs';
 import BaseDialog from "./BaseDialog";
 import DialogButtons from "../elements/DialogButtons";
+import FilesSvg from '../../../../res/img/feather-customised/files.svg';
 
 interface IProps {
     file: File;
@@ -94,7 +95,7 @@ export default class UploadConfirmDialog extends React.Component<IProps> {
             preview = <div>
                 <div>
                     <img className="mx_UploadConfirmDialog_fileIcon"
-                        src={require("../../../../res/img/feather-customised/files.svg")}
+                        src={FilesSvg}
                     />
                     { this.props.file.name } ({ filesize(this.props.file.size) })
                 </div>

--- a/src/components/views/dialogs/security/SetupEncryptionDialog.tsx
+++ b/src/components/views/dialogs/security/SetupEncryptionDialog.tsx
@@ -22,12 +22,14 @@ import { _t } from '../../../../languageHandler';
 import { SetupEncryptionStore, Phase } from '../../../../stores/SetupEncryptionStore';
 import { replaceableComponent } from "../../../../utils/replaceableComponent";
 import { IDialogProps } from "../IDialogProps";
+import VerifiedSvg from '../../../../../res/img/e2e/verified.svg';
+import WarningSvg from '../../../../../res/img/e2e/warning.svg';
 
 function iconFromPhase(phase: Phase) {
     if (phase === Phase.Done) {
-        return require("../../../../../res/img/e2e/verified.svg");
+        return VerifiedSvg;
     } else {
-        return require("../../../../../res/img/e2e/warning.svg");
+        return WarningSvg;
     }
 }
 

--- a/src/components/views/elements/AddressTile.tsx
+++ b/src/components/views/elements/AddressTile.tsx
@@ -24,6 +24,7 @@ import { mediaFromMxc } from "../../../customisations/Media";
 import { IUserAddress } from '../../../UserAddress';
 import BaseAvatar from '../avatars/BaseAvatar';
 import EmailUserIcon from "../../../../res/img/icon-email-user.svg";
+import AddressDeleteSvg from '../../../../res/img/icon-address-delete.svg';
 
 interface IProps {
     address: IUserAddress;
@@ -124,7 +125,7 @@ export default class AddressTile extends React.Component<IProps> {
         if (this.props.canDismiss) {
             dismiss = (
                 <div className="mx_AddressTile_dismiss" onClick={this.props.onDismissed}>
-                    <img src={require("../../../../res/img/icon-address-delete.svg")} width="9" height="9" />
+                    <img src={AddressDeleteSvg} width="9" height="9" />
                 </div>
             );
         }

--- a/src/components/views/elements/AppWarning.tsx
+++ b/src/components/views/elements/AppWarning.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import WarningSvg from '../../../../res/img/warning.svg';
+
 interface IProps {
     errorMsg?: string;
 }
@@ -8,7 +10,7 @@ const AppWarning: React.FC<IProps> = (props) => {
     return (
         <div className='mx_AppPermissionWarning'>
             <div className='mx_AppPermissionWarningImage'>
-                <img src={require("../../../../res/img/warning.svg")} alt='' />
+                <img src={WarningSvg} alt='' />
             </div>
             <div className='mx_AppPermissionWarningText'>
                 <span className='mx_AppPermissionWarningTextLabel'>{ props.errorMsg || "Error" }</span>

--- a/src/components/views/elements/SSOButtons.tsx
+++ b/src/components/views/elements/SSOButtons.tsx
@@ -25,6 +25,12 @@ import { _t } from "../../../languageHandler";
 import { IdentityProviderBrand, IIdentityProvider, ISSOFlow } from "../../../Login";
 import AccessibleTooltipButton from "./AccessibleTooltipButton";
 import { mediaFromMxc } from "../../../customisations/Media";
+import AppleSvg from '../../../../res/img/element-icons/brands/apple.svg';
+import FacebookSvg from '../../../../res/img/element-icons/brands/facebook.svg';
+import GithubSvg from '../../../../res/img/element-icons/brands/github.svg';
+import GitlabSvg from '../../../../res/img/element-icons/brands/gitlab.svg';
+import GoogleSvg from '../../../../res/img/element-icons/brands/google.svg';
+import TwitterSvg from '../../../../res/img/element-icons/brands/twitter.svg';
 
 interface ISSOButtonProps extends Omit<IProps, "flow"> {
     idp: IIdentityProvider;
@@ -34,17 +40,17 @@ interface ISSOButtonProps extends Omit<IProps, "flow"> {
 const getIcon = (brand: IdentityProviderBrand | string) => {
     switch (brand) {
         case IdentityProviderBrand.Apple:
-            return require(`../../../../res/img/element-icons/brands/apple.svg`);
+            return AppleSvg;
         case IdentityProviderBrand.Facebook:
-            return require(`../../../../res/img/element-icons/brands/facebook.svg`);
+            return FacebookSvg;
         case IdentityProviderBrand.Github:
-            return require(`../../../../res/img/element-icons/brands/github.svg`);
+            return GithubSvg;
         case IdentityProviderBrand.Gitlab:
-            return require(`../../../../res/img/element-icons/brands/gitlab.svg`);
+            return GitlabSvg;
         case IdentityProviderBrand.Google:
-            return require(`../../../../res/img/element-icons/brands/google.svg`);
+            return GoogleSvg;
         case IdentityProviderBrand.Twitter:
-            return require(`../../../../res/img/element-icons/brands/twitter.svg`);
+            return TwitterSvg;
         default:
             return null;
     }

--- a/src/components/views/groups/GroupMemberList.js
+++ b/src/components/views/groups/GroupMemberList.js
@@ -27,6 +27,7 @@ import { RightPanelPhases } from '../../../stores/right-panel/RightPanelStorePha
 import AutoHideScrollbar from "../../structures/AutoHideScrollbar";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import RightPanelStore from '../../../stores/right-panel/RightPanelStore';
+import EllipsisSvg from '../../../../res/img/ellipsis.svg';
 
 const INITIAL_LOAD_NUM_MEMBERS = 30;
 
@@ -89,7 +90,7 @@ export default class GroupMemberList extends React.Component {
             <EntityTile
                 className="mx_EntityTile_ellipsis"
                 avatarJsx={
-                    <BaseAvatar url={require("../../../../res/img/ellipsis.svg")} name="..." width={36} height={36} />
+                    <BaseAvatar url={EllipsisSvg} name="..." width={36} height={36} />
                 }
                 name={text}
                 presenceState="online"

--- a/src/components/views/groups/GroupRoomInfo.js
+++ b/src/components/views/groups/GroupRoomInfo.js
@@ -28,6 +28,7 @@ import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import AutoHideScrollbar from "../../structures/AutoHideScrollbar";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { mediaFromMxc } from "../../../customisations/Media";
+import CancelSvg from '../../../../res/img/cancel.svg';
 
 @replaceableComponent("views.groups.GroupRoomInfo")
 export default class GroupRoomInfo extends React.Component {
@@ -216,7 +217,7 @@ export default class GroupRoomInfo extends React.Component {
             <div className="mx_MemberInfo" role="tabpanel">
                 <AutoHideScrollbar>
                     <AccessibleButton className="mx_MemberInfo_cancel" onClick={this._onCancel}>
-                        <img src={require("../../../../res/img/cancel.svg")} width="18" height="18" className="mx_filterFlipColor" />
+                        <img src={CancelSvg} width="18" height="18" className="mx_filterFlipColor" />
                     </AccessibleButton>
                     { avatarElement }
 

--- a/src/components/views/groups/GroupRoomList.js
+++ b/src/components/views/groups/GroupRoomList.js
@@ -23,6 +23,7 @@ import { showGroupAddRoomDialog } from '../../../GroupAddressPicker';
 import AccessibleButton from '../elements/AccessibleButton';
 import AutoHideScrollbar from "../../structures/AutoHideScrollbar";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
+import EllipsisSvg from '../../../../res/img/ellipsis.svg';
 
 const INITIAL_LOAD_NUM_ROOMS = 30;
 
@@ -80,7 +81,7 @@ export default class GroupRoomList extends React.Component {
             <EntityTile
                 className="mx_EntityTile_ellipsis"
                 avatarJsx={
-                    <BaseAvatar url={require("../../../../res/img/ellipsis.svg")} name="..." width={36} height={36} />
+                    <BaseAvatar url={EllipsisSvg} name="..." width={36} height={36} />
                 }
                 name={text}
                 presenceState="online"

--- a/src/components/views/messages/MAudioBody.tsx
+++ b/src/components/views/messages/MAudioBody.tsx
@@ -29,6 +29,7 @@ import { PlaybackManager } from "../../../audio/PlaybackManager";
 import { isVoiceMessage } from "../../../utils/EventUtils";
 import { PlaybackQueue } from "../../../audio/PlaybackQueue";
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
+import WarningSvg from '../../../../res/img/warning.svg';
 
 interface IState {
     error?: Error;
@@ -96,7 +97,7 @@ export default class MAudioBody extends React.PureComponent<IBodyProps, IState> 
         if (this.state.error) {
             return (
                 <span className="mx_MAudioBody">
-                    <img src={require("../../../../res/img/warning.svg")} width="16" height="16" />
+                    <img src={WarningSvg} width="16" height="16" />
                     { _t("Error processing audio message") }
                 </span>
             );

--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -37,6 +37,7 @@ import { IBodyProps } from "./IBodyProps";
 import { ImageSize, suggestedSize as suggestedImageSize } from "../../../settings/enums/ImageSize";
 import { MatrixClientPeg } from '../../../MatrixClientPeg';
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
+import WarningSvg from '../../../../res/img/warning.svg';
 
 interface IState {
     decryptedUrl?: string;
@@ -543,7 +544,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         if (this.state.error !== null) {
             return (
                 <div className="mx_MImageBody">
-                    <img src={require("../../../../res/img/warning.svg")} width="16" height="16" />
+                    <img src={WarningSvg} width="16" height="16" />
                     { _t("Error decrypting image") }
                 </div>
             );

--- a/src/components/views/messages/MStickerBody.tsx
+++ b/src/components/views/messages/MStickerBody.tsx
@@ -20,6 +20,7 @@ import MImageBody from './MImageBody';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { BLURHASH_FIELD } from "../../../ContentMessages";
 import Tooltip from "../elements/Tooltip";
+import ShowStickersSvg from '../../../../res/img/icons-show-stickers.svg';
 
 @replaceableComponent("views.messages.MStickerBody")
 export default class MStickerBody extends MImageBody {
@@ -45,7 +46,7 @@ export default class MStickerBody extends MImageBody {
     // img onLoad hasn't fired yet.
     protected getPlaceholder(width: number, height: number): JSX.Element {
         if (this.props.mxEvent.getContent().info?.[BLURHASH_FIELD]) return super.getPlaceholder(width, height);
-        return <img src={require("../../../../res/img/icons-show-stickers.svg")} width="75" height="75" />;
+        return <img src={ShowStickersSvg} width="75" height="75" />;
     }
 
     // Tooltip to show on mouse over

--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -29,6 +29,7 @@ import { IBodyProps } from "./IBodyProps";
 import MFileBody from "./MFileBody";
 import { ImageSize, suggestedSize as suggestedVideoSize } from "../../../settings/enums/ImageSize";
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
+import WarningSvg from '../../../../res/img/warning.svg';
 
 interface IState {
     decryptedUrl?: string;
@@ -257,7 +258,7 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         if (this.state.error !== null) {
             return (
                 <span className="mx_MVideoBody">
-                    <img src={require("../../../../res/img/warning.svg")} width="16" height="16" />
+                    <img src={WarningSvg} width="16" height="16" />
                     { _t("Error decrypting video") }
                 </span>
             );

--- a/src/components/views/messages/MVoiceMessageBody.tsx
+++ b/src/components/views/messages/MVoiceMessageBody.tsx
@@ -22,6 +22,7 @@ import { _t } from "../../../languageHandler";
 import RecordingPlayback from "../audio_messages/RecordingPlayback";
 import MAudioBody from "./MAudioBody";
 import MFileBody from "./MFileBody";
+import WarningSvg from '../../../../res/img/warning.svg';
 
 @replaceableComponent("views.messages.MVoiceMessageBody")
 export default class MVoiceMessageBody extends MAudioBody {
@@ -30,7 +31,7 @@ export default class MVoiceMessageBody extends MAudioBody {
         if (this.state.error) {
             return (
                 <span className="mx_MVoiceMessageBody">
-                    <img src={require("../../../../res/img/warning.svg")} width="16" height="16" />
+                    <img src={WarningSvg} width="16" height="16" />
                     { _t("Error processing voice message") }
                 </span>
             );

--- a/src/components/views/right_panel/EncryptionPanel.tsx
+++ b/src/components/views/right_panel/EncryptionPanel.tsx
@@ -34,6 +34,7 @@ import * as sdk from "../../../index";
 import { _t } from "../../../languageHandler";
 import { RightPanelPhases } from '../../../stores/right-panel/RightPanelStorePhases';
 import RightPanelStore from "../../../stores/right-panel/RightPanelStore";
+import WarningSvg from '../../../../res/img/e2e/warning.svg';
 
 // cancellation codes which constitute a key mismatch
 const MISMATCHES = ["m.key_mismatch", "m.user_error", "m.mismatched_sas"];
@@ -87,7 +88,7 @@ const EncryptionPanel: React.FC<IProps> = (props: IProps) => {
             // FIXME: Using an import will result in test failures
             const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
             Modal.createTrackedDialog("Verification failed", "insecure", ErrorDialog, {
-                headerImage: require("../../../../res/img/e2e/warning.svg"),
+                headerImage: WarningSvg,
                 title: _t("Your messages are not secure"),
                 description: <div>
                     { _t("One of the following may be compromised:") }

--- a/src/components/views/rooms/EntityTile.tsx
+++ b/src/components/views/rooms/EntityTile.tsx
@@ -25,6 +25,7 @@ import E2EIcon, { E2EState } from './E2EIcon';
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import BaseAvatar from '../avatars/BaseAvatar';
 import PresenceLabel from "./PresenceLabel";
+import PlusSvg from '../../../../res/img/plus.svg';
 
 export enum PowerStatus {
     Admin = "admin",
@@ -159,7 +160,7 @@ export default class EntityTile extends React.PureComponent<IProps, IState> {
         if (this.props.showInviteButton) {
             inviteButton = (
                 <div className="mx_EntityTile_invite">
-                    <img src={require("../../../../res/img/plus.svg")} width="16" height="16" />
+                    <img src={PlusSvg} width="16" height="16" />
                 </div>
             );
         }

--- a/src/components/views/rooms/LinkPreviewGroup.tsx
+++ b/src/components/views/rooms/LinkPreviewGroup.tsx
@@ -25,6 +25,7 @@ import AccessibleButton from "../elements/AccessibleButton";
 import { _t } from "../../../languageHandler";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { useAsyncMemo } from "../../../hooks/useAsyncMemo";
+import CancelSvg from '../../../../res/img/cancel.svg';
 
 const INITIAL_NUM_PREVIEWS = 2;
 
@@ -72,7 +73,7 @@ const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick, onH
                             className="mx_filterFlipColor"
                             alt=""
                             role="presentation"
-                            src={require("../../../../res/img/cancel.svg")}
+                            src={CancelSvg}
                             width="18"
                             height="18"
                         />

--- a/src/components/views/rooms/MemberList.tsx
+++ b/src/components/views/rooms/MemberList.tsx
@@ -50,6 +50,7 @@ import SpaceStore from "../../../stores/spaces/SpaceStore";
 import { shouldShowComponent } from "../../../customisations/helpers/UIComponents";
 import { UIComponent } from "../../../settings/UIFeature";
 import PosthogTrackers from "../../../PosthogTrackers";
+import EllipsisSvg from '../../../../res/img/ellipsis.svg';
 
 const INITIAL_LOAD_NUM_MEMBERS = 30;
 const INITIAL_LOAD_NUM_INVITED = 5;
@@ -316,7 +317,7 @@ export default class MemberList extends React.Component<IProps, IState> {
             <EntityTile
                 className="mx_EntityTile_ellipsis"
                 avatarJsx={
-                    <BaseAvatar url={require("../../../../res/img/ellipsis.svg")} name="..." width={36} height={36} />
+                    <BaseAvatar url={EllipsisSvg} name="..." width={36} height={36} />
                 }
                 name={text}
                 presenceState="online"

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -52,6 +52,7 @@ import { SettingUpdatedPayload } from "../../../dispatcher/payloads/SettingUpdat
 import MessageComposerButtons from './MessageComposerButtons';
 import { ButtonEvent } from '../elements/AccessibleButton';
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
+import RoomReplaceSvg from '../../../../res/img/room_replaced.svg';
 
 let instanceCount = 0;
 
@@ -408,7 +409,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             controls.push(<div className="mx_MessageComposer_replaced_wrapper" key="room_replaced">
                 <div className="mx_MessageComposer_replaced_valign">
                     <img className="mx_MessageComposer_roomReplaced_icon"
-                        src={require("../../../../res/img/room_replaced.svg")}
+                        src={RoomReplaceSvg}
                     />
                     <span className="mx_MessageComposer_roomReplaced_header">
                         { _t("This room has been replaced and is no longer active.") }

--- a/src/components/views/rooms/ReplyPreview.tsx
+++ b/src/components/views/rooms/ReplyPreview.tsx
@@ -23,6 +23,7 @@ import { RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import ReplyTile from './ReplyTile';
 import RoomContext, { TimelineRenderingType } from '../../../contexts/RoomContext';
+import CancelSvg from '../../../../res/img/cancel.svg';
 
 function cancelQuoting(context: TimelineRenderingType) {
     dis.dispatch({
@@ -52,7 +53,7 @@ export default class ReplyPreview extends React.Component<IProps> {
                 <div className="mx_ReplyPreview_header mx_ReplyPreview_cancel">
                     <img
                         className="mx_filterFlipColor"
-                        src={require("../../../../res/img/cancel.svg")}
+                        src={CancelSvg}
                         width="18"
                         height="18"
                         onClick={() => cancelQuoting(this.context.timelineRenderingType)}

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -40,6 +40,7 @@ import ErrorDialog from "../../../dialogs/ErrorDialog";
 import SettingsFieldset from '../../SettingsFieldset';
 import ExternalLink from '../../../elements/ExternalLink';
 import PosthogTrackers from "../../../../../PosthogTrackers";
+import WarningSvg from '../../../../../../res/img/warning.svg';
 
 interface IProps {
     roomId: string;
@@ -263,7 +264,7 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
         if (room.getJoinRule() === JoinRule.Public && !this.state.hasAliases) {
             aliasWarning = (
                 <div className='mx_SecurityRoomSettingsTab_warning'>
-                    <img src={require("../../../../../../res/img/warning.svg")} width={15} height={15} />
+                    <img src={WarningSvg} width={15} height={15} />
                     <span>
                         { _t("To link to this room, please add an address.") }
                     </span>

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.tsx
@@ -51,6 +51,7 @@ import ChangePassword from "../../ChangePassword";
 import InlineTermsAgreement from "../../../terms/InlineTermsAgreement";
 import SetIdServer from "../../SetIdServer";
 import SetIntegrationManager from "../../SetIntegrationManager";
+import WarningTriangleSvg from '../../../../../../res/img/feather-customised/warning-triangle.svg';
 
 interface IProps {
     closeSettingsFn: () => void;
@@ -453,7 +454,7 @@ export default class GeneralUserSettingsTab extends React.Component<IProps, ISta
         const discoWarning = this.state.requiredPolicyInfo.hasTerms
             ? <img
                 className='mx_GeneralUserSettingsTab_warningIcon'
-                src={require("../../../../../../res/img/feather-customised/warning-triangle.svg")}
+                src={WarningTriangleSvg}
                 width="18"
                 height="18"
                 alt={_t("Warning")}


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Fixes: https://github.com/vector-im/element-web/issues/21271
Update all require imports of svgs to use ESM imports.
Ideally we wouldn't use these img tag icons any longer, but replacing them with react icon components would involve style changes and would be error prone in a batch as large as this.

<img width="246" alt="Screenshot 2022-03-02 at 16 21 37" src="https://user-images.githubusercontent.com/3055605/156391958-4150c422-b811-4f36-8b21-0c1e3dfadf2c.png">
<img width="734" alt="Screenshot 2022-03-02 at 16 18 12" src="https://user-images.githubusercontent.com/3055605/156391960-ac2628af-e4fd-403c-9aa7-337e79d13ab0.png">


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7948--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
