### PR TITLE
Add a dialog showing all reactions to a message

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -116,6 +116,7 @@
 @import "./views/dialogs/_ModalWidgetDialog.scss";
 @import "./views/dialogs/_NewSessionReviewDialog.scss";
 @import "./views/dialogs/_PollCreateDialog.scss";
+@import "./views/dialogs/_ReactionsDialog.scss";
 @import "./views/dialogs/_RegistrationEmailPromptDialog.scss";
 @import "./views/dialogs/_RoomSettingsDialog.scss";
 @import "./views/dialogs/_RoomSettingsDialogBridges.scss";

--- a/res/css/views/context_menus/_MessageContextMenu.scss
+++ b/res/css/views/context_menus/_MessageContextMenu.scss
@@ -113,4 +113,8 @@ limitations under the License.
     .mx_MessageContextMenu_jumpToEvent::before {
         mask-image: url('$(res)/img/element-icons/child-relationship.svg');
     }
+
+    .mx_MessageContextMenu_iconEmoji::before {
+        mask-image: url('$(res)/img/element-icons/room/composer/emoji.svg');
+    }
 }

--- a/res/css/views/dialogs/_ReactionsDialog.scss
+++ b/res/css/views/dialogs/_ReactionsDialog.scss
@@ -1,0 +1,67 @@
+.mx_ReactionsDialog {
+    width: 520px;
+    color: $primary-content;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    min-height: 0;
+    height: 80vh;
+
+    .mx_ReactionsWrapper {
+        display: flex;
+        flex-direction: row;
+
+        > .mx_EmojiList {
+            margin-right: 1em;
+            padding-left: 1em;
+            padding-right: 1em;
+        }
+
+        > ul {
+            list-style-type: none;
+        }
+
+        .mx_SenderList {
+            padding: 0;
+            li {
+                margin-top: 0.5em;
+                margin-bottom: 0.5em;
+            }
+        }
+    }
+
+    .mx_EmojiFilterButton {
+        display: inline-flex;
+        line-height: $font-20px;
+        margin-right: 6px;
+        margin-bottom: 0.5em;
+        padding: 1px 6px;
+        border: 1px solid $message-action-bar-border-color;
+        border-radius: 10px;
+        background-color: $header-panel-bg-color;
+        cursor: pointer;
+        user-select: none;
+        vertical-align: middle;
+
+        &:hover {
+            border-color: $reaction-row-button-hover-border-color;
+        }
+
+        &.mx_ReactionsRowButton_selected {
+            background-color: $reaction-row-button-selected-bg-color;
+            border-color: $accent;
+        }
+
+        &.mx_AccessibleButton_disabled {
+            cursor: not-allowed;
+        }
+
+        .mx_ReactionsRowButton_content {
+            max-width: 100px;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            padding-right: 4px;
+        }
+    }
+}

--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -41,6 +41,7 @@ import ContextMenu, { toRightOf, IPosition, ChevronFace } from '../../structures
 import ReactionPicker from '../emojipicker/ReactionPicker';
 import ViewSource from '../../structures/ViewSource';
 import { createRedactEventDialog } from '../dialogs/ConfirmRedactDialog';
+import ReactionsDialog from '../dialogs/ReactionsDialog';
 import ShareDialog from '../dialogs/ShareDialog';
 import RoomContext, { TimelineRenderingType } from '../../../contexts/RoomContext';
 import { ComposerInsertPayload } from "../../../dispatcher/payloads/ComposerInsertPayload";
@@ -73,7 +74,11 @@ interface IProps extends IPosition {
     // A permalink to this event or an href of an anchor element the user has clicked
     link?: string;
 
-    getRelationsForEvent?: GetRelationsForEvent;
+    getRelationsForEvent?: (
+        eventId: string,
+        relationType: string,
+        eventType: string
+    ) => Relations;
 }
 
 interface IState {
@@ -175,6 +180,14 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
     private onViewSourceClick = (): void => {
         Modal.createTrackedDialog('View Event Source', '', ViewSource, {
             mxEvent: this.props.mxEvent,
+        }, 'mx_Dialog_viewsource');
+        this.closeMenu();
+    };
+
+    private onReactionsClick = (): void => {
+        Modal.createTrackedDialog('Reactions', '', ReactionsDialog, {
+            mxEvent: this.props.mxEvent,
+            reactions: this.props.reactions,
         }, 'mx_Dialog_viewsource');
         this.closeMenu();
     };
@@ -420,6 +433,14 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
             );
         }
 
