### PR TITLE
Fix unexpected coverage diffs for PRs that aren't up to date

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # If this is a pull request, make sure we check out its head rather than the
+          # automatically generated merge commit, so that the coverage diff excludes
+          # unrelated changes in the base branch
+          ref: ${{ github.event.type == 'PullRequestEvent' && github.event.pull_request.head.sha || '' }}
 
       - name: Yarn cache
         uses: c-hive/gha-yarn-cache@v2


### PR DESCRIPTION
Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8161--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
