### PR TITLE
Fix incorrect typing on SdkConfig defaults

### DIFF
--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -22,7 +22,7 @@ import { IConfigOptions, ISsoRedirectOptions } from "./IConfigOptions";
 import { KeysWithObjectShape } from "./@types/common";
 
 // see element-web config.md for docs, or the IConfigOptions interface for dev docs
-export const DEFAULTS: Partial<IConfigOptions> = {
+export const DEFAULTS: IConfigOptions = {
     brand: "Element",
     integrations_ui_url: "https://scalar.vector.im/",
     integrations_rest_url: "https://scalar.vector.im/api",


### PR DESCRIPTION
It's not a partial anymore - it's a full-fledged object with proper types.

Without this change, `SdkConfig.put(DEFAULTS)` is broken.

Required for https://github.com/matrix-org/matrix-react-sdk/pull/7962

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8147--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
