### PR TITLE
Live location sharing - Stop publishing location to beacons with consecutive errors

### DIFF
--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -142,9 +142,10 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     public resetWireError(beaconId: string): void {
         this.incrementBeaconWireErrorCount(beaconId, false);
 
-        // we always publish to all available beacons
+        // always publish to all live beacons together
+        // instead of just one that was changed
         // to keep lastPublishedTimestamp simple
-        // and extra locations don't hurt
+        // and extra published locations don't hurt
         this.publishCurrentLocationToBeacons();
     }
 

--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -444,11 +444,9 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         try {
             console.log(beacon.beaconInfoId);
             await this.matrixClient.sendEvent(beacon.roomId, M_BEACON.name, content);
-            // clear any error count
             this.incrementBeaconWireErrorCount(beacon.identifier, false);
         } catch (error) {
             logger.error(error);
-            // increment error count for beacon
             this.incrementBeaconWireErrorCount(beacon.identifier, true);
         }
     };

--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -48,10 +48,13 @@ const isOwnBeacon = (beacon: Beacon, userId: string): boolean => beacon.beaconIn
 export enum OwnBeaconStoreEvent {
     LivenessChange = 'OwnBeaconStore.LivenessChange',
     MonitoringLivePosition = 'OwnBeaconStore.MonitoringLivePosition',
+    WireError = 'WireError',
 }
 
 const MOVING_UPDATE_INTERVAL = 2000;
 const STATIC_UPDATE_INTERVAL = 30000;
