### PR TITLE
Don't try show saved thread panel state if threads is disabled

### DIFF
--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -249,6 +249,9 @@ export default class RightPanelStore extends ReadyWatchingStore {
     private filterValidCards(rightPanelForRoom?: IRightPanelForRoom) {
         if (!rightPanelForRoom?.history) return;
         rightPanelForRoom.history = rightPanelForRoom.history.filter((card) => this.isCardStateValid(card));
+        if (!rightPanelForRoom.history.length) {
+            rightPanelForRoom.isOpen = false;
+        }
     }
 
     private isCardStateValid(card: IRightPanelCard) {
@@ -259,7 +262,11 @@ export default class RightPanelStore extends ReadyWatchingStore {
         // or potentially other errors.
         // (A nicer fix could be to indicate, that the right panel is loading if there is missing state data and re-emit if the data is available)
         switch (card.phase) {
+            case RightPanelPhases.ThreadPanel:
+                if (!SettingsStore.getValue("feature_thread")) return false;
+                break;
             case RightPanelPhases.ThreadView:
+                if (!SettingsStore.getValue("feature_thread")) return false;
                 if (!card.state.threadHeadEvent) {
                     console.warn("removed card from right panel because of missing threadHeadEvent in card state");
                 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21618

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8203--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
