### PR TITLE
Fix explicit replies in threads

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -47,6 +47,7 @@ import { decorateStartSendingTime, sendRoundTripMetric } from "./sendTimePerform
 import { TimelineRenderingType } from "./contexts/RoomContext";
 import RoomViewStore from "./stores/RoomViewStore";
 import { addReplyToMessageContent } from "./utils/Reply";
+import { attachRelation } from "./components/views/rooms/SendMessageComposer";
 
 const MAX_WIDTH = 800;
 const MAX_HEIGHT = 600;
@@ -585,10 +586,7 @@ export default class ContentMessages {
             msgtype: "", // set later
         };
 
-        if (relation) {
-            content["m.relates_to"] = relation;
-        }
-
+        attachRelation(content, relation);
         if (replyToEvent) {
             addReplyToMessageContent(content, replyToEvent, {
                 includeLegacyFallback: false,

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -60,14 +60,12 @@ import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { PosthogAnalytics } from "../../../PosthogAnalytics";
 import { addReplyToMessageContent } from '../../../utils/Reply';
 
-export function attachRelation(
-    content: IContent,
-    relation?: IEventRelation,
-): void {
+// Merges favouring the given relation
+export function attachRelation(content: IContent, relation?: IEventRelation): void {
     if (relation) {
         content['m.relates_to'] = {
-            ...relation, // the composer can have a default
-            ...content['m.relates_to'],
+            ...(content['m.relates_to'] || {}),
+            ...relation,
         };
     }
 }
@@ -100,18 +98,12 @@ export function createMessageContent(
         content.formatted_body = formattedBody;
     }
 
+    attachRelation(content, relation);
     if (replyToEvent) {
         addReplyToMessageContent(content, replyToEvent, {
             permalinkCreator,
             includeLegacyFallback: includeReplyLegacyFallback,
         });
-    }
-
-    if (relation) {
-        content['m.relates_to'] = {
-            ...relation,
-            ...content['m.relates_to'],
-        };
     }
 
     return content;

--- a/src/utils/Reply.ts
+++ b/src/utils/Reply.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IContent, MatrixEvent } from "matrix-js-sdk/src/models/event";
+import { IContent, IEventRelation, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import sanitizeHtml from "sanitize-html";
 import escapeHtml from "escape-html";
 import { THREAD_RELATION_TYPE } from "matrix-js-sdk/src/models/thread";
@@ -22,7 +22,6 @@ import { MsgType } from "matrix-js-sdk/src/@types/event";
 
 import { PERMITTED_URL_SCHEMES } from "../HtmlUtils";
 import { makeUserPermalink, RoomPermalinkCreator } from "./permalinks/Permalinks";
-import { RecursivePartial } from "../@types/common";
 import SettingsStore from "../settings/SettingsStore";
 
 export function getParentEventId(ev?: MatrixEvent): string | undefined {
@@ -144,16 +143,20 @@ export function getNestedReplyText(
     return { body, html };
 }
 
-export function makeReplyMixIn(ev?: MatrixEvent): RecursivePartial<IContent> {
+export function makeReplyMixIn(ev?: MatrixEvent): IEventRelation {
     if (!ev) return {};
 
-    return {
-        'm.relates_to': {
-            'm.in_reply_to': {
-                'event_id': ev.getId(),
-            },
+    const mixin: IEventRelation = {
+        'm.in_reply_to': {
+            'event_id': ev.getId(),
         },
     };
+
+    if (SettingsStore.getValue("feature_thread") && ev.threadRootId) {
+        mixin.is_falling_back = false;
+    }
+
+    return mixin;
 }
 
 export function shouldDisplayReply(event: MatrixEvent): boolean {
@@ -189,8 +192,10 @@ export function addReplyToMessageContent(
         includeLegacyFallback: true,
     },
 ): void {
-    const replyContent = makeReplyMixIn(replyToEvent);
-    Object.assign(content, replyContent);
+    content["m.relates_to"] = {
+        ...(content["m.relates_to"] || {}),
+        ...makeReplyMixIn(replyToEvent),
+    };
 
     if (opts.includeLegacyFallback) {
         // Part of Replies fallback support - prepend the text we're sending with the text we're replying to


### PR DESCRIPTION
Fixed by https://github.com/vector-im/element-web/issues/21626

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8210--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
