### PR TITLE
Improve end-to-end test logging by rendering JSHandles

### DIFF
--- a/test/end-to-end-tests/src/session.ts
+++ b/test/end-to-end-tests/src/session.ts
@@ -19,7 +19,7 @@ import * as puppeteer from 'puppeteer';
 
 import { Logger } from './logger';
 import { LogBuffer } from './logbuffer';
-import { delay } from './util';
+import { delay, serializeLog } from './util';
 
 const DEFAULT_TIMEOUT = 20000;
 
@@ -35,7 +35,7 @@ export class ElementSession {
     constructor(readonly browser: puppeteer.Browser, readonly page: puppeteer.Page, readonly username: string,
                 readonly elementServer: string, readonly hsUrl: string) {
         this.consoleLog = new LogBuffer(page, "console",
-            async (msg: puppeteer.ConsoleMessage) => Promise.resolve(`${msg.text()}\n`));
+            async (msg: puppeteer.ConsoleMessage) => `${await serializeLog(msg)}\n`);
         this.networkLog = new LogBuffer(page,
             "requestfinished", async (req: puppeteer.HTTPRequest) => {
                 const type = req.resourceType();

--- a/test/end-to-end-tests/src/util.ts
+++ b/test/end-to-end-tests/src/util.ts
@@ -15,6 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { ConsoleMessage } from "puppeteer";
+import { padEnd } from "lodash";
+
 import { ElementSession } from "./session";
 
 export const range = function(start: number, amount: number, step = 1): Array<number> {
@@ -50,4 +53,51 @@ export async function applyConfigChange(session: ElementSession, config: any): P
             window.mxReactSdkConfig[k] = v;
         }
     }, config);
+}
+
+export async function serializeLog(msg: ConsoleMessage): Promise<string> {
+    // 9 characters padding is somewhat arbitrary ("warning".length + some)
+    let s = `${padEnd(msg.type(), 9, ' ')}| ${msg.text()} `; // trailing space is intentional
+    const args = msg.args();
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        const val = await arg.jsonValue();
+
+        // We handle strings a bit differently because the `jsonValue` will be in a weird-looking
+        // shape ("JSHandle:words are here"). Weirdly, `msg.text()` also catches text nodes that
+        // we can't with our parsing, so we trust that it's correct whenever we can.
+        if (typeof val === 'string') {
+            if (i === 0) {
+                // if it's a string, just ignore it because it should have already been caught
+                // by the `msg.text()` in the initial `s` construction.
+                continue;
+            }
+
+            // evaluate the arg as a string by running it through the page context
+            s += `${await arg.evaluate(a => a.toString())} `; // trailing space is intentional
+            continue;
+        }
+
+        // Try and parse the value as an error object first (which will be an empty JSON
+        // object). Otherwise, parse the object to a string.
+        //
+        // Note: we have to run the checks against the object in the page context, so call
+        // evaluate instead of just doing it ourselves.
+        const stringyArg: string = await arg.evaluate((argInContext: any) => {
+            if (argInContext.stack || (argInContext instanceof Error)) {
+                // probably an error - toString it and append any properties which might not be
+                // caught. For example, on HTTP errors the JSON stringification will capture the
+                // status code.
+                //
+                // String format is a bit weird, but basically we're trying to get away from the
+                // stack trace so the context doesn't blend in but is otherwise indented correctly.
+                return `${argInContext.toString()}\n\n    Error context: ${JSON.stringify(argInContext)}`;
+            }
+
+            // not an error, as far as we're concerned - return it as human-readable JSON
+            return JSON.stringify(argInContext, null, 4);
+        });
+        s += `${stringyArg} `; // trailing space is intentional
+    }
+    return s;
 }

--- a/test/end-to-end-tests/start.ts
+++ b/test/end-to-end-tests/start.ts
@@ -112,7 +112,7 @@ async function runTests() {
         /**
          * TODO: temporary only use one user session data
          */
-        performanceEntries = JSON.parse(measurements);
+        performanceEntries = JSON.parse(measurements ?? "[]");
         return session.close();
     }));
     if (performanceEntries?.length > 0) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/13276

It's still not super pretty, but it works.

