### PR TITLE
Fix some image/video scroll jumps

### DIFF
--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -17,40 +17,42 @@ limitations under the License.
 
 $timeline-image-border-radius: 8px;
 
-.mx_MImageBody_thumbnail--blurhash {
+.mx_MImageBody_placeholder {
+    // Position the placeholder on top of the thumbnail, so that the reveal animation can work
     position: absolute;
     left: 0;
     top: 0;
-}
-
-.mx_MImageBody_thumbnail {
-    object-fit: contain;
-    border-radius: $timeline-image-border-radius;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
     height: 100%;
     width: 100%;
 
-    // this is needed so that the Blurhash can get have rounded corners without beeing the correct size during loading.
-    overflow: hidden;
+    background-color: $background;
+
     .mx_Blurhash > canvas {
         animation: mx--anim-pulse 1.75s infinite cubic-bezier(.4, 0, .6, 1);
-    }
-
-    .mx_no-image-placeholder {
-        background-color: $primary-content;
     }
 }
 
 .mx_MImageBody_thumbnail_container {
-    // Prevent the padding-bottom (added inline in MImageBody.js) from
-    // affecting elements below the container.
-    overflow: hidden;
+    border-radius: $timeline-image-border-radius;
 
-    // Make sure the _thumbnail is positioned relative to the _container
-    position: relative;
+    // Necessary for the border radius to apply correctly to the placeholder
+    overflow: hidden;
+    contain: paint;
+}
+
+.mx_MImageBody_thumbnail {
+    display: block;
+
+    // Force the image to be the full size of the container, even if the
+    // pixel size is smaller. The problem here is that we don't know what
+    // thumbnail size the HS is going to give us, but we have to commit to
+    // a container size immediately and not change it when the image loads
+    // or we'll get a scroll jump (or have to leave blank space).
+    // This will obviously result in an upscaled image which will be a bit
+    // blurry. The best fix would be for the HS to advertise what size thumbnails
+    // it guarantees to produce.
+    height: 100%;
+    width: 100%;
 }
 
 .mx_MImageBody_gifLabel {

--- a/res/css/views/messages/_MVideoBody.scss
+++ b/res/css/views/messages/_MVideoBody.scss
@@ -15,7 +15,13 @@ limitations under the License.
 */
 
 span.mx_MVideoBody {
-    video.mx_MVideoBody {
+    .mx_MVideoBody_container {
         border-radius: $timeline-image-border-radius;
+        overflow: hidden;
+
+        video {
+            height: 100%;
+            width: 100%;
+        }
     }
 }

--- a/res/css/views/messages/_MVideoBody.scss
+++ b/res/css/views/messages/_MVideoBody.scss
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 span.mx_MVideoBody {
+    overflow: hidden;
+
     .mx_MVideoBody_container {
         border-radius: $timeline-image-border-radius;
         overflow: hidden;

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -126,8 +126,9 @@ limitations under the License.
         .mx_EventTile_line {
             border-bottom-right-radius: var(--cornerRadius);
 
-            .mx_MImageBody .mx_MImageBody_thumbnail,
+            .mx_MImageBody .mx_MImageBody_thumbnail_container,
             .mx_MImageBody::before,
+            .mx_MVideoBody .mx_MVideoBody_container,
             .mx_MediaBody,
             .mx_MLocationBody_map {
                 border-bottom-right-radius: var(--cornerRadius) !important;
@@ -150,8 +151,9 @@ limitations under the License.
             float: right;
             border-bottom-left-radius: var(--cornerRadius);
 
-            .mx_MImageBody .mx_MImageBody_thumbnail,
+            .mx_MImageBody .mx_MImageBody_thumbnail_container,
             .mx_MImageBody::before,
+            .mx_MVideoBody .mx_MVideoBody_container,
             .mx_MediaBody,
             .mx_MLocationBody_map {
                 border-bottom-left-radius: var(--cornerRadius) !important;
@@ -266,7 +268,8 @@ limitations under the License.
         }
 
         //noinspection CssReplaceWithShorthandSafely
-        .mx_MImageBody .mx_MImageBody_thumbnail,
+        .mx_MImageBody .mx_MImageBody_thumbnail_container,
+        .mx_MVideoBody .mx_MVideoBody_container,
         .mx_MediaBody {
             border-radius: unset;
             border-top-left-radius: var(--cornerRadius);
@@ -293,7 +296,8 @@ limitations under the License.
     &.mx_EventTile_continuation[data-self=false] .mx_EventTile_line {
         border-top-left-radius: 0;
 
-        .mx_MImageBody .mx_MImageBody_thumbnail,
+        .mx_MImageBody .mx_MImageBody_thumbnail_container,
+        .mx_MVideoBody .mx_MVideoBody_container,
         .mx_MImageBody::before,
         .mx_MediaBody,
         .mx_MLocationBody_map {
@@ -303,7 +307,8 @@ limitations under the License.
     &.mx_EventTile_lastInSection[data-self=false] .mx_EventTile_line {
         border-bottom-left-radius: var(--cornerRadius);
 
-        .mx_MImageBody .mx_MImageBody_thumbnail,
+        .mx_MImageBody .mx_MImageBody_thumbnail_container,
+        .mx_MVideoBody .mx_MVideoBody_container,
         .mx_MImageBody::before,
         .mx_MediaBody,
         .mx_MLocationBody_map {
@@ -314,7 +319,8 @@ limitations under the License.
     &.mx_EventTile_continuation[data-self=true] .mx_EventTile_line {
         border-top-right-radius: 0;
 
-        .mx_MImageBody .mx_MImageBody_thumbnail,
+        .mx_MImageBody .mx_MImageBody_thumbnail_container,
+        .mx_MVideoBody .mx_MVideoBody_container,
         .mx_MImageBody::before,
         .mx_MediaBody,
         .mx_MLocationBody_map {
@@ -324,7 +330,8 @@ limitations under the License.
     &.mx_EventTile_lastInSection[data-self=true] .mx_EventTile_line {
         border-bottom-right-radius: var(--cornerRadius);
 
-        .mx_MImageBody .mx_MImageBody_thumbnail,
+        .mx_MImageBody .mx_MImageBody_thumbnail_container,
+        .mx_MVideoBody .mx_MVideoBody_container,
         .mx_MImageBody::before,
         .mx_MediaBody,
         .mx_MLocationBody_map {

--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -228,6 +228,18 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         const content = this.props.mxEvent.getContent();
         const autoplay = SettingsStore.getValue("autoplayVideo");
 
+        let aspectRatio;
+        if (content.info?.w && content.info?.h) {
+            aspectRatio = content.info.w / content.info.h;
+        }
+        const { w: maxWidth, h: maxHeight } = suggestedVideoSize(
+            SettingsStore.getValue("Images.size") as ImageSize,
+            { w: content.info?.w, h: content.info?.h },
+        );
+
+        // HACK: This div fills out space while the video loads, to prevent scroll jumps
+        const spaceFiller = <div style={{ width: maxWidth, height: maxHeight }} />;
+
         if (this.state.error !== null) {
             return (
                 <span className="mx_MVideoBody">
@@ -241,20 +253,16 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         if (!this.props.forExport && content.file !== undefined && this.state.decryptedUrl === null && autoplay) {
             // Need to decrypt the attachment
             // The attachment is decrypted in componentDidMount.
-            // For now add an img tag with a spinner.
+            // For now show a spinner.
             return (
                 <span className="mx_MVideoBody">
-                    <div className="mx_MImageBody_thumbnail mx_MImageBody_thumbnail_spinner">
+                    <div className="mx_MVideoBody_container" style={{ maxWidth, maxHeight, aspectRatio }}>
                         <InlineSpinner />
                     </div>
+                    { spaceFiller }
                 </span>
             );
         }
-
-        const { w: maxWidth, h: maxHeight } = suggestedVideoSize(
-            SettingsStore.getValue("Images.size") as ImageSize,
-            { w: content.info?.w, h: content.info?.h },
-        );
 
         const contentUrl = this.getContentUrl();
         const thumbUrl = this.getThumbUrl();
@@ -268,19 +276,21 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         const fileBody = this.getFileBody();
         return (
             <span className="mx_MVideoBody">
-                <video
-                    className="mx_MVideoBody"
-                    ref={this.videoRef}
-                    src={contentUrl}
-                    title={content.body}
-                    controls
-                    preload={preload}
-                    muted={autoplay}
-                    autoPlay={autoplay}
-                    style={{ maxHeight, maxWidth }}
-                    poster={poster}
-                    onPlay={this.videoOnPlay}
-                />
+                <div className="mx_MVideoBody_container" style={{ maxWidth, maxHeight, aspectRatio }}>
+                    <video
+                        className="mx_MVideoBody"
+                        ref={this.videoRef}
+                        src={contentUrl}
+                        title={content.body}
+                        controls
+                        preload={preload}
+                        muted={autoplay}
+                        autoPlay={autoplay}
+                        poster={poster}
+                        onPlay={this.videoOnPlay}
+                    />
+                    { spaceFiller }
+                </div>
                 { fileBody }
             </span>
         );

--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -230,7 +230,7 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
 
         let aspectRatio;
         if (content.info?.w && content.info?.h) {
-            aspectRatio = content.info.w / content.info.h;
+            aspectRatio = `${content.info.w}/${content.info.h}`;
         }
         const { w: maxWidth, h: maxHeight } = suggestedVideoSize(
             SettingsStore.getValue("Images.size") as ImageSize,


### PR DESCRIPTION
Images without a blurhash and all videos were not reserving the correct amount of space in the timeline while loading. Fixing this also involved fixing an unreported regression in the blurhash reveal animation, which previously faded to white instead of fading to the actual image.

Type: defect

Related: https://github.com/vector-im/element-web/issues/6236.
Related: https://github.com/vector-im/element-web/issues/20154.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix some image/video scroll jumps ([\#8182](https://github.com/matrix-org/matrix-react-sdk/pull/8182)).<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8182--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
