### PR TITLE
Support custom emoji in editor and completions.

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -14,6 +14,14 @@
     padding-left: 0;
 }
 
+.mx_CustomEmojiPill {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    padding-left: 1px;
+    font-size: 0;
+}
+
 a.mx_Pill {
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/res/css/views/rooms/_BasicMessageComposer.scss
+++ b/res/css/views/rooms/_BasicMessageComposer.scss
@@ -73,6 +73,24 @@ limitations under the License.
                 }
             }
 
+            span.mx_CustomEmojiPill {
+                position: relative;
+                user-select: all;
+
+                // avatar psuedo element
+                &::before {
+                    content: var(--avatar-letter);
+                    width: $font-18px;
+                    height: $font-18px;
+                    background: var(--avatar-background), $background;
+                    color: $avatar-initial-color;
+                    background-repeat: no-repeat;
+                    background-size: $font-18px;
+                    text-align: center;
+                    font-weight: normal;
+                }
+            }
+
             span.mx_UserPill {
                 cursor: pointer;
             }

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -41,6 +41,9 @@ function isAllowedHtmlTag(node: commonmark.Node): boolean {
     if (node.literal != null &&
         node.literal.match('^<((div|span) data-mx-maths="[^"]*"|/(div|span))>$') != null) {
         return true;
+    } else if (node.literal != null &&
+        node.literal.match('^<img data-mx-emoticon') != null) {
+        return true;
     }
 
     // Regex won't work for tags with attrs, but we only

--- a/src/autocomplete/Autocompleter.ts
+++ b/src/autocomplete/Autocompleter.ts
@@ -37,11 +37,11 @@ export interface ISelectionRange {
 }
 
 export interface ICompletion {
-    type: "at-room" | "command" | "community" | "room" | "user";
+    type?: "at-room" | "command" | "community" | "room" | "user" | "customEmoji";
     completion: string;
     completionId?: string;
     component?: ReactElement;
-    range: ISelectionRange;
+    range?: ISelectionRange;
     command?: string;
     suffix?: string;
     // If provided, apply a LINK entity to the completion with the

--- a/src/autocomplete/UserProvider.tsx
+++ b/src/autocomplete/UserProvider.tsx
@@ -54,7 +54,7 @@ export default class UserProvider extends AutocompleteProvider {
             renderingType,
         });
         this.room = room;
-        this.matcher = new QueryMatcher([], {
+        this.matcher = new QueryMatcher<RoomMember>([], {
             keys: ['name'],
             funcs: [obj => obj.userId.slice(1)], // index by user id minus the leading '@'
             shouldMatchWordsOnly: false,

--- a/src/editor/autocomplete.ts
+++ b/src/editor/autocomplete.ts
@@ -109,6 +109,8 @@ export default class AutocompleteWrapperModel {
             case "command":
                 // command needs special handling for auto complete, but also renders as plain texts
                 return [(this.partCreator as CommandPartCreator).command(text)];
+            case "customEmoji":
+                return [this.partCreator.customEmoji(text, completionId)];
             default:
                 // used for emoji and other plain text completion replacement
                 return this.partCreator.plainWithEmoji(text);

--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { AllHtmlEntities } from 'html-entities';
 import cheerio from 'cheerio';
+import _ from 'lodash';
 
 import Markdown from '../Markdown';
 import { makeGenericPermalink } from "../utils/permalinks/Permalinks";
@@ -44,6 +45,10 @@ export function mdSerialize(model: EditorModel): string {
             case Type.UserPill:
                 return html +
                     `[${part.text.replace(/[[\\\]]/g, c => "\\" + c)}](${makeGenericPermalink(part.resourceId)})`;
+            case Type.CustomEmoji:
+                return html +
+                    `<img data-mx-emoticon height="18" src="${encodeURI(part.resourceId)}"`
+                    + ` title=":${_.escape(part.text)}:" alt=":${_.escape(part.text)}:">`;
         }
     }, "");
 }
@@ -176,6 +181,8 @@ export function textSerialize(model: EditorModel): string {
                 return text + `${part.resourceId}`;
             case Type.UserPill:
                 return text + `${part.text}`;
+            case Type.CustomEmoji:
+                return text + `:${part.text}:`;
         }
     }, "");
 }

--- a/test/editor/serialize-test.js
+++ b/test/editor/serialize-test.js
@@ -38,6 +38,13 @@ describe('editor/serialize', function() {
         const html = htmlSerializeIfNeeded(model, {});
         expect(html).toBeFalsy();
     });
+    it('custom emoji pill turns message into html', function() {
+        const pc = createPartCreator();
+        const model = new EditorModel([pc.customEmoji("poggers", "mxc://matrix.org/test")]);
+        const html = htmlSerializeIfNeeded(model, {});
+        expect(html).toBe("<img data-mx-emoticon height=\"18\" src=\"mxc://matrix.org/test\""
+        + " title=\":poggers:\" alt=\":poggers:\">");
+    });
     it('any markdown turns message into html', function() {
         const pc = createPartCreator();
         const model = new EditorModel([pc.plain("*hello* world")]);


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->
This change implements custom inline emojis as specified in https://github.com/matrix-org/matrix-spec-proposals/pull/2545 in the editor and autocompletion suggestions.  This does not implement a UI for configuring room image sets, but element users may be in rooms with image sets that were set up in other clients such as Fluffy Chat.

<img width="330" alt="Screen Shot 2022-03-19 at 9 04 00 AM" src="https://user-images.githubusercontent.com/89478935/159130638-fe28377b-08a6-491e-b88e-432e68bba288.png">
<img width="330" alt="Screen Shot 2022-03-19 at 9 03 48 AM" src="https://user-images.githubusercontent.com/89478935/159130640-57323031-7bfe-440d-aaf9-32fa82a069f3.png">


The emoji picker will be updated in a separate pr.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
Signed-off-by: Andrew Ryan <andrewryanchama@clover.club>
<!-- To specify text for the changelog entry (otherwise the PR title will be used):


Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support custom emoji in editor and completions. ([\#8087](https://github.com/matrix-org/matrix-react-sdk/pull/8087)). Contributed by @AndrewRyanChama.<!-- CHANGELOG_PREVIEW_END -->