### PR TITLE
fix ugly warning from nesting div tags in p tags

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1416,7 +1416,7 @@ const BasicUserInfo: React.FC<{
 
     let editDevices;
     if (member.userId == cli.getUserId()) {
-        editDevices = (<p>
+        editDevices = (<div>
             <AccessibleButton
                 className="mx_UserInfo_field"
                 onClick={() => {
@@ -1428,7 +1428,7 @@ const BasicUserInfo: React.FC<{
             >
                 { _t("Edit devices") }
             </AccessibleButton>
-        </p>);
+        </div>);
     }
 
     const securitySection = (


### PR DESCRIPTION
Stops a massive red stacktrace constantly nagging you about invalid nested divs.  Might minutely change the padding of the text buttons (ban, kick etc) on MemberInfo, but if it does it's negligible.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8094--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
