### PR TITLE
Avoid using .render() in forward dialog test

### DIFF
--- a/test/components/views/dialogs/ForwardDialog-test.js
+++ b/test/components/views/dialogs/ForwardDialog-test.js
@@ -53,6 +53,7 @@ describe("ForwardDialog", () => {
             // Wait one tick for our profile data to load so the state update happens within act
             await new Promise(resolve => setImmediate(resolve));
         });
+        wrapper.update();
 
         return wrapper;
     };
@@ -97,31 +98,42 @@ describe("ForwardDialog", () => {
             cancelSend = reject;
         }));
 
-        const firstButton = wrapper.find("AccessibleButton.mx_ForwardList_sendButton").first();
-        expect(firstButton.render().is(".mx_ForwardList_canSend")).toBe(true);
+        let firstButton;
+        let secondButton;
+        const update = () => {
+            wrapper.update();
+            firstButton = wrapper.find("AccessibleButton.mx_ForwardList_sendButton").first();
+            secondButton = wrapper.find("AccessibleButton.mx_ForwardList_sendButton").at(1);
+        };
+        update();
+
+        expect(firstButton.is(".mx_ForwardList_canSend")).toBe(true);
 
         act(() => { firstButton.simulate("click"); });
-        expect(firstButton.render().is(".mx_ForwardList_sending")).toBe(true);
+        update();
+        expect(firstButton.is(".mx_ForwardList_sending")).toBe(true);
 
         await act(async () => {
             cancelSend();
             // Wait one tick for the button to realize the send failed
             await new Promise(resolve => setImmediate(resolve));
         });
-        expect(firstButton.render().is(".mx_ForwardList_sendFailed")).toBe(true);
+        update();
+        expect(firstButton.is(".mx_ForwardList_sendFailed")).toBe(true);
 
-        const secondButton = wrapper.find("AccessibleButton.mx_ForwardList_sendButton").at(1);
-        expect(secondButton.render().is(".mx_ForwardList_canSend")).toBe(true);
+        expect(secondButton.is(".mx_ForwardList_canSend")).toBe(true);
 
         act(() => { secondButton.simulate("click"); });
-        expect(secondButton.render().is(".mx_ForwardList_sending")).toBe(true);
+        update();
+        expect(secondButton.is(".mx_ForwardList_sending")).toBe(true);
 
         await act(async () => {
             finishSend();
             // Wait one tick for the button to realize the send succeeded
             await new Promise(resolve => setImmediate(resolve));
         });
-        expect(secondButton.render().is(".mx_ForwardList_sent")).toBe(true);
+        update();
+        expect(secondButton.is(".mx_ForwardList_sent")).toBe(true);
     });
 
     it("can render replies", async () => {


### PR DESCRIPTION
Not especially important, but it had always annoyed me that I couldn't figure out how to do this test without `.render()`, which I've now learned.

Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7961--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
