### PR TITLE
Floor media dimensions to prevent blurhash errors

### DIFF
--- a/src/settings/enums/ImageSize.ts
+++ b/src/settings/enums/ImageSize.ts
@@ -52,9 +52,9 @@ export function suggestedSize(size: ImageSize, contentSize: Dimensions, maxHeigh
 
     if (constrainedSize.h * aspectRatio < constrainedSize.w) {
         // Height dictates width
-        return { w: constrainedSize.h * aspectRatio, h: constrainedSize.h };
+        return { w: Math.floor(constrainedSize.h * aspectRatio), h: constrainedSize.h };
     } else {
         // Width dictates height
-        return { w: constrainedSize.w, h: constrainedSize.w / aspectRatio };
+        return { w: constrainedSize.w, h: Math.floor(constrainedSize.w / aspectRatio) };
     }
 }

--- a/test/settings/enums/ImageSize-test.ts
+++ b/test/settings/enums/ImageSize-test.ts
@@ -34,5 +34,9 @@ describe("ImageSize", () => {
             const size = suggestedSize(ImageSize.Normal, { w: null, h: null });
             expect(size).toStrictEqual({ w: 324, h: 324 });
         });
+        it("returns integer values", () => {
+            const size = suggestedSize(ImageSize.Normal, { w: 642, h: 350 }); // does not divide evenly
+            expect(size).toStrictEqual({ w: 324, h: 176 });
+        });
     });
 });


### PR DESCRIPTION
The blurhash code can explode on non-integer dimensions, so we need to make sure they're integers.

Type: defect

Notes: none
element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8157--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
