### PR TITLE
fix Searching for a mxid in an encrypted room

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1319,11 +1319,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     }
 
     private onSearch = (term: string, scope: SearchScope) => {
-
-        // if we search for a user mxId or an organisation mxId, we need to 
+        // if we search for a user mxId or an organisation mxId, we need to
         // search with only the userId or the organizationId.
-        let regex = /^@.*:|^#.*:/;
-        if(regex.test(term)) {
+        const regex = /^@.*:|^#.*:/;
+        if (regex.test(term)) {
             term = term.split(':')[0];
         }
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1319,6 +1319,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     }
 
     private onSearch = (term: string, scope: SearchScope) => {
+
+        // if we search for a user mxId or an organisation mxId, we need to 
+        // search with only the userId or the organizationId.
+        let regex = /^@.*:|^#.*:/;
+        if(regex.test(term)) {
+            term = term.split(':')[0];
+        }
+
         this.setState({
             searchTerm: term,
             searchScope: scope,


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->

### Bug fixes: 
** #Fixed Searching for a mxid in an encrypted room yields**

Fixes https://github.com/vector-im/element-desktop/issues/913

In the PR, I added a check to know when a user is searching for a mxid and to search for the id only. eg. 
when a user searches for `@userId:example.org`, the search term will be `@userId`

The code before:
![before](https://user-images.githubusercontent.com/63562663/160801591-52a08c91-ff09-41d1-a9cb-f2c1267b210d.PNG)

The code after:
![after](https://user-images.githubusercontent.com/63562663/160801816-661a4b21-2cbc-4e19-8ed1-f6c8def8df4c.PNG)

This links to the [issue](https://github.com/vector-im/element-desktop/issues/913) 


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * fix Searching for a mxid in an encrypted room ([\#8191](https://github.com/matrix-org/matrix-react-sdk/pull/8191)). Fixes vector-im/element-desktop#913. Contributed by @EECvision.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8191--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
