### PR TITLE
Add margins between labs sections

### DIFF
--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -15,18 +15,18 @@ limitations under the License.
 */
 
 .mx_LabsUserSettingsTab {
-    .mx_SettingsTab_section {
-        margin-top: 32px;
+    .mx_SettingsTab_subsectionText, .mx_SettingsTab_section {
+        margin-bottom: 30px;
+    }
 
-        .mx_SettingsFlag {
-            margin-right: 0; // remove right margin to align with beta cards
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
+    .mx_SettingsTab_section .mx_SettingsFlag {
+        margin-right: 0; // remove right margin to align with beta cards
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
 
-            .mx_ToggleSwitch {
-                float: unset;
-            }
+        .mx_ToggleSwitch {
+            float: unset;
         }
     }
 }

--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
@@ -85,7 +85,7 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
             </div>;
         }
 
-        let labsSection;
+        let labsSections;
         if (SdkConfig.get("show_labs_settings")) {
             const groups = new EnhancedMap<LabGroup, JSX.Element[]>();
             labs.forEach(f => {
@@ -143,14 +143,14 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
                 );
             }
 
-            labsSection = <div className="mx_SettingsTab_section">
+            labsSections = <>
                 { sortBy(Array.from(groups.entries()), "0").map(([group, flags]) => (
-                    <div key={group}>
+                    <div className="mx_SettingsTab_section" key={group}>
                         <span className="mx_SettingsTab_subheading">{ _t(labGroupNames[group]) }</span>
                         { flags }
                     </div>
                 )) }
-            </div>;
+            </>;
         }
 
         return (
@@ -172,7 +172,7 @@ export default class LabsUserSettingsTab extends React.Component<{}, IState> {
                     }
                 </div>
                 { betaSection }
-                { labsSection }
+                { labsSections }
             </div>
         );
     }


### PR DESCRIPTION
Makes labs a little bit more readable by using the same margins as the preferences tab.

![Screenshot 2022-03-27 at 18-30-59 Element Test room](https://user-images.githubusercontent.com/48614497/160303844-3ceb5bda-952c-495a-bd88-ddebaf33923a.png)

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add margins between labs sections ([\#8169](https://github.com/matrix-org/matrix-react-sdk/pull/8169)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8169--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
