### PR TITLE
Fix null-guarding regression around reply_to_event dispatch

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -844,7 +844,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             case 'reply_to_event':
                 if (!this.unmounted &&
                     this.state.searchResults &&
-                    payload.event.getRoomId() === this.state.roomId &&
+                    payload.event?.getRoomId() === this.state.roomId &&
                     payload.context === TimelineRenderingType.Search
                 ) {
                     this.onCancelSearchClick();

--- a/src/stores/RoomViewStore.tsx
+++ b/src/stores/RoomViewStore.tsx
@@ -201,7 +201,7 @@ class RoomViewStore extends Store<ActionPayload> {
                 // this can happen when performing a search across all rooms. Persist the data from this event for
                 // both room and search timeline rendering types, search will get auto-closed by RoomView at this time.
                 if ([TimelineRenderingType.Room, TimelineRenderingType.Search].includes(payload.context)) {
-                    if (payload.event?.getRoomId() !== this.state.roomId) {
+                    if (payload.event && payload.event.getRoomId() !== this.state.roomId) {
                         dis.dispatch<ViewRoomPayload>({
                             action: Action.ViewRoom,
                             room_id: payload.event.getRoomId(),


### PR DESCRIPTION
Would prevent cancelling a reply