### PR TITLE
Fix incorrect usage of unstable variant of `is_falling_back`

### DIFF
--- a/src/utils/Reply.ts
+++ b/src/utils/Reply.ts
@@ -149,7 +149,7 @@ export function makeReplyMixIn(ev?: MatrixEvent, inThread = false): RecursivePar
         'm.relates_to': {
             'm.in_reply_to': {
                 'event_id': ev.getId(),
-                'io.element.is_falling_back': !inThread, // MSC3440 unstable `is_falling_back` field
+                'io.element.show_reply': inThread, // MSC3440 unstable `is_falling_back` field
             },
         },
     };
@@ -177,6 +177,5 @@ export function shouldDisplayReply(event: MatrixEvent, inThread = false): boolea
     if (!inThread) return true;
 
     const inReplyTo = event.getRelation()?.["m.in_reply_to"];
-    const isFallingBack = inReplyTo?.is_falling_back ?? inReplyTo?.["io.element.is_falling_back"];
-    return !isFallingBack;
+    return inReplyTo?.is_falling_back ?? inReplyTo?.["io.element.show_reply"] ?? false;
 }


### PR DESCRIPTION
Fixes thread responses showing up as replies wrongly
Fixes incorrect unstable msc variant being used
Fixes a reply within a thread as showing up as a reply to all prior events in the thread due to chaining not respecting `is_falling_back`

Requires https://github.com/matrix-org/matrix-js-sdk/pull/2227

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect usage of unstable variant of `is_falling_back` ([\#8016](https://github.com/matrix-org/matrix-react-sdk/pull/8016)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8016--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
