### PR TITLE
Pass room to getRoomTombstone to avoid racing with setState

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1028,13 +1028,13 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         this.checkWidgets(room);
 
         this.setState({
-            tombstone: this.getRoomTombstone(),
+            tombstone: this.getRoomTombstone(room),
             liveTimeline: room.getLiveTimeline(),
         });
     };
 
-    private getRoomTombstone() {
-        return this.state.room?.currentState.getStateEvents(EventType.RoomTombstone, "");
+    private getRoomTombstone(room = this.state.room) {
+        return room?.currentState.getStateEvents(EventType.RoomTombstone, "");
     }
 
     private async calculateRecommendedVersion(room: Room) {


### PR DESCRIPTION
Fixes race condition in https://github.com/matrix-org/matrix-react-sdk/pull/7975

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Pass room to getRoomTombstone to avoid racing with setState ([\#7986](https://github.com/matrix-org/matrix-react-sdk/pull/7986)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr7986--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
