### PR TITLE
Set max-width to user context menu

### DIFF
--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -64,9 +64,13 @@ limitations under the License.
     }
 }
 
-.mx_UserMenu_contextMenu {
-    width: 258px;
+.mx_IconizedContextMenu {
+    &.mx_UserMenu_contextMenu {
+        width: 258px;
+    }
+}
 
+.mx_UserMenu_contextMenu {
     &.mx_IconizedContextMenu .mx_IconizedContextMenu_optionList_red {
         .mx_AccessibleButton {
             padding-top: 16px;
@@ -87,12 +91,15 @@ limitations under the License.
             flex-direction: column;
             width: calc(100% - 40px); // 40px = 32px theme button + 8px margin to theme button
 
-            * {
-                // Automatically grow all subelements to fit the container
+            .mx_UserMenu_contextMenu_displayName,
+            .mx_UserMenu_contextMenu_userId {
+                font-size: $font-15px;
+
+                // Automatically grow subelements to fit the container
                 flex: 1;
                 width: 100%;
 
-                // Ellipsize any text overflow
+                // Ellipsize text overflow
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
@@ -100,12 +107,10 @@ limitations under the License.
 
             .mx_UserMenu_contextMenu_displayName {
                 font-weight: bold;
-                font-size: $font-15px;
                 line-height: $font-20px;
             }
 
             .mx_UserMenu_contextMenu_userId {
-                font-size: $font-15px;
                 line-height: $font-24px;
             }
         }


### PR DESCRIPTION
Fixes vector-im/element-web#21486

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

![Untitled](https://user-images.githubusercontent.com/3362943/159763460-eb97ac46-7e5a-4760-9974-41360cf41ebb.png)

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set max-width to user context menu ([\#8089](https://github.com/matrix-org/matrix-react-sdk/pull/8089)). Fixes vector-im/element-web#21486. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8089--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
