### PR TITLE
Remove padding of InviteDialog & fix visual regression

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -278,15 +278,19 @@ limitations under the License.
         margin-right: 0;
     }
 
-    .mx_InviteDialog_content {
-        .mx_InviteDialog_userSections {
-            height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
-            padding-right: 0;
+    .mx_InviteDialog_userSections {
+        height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
+        padding-right: 0;
 
-            .mx_InviteDialog_section {
-                padding-bottom: 0;
-                margin-top: 12px;
-            }
+        .mx_InviteDialog_section {
+            padding-bottom: 0;
+            margin-top: 12px;
+        }
+    }
+
+    .mx_InviteDialog_hasFooter {
+        .mx_InviteDialog_userSections {
+            height: calc(100% - 175px); // For displaying an invite link on the footer of the dialog
         }
     }
 }

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -273,15 +273,12 @@ limitations under the License.
 .mx_InviteDialog_other {
     // Prevent the dialog from jumping around randomly when elements change.
     height: 600px;
-    padding-left: 20px; // the design wants some padding on the left
 
     .mx_InviteDialog_addressBar {
         margin-right: 0;
     }
 
     .mx_InviteDialog_content {
-        padding-right: 20px; // same padding on the right
-
         .mx_InviteDialog_userSections {
             height: calc(100% - 115px); // mx_InviteDialog's height minus some for the upper and lower elements
             padding-right: 0;


### PR DESCRIPTION
Closes vector-im/element-web#20631

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

To: 
![after](https://user-images.githubusercontent.com/3362943/158862943-1cc428ab-caba-4b48-b00f-f2462e9e233f.png)

@niquewoodhouse would you please review?

This PR also fixes a visual regression which was introduced with https://github.com/matrix-org/matrix-react-sdk/pull/8063.

Steps to confirm the fix:

1. Start new chat (DM)
2. Make sure the footer (invite link textarea) is displayed

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove padding of InviteDialog & fix visual regression ([\#8076](https://github.com/matrix-org/matrix-react-sdk/pull/8076)). Fixes vector-im/element-web#20631. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8076--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
