### PR TITLE
Make margin and padding of mx_InviteDialog_other consistent

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -275,8 +275,17 @@ limitations under the License.
     height: 600px;
     padding-left: 20px; // the design wants some padding on the left
 
-    .mx_InviteDialog_userSections {
-        height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
+    .mx_InviteDialog_addressBar {
+        margin-right: 0;
+    }
+
+    .mx_InviteDialog_content {
+        padding-right: 20px; // same padding on the right
+
+        .mx_InviteDialog_userSections {
+            height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
+            padding-right: 0;
+        }
     }
 }
 

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -285,6 +285,11 @@ limitations under the License.
         .mx_InviteDialog_userSections {
             height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
             padding-right: 0;
+
+            .mx_InviteDialog_section {
+                padding-bottom: 0;
+                margin-top: 12px;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes: vector-im/element-web#20631

This commit removes the margin-right of the address bar, keeping the
same padding on the right and left side of the panel. The padding-right
of mx_InviteDialog_roomTile should be retained as there is padding-left
for the list of the rooms.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

![after](https://user-images.githubusercontent.com/3362943/158556142-c29d6422-3082-41dc-b75d-7b68e905168d.png)

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make margin and padding of mx_InviteDialog_other consistent ([\#8063](https://github.com/matrix-org/matrix-react-sdk/pull/8063)). Fixes vector-im/element-web#20631. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8063--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