+
+const BAIL_AFTER_CONSECUTIVE_ERROR_COUNT = 2;
 
 type OwnBeaconStoreState = {
     beacons: Map<string, Beacon>;
@@ -65,9 +68,11 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     public readonly beacons = new Map<string, Beacon>();
     public readonly beaconsByRoomId = new Map<Room['roomId'], Set<string>>();
     /**
-     * Track over the wire errors for beacons
+     * Track over the wire errors for published positions
+     * Counts consecutive wire errors per beacon
+     * Reset on successful publish of location
      */
-    public readonly beaconWireErrors = new Map<string, Error>();
+    public readonly beaconWireErrorCounts = new Map<string, number>();
     private liveBeaconIds = [];
     private locationInterval: number;
     private geolocationError: GeolocationError | undefined;
@@ -106,7 +111,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         this.beacons.clear();
         this.beaconsByRoomId.clear();
         this.liveBeaconIds = [];
-        this.beaconWireErrors.clear();
+        this.beaconWireErrorCounts.clear();
     }
 
     protected async onReady(): Promise<void> {
@@ -123,6 +128,24 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
 
     public hasLiveBeacons(roomId?: string): boolean {
         return !!this.getLiveBeaconIds(roomId).length;
+    }
+
+    /**
+     * If a beacon has failed to publish position
+     * past the allowed consecutive failure count (BAIL_AFTER_CONSECUTIVE_ERROR_COUNT)
+     * Then consider it to have an error
+     */
+    public hasWireError(beaconId: string): boolean {
+        return this.beaconWireErrorCounts.get(beaconId) >= BAIL_AFTER_CONSECUTIVE_ERROR_COUNT;
+    }
+
+    public resetWireError(beaconId: string): void {
+        this.incrementBeaconWireErrorCount(beaconId, false);
+
+        // we always publish to all available beacons
+        // to keep lastPublishedTimestamp simple
+        // and extra locations don't hurt
+        this.publishCurrentLocationToBeacons();
     }
 
     public getLiveBeaconIds(roomId?: string): string[] {
@@ -201,6 +224,13 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     /**
      * State management
      */
+
+    /**
+     * Live beacon ids that do not have wire errors
+     */
+    private get healthyLiveBeaconIds() {
+        return this.liveBeaconIds.filter(beaconId => !this.hasWireError(beaconId));
+    }
 
     private initialiseBeaconState = () => {
         const userId = this.matrixClient.getUserId();
@@ -399,7 +429,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
      */
     private publishLocationToBeacons = async (position: TimedGeoUri) => {
         this.lastPublishedPositionTimestamp = Date.now();
-        await Promise.all(this.liveBeaconIds.map(beaconId =>
+        await Promise.all(this.healthyLiveBeaconIds.map(beaconId =>
             this.sendLocationToBeacon(this.beacons.get(beaconId), position)),
         );
     };
@@ -412,10 +442,39 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     private sendLocationToBeacon = async (beacon: Beacon, { geoUri, timestamp }: TimedGeoUri) => {
         const content = makeBeaconContent(geoUri, timestamp, beacon.beaconInfoId);
         try {
+            console.log(beacon.beaconInfoId);
             await this.matrixClient.sendEvent(beacon.roomId, M_BEACON.name, content);
+            // clear any error count
+            this.incrementBeaconWireErrorCount(beacon.identifier, false);
         } catch (error) {
             logger.error(error);
-            this.beaconWireErrors.set(beacon.identifier, error);
+            // increment error count for beacon
+            this.incrementBeaconWireErrorCount(beacon.identifier, true);
+        }
+    };
+
+    /**
+     * Manage beacon wire error count
+     * - clear count for beacon when not error
+     * - increment count for beacon when is error
+     * - emit if beacon error count crossed threshold
+     */
+    private incrementBeaconWireErrorCount = (beaconId: string, isError: boolean): void => {
+        const hadError = this.hasWireError(beaconId);
+
+        if (isError) {
+            // increment error count
+            this.beaconWireErrorCounts.set(
+                beaconId,
+                (this.beaconWireErrorCounts.get(beaconId) ?? 0) + 1,
+            );
+        } else {
+            // clear any error count
+            this.beaconWireErrorCounts.delete(beaconId);
+        }
+
+        if (this.hasWireError(beaconId) !== hadError) {
+            this.emit(OwnBeaconStoreEvent.WireError, beaconId);
         }
     };
 }

--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -443,7 +443,6 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     private sendLocationToBeacon = async (beacon: Beacon, { geoUri, timestamp }: TimedGeoUri) => {
         const content = makeBeaconContent(geoUri, timestamp, beacon.beaconInfoId);
         try {
-            console.log(beacon.beaconInfoId);
             await this.matrixClient.sendEvent(beacon.roomId, M_BEACON.name, content);
             this.incrementBeaconWireErrorCount(beacon.identifier, false);
         } catch (error) {

--- a/test/stores/OwnBeaconStore-test.ts
+++ b/test/stores/OwnBeaconStore-test.ts
@@ -825,7 +825,7 @@ describe('OwnBeaconStore', () => {
             });
         });
 
-        describe('errors publishing positions', () => {
+        describe('when publishing position fails', () => {
             beforeEach(() => {
                 geolocation.watchPosition.mockImplementation(
                     watchPositionMockImplementation([0, 1000, 3000, 3000, 3000]),

--- a/test/stores/OwnBeaconStore-test.ts
+++ b/test/stores/OwnBeaconStore-test.ts
@@ -166,7 +166,7 @@ describe('OwnBeaconStore', () => {
         geolocation = mockGeolocation();
         mockClient.getVisibleRooms.mockReturnValue([]);
         mockClient.unstable_setLiveBeacon.mockClear().mockResolvedValue({ event_id: '1' });
-        mockClient.sendEvent.mockClear().mockResolvedValue({ event_id: '1' });
+        mockClient.sendEvent.mockReset().mockResolvedValue({ event_id: '1' });
         jest.spyOn(global.Date, 'now').mockReturnValue(now);
         jest.spyOn(OwnBeaconStore.instance, 'emit').mockRestore();
         jest.spyOn(logger, 'error').mockRestore();
@@ -696,7 +696,7 @@ describe('OwnBeaconStore', () => {
         });
     });
 
-    describe('sending positions', () => {
+    describe('publishing positions', () => {
         it('stops watching position when user has no more live beacons', async () => {
             // geolocation is only going to emit 1 position
             geolocation.watchPosition.mockImplementation(
@@ -822,6 +822,136 @@ describe('OwnBeaconStore', () => {
                 // then both live beacons get current position published
                 // after new beacon is added
                 expect(mockClient.sendEvent).toHaveBeenCalledTimes(3);
+            });
+        });
+
+        describe('errors publishing positions', () => {
+            beforeEach(() => {
+                geolocation.watchPosition.mockImplementation(
+                    watchPositionMockImplementation([0, 1000, 3000, 3000, 3000]),
+                );
+
+                // eat expected console error logs
+                jest.spyOn(logger, 'error').mockImplementation(() => { });
+            });
+
+            // we need to advance time and then flush promises
+            // individually for each call to sendEvent
+            // otherwise the sendEvent doesn't reject/resolve and update state
+            // before the next call
+            // advance and flush every 1000ms
+            // until given ms is 'elapsed'
+            const advanceAndFlushPromises = async (timeMs: number) => {
+                while (timeMs > 0) {
+                    jest.advanceTimersByTime(1000);
+                    await flushPromisesWithFakeTimers();
+                    timeMs -= 1000;
+                }
+            };
+
+            it('continues publishing positions after one publish error', async () => {
+                // fail to send first event, then succeed
+                mockClient.sendEvent.mockRejectedValueOnce(new Error('oups')).mockResolvedValue({ event_id: '1' });
+                makeRoomsWithStateEvents([
+                    alicesRoom1BeaconInfo,
+                ]);
+                const store = await makeOwnBeaconStore();
+                // wait for store to settle
+                await flushPromisesWithFakeTimers();
+
+                await advanceAndFlushPromises(50000);
+
+                // called for each position from watchPosition
+                expect(mockClient.sendEvent).toHaveBeenCalledTimes(5);
+                expect(store.hasWireError(alicesRoom1BeaconInfo.getType())).toBe(false);
+            });
+
+            it('continues publishing positions when a beacon fails intermittently', async () => {
+                // every second event rejects
+                // meaning this beacon has more errors than the threshold
+                // but they are not consecutive
+                mockClient.sendEvent
+                    .mockRejectedValueOnce(new Error('oups'))
+                    .mockResolvedValueOnce({ event_id: '1' })
+                    .mockRejectedValueOnce(new Error('oups'))
+                    .mockResolvedValueOnce({ event_id: '1' })
+                    .mockRejectedValueOnce(new Error('oups'));
+
+                makeRoomsWithStateEvents([
+                    alicesRoom1BeaconInfo,
+                ]);
+                const store = await makeOwnBeaconStore();
+                const emitSpy = jest.spyOn(store, 'emit');
+                // wait for store to settle
+                await flushPromisesWithFakeTimers();
+
+                await advanceAndFlushPromises(50000);
+
+                // called for each position from watchPosition
+                expect(mockClient.sendEvent).toHaveBeenCalledTimes(5);
+                expect(store.hasWireError(alicesRoom1BeaconInfo.getType())).toBe(false);
+                expect(emitSpy).not.toHaveBeenCalledWith(
+                    OwnBeaconStoreEvent.WireError, alicesRoom1BeaconInfo.getType(),
+                );
+            });
+
+            it('stops publishing positions when a beacon fails consistently', async () => {
+                // always fails to send events
+                mockClient.sendEvent.mockRejectedValue(new Error('oups'));
+                makeRoomsWithStateEvents([
+                    alicesRoom1BeaconInfo,
+                ]);
+                const store = await makeOwnBeaconStore();
+                const emitSpy = jest.spyOn(store, 'emit');
+                // wait for store to settle
+                await flushPromisesWithFakeTimers();
+
+                // 5 positions from watchPosition in this period
+                await advanceAndFlushPromises(50000);
+
+                // only two allowed failures
+                expect(mockClient.sendEvent).toHaveBeenCalledTimes(2);
+                expect(store.hasWireError(alicesRoom1BeaconInfo.getType())).toBe(true);
+                expect(emitSpy).toHaveBeenCalledWith(
+                    OwnBeaconStoreEvent.WireError, alicesRoom1BeaconInfo.getType(),
+                );
+            });
+
+            it('restarts publishing a beacon after resetting wire error', async () => {
+                // always fails to send events
+                mockClient.sendEvent.mockRejectedValue(new Error('oups'));
+                makeRoomsWithStateEvents([
+                    alicesRoom1BeaconInfo,
+                ]);
+                const store = await makeOwnBeaconStore();
+                const emitSpy = jest.spyOn(store, 'emit');
+                // wait for store to settle
+                await flushPromisesWithFakeTimers();
+
+                // 3 positions from watchPosition in this period
+                await advanceAndFlushPromises(4000);
+
+                // only two allowed failures
+                expect(mockClient.sendEvent).toHaveBeenCalledTimes(2);
+                expect(store.hasWireError(alicesRoom1BeaconInfo.getType())).toBe(true);
+                expect(emitSpy).toHaveBeenCalledWith(
+                    OwnBeaconStoreEvent.WireError, alicesRoom1BeaconInfo.getType(),
+                );
+
+                // reset emitSpy mock counts to asser on wireError again
+                emitSpy.mockClear();
+                store.resetWireError(alicesRoom1BeaconInfo.getType());
+
+                expect(store.hasWireError(alicesRoom1BeaconInfo.getType())).toBe(false);
+
+                // 2 more positions from watchPosition in this period
+                await advanceAndFlushPromises(10000);
+
+                // 2 from before, 2 new ones
+                expect(mockClient.sendEvent).toHaveBeenCalledTimes(4);
+                expect(emitSpy).toHaveBeenCalledWith(
+                    OwnBeaconStoreEvent.WireError, alicesRoom1BeaconInfo.getType(),
+                );
             });
         });
 


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Stop publishing locations to a beacon after two consecutive wire failures, and expose an error state.
Allow this to be reset with a 'retry' mechanism (UI coming in next PR)

Figma:
<img width="846" alt="Screenshot 2022-03-30 at 15 45 46" src="https://user-images.githubusercontent.com/3055605/160850007-10449ec4-fc7d-4142-b694-3de8f03849ea.png">


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location sharing - Stop publishing location to beacons with consecutive errors ([\#8194](https://github.com/matrix-org/matrix-react-sdk/pull/8194)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->










<!-- Replace -->
Preview: https://pr8194--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
