### PR TITLE
Autofocus correct composer after sending reaction

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -918,8 +918,11 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             }
 
             case Action.FocusAComposer: {
-                // re-dispatch to the correct composer
-                dis.fire(this.state.editState ? Action.FocusEditMessageComposer : Action.FocusSendMessageComposer);
+                dis.dispatch({
+                    ...payload,
+                    // re-dispatch to the correct composer
+                    action: this.state.editState ? Action.FocusEditMessageComposer : Action.FocusSendMessageComposer,
+                });
                 break;
             }
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -107,6 +107,7 @@ import { JoinRoomPayload } from "../../dispatcher/payloads/JoinRoomPayload";
 import { DoAfterSyncPreparedPayload } from '../../dispatcher/payloads/DoAfterSyncPreparedPayload';
 import FileDropTarget from './FileDropTarget';
 import Measured from '../views/elements/Measured';
+import { FocusComposerPayload } from '../../dispatcher/payloads/FocusComposerPayload';
 
 const DEBUG = false;
 let debuglog = function(msg: string) {};
@@ -918,8 +919,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             }
 
             case Action.FocusAComposer: {
-                dis.dispatch({
-                    ...payload,
+                dis.dispatch<FocusComposerPayload>({
+                    ...(payload as FocusComposerPayload),
                     // re-dispatch to the correct composer
                     action: this.state.editState ? Action.FocusEditMessageComposer : Action.FocusSendMessageComposer,
                 });

--- a/src/components/views/emojipicker/ReactionPicker.tsx
+++ b/src/components/views/emojipicker/ReactionPicker.tsx
@@ -26,6 +26,7 @@ import dis from "../../../dispatcher/dispatcher";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { Action } from '../../../dispatcher/actions';
 import RoomContext from "../../../contexts/RoomContext";
+import { FocusComposerPayload } from '../../../dispatcher/payloads/FocusComposerPayload';
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -97,7 +98,7 @@ class ReactionPicker extends React.Component<IProps, IState> {
         const myReactions = this.getReactions();
         if (myReactions.hasOwnProperty(reaction)) {
             MatrixClientPeg.get().redactEvent(this.props.mxEvent.getRoomId(), myReactions[reaction]);
-            dis.dispatch({
+            dis.dispatch<FocusComposerPayload>({
                 action: Action.FocusAComposer,
                 context: this.context.timelineRenderingType,
             });
@@ -112,7 +113,7 @@ class ReactionPicker extends React.Component<IProps, IState> {
                 },
             });
             dis.dispatch({ action: "message_sent" });
-            dis.dispatch({
+            dis.dispatch<FocusComposerPayload>({
                 action: Action.FocusAComposer,
                 context: this.context.timelineRenderingType,
             });

--- a/src/components/views/emojipicker/ReactionPicker.tsx
+++ b/src/components/views/emojipicker/ReactionPicker.tsx
@@ -25,6 +25,7 @@ import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import dis from "../../../dispatcher/dispatcher";
 import { replaceableComponent } from "../../../utils/replaceableComponent";
 import { Action } from '../../../dispatcher/actions';
+import RoomContext from "../../../contexts/RoomContext";
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -38,8 +39,11 @@ interface IState {
 
 @replaceableComponent("views.emojipicker.ReactionPicker")
 class ReactionPicker extends React.Component<IProps, IState> {
-    constructor(props) {
-        super(props);
+    static contextType = RoomContext;
+    public context!: React.ContextType<typeof RoomContext>;
+
+    constructor(props: IProps, context: React.ContextType<typeof RoomContext>) {
+        super(props, context);
 
         this.state = {
             selectedEmojis: new Set(Object.keys(this.getReactions())),
@@ -93,7 +97,10 @@ class ReactionPicker extends React.Component<IProps, IState> {
         const myReactions = this.getReactions();
         if (myReactions.hasOwnProperty(reaction)) {
             MatrixClientPeg.get().redactEvent(this.props.mxEvent.getRoomId(), myReactions[reaction]);
-            dis.fire(Action.FocusAComposer);
+            dis.dispatch({
+                action: Action.FocusAComposer,
+                context: this.context.timelineRenderingType,
+            });
             // Tell the emoji picker not to bump this in the more frequently used list.
             return false;
         } else {
@@ -105,7 +112,10 @@ class ReactionPicker extends React.Component<IProps, IState> {
                 },
             });
             dis.dispatch({ action: "message_sent" });
-            dis.fire(Action.FocusAComposer);
+            dis.dispatch({
+                action: Action.FocusAComposer,
+                context: this.context.timelineRenderingType,
+            });
             return true;
         }
     };

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -77,8 +77,7 @@ export enum Action {
 
     /**
      * Focuses the user's cursor to the edit message composer or send message
-     * composer based on the current edit state. No additional payload
-     * information required.
+     * composer based on the current edit state. Should be used with a FocusComposerPayload.
      */
     FocusAComposer = "focus_a_composer",
 

--- a/src/dispatcher/payloads/FocusComposerPayload.ts
+++ b/src/dispatcher/payloads/FocusComposerPayload.ts
@@ -19,7 +19,10 @@ import { Action } from "../actions";
 import { TimelineRenderingType } from "../../contexts/RoomContext";
 
 export interface FocusComposerPayload extends ActionPayload {
-    action: Action.FocusEditMessageComposer | Action.FocusSendMessageComposer | "reply_to_event";
+    action: Action.FocusAComposer
+        | Action.FocusEditMessageComposer
+        | Action.FocusSendMessageComposer
+        | "reply_to_event";
 
     context?: TimelineRenderingType; // defaults to Room type for backwards compatibility
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21273

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Autofocus correct composer after sending reaction ([\#7950](https://github.com/matrix-org/matrix-react-sdk/pull/7950)). Fixes vector-im/element-web#21273.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7950--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
