### PR TITLE
`forceDestroy` when resetting a widget

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -328,7 +328,7 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private resetWidget(newProps: IProps): void {
-        this.sgWidget?.stopMessaging();
+        this.sgWidget?.stopMessaging({ forceDestroy: true });
         this.stopSgListeners();
 
         try {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21399
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * `forceDestroy` when resetting a widget ([\#8045](https://github.com/matrix-org/matrix-react-sdk/pull/8045)). Fixes vector-im/element-web#21399. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8045--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