Sample exception to cause the error:
```diff
diff --git a/src/components/views/auth/RegistrationForm.tsx b/src/components/views/auth/RegistrationForm.tsx
index 2665e1789f..e8a5451a59 100644
--- a/src/components/views/auth/RegistrationForm.tsx
+++ b/src/components/views/auth/RegistrationForm.tsx
@@ -497,6 +497,7 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
     }

     renderUsername() {
+        throw new Error("@@ CATCH ME");
         return <Field
             id="mx_RegistrationForm_username"
             ref={field => this[RegistrationField.Username] = field}
```

<details>
<summary>Sample logs (click to expand)</summary>

```
error    | Failed to load resource: the server responded with a status of 404 (Not Found) 
log      | [HMR] Waiting for update signal from WDS... 
error    | Failed to load resource: the server responded with a status of 404 (Not Found) 
log      | Initialised rageshake. 
log      | To fix line numbers in Chrome: Meatball menu → Settings → Ignore list → Add /rageshake\.js$ 
log      | Using Web platform 
info     | [WDS] Hot Module Replacement enabled. 
info     | [WDS] Live Reloading enabled. 
error    | Failed to load resource: the server responded with a status of 404 (Not Found) 
log      | Configuring rageshake persistence... 
log      | Loading skin... 
log      | Skin loaded! 
log      | Using WebAssembly Olm 
log      | set language to en-us 
log      | Application is running in development mode 
log      | Vector starting at http://localhost:8080/ 
log      | Verifying homeserver configuration 
log      | Config uses a default_hs_url - constructing a default_server_config using this information 
warning  | DEPRECATED CONFIG OPTION: In the future, default_hs_url will not be accepted. Please use default_server_config instead. 
log      | Config uses a default_server_config - validating object 
error    | Failed to load resource: the server responded with a status of 404 (Not Found) 
error    | Failed to poll for update JSHandle@object {
    "status": 404
} 
log      | Updating SdkConfig with validated discovery information 
log      | Using homeserver config: JSHandle@object {
    "hsUrl": "https://matrix.org",
    "hsName": "matrix.org",
    "hsNameIsDifferent": false,
    "isUrl": "https://vector.im",
    "isDefault": true,
    "isNameResolvable": true,
    "warning": null
} 
log      | newscreen register 
log      | Starting load of AsyncWrapper for modal 
error    | Failed to load resource: the server responded with a status of 401 (Unauthorized) 
error    | The above error occurred in the <RegistrationForm> component:

    at RegistrationForm (webpack-internal:///1788:89:5)
    at div
    at div
    at AuthBody (webpack-internal:///1795:28:151)
    at div
    at div
    at div
    at VectorAuthPage (webpack-internal:///2121:32:1)
    at Registration (webpack-internal:///1798:77:5)
    at ErrorBoundary (webpack-internal:///1620:55:5)
    at MatrixChat (webpack-internal:///1438:227:5)

React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary. 
error    | The above error occured while React was rendering the following components: 
    at RegistrationForm (webpack-internal:///1788:89:5)
    at div
    at div
    at AuthBody (webpack-internal:///1795:28:151)
    at div
    at div
    at div
    at VectorAuthPage (webpack-internal:///2121:32:1)
    at Registration (webpack-internal:///1798:77:5)
    at ErrorBoundary (webpack-internal:///1620:55:5)
    at MatrixChat (webpack-internal:///1438:227:5) 
    at RegistrationForm (webpack-internal:///1788:89:5)
    at div
    at div
    at AuthBody (webpack-internal:///1795:28:151)
    at div
    at div
    at div
    at VectorAuthPage (webpack-internal:///2121:32:1)
    at Registration (webpack-internal:///1798:77:5)
    at ErrorBoundary (webpack-internal:///1620:55:5)
    at MatrixChat (webpack-internal:///1438:227:5) 
error    | JSHandle@error Error: @@ CATCH ME

    Error context: {} 
error    | Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s the componentWillUnmount method 
    at Registration (webpack-internal:///1798:77:5) the componentWillUnmount method 
    at Registration (webpack-internal:///1798:77:5) 
error    | Failed to load resource: the server responded with a status of 401 (Unauthorized) 

```

</details>

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7959--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
