### PR TITLE
Fix button border color of LeaveSpaceDialog

### DIFF
--- a/res/css/views/dialogs/_LeaveSpaceDialog.scss
+++ b/res/css/views/dialogs/_LeaveSpaceDialog.scss
@@ -19,58 +19,56 @@ limitations under the License.
         display: flex;
         flex-direction: column;
         padding: 24px 32px;
-    }
-}
 
-.mx_LeaveSpaceDialog {
-    width: 440px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    height: 520px;
+        .mx_LeaveSpaceDialog {
+            width: 440px;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: 520px;
 
-    .mx_Dialog_content {
-        flex-grow: 1;
-        margin: 0;
-        overflow-y: auto;
+            .mx_Dialog_content {
+                flex-grow: 1;
+                margin: 0;
+                overflow-y: auto;
 
-        .mx_LeaveSpaceDialog_section_warning {
-            position: relative;
-            border-radius: 8px;
-            margin: 12px 0 0;
-            padding: 12px 8px 12px 42px;
-            background-color: $header-panel-bg-color;
+                .mx_LeaveSpaceDialog_section_warning {
+                    position: relative;
+                    border-radius: 8px;
+                    margin: 12px 0 0;
+                    padding: 12px 8px 12px 42px;
+                    background-color: $header-panel-bg-color;
 
-            font-size: $font-12px;
-            line-height: $font-15px;
-            color: $secondary-content;
+                    font-size: $font-12px;
+                    line-height: $font-15px;
+                    color: $secondary-content;
 
-            &::before {
-                content: '';
-                position: absolute;
-                left: 10px;
-                top: calc(50% - 8px); // vertical centering
-                height: 16px;
-                width: 16px;
-                background-color: $secondary-content;
-                mask-repeat: no-repeat;
-                mask-size: contain;
-                mask-image: url('$(res)/img/element-icons/room/room-summary.svg');
-                mask-position: center;
+                    &::before {
+                        content: '';
+                        position: absolute;
+                        left: 10px;
+                        top: calc(50% - 8px); // vertical centering
+                        height: 16px;
+                        width: 16px;
+                        background-color: $secondary-content;
+                        mask-repeat: no-repeat;
+                        mask-size: contain;
+                        mask-image: url('$(res)/img/element-icons/room/room-summary.svg');
+                        mask-position: center;
+                    }
+                }
+
+                > p {
+                    color: $primary-content;
+                }
             }
-        }
 
-        > p {
-            color: $primary-content;
-        }
-    }
-
-    .mx_Dialog_buttons {
-        margin-top: 20px;
-
-        .mx_Dialog_primary {
-            background-color: $alert !important; // override default colour
-            border-color: $alert;
+            .mx_Dialog_buttons {
+                .mx_Dialog_primary {
+                    background-color: $alert;
+                    border-color: $alert;
+                }
+            }
         }
     }
 }

--- a/res/css/views/dialogs/_LeaveSpaceDialog.scss
+++ b/res/css/views/dialogs/_LeaveSpaceDialog.scss
@@ -62,13 +62,6 @@ limitations under the License.
                     color: $primary-content;
                 }
             }
-
-            .mx_Dialog_buttons {
-                .mx_Dialog_primary {
-                    background-color: $alert;
-                    border-color: $alert;
-                }
-            }
         }
     }
 }

--- a/src/components/views/dialogs/LeaveSpaceDialog.tsx
+++ b/src/components/views/dialogs/LeaveSpaceDialog.tsx
@@ -105,6 +105,7 @@ const LeaveSpaceDialog: React.FC<IProps> = ({ space, onFinished }) => {
         </div>
         <DialogButtons
             primaryButton={_t("Leave space")}
+            primaryButtonClass="danger"
             onPrimaryButtonClick={() => onFinished(true, roomsToLeave)}
             hasCancel={true}
             onCancel={() => onFinished(false)}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21365

This commit fixes the confirmation button border color of LeaveSpaceDialog by moving `.mx_LeaveSpaceDialog` inside `.mx_Dialog`. Thanks to this change `!important` and `margin-top` became redundant.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

![after](https://user-images.githubusercontent.com/3362943/157452286-d1d56a8f-5a3d-4b54-82b0-1a5d7c4d37ce.png)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Notes: Fix button border color of LeaveSpaceDialog

<!-- To specify text for the changelog entry (otherwise the PR title will be used):


Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix button border color of LeaveSpaceDialog ([\#8010](https://github.com/matrix-org/matrix-react-sdk/pull/8010)). Fixes vector-im/element-web#21365. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8010--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