+        const reactionsButton = (
+            <IconizedContextMenuOption
+                iconClassName="mx_MessageContextMenu_iconEmoji"
+                label={_t("Reactions")}
+                onClick={this.onReactionsClick}
+            />
+        );
+
         let permalinkButton: JSX.Element;
         if (permalink) {
             permalinkButton = (
@@ -632,6 +653,7 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
                 { jumpToRelatedEventButton }
                 { unhidePreviewButton }
                 { viewSourceButton }
+                { reactionsButton }
                 { resendReactionsButton }
                 { collapseReplyChainButton }
             </IconizedContextMenuOptionList>

--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -185,8 +185,11 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
     };
 
     private onReactionsClick = (): void => {
+        const cli = MatrixClientPeg.get();
+        const room = cli.getRoom(this.props.mxEvent.getRoomId());
+
         Modal.createTrackedDialog('Reactions', '', ReactionsDialog, {
-            mxEvent: this.props.mxEvent,
+            room,
             reactions: this.props.reactions,
         }, 'mx_Dialog_viewsource');
         this.closeMenu();

--- a/src/components/views/dialogs/ReactionsDialog.tsx
+++ b/src/components/views/dialogs/ReactionsDialog.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { MatrixEvent } from "matrix-js-sdk/src/models/event";
+import { Relations } from 'matrix-js-sdk/src/models/relations';
+
+import { _t } from '../../../languageHandler';
+import { IDialogProps } from "./IDialogProps";
+import { replaceableComponent } from "../../../utils/replaceableComponent";
+import BaseDialog from "./BaseDialog";
+import { MatrixClientPeg } from '../../../MatrixClientPeg';
+import AccessibleButton from '../elements/AccessibleButton';
+
+interface IProps extends IDialogProps {
+    mxEvent: MatrixEvent;
+    reactions: Relations;
+}
+
+interface IState {
+    filteredEmoji: string|null;
+    allAnnotations: any[];
+}
+
+@replaceableComponent("views.dialogs.ReactionsDialog")
+export default class ReactionsDialog extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+    }
+
+    state = {
+        filteredEmoji: null,
+        allAnnotations: [],
+    };
+
+    componentDidMount() {
+        this.setState({ allAnnotations: this.getAllAnnotations() });
+    }
+
+    private sortAnnotations(arr1, arr2) {
+        return arr2[1].size - arr1[1].size;
+    }
+
+    private getAllAnnotations() {
+        const client = MatrixClientPeg.get();
+        const room = client.getRoom(this.props.mxEvent.getRoomId());
+        const reactions = this.props.reactions;
+        const sortedAnnotations = reactions.getSortedAnnotationsByKey()
+            .sort(this.sortAnnotations);
+        const senders = [];
+        for (const reaction of sortedAnnotations) {
+            const emoji = reaction[0];
+            const reactionEvents = reaction[1];
+            for (const reactionEvent of reactionEvents) {
+                const member = room.getMember(reactionEvent.getSender());
+                const name = member ? member.name : reactionEvent.getSender();
+                senders.push([emoji, name]);
+            }
+        }
+        return senders;
+    }
+
+    private getFilteredAnnotations() {
+        const filterEmoji = this.state.filteredEmoji;
+        return this.state.allAnnotations
+            .filter(ann => filterEmoji === null || ann[0] == filterEmoji);
+    }
+
+    private setFilterEmoji(emoji) {
+        const matchingEmoji = this.state.allAnnotations
+            .filter(([existingEmoji, _]) => emoji === existingEmoji);
+        if (matchingEmoji.length == 0) {
+            emoji = null;
+        }
+        this.setState({ filteredEmoji: emoji });
+    }
+
+    private emojiFilterButton(emoji, size) {
+        return (<AccessibleButton
+            className="mx_EmojiFilterButton"
+            onClick={() => this.setFilterEmoji(emoji)}
+        >
+            { emoji } { size }
+        </AccessibleButton>);
+    }
+
+    render() {
+        const reactions = this.props.reactions.getSortedAnnotationsByKey()
+            .map(([emoji, senders]): [string, number] => [emoji, senders.size]);
+        const totalReactions = reactions.reduce((acc, [_, size]) => size + acc, 0);
+        reactions.unshift([_t('All'), totalReactions]);
+
+        const emojiList = reactions.map(([emoji, size]) =>
+            (<li key={emoji}>{ this.emojiFilterButton(emoji, size) }</li>));
+        const senderList = this.getFilteredAnnotations()
+            .map(([emoji, sender]) => (<li key={emoji + sender}>{ emoji }&nbsp;{ sender }</li>));
+        return (
+            <BaseDialog
+                className="mx_ReactionsDialog"
+                onFinished={this.props.onFinished}
+                title={_t('Reactions')}
+                contentId='mx_ReactionsDialog'
+            >
+                <div className="mx_ReactionsWrapper">
+                    <ul className="mx_EmojiList">
+                        { emojiList }
+                    </ul>
+                    <ul className="mx_SenderList">
+                        { senderList }
+                    </ul>
+                </div>
+            </BaseDialog>
+        );
+    }
+}

