### PR TITLE
Fix destructuring when threads has no server support

### DIFF
--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -186,8 +186,10 @@ export default class ThreadView extends React.Component<IProps, IState> {
             }, async () => {
                 thread.emit(ThreadEvent.ViewThread);
                 if (!thread.initialEventsFetched) {
-                    const { nextBatch } = await thread.fetchInitialEvents();
-                    this.nextBatch = nextBatch;
+                    const response = await thread.fetchInitialEvents();
+                    if (response?.nextBatch) {
+                        this.nextBatch = response.nextBatch;
+                    }
                 }
 
                 this.timelinePanel.current?.refreshTimeline();


### PR DESCRIPTION
`fetchInitialEvents` can return `null` and was causing an exception when there's no server support

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7976--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
