### PR TITLE
Use appropriate Member object when rendering thread summary

### DIFF
--- a/src/components/views/rooms/ThreadSummary.tsx
+++ b/src/components/views/rooms/ThreadSummary.tsx
@@ -90,17 +90,16 @@ export const ThreadMessagePreview = ({ thread, showDisplayname = false }: IPrevi
     }, [lastReply, replacingEventId]);
     if (!preview) return null;
 
-    const sender = thread.roomState.getSentinelMember(lastReply.getSender());
     return <>
         <MemberAvatar
-            member={sender}
+            member={lastReply.sender}
             fallbackUserId={lastReply.getSender()}
             width={24}
             height={24}
             className="mx_ThreadInfo_avatar"
         />
         { showDisplayname && <div className="mx_ThreadInfo_sender">
-            { sender?.name ?? lastReply.getSender() }
+            { lastReply.sender?.name ?? lastReply.getSender() }
         </div> }
         <div className="mx_ThreadInfo_content">
             <span className="mx_ThreadInfo_message-preview">


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21621

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8204--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
