### PR TITLE
Fix emoting with emoji or pills

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -153,13 +153,11 @@ export class Command {
     public run(roomId: string, threadId: string, args: string): RunResult {
         // if it has no runFn then its an ignored/nop command (autocomplete only) e.g `/me`
         if (!this.runFn) {
-            reject(
+            return reject(
                 newTranslatableError(
                     "Command error: Unable to handle slash command.",
                 ),
             );
-
-            return;
         }
 
         const renderingType = threadId

--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -181,7 +181,9 @@ export function textSerialize(model: EditorModel): string {
 }
 
 export function containsEmote(model: EditorModel): boolean {
-    return startsWith(model, "/me ", false) && model.parts[0]?.text?.length > 4;
+    const hasCommand = startsWith(model, "/me ", false);
+    const hasArgument = model.parts[0]?.text?.length > 4 || model.parts.length > 1;
+    return hasCommand && hasArgument;
 }
 
 export function startsWith(model: EditorModel, prefix: string, caseSensitive = true): boolean {

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -194,7 +194,7 @@ describe('<SendMessageComposer/>', () => {
             });
         };
 
-        fit("renders text and placeholder correctly", () => {
+        it("renders text and placeholder correctly", () => {
             const wrapper = getComponent({ placeholder: "placeholder string" });
 
             expect(wrapper.find('[aria-label="placeholder string"]')).toHaveLength(1);

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -131,6 +131,20 @@ describe('<SendMessageComposer/>', () => {
             });
         });
 
+        it("allows emoting with non-text parts", () => {
+            const model = new EditorModel([], createPartCreator(), createRenderer());
+            const documentOffset = new DocumentOffset(16, true);
+            model.update("/me ✨sparkles✨", "insertText", documentOffset);
+            expect(model.parts.length).toEqual(4); // Emoji count as non-text
+
+            const content = createMessageContent(model, null, undefined, permalinkCreator);
+
+            expect(content).toEqual({
+                body: "✨sparkles✨",
+                msgtype: "m.emote",
+            });
+        });
+
         it("allows sending double-slash escaped slash commands correctly", () => {
             const model = new EditorModel([], createPartCreator(), createRenderer());
             const documentOffset = new DocumentOffset(32, true);


### PR DESCRIPTION
Type: defect

Closes https://github.com/vector-im/element-web/issues/21497.

Also fixes a small bug discovered in the above issue, where the error for no-op commands like /me wouldn't be displayed.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix emoting with emoji or pills ([\#8105](https://github.com/matrix-org/matrix-react-sdk/pull/8105)). Fixes vector-im/element-web#21497.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8105--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
