### PR TITLE
Improve handling of animated GIF and WEBP images

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -106,15 +106,17 @@ interface IThumbnail {
  * @param {HTMLElement} element The element to thumbnail.
  * @param {number} inputWidth The width of the image in the input element.
  * @param {number} inputHeight the width of the image in the input element.
- * @param {String} mimeType The mimeType to save the blob as.
+ * @param {string} mimeType The mimeType to save the blob as.
+ * @param {boolean} calculateBlurhash Whether to calculate a blurhash of the given image too.
  * @return {Promise} A promise that resolves with an object with an info key
  *  and a thumbnail key.
  */
-async function createThumbnail(
+export async function createThumbnail(
     element: ThumbnailableElement,
     inputWidth: number,
     inputHeight: number,
     mimeType: string,
+    calculateBlurhash = true,
 ): Promise<IThumbnail> {
     let targetWidth = inputWidth;
     let targetHeight = inputHeight;
@@ -152,7 +154,7 @@ async function createThumbnail(
 
     const imageData = context.getImageData(0, 0, targetWidth, targetHeight);
     // thumbnailPromise and blurhash promise are being awaited concurrently
-    const blurhash = await BlurhashEncoder.instance.getBlurhash(imageData);
+    const blurhash = calculateBlurhash ? await BlurhashEncoder.instance.getBlurhash(imageData) : undefined;
     const thumbnail = await thumbnailPromise;
 
     return {

--- a/src/components/views/messages/MImageReplyBody.tsx
+++ b/src/components/views/messages/MImageReplyBody.tsx
@@ -41,14 +41,12 @@ export default class MImageReplyBody extends MImageBody {
     }
 
     render() {
-        if (this.state.error !== null) {
+        if (this.state.error) {
             return super.render();
         }
 
         const content = this.props.mxEvent.getContent<IMediaEventContent>();
-
-        const contentUrl = this.getContentUrl();
-        const thumbnail = this.messageContent(contentUrl, this.getThumbUrl(), content, FORCED_IMAGE_HEIGHT);
+        const thumbnail = this.messageContent(this.state.contentUrl, this.state.thumbUrl, content, FORCED_IMAGE_HEIGHT);
         const fileBody = this.getFileBody();
         const sender = <SenderProfile
             mxEvent={this.props.mxEvent}

--- a/src/utils/Image.ts
+++ b/src/utils/Image.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function mayBeAnimated(mimeType: string): boolean {
+    // Both GIF and WEBP can be animated, and here we assume they are, as checking is much more difficult.
+    return ["image/gif", "image/webp"].includes(mimeType);
+}
+
+function arrayBufferRead(arr: ArrayBuffer, start: number, len: number): Uint8Array {
+    return new Uint8Array(arr.slice(start, start + len));
+}
+
+function arrayBufferReadStr(arr: ArrayBuffer, start: number, len: number): string {
+    return String.fromCharCode.apply(null, arrayBufferRead(arr, start, len));
+}
+
+export async function blobIsAnimated(mimeType: string, blob: Blob): Promise<boolean> {
+    if (!mayBeAnimated(mimeType)) return false;
+
+    if (mimeType === "image/webp") {
+        // Only extended file format WEBP images support animation, so grab the expected data range and verify header.
+        // Based on https://developers.google.com/speed/webp/docs/riff_container#extended_file_format
+        const arr = await blob.slice(0, 16).arrayBuffer();
+        if (
+            arrayBufferReadStr(arr, 0, 4) === "RIFF" &&
+            arrayBufferReadStr(arr, 8, 4) === "WEBP" &&
+            arrayBufferReadStr(arr, 12, 4) === "VP8X"
+        ) {
+            const [flags] = arrayBufferRead(arr, 16, 1);
+            // Flags: R R I L E X _A_ R (reversed)
+            const animationFlagMask = 1 << 1;
+            return (flags & animationFlagMask) != 0;
+        }
+    } else if (mimeType === "image/gif") {
+        // Based on https://gist.github.com/zakirt/faa4a58cec5a7505b10e3686a226f285
+        // More info at http://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
+        const dv = new DataView(await blob.arrayBuffer(), 10);
+
+        const globalColorTable = dv.getUint8(0);
+        let globalColorTableSize = 0;
+        // check first bit, if 0, then we don't have a Global Color Table
+        if (globalColorTable & 0x80) {
+            // grab the last 3 bits, to calculate the global color table size -> RGB * 2^(N+1)
+            // N is the value in the last 3 bits.
+            globalColorTableSize = 3 * Math.pow(2, (globalColorTable & 0x7) + 1);
+        }
+
+        // move on to the Graphics Control Extension
+        const offset = 3 + globalColorTableSize;
+
+        const extensionIntroducer = dv.getUint8(offset);
+        const graphicsControlLabel = dv.getUint8(offset + 1);
+        let delayTime = 0;
+
+        // Graphics Control Extension section is where GIF animation data is stored
+        // First 2 bytes must be 0x21 and 0xF9
+        if ((extensionIntroducer & 0x21) && (graphicsControlLabel & 0xF9)) {
+            // skip to the 2 bytes with the delay time
+            delayTime = dv.getUint16(offset + 4);
+        }
+
+        return !!delayTime;
+    }
+
+    return false;
+}

--- a/src/utils/blobs.ts
+++ b/src/utils/blobs.ts
@@ -52,6 +52,7 @@ const ALLOWED_BLOB_MIMETYPES = [
     'image/jpeg',
     'image/gif',
     'image/png',
+    'image/webp',
 
     'video/mp4',
     'video/webm',


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16193
Fixes https://github.com/vector-im/element-web/issues/6684

+ Fixes non-animated GIFs in encrypted rooms being shown as animated
+ Shows preview of WEBP images in uploader
+ Fixes missing animation of animated WEBP images
+ Fixes reliance on the server or sender to give us a non-animated thumbnail of animated source images