### PR TITLE
Add width to roomTile_nameStack in _InviteDialog.scss

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -195,6 +195,7 @@ limitations under the License.
     .mx_InviteDialog_roomTile_nameStack {
         display: inline-block;
         overflow: hidden;
+        width: calc(70%);
     }
 
     .mx_InviteDialog_roomTile_name {


### PR DESCRIPTION
This PR fixes [vector-im/element-web#19463](https://github.com/vector-im/element-web/issues/19463) by adding a width to `roomTile_namestack` in `_InviteDialgo.scss`. 

Before:
![image](https://user-images.githubusercontent.com/33722438/159163991-6933e024-1294-43dd-a911-756d5ac3bf16.png)

After:
![image](https://user-images.githubusercontent.com/33722438/159164040-7395f4c7-3059-4da9-9ea2-e224b9748569.png)


Please add the T-Defect label.

Signed-off-by: Raymond d'Anjou r.danjou@student.tudelft.nl

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add width to roomTile_nameStack in _InviteDialog.scss ([\#8092](https://github.com/matrix-org/matrix-react-sdk/pull/8092)). Contributed by @SpookyDooky.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8092--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
