### PR TITLE
Display button as inline in room directory dialog

### DIFF
--- a/src/components/structures/RoomDirectory.tsx
+++ b/src/components/structures/RoomDirectory.tsx
@@ -727,9 +727,9 @@ export default class RoomDirectory extends React.Component<IProps, IState> {
             </div>;
         }
         const explanation =
-            _t("If you can't find the room you're looking for, ask for an invite or <a>Create a new room</a>.", null,
+            _t("If you can't find the room you're looking for, ask for an invite or <a>create a new room</a>.", null,
                 { a: sub => (
-                    <AccessibleButton kind="secondary" onClick={this.onCreateRoomClick}>
+                    <AccessibleButton kind="link_inline" onClick={this.onCreateRoomClick}>
                         { sub }
                     </AccessibleButton>
                 ) },

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3007,7 +3007,7 @@
     "Try different words or check for typos. Some results may not be visible as they're private and you need an invite to join them.": "Try different words or check for typos. Some results may not be visible as they're private and you need an invite to join them.",
     "Find a room…": "Find a room…",
     "Find a room… (e.g. %(exampleRoom)s)": "Find a room… (e.g. %(exampleRoom)s)",
-    "If you can't find the room you're looking for, ask for an invite or <a>Create a new room</a>.": "If you can't find the room you're looking for, ask for an invite or <a>Create a new room</a>.",
+    "If you can't find the room you're looking for, ask for an invite or <a>create a new room</a>.": "If you can't find the room you're looking for, ask for an invite or <a>create a new room</a>.",
     "Filter": "Filter",
     "Filter rooms and people": "Filter rooms and people",
     "Clear filter": "Clear filter",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21567

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

This PR fixes the link `create a new room` to be treated as an inline text.

![after](https://user-images.githubusercontent.com/3362943/160232823-5d604c2d-7944-4b40-b9cf-339e3842dc5f.png)

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set inline to link button inside the text of room directory dialog ([\#8164](https://github.com/matrix-org/matrix-react-sdk/pull/8164)). Fixes vector-im/element-web#21567. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8164--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
