### PR TITLE
Scale emoji with size of surrounding text

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -78,7 +78,7 @@ a.mx_Pill {
 .mx_Emoji {
     // Should be 1.8rem for our default 1.4rem message bodies,
     // and scale with the size of the surrounding text
-    font-size: calc(18/14 * 1em);
+    font-size: calc(18 / 14 * 1em);
     vertical-align: bottom;
 }
 


### PR DESCRIPTION
This ensures that they actually display larger when used in `h1`s.

Before|After
-|-
![Screenshot 2022-04-04 at 09-59-13 Element Test room](https://user-images.githubusercontent.com/48614497/161560309-6dc5ef21-b6ef-47a7-9ce8-a350aad27383.png)|![Screenshot 2022-04-04 at 09-58-50 Element Test room](https://user-images.githubusercontent.com/48614497/161560306-f0c6e136-cd4e-4222-8d20-b61dcfa12101.png)

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Scale emoji with size of surrounding text ([\#8224](https://github.com/matrix-org/matrix-react-sdk/pull/8224)).<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8224--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
