### PR TITLE
extract reusable styled live beacon icon

### DIFF
--- a/res/css/_components.scss
+++ b/res/css/_components.scss
@@ -5,6 +5,7 @@
 @import "./_font-weights.scss";
 @import "./_spacing.scss";
 @import "./components/views/beacon/_LeftPanelLiveShareWarning.scss";
+@import "./components/views/beacon/_StyledLiveBeaconIcon.scss";
 @import "./components/views/location/_LiveDurationDropdown.scss";
 @import "./components/views/location/_LocationShareMenu.scss";
 @import "./components/views/location/_MapError.scss";

--- a/res/css/components/views/beacon/_StyledLiveBeaconIcon.scss
+++ b/res/css/components/views/beacon/_StyledLiveBeaconIcon.scss
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_StyledLiveBeaconIcon {
+    flex-grow: 0;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    border-width: 2px;
+    border-style: solid;
+    border-radius: 50%;
+
+    background-color: $location-live-color;
+    // 20% brightness $location-live-color
+    border-color: #deddfd;
+    padding: 2px;
+    // colors icon
+    color: white;
+}

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -83,17 +83,10 @@ limitations under the License.
     border-style: solid;
     border-radius: 50%;
 
+    // Live is styled by StyledLiveBeaconIcon
+
     &.Own {
         border-color: $accent;
-    }
-
-    &.Live {
-        background-color: $location-live-color;
-        // 20% brightness $location-live-color
-        border-color: #deddfd;
-        padding: 2px;
-        // colors icon
-        color: white;
     }
 
     &.Pin {

--- a/src/components/views/beacon/StyledLiveBeaconIcon.tsx
+++ b/src/components/views/beacon/StyledLiveBeaconIcon.tsx
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import classNames from 'classnames';
+
+import { Icon as LiveLocationIcon } from '../../../../res/img/location/live-location.svg';
+
+const StyledLiveBeaconIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...props }) =>
+    <LiveLocationIcon
+        {...props}
+        className={classNames('mx_StyledLiveBeaconIcon', className)}
+    />;
+
+export default StyledLiveBeaconIcon;

--- a/src/components/views/location/ShareType.tsx
+++ b/src/components/views/location/ShareType.tsx
@@ -23,8 +23,8 @@ import BaseAvatar from '../avatars/BaseAvatar';
 import AccessibleButton from '../elements/AccessibleButton';
 import Heading from '../typography/Heading';
 import { Icon as LocationIcon } from '../../../../res/img/element-icons/location.svg';
-import { Icon as LiveLocationIcon } from '../../../../res/img/location/live-location.svg';
 import { LocationShareType } from './shareLocation';
+import StyledLiveBeaconIcon from '../beacon/StyledLiveBeaconIcon';
 
 const UserAvatar = () => {
     const matrixClient = useContext(MatrixClientContext);
@@ -59,7 +59,7 @@ const ShareTypeOption: React.FC<ShareTypeOptionProps> = ({
     { shareType === LocationShareType.Pin &&
             <LocationIcon className={`mx_ShareType_option-icon ${LocationShareType.Pin}`} /> }
     { shareType === LocationShareType.Live &&
-            <LiveLocationIcon className={`mx_ShareType_option-icon ${LocationShareType.Live}`} /> }
+            <StyledLiveBeaconIcon className={`mx_ShareType_option-icon ${LocationShareType.Live}`} /> }
 
     { label }
 </AccessibleButton>;


### PR DESCRIPTION

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Extract live beacon icon so it can be used in rest of beacon UI

<img width="57" alt="Screenshot 2022-03-21 at 17 14 17" src="https://user-images.githubusercontent.com/3055605/159304007-cadd6f87-28db-491a-8436-a9d57202a90b.png">



<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
