### PR TITLE
Fix the link which was not supporting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ practices that anyone working with the SDK needs to be aware of and uphold:
 
   * The view's CSS file MUST have the same name (e.g. view/rooms/MessageTile.css).
     CSS for matrix-react-sdk currently resides in
-    https://github.com/vector-im/element-web/tree/master/src/skins/vector/css/matrix-react-sdk.
+    https://github.com/matrix-org/matrix-react-sdk/tree/develop/res/css.
 
   * Per-view CSS is optional - it could choose to inherit all its styling from
     the context of the rest of the app, although this is unusual for any but

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ practices that anyone working with the SDK needs to be aware of and uphold:
 
   * The view's CSS file MUST have the same name (e.g. view/rooms/MessageTile.css).
     CSS for matrix-react-sdk currently resides in
-    https://github.com/matrix-org/matrix-react-sdk/tree/develop/res/css.
+    https://github.com/matrix-org/matrix-react-sdk/tree/master/res/css.
 
   * Per-view CSS is optional - it could choose to inherit all its styling from
     the context of the rest of the app, although this is unusual for any but


### PR DESCRIPTION
I have updated the link to the CSS of matrix-react-sdk.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
Before : Page not found
![Screenshot (32)](https://user-images.githubusercontent.com/86149243/161686496-06459ec6-ea5e-4c6e-a874-3d9cb40bf02c.png)
After: Redirecting to the CSS of matrix-react-sdk
![Screenshot (39)](https://user-images.githubusercontent.com/86149243/161686737-84521d20-2e7e-454a-a1a1-c924966a065a.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8229--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
