### PR TITLE
Fix editing <ol> tags with a non-1 start attribute

### DIFF
--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -218,7 +218,7 @@ function parseNode(n: Node, pc: PartCreator, mkListItem?: (li: Node) => Part[]):
                     return parts;
                 }
                 case "OL": {
-                    let counter = 1;
+                    let counter = (n as HTMLOListElement).start ?? 1;
                     const parts = parseChildren(n, pc, li => {
                         const parts = [pc.plain(`${counter}. `), ...parseChildren(li, pc)];
                         counter++;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21625

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix editing <ol> tags with a non-1 start attribute ([\#8211](https://github.com/matrix-org/matrix-react-sdk/pull/8211)). Fixes vector-im/element-web#21625.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8211--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
