### PR TITLE
Fix beta pill label breaking

### DIFF
--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -101,9 +101,10 @@ limitations under the License.
     font-size: 12px;
     font-weight: $font-semi-bold;
     line-height: 15px;
-    color: #FFFFFF;
+    color: #fff;
     display: inline-block;
     vertical-align: text-bottom;
+    word-break: keep-all; // avoid multiple lines on CJK language
 
     &.mx_AccessibleButton {
         cursor: pointer;

--- a/res/css/views/beta/_BetaCard.scss
+++ b/res/css/views/beta/_BetaCard.scss
@@ -101,7 +101,7 @@ limitations under the License.
     font-size: 12px;
     font-weight: $font-semi-bold;
     line-height: 15px;
-    color: #fff;
+    color: #FFFFFF;
     display: inline-block;
     vertical-align: text-bottom;
     word-break: keep-all; // avoid multiple lines on CJK language


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21566

This commit ensures word break is not used for beta pill label (`ベータ版`) in CJK languages.

![after](https://user-images.githubusercontent.com/3362943/160228194-1a564109-29fe-4a06-8dcb-bd8f7bce974e.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix beta pill label breaking ([\#8162](https://github.com/matrix-org/matrix-react-sdk/pull/8162)). Fixes vector-im/element-web#21566. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8162--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