--- a/src/components/views/messages/MessageActionBar.tsx
+++ b/src/components/views/messages/MessageActionBar.tsx
@@ -61,6 +61,7 @@ interface IOptionsButtonProps {
         relationType: string,
         eventType: string
     ) => Relations;
+    reactions: Relations;
 }
 
 const OptionsButton: React.FC<IOptionsButtonProps> = ({
@@ -70,6 +71,7 @@ const OptionsButton: React.FC<IOptionsButtonProps> = ({
     permalinkCreator,
     onFocusChange,
     getRelationsForEvent,
+    reactions,
 }) => {
     const [menuDisplayed, button, openMenu, closeMenu] = useContextMenu();
     const [onFocus, isActive, ref] = useRovingTabIndex(button);
@@ -102,6 +104,7 @@ const OptionsButton: React.FC<IOptionsButtonProps> = ({
             collapseReplyChain={replyChain && replyChain.canCollapse() ? replyChain.collapse : undefined}
             onFinished={closeMenu}
             getRelationsForEvent={getRelationsForEvent}
+            reactions={reactions}
         />;
     }
 
@@ -495,6 +498,7 @@ export default class MessageActionBar extends React.PureComponent<IMessageAction
                 onFocusChange={this.onFocusChange}
                 key="menu"
                 getRelationsForEvent={this.props.getRelationsForEvent}
+                reactions={this.props.reactions}
             />);
         }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2679,6 +2679,7 @@
     "Message edits": "Message edits",
     "Modal Widget": "Modal Widget",
     "Data on this screen is shared with %(widgetDomain)s": "Data on this screen is shared with %(widgetDomain)s",
+    "All": "All",
     "Continuing without email": "Continuing without email",
     "Just a heads up, if you don't add an email and forget your password, you could <b>permanently lose access to your account</b>.": "Just a heads up, if you don't add an email and forget your password, you could <b>permanently lose access to your account</b>.",
     "Email (optional)": "Email (optional)",

--- a/test/components/views/dialogs/ReactionsDialog-test.js
+++ b/test/components/views/dialogs/ReactionsDialog-test.js
@@ -1,0 +1,118 @@
+import "../../../skinned-sdk";
+
+import React from "react";
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+
+import * as TestUtils from "../../../test-utils";
+import ReactionsDialog from "../../../../src/components/views/dialogs/ReactionsDialog";
+
+describe("ReactionsDialog", () => {
+    const sourceRoom = "!111111111111111111:example.org";
+    const defaultMessage = TestUtils.mkMessage({
+        room: sourceRoom,
+        user: "@alice:example.org",
+        msg: "Hello world!",
+        event: true,
+    });
+    const room = TestUtils.mkStubRoom(sourceRoom);
+    room.getMember = (name) => ({ name });
+
+    const event1 = TestUtils.mkEvent({
+        type: "m.reaction",
+        content: ":)", // content is required
+        user: 'matti',
+        event: true,
+    });
+    const event2 = TestUtils.mkEvent({
+        type: "m.reaction",
+        content: ":)",
+        user: 'teppo',
+        event: true,
+    });
+    const mountReactionsDialog = async (message = defaultMessage) => {
+        const reactions = [
+            ["😊", new Set([event1])],
+            ["🌴", new Set([event2, event1])],
+        ];
+        reactions.getSortedAnnotationsByKey = jest.fn().mockReturnValue(reactions);
+
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(
+                <ReactionsDialog
+                    reactions={reactions}
+                    room={room}
+                />,
+            );
+            // Wait one tick for our profile data to load so the state update happens within act
+            await new Promise(resolve => setImmediate(resolve));
+        });
+        wrapper.update();
+
+        return wrapper;
+    };
+
+    let wrapper;
+    describe("emoji list", () => {
+        beforeEach(async () => {
+            wrapper = await mountReactionsDialog();
+        });
+
+        it("shows correct total number of reactions", async () => {
+            const emojiList = wrapper.find('.mx_EmojiList > li');
+            expect(emojiList).toHaveLength(3);
+            expect(emojiList.at(0).text()).toContain('3');
+        });
+
+        it("shows correct reactions ordered by reaction count", async () => {
+            const emojiList = wrapper.find('.mx_EmojiList > li');
+            expect(emojiList.at(1).text()).toContain("🌴");
+            expect(emojiList.at(1).text()).toContain("2");
+            expect(emojiList.at(2).text()).toContain("😊");
+            expect(emojiList.at(2).text()).toContain("1");
+        });
+    });
+
+    describe("sender list", () => {
+        beforeEach(async () => {
+            wrapper = await mountReactionsDialog();
+        });
+
+        it("shows all senders and emojis by default, ordered by reaction count, sender name", async () => {
+            const senderList = wrapper.find('.mx_SenderList > li');
+            expect(senderList).toHaveLength(3);
+            expect(senderList.at(0).text()).toContain("🌴");
+            expect(senderList.at(0).text()).toContain("matti");
+            expect(senderList.at(1).text()).toContain("🌴");
+            expect(senderList.at(1).text()).toContain("teppo");
+            expect(senderList.at(2).text()).toContain("😊");
+            expect(senderList.at(2).text()).toContain("matti");
+        });
+
+        it("filters senders when clicking an emoji", async () => {
+            const emojiButtons = wrapper.find('.mx_EmojiList > li');
+
+            // 🌴
+            emojiButtons.at(1).find('div').simulate('click');
+            await new Promise(resolve => setImmediate(resolve));
+            let senderList = wrapper.find('.mx_SenderList > li');
+            expect(senderList).toHaveLength(2);
+            expect(senderList.at(0).text()).toContain('🌴');
+            expect(senderList.at(0).text()).toContain('matti');
+
+            // 😊
+            emojiButtons.at(2).find('div').simulate('click');
+            await new Promise(resolve => setImmediate(resolve));
+            senderList = wrapper.find('.mx_SenderList > li');
+            expect(senderList).toHaveLength(1);
+            expect(senderList.at(0).text()).toContain('😊');
+
+            // All
+            emojiButtons.at(0).find('div').simulate('click');
+            await new Promise(resolve => setImmediate(resolve));
+            senderList = wrapper.find('.mx_SenderList > li');
+            expect(senderList).toHaveLength(3);
+        });
+    });
+});


### PR DESCRIPTION
This PR partly implements the features described here: https://github.com/vector-im/element-web/issues/9723

What is NOT implemented as in the above issue:
- Timestamps on hover
- Moderator functionalities

Here's a few screenshots:
![Screenshot 2022-03-14 at 12 05 01](https://user-images.githubusercontent.com/99487983/158150816-ec2d4783-9e60-416c-9d33-fe3dbd8001e0.png)
![Screenshot 2022-03-14 at 12 05 13](https://user-images.githubusercontent.com/99487983/158150827-ee23705d-a0b4-4d53-980d-6116e91a152a.png)

*NOTE!* I could not do the sign-off part for this PR, because I do not wish to associate my real name with this GitHub account. I've sent an email to dco@matrix.org regarding anonymous contributions, but so far I've recieved no reply. I'm opening this PR in order to avoid my work going to waste.



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a dialog showing all reactions to a message ([\#8051](https://github.com/matrix-org/matrix-react-sdk/pull/8051)). Contributed by @chillmastonmuutos.<!-- CHANGELOG_PREVIEW_END -->