### PR TITLE
Fix warning in `yarn start` output

### DIFF
--- a/src/components/views/location/MapError.tsx
+++ b/src/components/views/location/MapError.tsx
@@ -37,3 +37,5 @@ export const MapError: React.FC<Props> = ({
     </p>
     <AccessibleButton element='button' kind="primary" onClick={onFinished}>{ _t("OK") }</AccessibleButton>
 </div>);
+
+export default MapError;


### PR DESCRIPTION
Fixes the warning below

```
WARNING in ../matrix-react-sdk/src/component-index.js 551:68-91
"export 'default' (imported as 'views$location$MapError') was not found in './components/views/location/MapError'
```

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8200--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
