### PR TITLE
Don't use m.call for Jitsi video rooms

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -375,7 +375,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private getMainSplitContentType = (room: Room) => {
-        if (SettingsStore.getValue("feature_video_rooms") && room.isCallRoom()) {
+        if (SettingsStore.getValue("feature_video_rooms") && room.isElementVideoRoom()) {
             return MainSplitContentType.Video;
         }
         if (WidgetLayoutStore.instance.hasMaximisedWidget(room)) {

--- a/src/components/structures/SpaceRoomView.tsx
+++ b/src/components/structures/SpaceRoomView.tsx
@@ -347,7 +347,7 @@ const SpaceLandingAddButton = ({ space }) => {
                             e.stopPropagation();
                             closeMenu();
 
-                            if (await showCreateNewRoom(space, RoomType.UnstableCall)) {
+                            if (await showCreateNewRoom(space, RoomType.ElementVideo)) {
                                 defaultDispatcher.fire(Action.UpdateSpaceHierarchy);
                             }
                         }}

--- a/src/components/views/context_menus/RoomContextMenu.tsx
+++ b/src/components/views/context_menus/RoomContextMenu.tsx
@@ -105,7 +105,7 @@ const RoomContextMenu = ({ room, onFinished, ...props }: IProps) => {
     }
 
     const isDm = DMRoomMap.shared().getUserIdForRoomId(room.roomId);
-    const isVideoRoom = useFeatureEnabled("feature_video_rooms") && room.isCallRoom();
+    const isVideoRoom = useFeatureEnabled("feature_video_rooms") && room.isElementVideoRoom();
 
     let inviteOption: JSX.Element;
     if (room.canInvite(cli.getUserId()) && !isDm) {

--- a/src/components/views/dialogs/CreateRoomDialog.tsx
+++ b/src/components/views/dialogs/CreateRoomDialog.tsx
@@ -221,7 +221,7 @@ export default class CreateRoomDialog extends React.Component<IProps, IState> {
     });
 
     render() {
-        const isVideoRoom = this.props.type === RoomType.UnstableCall;
+        const isVideoRoom = this.props.type === RoomType.ElementVideo;
 
         let aliasField;
         if (this.state.joinRule === JoinRule.Public) {

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -269,7 +269,7 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, onClose }) => {
     const isRoomEncrypted = useIsEncrypted(cli, room);
     const roomContext = useContext(RoomContext);
     const e2eStatus = roomContext.e2eStatus;
-    const isVideoRoom = useFeatureEnabled("feature_video_rooms") && room.isCallRoom();
+    const isVideoRoom = useFeatureEnabled("feature_video_rooms") && room.isElementVideoRoom();
 
     const alias = room.getCanonicalAlias() || room.getAltAliases()[0] || "";
     const header = <React.Fragment>

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -243,7 +243,7 @@ const UntaggedAuxButton = ({ tabIndex }: IAuxButtonProps) => {
                                 e.preventDefault();
                                 e.stopPropagation();
                                 closeMenu();
-                                showCreateNewRoom(activeSpace, RoomType.UnstableCall);
+                                showCreateNewRoom(activeSpace, RoomType.ElementVideo);
                             }}
                             disabled={!canAddRooms}
                             tooltip={canAddRooms ? undefined
@@ -289,7 +289,7 @@ const UntaggedAuxButton = ({ tabIndex }: IAuxButtonProps) => {
                         closeMenu();
                         defaultDispatcher.dispatch({
                             action: "view_create_room",
-                            type: RoomType.UnstableCall,
+                            type: RoomType.ElementVideo,
                         });
                     }}
                 /> }

--- a/src/components/views/rooms/RoomListHeader.tsx
+++ b/src/components/views/rooms/RoomListHeader.tsx
@@ -217,7 +217,7 @@ const RoomListHeader = ({ onVisibilityChange }: IProps) => {
                     onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        showCreateNewRoom(activeSpace, RoomType.UnstableCall);
+                        showCreateNewRoom(activeSpace, RoomType.ElementVideo);
                         closePlusMenu();
                     }}
                 /> }
@@ -310,7 +310,7 @@ const RoomListHeader = ({ onVisibilityChange }: IProps) => {
                         e.stopPropagation();
                         defaultDispatcher.dispatch({
                             action: "view_create_room",
-                            type: RoomType.UnstableCall,
+                            type: RoomType.ElementVideo,
                         });
                         closePlusMenu();
                     }}

--- a/src/components/views/rooms/RoomTile.tsx
+++ b/src/components/views/rooms/RoomTile.tsx
@@ -123,7 +123,7 @@ export default class RoomTile extends React.PureComponent<IProps, IState> {
 
         this.notificationState = RoomNotificationStateStore.instance.getRoomState(this.props.room);
         this.roomProps = EchoChamber.forRoom(this.props.room);
-        this.isVideoRoom = SettingsStore.getValue("feature_video_rooms") && this.props.room.isCallRoom();
+        this.isVideoRoom = SettingsStore.getValue("feature_video_rooms") && this.props.room.isElementVideoRoom();
     }
 
     private onRoomNameUpdate = (room: Room) => {

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -129,7 +129,7 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
         };
 
         // In video rooms, allow all users to send video member updates
-        if (opts.roomType === RoomType.UnstableCall) {
+        if (opts.roomType === RoomType.ElementVideo) {
             createOpts.power_level_content_override = {
                 events: {
                     [VIDEO_CHANNEL_MEMBER]: 0,
@@ -263,7 +263,7 @@ export default async function createRoom(opts: IOpts): Promise<string | null> {
         }
     }).then(() => {
         // Set up video rooms with a Jitsi widget
-        if (opts.roomType === RoomType.UnstableCall) {
+        if (opts.roomType === RoomType.ElementVideo) {
             return addVideoChannel(roomId, createOpts.name);
         }
     }).then(function() {

--- a/test/components/views/rooms/RoomTile-test.tsx
+++ b/test/components/views/rooms/RoomTile-test.tsx
@@ -73,7 +73,7 @@ describe("RoomTile", () => {
 
     describe("video rooms", () => {
         const room = mkRoom(cli, "!1:example.org");
-        room.isCallRoom.mockReturnValue(true);
+        room.isElementVideoRoom.mockReturnValue(true);
 
         it("tracks connection state", () => {
             const tile = mount(

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -367,7 +367,7 @@ export function mkStubRoom(roomId: string = null, name: string, client: MatrixCl
         getAvatarUrl: () => 'mxc://avatar.url/room.png',
         getMxcAvatarUrl: () => 'mxc://avatar.url/room.png',
         isSpaceRoom: jest.fn().mockReturnValue(false),
-        isCallRoom: jest.fn().mockReturnValue(false),
+        isElementVideoRoom: jest.fn().mockReturnValue(false),
         getUnreadNotificationCount: jest.fn(() => 0),
         getEventReadUpTo: jest.fn(() => null),
         getCanonicalAlias: jest.fn(),


### PR DESCRIPTION
We want to avoid using `m.call` for the current Jitsi implementation of video rooms, to avoid confusion with native VoIP down the line.

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/2273

Type: defect