### PR TITLE
Fix logging in end-to-end tests

### DIFF
--- a/test/end-to-end-tests/src/session.ts
+++ b/test/end-to-end-tests/src/session.ts
@@ -40,7 +40,7 @@ export class ElementSession {
             "requestfinished", async (req: puppeteer.HTTPRequest) => {
                 const type = req.resourceType();
                 const response = await req.response();
-                return `${type} ${response.status()} ${req.method()} ${req.url()} \n`;
+                return `${type} ${response?.status() ?? '<no response>'} ${req.method()} ${req.url()} \n`;
             });
         this.log = new Logger(this.username);
     }

--- a/test/end-to-end-tests/src/util.ts
+++ b/test/end-to-end-tests/src/util.ts
@@ -84,7 +84,8 @@ export async function serializeLog(msg: ConsoleMessage): Promise<string> {
         // Note: we have to run the checks against the object in the page context, so call
         // evaluate instead of just doing it ourselves.
         const stringyArg: string = await arg.evaluate((argInContext: any) => {
-            if (argInContext.stack || (argInContext instanceof Error)) {
+            // sometimes the argument will be `null` or similar - treat it safely.
+            if (argInContext?.stack || (argInContext instanceof Error)) {
                 // probably an error - toString it and append any properties which might not be
                 // caught. For example, on HTTP errors the JSON stringification will capture the
                 // status code.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21386

There were two issues:
* Lack of null checking on the object to be logged
* Somewhere in a puppeteer update `requestfinished` became a bit of a non-fatal race

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr8028--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
