### PR TITLE
Fix freeze/crash when 1:1 calling

### DIFF
--- a/src/components/views/voip/AudioFeed.tsx
+++ b/src/components/views/voip/AudioFeed.tsx
@@ -93,7 +93,7 @@ export default class AudioFeed extends React.Component<IProps, IState> {
             // load() explicitly, it shouldn't be a problem. - Dave
             await element.load();
         } catch (e) {
-            logger.info("Failed to play media element with feed", this.props.feed, e);
+            logger.info("Failed to play media element with feed for userId", this.props.feed.userId, e);
         }
     }
 

--- a/src/components/views/voip/VideoFeed.tsx
+++ b/src/components/views/voip/VideoFeed.tsx
@@ -138,7 +138,7 @@ export default class VideoFeed extends React.PureComponent<IProps, IState> {
             // load() explicitly, it shouldn't be a problem. - Dave
             await element.play();
         } catch (e) {
-            logger.info("Failed to play media element with feed", this.props.feed, e);
+            logger.info("Failed to play media element with feed for userID", this.props.feed.userId, e);
         }
     }
 


### PR DESCRIPTION
Don't log call feed objects because they reference the client and
it causes the client to get logged too.

Fixes https://github.com/vector-im/element-web/issues/21181

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
