### PR TITLE
Refactor _KeyBackupFailedDialog.scss

### DIFF
--- a/res/css/views/dialogs/security/_KeyBackupFailedDialog.scss
+++ b/res/css/views/dialogs/security/_KeyBackupFailedDialog.scss
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 New Vector Ltd
+Copyright 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,28 +15,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_KeyBackupFailedDialog .mx_Dialog_title {
-    margin-bottom: 32px;
-}
-
-.mx_KeyBackupFailedDialog_title {
-    position: relative;
-    padding-left: 45px;
-    padding-bottom: 10px;
-
-    &::before {
-        mask: url("$(res)/img/e2e/lock-warning-filled.svg");
-        mask-repeat: no-repeat;
-        background-color: $primary-content;
-        content: "";
-        position: absolute;
-        top: -6px;
-        right: 0;
-        bottom: 0;
-        left: 0;
+.mx_KeyBackupFailedDialog {
+    .mx_Dialog_title {
+        margin-bottom: 32px;
     }
-}
 
-.mx_KeyBackupFailedDialog .mx_Dialog_buttons {
-    margin-top: 36px;
+    .mx_KeyBackupFailedDialog_title {
+        position: relative;
+        padding-left: 45px;
+        padding-bottom: 10px;
+
+        &::before {
+            mask: url("$(res)/img/e2e/lock-warning-filled.svg");
+            mask-repeat: no-repeat;
+            background-color: $primary-content;
+            content: "";
+            position: absolute;
+            top: -6px;
+            right: 0;
+            bottom: 0;
+            left: 0;
+        }
+    }
+
+    .mx_Dialog_buttons {
+        margin-top: 36px;
+    }
 }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21387

Moved everything under `.mx_KeyBackupFailedDialog`

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

The change is trivial, but this should ensure that unexpected styling would not be applied.

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Notes: none
element-web notes: none

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8029--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
