### PR TITLE
Don't show empty 3 dots in Message Composer when there aren't any more buttons

### DIFF
--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -101,7 +101,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
 
     return <UploadButtonContextProvider roomId={roomId} relation={props.relation}>
         { mainButtons }
-        { moreButtons.length != 0 && <AccessibleTooltipButton
+        { moreButtons.length > 0 && <AccessibleTooltipButton
             className={moreOptionsClasses}
             onClick={props.toggleButtonMenu}
             title={_t("More options")}

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -101,11 +101,11 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
 
     return <UploadButtonContextProvider roomId={roomId} relation={props.relation}>
         { mainButtons }
-        <AccessibleTooltipButton
+        { moreButtons.length != 0 && <AccessibleTooltipButton
             className={moreOptionsClasses}
             onClick={props.toggleButtonMenu}
             title={_t("More options")}
-        />
+        /> }
         { props.isMenuOpen && (
             <ContextMenu
                 onFinished={props.toggleButtonMenu}


### PR DESCRIPTION
if `moreButtons` is empty don't render `AccessibleTooltipButton`

Polls will always show because they are not configurable but maybe that'll change and then people will see this:
![image](https://user-images.githubusercontent.com/31655082/157715612-db892cd2-d38e-4498-aa8b-c6b8d2f9d721.png)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

Signed-off-by: Chagai Friedlander me@chagai.website


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8023--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
