### PR TITLE
Fix issue with replying outside a thread to a thread root

### DIFF
--- a/src/utils/Reply.ts
+++ b/src/utils/Reply.ts
@@ -147,30 +147,13 @@ export function getNestedReplyText(
 export function makeReplyMixIn(ev?: MatrixEvent): RecursivePartial<IContent> {
     if (!ev) return {};
 
-    const mixin: RecursivePartial<IContent> = {
+    return {
         'm.relates_to': {
             'm.in_reply_to': {
                 'event_id': ev.getId(),
             },
         },
     };
-
-    /**
-     * If the event replied is part of a thread
-     * Add the `m.thread` relation so that clients
-     * that know how to handle that relation will
-     * be able to render them more accurately
-     */
-    if (ev.isThreadRelation || ev.isThreadRoot) {
-        mixin['m.relates_to'] = {
-            ...mixin['m.relates_to'],
-            is_falling_back: false,
-            rel_type: THREAD_RELATION_TYPE.name,
-            event_id: ev.threadRootId,
-        };
-    }
-
-    return mixin;
 }
 
 export function shouldDisplayReply(event: MatrixEvent): boolean {
@@ -210,8 +193,7 @@ export function addReplyToMessageContent(
     Object.assign(content, replyContent);
 
     if (opts.includeLegacyFallback) {
-        // Part of Replies fallback support - prepend the text we're sending
-        // with the text we're replying to
+        // Part of Replies fallback support - prepend the text we're sending with the text we're replying to
         const nestedReply = getNestedReplyText(replyToEvent, opts.permalinkCreator);
         if (nestedReply) {
             if (content.formatted_body) {


### PR DESCRIPTION
The relation is added by the callers when relevant (when the reply happens within a thread) already.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8195--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
