### PR TITLE
Add lint for unused locals

### DIFF
--- a/src/ActiveRoomObserver.ts
+++ b/src/ActiveRoomObserver.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 New Vector Ltd
+Copyright 2017 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventSubscription } from 'fbemitter';
 import { logger } from "matrix-js-sdk/src/logger";
 
 import RoomViewStore from './stores/RoomViewStore';
@@ -33,11 +32,10 @@ type Listener = (isActive: boolean) => void;
 export class ActiveRoomObserver {
     private listeners: {[key: string]: Listener[]} = {};
     private _activeRoomId = RoomViewStore.getRoomId();
-    private readonly roomStoreToken: EventSubscription;
 
     constructor() {
         // TODO: We could self-destruct when the last listener goes away, or at least stop listening.
-        this.roomStoreToken = RoomViewStore.addListener(this.onRoomViewStoreUpdate);
+        RoomViewStore.addListener(this.onRoomViewStoreUpdate);
     }
 
     public get activeRoomId(): string {

--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 Michael Telatynski <7t3chguy@gmail.com>
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -166,7 +166,6 @@ const HEARTBEAT_INTERVAL = 30 * 1000; // seconds
 
 export class Analytics {
     private baseUrl: URL = null;
-    private siteId: string = null;
     private visitVariables: Record<number, [string, string]> = {}; // {[id: number]: [name: string, value: string]}
     private firstPage = true;
     private heartbeatIntervalID: number = null;

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -1,7 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017, 2018 New Vector Ltd
-Copyright 2019 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2022 The Matrix.org Foundation C.I.C.
 Copyright 2021 Šimon Brandner <simon.bra.ag@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -125,10 +125,6 @@ export default class CallHandler extends EventEmitter {
     private supportsPstnProtocol = null;
     private pstnSupportPrefixed = null; // True if the server only support the prefixed pstn protocol
     private supportsSipNativeVirtual = null; // im.vector.protocol.sip_virtual and im.vector.protocol.sip_native
-    private pstnSupportCheckTimer: number;
-    // For rooms we've been invited to, true if they're from virtual user, false if we've checked and they aren't.
-    private invitedRoomsAreVirtual = new Map<string, boolean>();
-    private invitedRoomCheckInProgress = false;
 
     // Map of the asserted identity users after we've looked them up using the API.
     // We need to be be able to determine the mapped room synchronously, so we
@@ -255,7 +251,7 @@ export default class CallHandler extends EventEmitter {
                 logger.log("Failed to check for protocol support and no retries remain: assuming no support", e);
             } else {
                 logger.log("Failed to check for protocol support: will retry", e);
-                this.pstnSupportCheckTimer = setTimeout(() => {
+                setTimeout(() => {
                     this.checkProtocols(maxTries - 1);
                 }, 10000);
             }

--- a/src/PasswordReset.ts
+++ b/src/PasswordReset.ts
@@ -1,6 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import { _t } from './languageHandler';
 export default class PasswordReset {
     private client: MatrixClient;
     private clientSecret: string;
-    private identityServerDomain: string;
     private password: string;
     private sessionId: string;
 
@@ -44,7 +43,6 @@ export default class PasswordReset {
             idBaseUrl: identityUrl,
         });
         this.clientSecret = this.client.generateClientSecret();
-        this.identityServerDomain = identityUrl ? identityUrl.split("://")[1] : null;
     }
 
     /**

--- a/src/audio/PlaybackQueue.ts
+++ b/src/audio/PlaybackQueue.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2021 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "matrix-js-sdk/src/client";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
 import { EventType } from "matrix-js-sdk/src/@types/event";
@@ -49,7 +48,7 @@ export class PlaybackQueue {
     private currentPlaybackId: string; // event ID, broken out from above for ease of use
     private recentFullPlays = new Set<string>(); // event IDs
 
-    constructor(private client: MatrixClient, private room: Room) {
+    constructor(private room: Room) {
         this.loadClocks();
 
         RoomViewStore.addListener(() => {
@@ -71,7 +70,7 @@ export class PlaybackQueue {
         if (PlaybackQueue.queues.has(room.roomId)) {
             return PlaybackQueue.queues.get(room.roomId);
         }
-        const queue = new PlaybackQueue(cli, room);
+        const queue = new PlaybackQueue(room);
         PlaybackQueue.queues.set(room.roomId, queue);
         return queue;
     }

--- a/src/components/structures/InteractiveAuth.tsx
+++ b/src/components/structures/InteractiveAuth.tsx
@@ -177,10 +177,6 @@ export default class InteractiveAuthComponent extends React.Component<IProps, IS
         }
     };
 
-    private tryContinue = (): void => {
-        this.stageComponent.current?.tryContinue?.();
-    };
-
     private authStateUpdated = (stageType: AuthType, stageState: IStageStatus): void => {
         const oldStage = this.state.authStage;
         this.setState({

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2015 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import AudioFeedArrayForCall from '../views/voip/AudioFeedArrayForCall';
 import { OwnProfileStore } from '../../stores/OwnProfileStore';
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
 import RoomView from './RoomView';
+import type { RoomView as RoomViewType } from './RoomView';
 import ToastContainer from './ToastContainer';
 import MyGroups from "./MyGroups";
 import UserView from "./UserView";
@@ -139,7 +140,7 @@ class LoggedInView extends React.Component<IProps, IState> {
     static displayName = 'LoggedInView';
 
     protected readonly _matrixClient: MatrixClient;
-    protected readonly _roomView: React.RefObject<any>;
+    protected readonly _roomView: React.RefObject<RoomViewType>;
     protected readonly _resizeContainer: React.RefObject<HTMLDivElement>;
     protected readonly resizeHandler: React.RefObject<HTMLDivElement>;
     protected layoutWatcherRef: string;

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -229,7 +229,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     private firstSyncPromise: IDeferred<void>;
 
     private screenAfterLogin?: IScreen;
-    private pageChanging: boolean;
     private tokenLogin?: boolean;
     private accountPassword?: string;
     private accountPasswordTimer?: number;
@@ -283,8 +282,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
         this.prevWindowWidth = UIStore.instance.windowWidth || 1000;
         UIStore.instance.on(UI_EVENTS.Resize, this.handleResize);
-
-        this.pageChanging = false;
 
         // For PersistentElement
         this.state.resizeNotifier.on("middlePanelResized", this.dispatchTimelineResize);

--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -78,7 +78,6 @@ interface IState {
 
 @replaceableComponent("structures.RoomDirectory")
 export default class RoomDirectory extends React.Component<IProps, IState> {
-    private readonly startTime: number;
     private unmounted = false;
     private nextBatch: string = null;
     private filterTimeout: number;

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1682,7 +1682,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
      * We pass it down to the scroll panel.
      */
     public handleScrollKey = ev => {
-        let panel;
+        let panel: ScrollPanel | TimelinePanel;
         if (this.searchResultsPanel.current) {
             panel = this.searchResultsPanel.current;
         } else if (this.messagePanel) {

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1681,7 +1681,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
      *
      * We pass it down to the scroll panel.
      */
-    private handleScrollKey = ev => {
+    public handleScrollKey = ev => {
         let panel;
         if (this.searchResultsPanel.current) {
             panel = this.searchResultsPanel.current;

--- a/src/components/views/auth/InteractiveAuthEntryComponents.tsx
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.tsx
@@ -326,10 +326,6 @@ export class TermsAuthEntry extends React.Component<ITermsAuthEntryProps, ITerms
         this.props.onPhaseChange(DEFAULT_PHASE);
     }
 
-    public tryContinue = () => {
-        this.trySubmit();
-    };
-
     private togglePolicy(policyId: string) {
         const newToggles = {};
         for (const policy of this.state.policies) {
@@ -832,7 +828,6 @@ export interface IStageComponentProps extends IAuthEntryProps {
 }
 
 export interface IStageComponent extends React.ComponentClass<React.PropsWithRef<IStageComponentProps>> {
-    tryContinue?(): void;
     attemptFailed?(): void;
     focus?(): void;
 }

--- a/src/components/views/dialogs/LogoutDialog.tsx
+++ b/src/components/views/dialogs/LogoutDialog.tsx
@@ -1,6 +1,6 @@
 /*
 Copyright 2018, 2019 New Vector Ltd
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -80,11 +80,6 @@ export default class LogoutDialog extends React.Component<IProps, IState> {
             });
         }
     }
-
-    private onSettingsLinkClick = (): void => {
-        // close dialog
-        this.props.onFinished(true);
-    };
 
     private onExportE2eKeysClicked = (): void => {
         Modal.createTrackedDialogAsync('Export E2E Keys', '',

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -25,10 +25,10 @@ import {
     ContentRules,
     IContentRules,
     PushRuleVectorState,
-    VectorPushRuleDefinition,
     VectorPushRulesDefinitions,
     VectorState,
 } from "../../../notifications";
+import type { VectorPushRuleDefinition } from "../../../notifications";
 import { _t, TranslatedString } from "../../../languageHandler";
 import LabelledToggleSwitch from "../elements/LabelledToggleSwitch";
 import SettingsStore from "../../../settings/SettingsStore";

--- a/src/components/views/settings/Notifications.tsx
+++ b/src/components/views/settings/Notifications.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2016 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import {
     ContentRules,
     IContentRules,
     PushRuleVectorState,
+    VectorPushRuleDefinition,
     VectorPushRulesDefinitions,
     VectorState,
 } from "../../../notifications";
@@ -209,7 +210,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
         for (const category of vectorCategories) {
             preparedNewState.vectorPushRules[category] = [];
             for (const rule of defaultRules[category]) {
-                const definition = VectorPushRulesDefinitions[rule.rule_id];
+                const definition: VectorPushRuleDefinition = VectorPushRulesDefinitions[rule.rule_id];
                 const vectorState = definition.ruleToVectorState(rule);
                 preparedNewState.vectorPushRules[category].push({
                     ruleId: rule.rule_id,
@@ -356,7 +357,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
                     }
                 }
             } else {
-                const definition = VectorPushRulesDefinitions[rule.ruleId];
+                const definition: VectorPushRuleDefinition = VectorPushRulesDefinitions[rule.ruleId];
                 const actions = definition.vectorStateToActions[checkedState];
                 if (!actions) {
                     await cli.setPushRuleEnabled('global', rule.rule.kind, rule.rule.rule_id, false);

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -98,18 +98,6 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
             dmUserId: SdkConfig.get().welcomeUserId,
             andView: true,
         });
-    };
-
-    private showSpoiler = (event) => {
-        const target = event.target;
-        target.innerHTML = target.getAttribute('data-spoiler');
-
-        const range = document.createRange();
-        range.selectNodeContents(target);
-
-        const selection = window.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(range);
     };
 
     private renderLegal() {

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
@@ -1,6 +1,5 @@
 /*
-Copyright 2019 New Vector Ltd
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -145,14 +144,6 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
                 invitedRoomIds: newInvitedRoomIds,
             };
         });
-    };
-
-    private onGoToUserProfileClick = (): void => {
-        dis.dispatch({
-            action: 'view_user_info',
-            userId: MatrixClientPeg.get().getUserId(),
-        });
-        this.props.closeSettingsFn();
     };
 
     private onUserUnignored = async (userId: string): Promise<void> => {

--- a/src/components/views/spaces/SpacePanel.tsx
+++ b/src/components/views/spaces/SpacePanel.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2021 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ const CreateSpaceButton = ({
 }: Pick<IInnerSpacePanelProps, "isPanelCollapsed" | "setPanelCollapsed">) => {
     // We don't need the handle as we position the menu in a constant location
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [menuDisplayed, handle, openMenu, closeMenu] = useContextMenu<void>();
+    const [menuDisplayed, _handle, openMenu, closeMenu] = useContextMenu<void>();
 
     useEffect(() => {
         if (!isPanelCollapsed && menuDisplayed) {

--- a/src/components/views/voip/CallViewForRoom.tsx
+++ b/src/components/views/voip/CallViewForRoom.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,8 +42,6 @@ interface IState {
  */
 @replaceableComponent("views.voip.CallViewForRoom")
 export default class CallViewForRoom extends React.Component<IProps, IState> {
-    private dispatcherRef: string;
-
     constructor(props: IProps) {
         super(props);
         this.state = {

--- a/src/notifications/VectorPushRulesDefinitions.ts
+++ b/src/notifications/VectorPushRulesDefinitions.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2016 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { PushRuleAction, PushRuleKind } from "matrix-js-sdk/src/@types/PushRules";
+import { IAnnotatedPushRule, PushRuleAction } from "matrix-js-sdk/src/@types/PushRules";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { _td } from '../languageHandler';
@@ -26,32 +26,29 @@ type StateToActionsMap = {
     [state in VectorState]?: PushRuleAction[];
 };
 
-interface IProps {
-    kind: PushRuleKind;
+interface IVectorPushRuleDefinition {
     description: string;
     vectorStateToActions: StateToActionsMap;
 }
 
 class VectorPushRuleDefinition {
-    private kind: PushRuleKind;
-    private description: string;
+    public readonly description: string;
     public readonly vectorStateToActions: StateToActionsMap;
 
-    constructor(opts: IProps) {
-        this.kind = opts.kind;
+    constructor(opts: IVectorPushRuleDefinition) {
         this.description = opts.description;
         this.vectorStateToActions = opts.vectorStateToActions;
     }
 
     // Translate the rule actions and its enabled value into vector state
-    public ruleToVectorState(rule): VectorPushRuleDefinition {
+    public ruleToVectorState(rule: IAnnotatedPushRule): VectorState {
         let enabled = false;
         if (rule) {
             enabled = rule.enabled;
         }
 
         for (const stateKey in PushRuleVectorState.states) { // eslint-disable-line guard-for-in
-            const state = PushRuleVectorState.states[stateKey];
+            const state: VectorState = PushRuleVectorState.states[stateKey];
             const vectorStateToActions = this.vectorStateToActions[state];
 
             if (!vectorStateToActions) {
@@ -78,6 +75,7 @@ class VectorPushRuleDefinition {
         return undefined;
     }
 }
+export type { VectorPushRuleDefinition };
 
 /**
  * The descriptions of rules managed by the Vector UI.
@@ -85,7 +83,6 @@ class VectorPushRuleDefinition {
 export const VectorPushRulesDefinitions = {
     // Messages containing user's display name
     ".m.rule.contains_display_name": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Override,
         description: _td("Messages containing my display name"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -96,7 +93,6 @@ export const VectorPushRulesDefinitions = {
 
     // Messages containing user's username (localpart/MXID)
     ".m.rule.contains_user_name": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Override,
         description: _td("Messages containing my username"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -107,7 +103,6 @@ export const VectorPushRulesDefinitions = {
 
     // Messages containing @room
     ".m.rule.roomnotif": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Override,
         description: _td("Messages containing @room"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -118,7 +113,6 @@ export const VectorPushRulesDefinitions = {
 
     // Messages just sent to the user in a 1:1 room
     ".m.rule.room_one_to_one": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("Messages in one-to-one chats"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -129,7 +123,6 @@ export const VectorPushRulesDefinitions = {
 
     // Encrypted messages just sent to the user in a 1:1 room
     ".m.rule.encrypted_room_one_to_one": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("Encrypted messages in one-to-one chats"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -142,7 +135,6 @@ export const VectorPushRulesDefinitions = {
     // 1:1 room messages are catched by the .m.rule.room_one_to_one rule if any defined
     // By opposition, all other room messages are from group chat rooms.
     ".m.rule.message": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("Messages in group chats"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -155,7 +147,6 @@ export const VectorPushRulesDefinitions = {
     // Encrypted 1:1 room messages are catched by the .m.rule.encrypted_room_one_to_one rule if any defined
     // By opposition, all other room messages are from group chat rooms.
     ".m.rule.encrypted": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("Encrypted messages in group chats"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -166,7 +157,6 @@ export const VectorPushRulesDefinitions = {
 
     // Invitation for the user
     ".m.rule.invite_for_me": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("When I'm invited to a room"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -177,7 +167,6 @@ export const VectorPushRulesDefinitions = {
 
     // Incoming call
     ".m.rule.call": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Underride,
         description: _td("Call invitation"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             [VectorState.On]: StandardActions.ACTION_NOTIFY,
@@ -188,7 +177,6 @@ export const VectorPushRulesDefinitions = {
 
     // Notifications from bots
     ".m.rule.suppress_notices": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Override,
         description: _td("Messages sent by bot"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: {
             // .m.rule.suppress_notices is a "negative" rule, we have to invert its enabled value for vector UI
@@ -200,7 +188,6 @@ export const VectorPushRulesDefinitions = {
 
     // Room upgrades (tombstones)
     ".m.rule.tombstone": new VectorPushRuleDefinition({
-        kind: PushRuleKind.Override,
         description: _td("When rooms are upgraded"), // passed through _t() translation in src/components/views/settings/Notifications.js
         vectorStateToActions: { // The actions for each vector state, or null to disable the rule.
             [VectorState.On]: StandardActions.ACTION_NOTIFY,

--- a/src/stores/notifications/ListNotificationState.ts
+++ b/src/stores/notifications/ListNotificationState.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ limitations under the License.
 import { Room } from "matrix-js-sdk/src/models/room";
 
 import { NotificationColor } from "./NotificationColor";
-import { TagID } from "../room-list/models";
 import { arrayDiff } from "../../utils/arrays";
 import { RoomNotificationState } from "./RoomNotificationState";
 import { NotificationState, NotificationStateEvents } from "./NotificationState";
@@ -28,7 +27,7 @@ export class ListNotificationState extends NotificationState {
     private rooms: Room[] = [];
     private states: { [roomId: string]: RoomNotificationState } = {};
 
-    constructor(private byTileCount = false, private tagId: TagID, private getRoomFn: FetchRoomFn) {
+    constructor(private byTileCount = false, private getRoomFn: FetchRoomFn) {
         super();
     }
 

--- a/src/stores/notifications/RoomNotificationStateStore.ts
+++ b/src/stores/notifications/RoomNotificationStateStore.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ export class RoomNotificationStateStore extends AsyncStoreWithClient<IState> {
         const getRoomFn: FetchRoomFn = (room: Room) => {
             return this.getRoomState(room);
         };
-        const state = new ListNotificationState(useTileCount, tagId, getRoomFn);
+        const state = new ListNotificationState(useTileCount, getRoomFn);
         this.listMap.set(tagId, state);
         return state;
     }

--- a/src/stores/notifications/SpaceNotificationState.ts
+++ b/src/stores/notifications/SpaceNotificationState.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2021 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ export class SpaceNotificationState extends NotificationState {
     public rooms: Room[] = []; // exposed only for tests
     private states: { [spaceId: string]: RoomNotificationState } = {};
 
-    constructor(private spaceId: string | symbol, private getRoomFn: FetchRoomFn) {
+    constructor(private getRoomFn: FetchRoomFn) {
         super();
     }
 

--- a/src/stores/room-list/RoomListStore.ts
+++ b/src/stores/room-list/RoomListStore.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2021 The Matrix.org Foundation C.I.C.
+Copyright 2018 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,8 +64,6 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     private algorithm = new Algorithm();
     private filterConditions: IFilterCondition[] = [];
     private prefilterConditions: IFilterCondition[] = [];
-    private tagWatcher: TagWatcher;
-    private spaceWatcher: SpaceWatcher;
     private updateFn = new MarkedExecution(() => {
         for (const tagId of Object.keys(this.orderedLists)) {
             RoomNotificationStateStore.instance.getListState(tagId).setRooms(this.orderedLists[tagId]);
@@ -83,10 +81,11 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
     }
 
     private setupWatchers() {
+        // TODO: Maybe destroy these if this class supports destruction
         if (SpaceStore.spacesEnabled) {
-            this.spaceWatcher = new SpaceWatcher(this);
+            new SpaceWatcher(this);
         } else {
-            this.tagWatcher = new TagWatcher(this);
+            new TagWatcher(this);
         }
     }
 
@@ -106,7 +105,6 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
         this.filterConditions = [];
         this.prefilterConditions = [];
         this.initialListsGenerated = false;
-        this.setupWatchers();
 
         this.algorithm.off(LIST_UPDATED_EVENT, this.onAlgorithmListUpdated);
         this.algorithm.off(FILTER_CHANGED, this.onAlgorithmListUpdated);
@@ -131,7 +129,6 @@ export class RoomListStoreClass extends AsyncStoreWithClient<IState> {
         this.algorithm.on(FILTER_CHANGED, this.onAlgorithmFilterUpdated);
         this.setupWatchers();
 
-        // Update any settings here, as some may have happened before we were logically ready.
         // Update any settings here, as some may have happened before we were logically ready.
         logger.log("Regenerating room lists: Startup");
         await this.readAndCacheSettingsFromStore();

--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2021 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1236,7 +1236,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
             return this.notificationStateMap.get(key);
         }
 
-        const state = new SpaceNotificationState(key, getRoomFn);
+        const state = new SpaceNotificationState(getRoomFn);
         this.notificationStateMap.set(key, state);
         return state;
     }

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 - 2021 The Matrix.org Foundation C.I.C.
+ * Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,10 +236,6 @@ export class StopGapWidget extends EventEmitter {
 
     public get started(): boolean {
         return !!this.messaging;
-    }
-
-    private get widgetId() {
-        return this.messaging.widget.id;
     }
 
     private onOpenModal = async (ev: CustomEvent<IModalWidgetOpenRequest>) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "target": "es2016",
     "noImplicitAny": false,
+    "noUnusedLocals": true,
     "sourceMap": false,
     "outDir": "./lib",
     "declaration": true,


### PR DESCRIPTION
TypeScript supports checking for "unused locals", which actually includes
locals, private fields, private methods, etc. If a private thing is actually
needed as part of the API surface, you can change it to public to resolve the
error.

This seems like a good check to have, as it highlights unused bits of code that
perhaps got lost while refactoring. This changes our config to reject them and
fixes up a few existing cases.

See also https://github.com/matrix-org/matrix-js-sdk/pull/2223

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8007--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
