### PR TITLE
Fix the header of Space landing page

### DIFF
--- a/res/css/structures/_SpaceRoomView.scss
+++ b/res/css/structures/_SpaceRoomView.scss
@@ -152,6 +152,7 @@ $SpaceRoomViewInnerWidth: 428px;
             right: 24px;
             top: 32px;
         }
+
         // XXX remove this when spaces leaves Beta
         .mx_SpaceRoomView_preview_spaceBetaPrompt {
             font-weight: $font-semi-bold;
@@ -266,6 +267,7 @@ $SpaceRoomViewInnerWidth: 428px;
                 }
             }
 
+            // XXX: Temporary for the Spaces release only
             .mx_SpaceFeedbackPrompt {
                 padding: 7px; // 8px - 1px border
                 border: 1px solid rgba($primary-content, .1);

--- a/res/css/structures/_SpaceRoomView.scss
+++ b/res/css/structures/_SpaceRoomView.scss
@@ -254,13 +254,26 @@ $SpaceRoomViewInnerWidth: 428px;
         flex-direction: column;
         min-width: 0;
 
-        > .mx_BaseAvatar {
-            width: 80px;
-        }
+        .mx_SpaceRoomView_landing_header {
+            display: flex;
+            justify-content: space-between;
 
-        > .mx_BaseAvatar_image,
-        > .mx_BaseAvatar > .mx_BaseAvatar_image {
-            border-radius: 12px;
+            .mx_BaseAvatar {
+                width: 80px;
+
+                .mx_BaseAvatar_image {
+                    border-radius: 12px;
+                }
+            }
+
+            .mx_SpaceFeedbackPrompt {
+                padding: 7px; // 8px - 1px border
+                border: 1px solid rgba($primary-content, .1);
+                border-radius: 8px;
+                width: max-content;
+                height: fit-content;
+                margin-left: 24px;
+            }
         }
 
         .mx_SpaceRoomView_landing_name {
@@ -359,14 +372,6 @@ $SpaceRoomViewInnerWidth: 428px;
         .mx_SearchBox {
             margin: 0 0 20px;
             flex: 0;
-        }
-
-        .mx_SpaceFeedbackPrompt {
-            padding: 7px; // 8px - 1px border
-            border: 1px solid rgba($primary-content, .1);
-            border-radius: 8px;
-            width: max-content;
-            margin: 0 0 -40px auto; // collapse its own height to not push other components down
         }
     }
 

--- a/res/css/views/spaces/_SpaceCreateMenu.scss
+++ b/res/css/views/spaces/_SpaceCreateMenu.scss
@@ -43,6 +43,7 @@ $spacePanelWidth: 68px;
                 color: $secondary-content;
             }
 
+            // XXX: Temporary for the Spaces release only
             .mx_SpaceFeedbackPrompt {
                 border-top: 1px solid $input-border-color;
                 padding-top: 12px;

--- a/res/css/views/spaces/_SpaceCreateMenu.scss
+++ b/res/css/views/spaces/_SpaceCreateMenu.scss
@@ -112,14 +112,13 @@ $spacePanelWidth: 68px;
         position: relative;
         font-size: inherit;
         line-height: inherit;
-        margin-right: auto;
+        margin-right: 8px;
     }
 
     .mx_AccessibleButton_kind_link {
         color: $accent;
         position: relative;
         padding: 0;
-        margin-left: 8px;
         font-size: inherit;
         line-height: inherit;
     }

--- a/src/components/structures/SpaceRoomView.tsx
+++ b/src/components/structures/SpaceRoomView.tsx
@@ -479,8 +479,10 @@ const SpaceLanding = ({ space }: { space: Room }) => {
     };
 
     return <div className="mx_SpaceRoomView_landing">
-        <SpaceFeedbackPrompt />
-        <RoomAvatar room={space} height={80} width={80} viewAvatarOnClick={true} />
+        <div className="mx_SpaceRoomView_landing_header">
+            <RoomAvatar room={space} height={80} width={80} viewAvatarOnClick={true} />
+            <SpaceFeedbackPrompt />
+        </div>
         <div className="mx_SpaceRoomView_landing_name">
             <RoomName room={space}>
                 { (name) => {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21402

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

This PR fixes the header of the Space landing page

From:

https://user-images.githubusercontent.com/3362943/158019698-4bd6dea5-6a4b-4fed-b542-0a451b97d866.mp4

To:

https://user-images.githubusercontent.com/3362943/158019696-4fa3717d-5a2d-4437-a54c-54c0f06dbe5e.mp4

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the header of Space landing page ([\#8048](https://github.com/matrix-org/matrix-react-sdk/pull/8048)). Fixes vector-im/element-web#21402. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://pr8048--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
