### PR TITLE
Fixes a broken link and set margin around links

### DIFF
--- a/res/css/views/auth/_AuthBody.scss
+++ b/res/css/views/auth/_AuthBody.scss
@@ -94,6 +94,22 @@ limitations under the License.
             background-color: $authpage-focus-bg-color;
         }
     }
+
+    .mx_recaptchaContainer {
+        .mx_recaptchaContainer_info,
+        .mx_recaptchaContainer_error {
+            margin: 12px auto;
+        }
+    }
+
+    .mx_AuthBody_link_goBack {
+        margin: 12px auto 6px;
+        max-width: fit-content;
+    }
+
+    .mx_AuthBody_link_signIn {
+        margin-top: 6px;
+    }
 }
 
 .mx_AuthBody_fieldRow {

--- a/src/components/structures/auth/Registration.tsx
+++ b/src/components/structures/auth/Registration.tsx
@@ -614,8 +614,8 @@ export default class Registration extends React.Component<IProps, IState> {
                     onServerConfigChange={this.state.doingUIAuth ? undefined : this.props.onServerConfigChange}
                 />
                 { this.renderRegisterComponent() }
-                { goBack }
-                { signIn }
+                <div className="mx_AuthBody_link_goBack">{ goBack }</div>
+                <div className="mx_AuthBody_link_signIn">{ signIn }</div>
             </div>;
         }
 

--- a/src/components/views/auth/CaptchaForm.tsx
+++ b/src/components/views/auth/CaptchaForm.tsx
@@ -126,19 +126,22 @@ export default class CaptchaForm extends React.Component<ICaptchaFormProps, ICap
         let error = null;
         if (this.state.errorText) {
             error = (
-                <div className="error">
+                <div className="error" role="alert">
                     { this.state.errorText }
                 </div>
             );
         }
 
         return (
-            <div ref={this.recaptchaContainer}>
-                <p>{ _t(
+            <div className="mx_recaptchaContainer" ref={this.recaptchaContainer}>
+                <p className="mx_recaptchaContainer_info">{ _t(
                     "This homeserver would like to make sure you are not a robot.",
                 ) }</p>
-                <div id={DIV_ID} />
-                { error }
+                <div
+                    className="mx_recaptchaContainer_recaptcha"
+                    id={DIV_ID}
+                />
+                <div className="mx_recaptchaContainer_error">{ error }</div>
             </div>
         );
     }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21624

- Add margin around links
- Fixes the bug that `Go back` link is enabled over the row
- Also add the role to the error div

![after](https://user-images.githubusercontent.com/3362943/161065922-c60e5d8e-4573-43d3-beaa-c716cdbabb91.png)


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
