### PR TITLE
Set text-overflow to mx_ThreadInfo_sender

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -794,15 +794,19 @@ $left-gutter: 64px;
 
 $threadInfoLineHeight: calc(2 * $font-12px);
 
+.mx_ThreadInfo_content,
+.mx_ThreadInfo_sender {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .mx_ThreadInfo_sender {
     font-weight: $font-semi-bold;
     line-height: $threadInfoLineHeight;
 }
 
 .mx_ThreadInfo_content {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
     margin-left: 4px;
     font-size: $font-12px;
     line-height: $threadInfoLineHeight;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21472

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

**Before**

![before](https://user-images.githubusercontent.com/3362943/159178334-3f1c4d75-4bf0-4b1d-b42c-29acbfc5f703.png)

**After**

![after](https://user-images.githubusercontent.com/3362943/159178327-8f27b9f0-b56c-4481-a380-7f148636cc9d.png)

Steps to verify fix:

1. Change your display name into one with max length
2. Send a message
3. Send a reply with thread

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
