### PR TITLE
Enable Codecov coverage offsets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,5 @@
+codecov:
+  allow_coverage_offsets: True
 coverage:
   status:
     project: off


### PR DESCRIPTION
An attempt to make the coverage diffs less weird. (See https://docs.codecov.com/docs/comparing-commits#pseudo-comparison)

Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8139--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
