### PR TITLE
Fix regression around replying to search results

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -849,23 +849,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                     this.onCancelSearchClick();
                 }
                 break;
-            case 'quote':
-                if (this.state.searchResults) {
-                    const roomId = payload.event.getRoomId();
-                    if (roomId === this.state.roomId) {
-                        this.onCancelSearchClick();
-                    }
-
-                    setImmediate(() => {
-                        dis.dispatch<ViewRoomPayload>({
-                            action: Action.ViewRoom,
-                            room_id: roomId,
-                            deferred_action: payload,
-                            metricsTrigger: "MessageSearch",
-                        });
-                    });
-                }
-                break;
             case 'MatrixActions.sync':
                 if (!this.state.matrixClientIsReady) {
                     this.setState({

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -842,11 +842,13 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 });
                 break;
             case 'reply_to_event':
-                if (this.state.searchResults
-                        && payload.event.getRoomId() === this.state.roomId
-                        && !this.unmounted
-                        && payload.context === TimelineRenderingType.Room) {
+                if (!this.unmounted &&
+                    this.state.searchResults &&
+                    payload.event.getRoomId() === this.state.roomId &&
+                    payload.context === TimelineRenderingType.Search
+                ) {
                     this.onCancelSearchClick();
+                    // we don't need to re-dispatch as RoomViewStore knows to persist with context=Search also
                 }
                 break;
             case 'MatrixActions.sync':

--- a/src/stores/RoomViewStore.tsx
+++ b/src/stores/RoomViewStore.tsx
@@ -198,10 +198,10 @@ class RoomViewStore extends Store<ActionPayload> {
                 break;
             case 'reply_to_event':
                 // If currently viewed room does not match the room in which we wish to reply then change rooms
-                // this can happen when performing a search across all rooms
-                if (payload.context === TimelineRenderingType.Room) {
-                    if (payload.event
-                        && payload.event.getRoomId() !== this.state.roomId) {
+                // this can happen when performing a search across all rooms. Persist the data from this event for
+                // both room and search timeline rendering types, search will get auto-closed by RoomView at this time.
+                if ([TimelineRenderingType.Room, TimelineRenderingType.Search].includes(payload.context)) {
+                    if (payload.event?.getRoomId() !== this.state.roomId) {
                         dis.dispatch<ViewRoomPayload>({
                             action: Action.ViewRoom,
                             room_id: payload.event.getRoomId(),


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21389

Regressed by consolidation between TileShape and TimelineRenderingType

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix regression around replying to search results ([\#8035](https://github.com/matrix-org/matrix-react-sdk/pull/8035)). Fixes vector-im/element-web#21389.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8035--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
