### PR TITLE
Fix wrongly asserting that PushRule::conditions is non-null

### DIFF
--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -223,7 +223,7 @@ function findOverrideMuteRule(roomId: string): IPushRule {
 }
 
 function isRuleForRoom(roomId: string, rule: IPushRule): boolean {
-    if (rule.conditions.length !== 1) {
+    if (rule.conditions?.length !== 1) {
         return false;
     }
     const cond = rule.conditions[0];

--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -77,14 +77,14 @@ export function getRoomNotifsState(roomId: string): RoomNotifState {
         roomRule = MatrixClientPeg.get().getRoomPushRule('global', roomId);
     } catch (err) {
         // Possible that the client doesn't have pushRules yet. If so, it
-        // hasn't started eiher, so indicate that this room is not notifying.
+        // hasn't started either, so indicate that this room is not notifying.
         return null;
     }
 
     // XXX: We have to assume the default is to notify for all messages
     // (in particular this will be 'wrong' for one to one rooms because
     // they will notify loudly for all messages)
-    if (!roomRule || !roomRule.enabled) return RoomNotifState.AllMessages;
+    if (!roomRule?.enabled) return RoomNotifState.AllMessages;
 
     // a mute at the room level will still allow mentions
     // to notify
@@ -202,10 +202,8 @@ function findOverrideMuteRule(roomId: string): IPushRule {
         return null;
     }
     for (const rule of cli.pushRules.global.override) {
-        if (isRuleForRoom(roomId, rule)) {
-            if (isMuteRule(rule) && rule.enabled) {
-                return rule;
-            }
+        if (rule.enabled && isRuleForRoom(roomId, rule) && isMuteRule(rule)) {
+            return rule;
         }
     }
     return null;

--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -61,17 +61,6 @@ export function aggregateNotificationCount(rooms: Room[]): {count: number, highl
     }, { count: 0, highlight: false });
 }
 
-export function getRoomHasBadge(room: Room): boolean {
-    const roomNotifState = getRoomNotifsState(room.roomId);
-    const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight) > 0;
-    const notificationCount = room.getUnreadNotificationCount();
-
-    const notifBadges = notificationCount > 0 && shouldShowNotifBadge(roomNotifState);
-    const mentionBadges = highlight && shouldShowMentionBadge(roomNotifState);
-
-    return notifBadges || mentionBadges;
-}
-
 export function getRoomNotifsState(roomId: string): RoomNotifState {
     if (MatrixClientPeg.get().isGuest()) return RoomNotifState.AllMessages;
 

--- a/test/RoomNotifs-test.ts
+++ b/test/RoomNotifs-test.ts
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ConditionKind, PushRuleActionName, TweakName } from "matrix-js-sdk/src/@types/PushRules";
+
+import { stubClient } from "./test-utils";
+import { MatrixClientPeg } from "../src/MatrixClientPeg";
+import { getRoomNotifsState, RoomNotifState } from "../src/RoomNotifs";
+
+describe("RoomNotifs test", () => {
+    beforeEach(() => {
+        stubClient();
+    });
+
+    it("getRoomNotifsState handles rules with no conditions", () => {
+        MatrixClientPeg.get().pushRules = {
+            global: {
+                override: [{
+                    rule_id: "!roomId:server",
+                    enabled: true,
+                    default: false,
+                    actions: [],
+                }],
+            },
+        };
+        expect(getRoomNotifsState("!roomId:server")).toBe(null);
+    });
+
+    it("getRoomNotifsState handles guest users", () => {
+        MatrixClientPeg.get().isGuest.mockReturnValue(true);
+        expect(getRoomNotifsState("!roomId:server")).toBe(RoomNotifState.AllMessages);
+    });
+
+    it("getRoomNotifsState handles mute state", () => {
+        MatrixClientPeg.get().pushRules = {
+            global: {
+                override: [{
+                    rule_id: "!roomId:server",
+                    enabled: true,
+                    default: false,
+                    conditions: [{
+                        kind: ConditionKind.EventMatch,
+                        key: "room_id",
+                        pattern: "!roomId:server",
+                    }],
+                    actions: [PushRuleActionName.DontNotify],
+                }],
+            },
+        };
+        expect(getRoomNotifsState("!roomId:server")).toBe(RoomNotifState.Mute);
+    });
+
+    it("getRoomNotifsState handles mentions only", () => {
+        MatrixClientPeg.get().getRoomPushRule = () => ({
+            rule_id: "!roomId:server",
+            enabled: true,
+            default: false,
+            actions: [PushRuleActionName.DontNotify],
+        });
+        expect(getRoomNotifsState("!roomId:server")).toBe(RoomNotifState.MentionsOnly);
+    });
+
+    it("getRoomNotifsState handles noisy", () => {
+        MatrixClientPeg.get().getRoomPushRule = () => ({
+            rule_id: "!roomId:server",
+            enabled: true,
+            default: false,
+            actions: [{ set_tweak: TweakName.Sound }],
+        });
+        expect(getRoomNotifsState("!roomId:server")).toBe(RoomNotifState.AllMessagesLoud);
+    });
+});

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -100,7 +100,7 @@ export function createTestClient() {
         sendStateEvent: jest.fn().mockResolvedValue(),
         getSyncState: () => "SYNCING",
         generateClientSecret: () => "t35tcl1Ent5ECr3T",
-        isGuest: () => false,
+        isGuest: jest.fn().mockReturnValue(false),
         isCryptoEnabled: () => false,
         getRoomHierarchy: jest.fn().mockReturnValue({
             rooms: [],


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21305
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2217

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrongly asserting that PushRule::conditions is non-null ([\#7973](https://github.com/matrix-org/matrix-react-sdk/pull/7973)). Fixes vector-im/element-web#21305.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr7973--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
