### PR TITLE
Responsive BetaCard on Labs

### DIFF
--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -50,7 +50,7 @@ limitations under the License.
 
             .mx_BetaCard_buttons {
                 display: flex;
-                flex-wrap: wrap;
+                flex-wrap: wrap-reverse;
                 gap: 12px;
                 margin: 20px auto;
 
@@ -59,6 +59,10 @@ limitations under the License.
                     width: auto;
                     flex: 1;
                     white-space: nowrap; // text might overflow
+
+                    &:nth-child(1) {
+                        order: 2; // Place feedback button top and right
+                    }
                 }
             }
 

--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -24,7 +24,7 @@ limitations under the License.
     .mx_BetaCard_columns {
         display: flex;
         flex-flow: wrap;
-        gap: 12px 20px;
+        gap: 20px;
         justify-content: center;
 
         .mx_BetaCard_columns_description {
@@ -49,18 +49,24 @@ limitations under the License.
                 margin-bottom: 20px;
             }
 
-            .mx_BetaCard_buttons .mx_AccessibleButton {
-                display: block;
-                margin: 12px 0;
-                padding: 7px 40px;
-                width: auto;
+            .mx_BetaCard_buttons {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 12px;
+                margin: 20px auto;
+
+                .mx_AccessibleButton {
+                    padding: 7px 40px;
+                    width: auto;
+                    flex: 1;
+                    white-space: nowrap; // text might overflow
+                }
             }
 
             .mx_BetaCard_disclaimer {
                 font-size: $font-12px;
                 line-height: $font-15px;
                 color: $secondary-content;
-                margin-top: 20px;
 
                 > h4 {
                     margin: 0;

--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -46,7 +46,6 @@ limitations under the License.
                 font-size: $font-15px;
                 line-height: $font-20px;
                 color: $secondary-content;
-                margin-bottom: 20px;
             }
 
             .mx_BetaCard_buttons {

--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -68,22 +68,25 @@ limitations under the License.
                 color: $secondary-content;
 
                 > h4 {
-                    margin: 0;
+                    margin: 12px 0 0;
                 }
 
                 > p {
-                    margin-top: 0;
+                    margin: 0;
                 }
             }
         }
 
-        .mx_BetaCard_columns_image {
+        .mx_BetaCard_columns_image_wrapper {
             margin: auto 0;
-            width: 100%;
-            max-width: 300px;
-            object-fit: contain;
-            height: 100%;
-            border-radius: 4px;
+
+            .mx_BetaCard_columns_image {
+                width: 100%;
+                max-width: 300px;
+                object-fit: contain;
+                height: 100%;
+                border-radius: 4px;
+            }
         }
     }
 

--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -23,8 +23,13 @@ limitations under the License.
 
     .mx_BetaCard_columns {
         display: flex;
+        flex-flow: wrap;
+        gap: 12px 20px;
+        justify-content: center;
 
-        > div {
+        .mx_BetaCard_columns_description {
+            flex: 1;
+
             .mx_BetaCard_title {
                 font-weight: $font-semi-bold;
                 font-size: $font-18px;
@@ -32,9 +37,9 @@ limitations under the License.
                 color: $primary-content;
                 margin: 4px 0 14px;
 
-                .mx_BetaCard_betaPill {
-                    margin-left: 12px;
-                }
+                display: flex;
+                align-items: center;
+                column-gap: 12px;
             }
 
             .mx_BetaCard_caption {
@@ -67,9 +72,10 @@ limitations under the License.
             }
         }
 
-        > img {
-            margin: auto 0 auto 20px;
-            width: 300px;
+        .mx_BetaCard_columns_image {
+            margin: auto 0;
+            width: 100%;
+            max-width: 300px;
             object-fit: contain;
             height: 100%;
             border-radius: 4px;

--- a/src/components/views/beta/BetaCard.tsx
+++ b/src/components/views/beta/BetaCard.tsx
@@ -106,7 +106,7 @@ const BetaCard = ({ title: titleOverride, featureId }: IProps) => {
                     <span>{ titleOverride || _t(title) }</span>
                     <BetaPill />
                 </h3>
-                <span className="mx_BetaCard_caption">{ caption() }</span>
+                <div className="mx_BetaCard_caption">{ caption() }</div>
                 <div className="mx_BetaCard_buttons">
                     { feedbackButton }
                     <AccessibleButton

--- a/src/components/views/beta/BetaCard.tsx
+++ b/src/components/views/beta/BetaCard.tsx
@@ -132,7 +132,9 @@ const BetaCard = ({ title: titleOverride, featureId }: IProps) => {
                     { disclaimer(value) }
                 </div> }
             </div>
-            <img className="mx_BetaCard_columns_image" src={image} alt="" />
+            <div className="mx_BetaCard_columns_image_wrapper">
+                <img className="mx_BetaCard_columns_image" src={image} alt="" />
+            </div>
         </div>
         { extraSettings && value && <div className="mx_BetaCard_relatedSettings">
             { extraSettings.map(key => (

--- a/src/components/views/beta/BetaCard.tsx
+++ b/src/components/views/beta/BetaCard.tsx
@@ -101,9 +101,9 @@ const BetaCard = ({ title: titleOverride, featureId }: IProps) => {
 
     return <div className="mx_BetaCard">
         <div className="mx_BetaCard_columns">
-            <div>
+            <div className="mx_BetaCard_columns_description">
                 <h3 className="mx_BetaCard_title">
-                    { titleOverride || _t(title) }
+                    <span>{ titleOverride || _t(title) }</span>
                     <BetaPill />
                 </h3>
                 <span className="mx_BetaCard_caption">{ caption() }</span>
@@ -132,7 +132,7 @@ const BetaCard = ({ title: titleOverride, featureId }: IProps) => {
                     { disclaimer(value) }
                 </div> }
             </div>
-            <img src={image} alt="" />
+            <img className="mx_BetaCard_columns_image" src={image} alt="" />
         </div>
         { extraSettings && value && <div className="mx_BetaCard_relatedSettings">
             { extraSettings.map(key => (


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21554

This PR fixes the overflow of beta cards on Labs, tweaking some margin settings as well.

https://user-images.githubusercontent.com/3362943/160146542-d9953679-619b-4c06-8f32-957d751e35db.mp4

![after1](https://user-images.githubusercontent.com/3362943/160146582-287926eb-4733-4782-8872-371b9b3f6692.png)

![after2](https://user-images.githubusercontent.com/3362943/160146588-4d62f048-cfc3-431f-b443-1353e9e773c0.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Responsive BetaCard on Labs ([\#8154](https://github.com/matrix-org/matrix-react-sdk/pull/8154)). Fixes vector-im/element-web#21554. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8154--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
