### PR TITLE
Keyboard shortcut to open the sticker picker

### DIFF
--- a/src/accessibility/KeyboardShortcuts.ts
+++ b/src/accessibility/KeyboardShortcuts.ts
@@ -35,6 +35,8 @@ export enum KeyBindingAction {
     EditNextMessage = 'KeyBinding.editNextMessage',
     /** Cancel editing a message or cancel replying to a message */
     CancelReplyOrEdit = 'KeyBinding.cancelReplyInComposer',
+    /** Show the sticker picker */
+    ShowStickerPicker = 'KeyBinding.showStickerPicker',
 
     /** Set bold format the current selection */
     FormatBold = 'KeyBinding.toggleBoldInComposer',
@@ -227,6 +229,7 @@ export const CATEGORIES: Record<CategoryName, ICategory> = {
             KeyBindingAction.EditPrevMessage,
             KeyBindingAction.SelectNextSendHistory,
             KeyBindingAction.SelectPrevSendHistory,
+            KeyBindingAction.ShowStickerPicker,
         ],
     }, [CategoryName.CALLS]: {
         categoryLabel: _td("Calls"),
@@ -391,6 +394,13 @@ export const KEYBOARD_SHORTCUTS: IKeyboardShortcuts = {
             key: Key.ARROW_UP,
         },
         displayName: _td("Navigate to previous message in composer history"),
+    },
+    [KeyBindingAction.ShowStickerPicker]: {
+        default: {
+            ctrlOrCmdKey: true,
+            key: Key.COMMA,
+        },
+        displayName: _td("Send a sticker"),
     },
     [KeyBindingAction.ToggleMicInCall]: {
         default: {

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -363,6 +363,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                     replyToEvent={this.props.replyToEvent}
                     onChange={this.onChange}
                     disabled={this.state.haveRecording}
+                    setStickerPickerOpen={this.setStickerPickerOpen}
                 />,
             );
 

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -173,6 +173,7 @@ interface ISendMessageComposerProps extends MatrixClientProps {
     disabled?: boolean;
     onChange?(model: EditorModel): void;
     includeReplyLegacyFallback?: boolean;
+    setStickerPickerOpen: (isStickerPickerOpen: boolean) => void;
 }
 
 @replaceableComponent("views.rooms.SendMessageComposer")
@@ -235,6 +236,11 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                     // We're selecting history, so prevent the key event from doing anything else
                     event.preventDefault();
                 }
+                break;
+            }
+            case KeyBindingAction.ShowStickerPicker: {
+                this.props.setStickerPickerOpen(true);
+                event.preventDefault();
                 break;
             }
             case KeyBindingAction.EditPrevMessage:

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3427,6 +3427,7 @@
     "Jump to end of the composer": "Jump to end of the composer",
     "Navigate to next message in composer history": "Navigate to next message in composer history",
     "Navigate to previous message in composer history": "Navigate to previous message in composer history",
+    "Send a sticker": "Send a sticker",
     "Toggle microphone mute": "Toggle microphone mute",
     "Toggle webcam on/off": "Toggle webcam on/off",
     "Dismiss read marker and jump to bottom": "Dismiss read marker and jump to bottom",


### PR DESCRIPTION
Inspired by the desire to reduce the pain of https://github.com/vector-im/element-web/issues/20887 this adds a keyboard shortcut to open the sticker picker.

![image](https://user-images.githubusercontent.com/76812/156798583-b626d4f8-3805-4c71-b0ef-cfca6817b695.png)

Notes for reviewer:

1. It was difficult to find a suitable key combination. I went for Ctrl-comma in the end, but suggestions welcome.  (Ctrl-S=save, Ctrl-T=new tab, Ctrl-I=Italic, Ctrl-C=copy, Ctrl-K=search, Ctrl-E=toggle webcam, Ctrl-R=refresh)

2. I followed the pattern of `KeyBindingAction.SelectPrevSendHistory` in my code, so this shortcut only works when the composer is focussed. Ideally it would work from more places, but my brain is not working brilliantly today and I feared running out of time before I made this work. Suggestions of how to do it better would be welcome, or we might decide needing to focus in the composer is right and fine?