### PR TITLE
Fix typo in key binding management docs

### DIFF
--- a/docs/features/keyboardShortcuts.md
+++ b/docs/features/keyboardShortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard shortcuts
 
-## Using the `KeyBindingManger`
+## Using the `KeyBindingManager`
 
 The `KeyBindingManager` (accessible using `getKeyBindingManager()`) is a class
 with several methods that allow you to get a `KeyBindingAction` based on a


### PR DESCRIPTION
I found a Typo error in KeyBindingManager, I have fixed that typo.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
Before:
![Screenshot (35)_LI](https://user-images.githubusercontent.com/86149243/161479924-9e4ace33-ee12-4d16-b341-ff0b713bbc42.jpg)
After:
![Screenshot (36)_LI](https://user-images.githubusercontent.com/86149243/161480157-74610d2d-bbcd-4b4b-8b3b-5cde473db97c.jpg)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->