### PR TITLE
Make thread panel re-render the whole timeline on prop change

### DIFF
--- a/src/components/structures/ThreadPanel.tsx
+++ b/src/components/structures/ThreadPanel.tsx
@@ -238,6 +238,7 @@ const ThreadPanel: React.FC<IProps> = ({
                 />
                 { timelineSet && (
                     <TimelinePanel
+                        key={timelineSet.getFilter().filterId}
                         ref={timelinePanel}
                         showReadReceipts={false} // No RR support in thread's MVP
                         manageReadReceipts={false} // No RR support in thread's MVP


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21630

There is a warning saying you should not update the `timelineSet` of a `TimelinePanel`

```
Replacing timelineSet on a TimelinePanel - confusion may ensue
```

Using `key` means that React will create a new component every time we change the timeline set instead of trying to do it in a smarter way



<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8213--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
