### PR TITLE
Improve link buttons and inline link buttons styling

### DIFF
--- a/res/css/structures/_RoomDirectory.scss
+++ b/res/css/structures/_RoomDirectory.scss
@@ -180,19 +180,11 @@ limitations under the License.
 .mx_RoomDirectory > span {
     font-size: $font-15px;
     margin-top: 0;
-
-    .mx_AccessibleButton {
-        padding: 0;
-    }
 }
 
 @media screen and (max-width: 700px) {
     .mx_RoomDirectory_roomMemberCount {
         padding: 0px;
-    }
-
-    .mx_AccessibleButton_kind_secondary {
-        padding: 0px !important;
     }
 
     .mx_RoomDirectory_join {

--- a/res/css/structures/auth/_SetupEncryptionBody.scss
+++ b/res/css/structures/auth/_SetupEncryptionBody.scss
@@ -20,7 +20,6 @@ limitations under the License.
 
     .mx_SetupEncryptionBody_reset_link {
         &.mx_AccessibleButton_kind_link_inline {
-            padding: 0;
             color: $alert;
         }
     }

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -256,10 +256,6 @@ limitations under the License.
 
 .mx_InviteDialog_helpText {
     margin: 0;
-
-    .mx_AccessibleButton_kind_link {
-        padding: 0;
-    }
 }
 
 .mx_InviteDialog_dialPad {

--- a/res/css/views/dialogs/_RoomSettingsDialogBridges.scss
+++ b/res/css/views/dialogs/_RoomSettingsDialogBridges.scss
@@ -17,12 +17,6 @@ limitations under the License.
 .mx_RoomSettingsDialog_BridgeList {
     padding: 0;
 
-    .mx_AccessibleButton {
-        display: inline;
-        margin: 0;
-        padding: 0;
-    }
-
     li {
         list-style-type: none;
 

--- a/res/css/views/dialogs/_ServerOfflineDialog.scss
+++ b/res/css/views/dialogs/_ServerOfflineDialog.scss
@@ -63,7 +63,6 @@ limitations under the License.
 
                     .mx_AccessibleButton {
                         float: right;
-                        padding: 0;
                     }
                 }
             }

--- a/res/css/views/dialogs/_SpotlightDialog.scss
+++ b/res/css/views/dialogs/_SpotlightDialog.scss
@@ -410,7 +410,6 @@ limitations under the License.
         }
 
         .mx_SpotlightDialog_recentSearches > h4 > .mx_AccessibleButton_kind_link {
-            padding: 0;
             float: right;
             font-size: $font-12px;
             line-height: $font-15px;
@@ -468,10 +467,6 @@ limitations under the License.
 
         > span {
             align-self: center;
-
-            .mx_AccessibleButton_kind_link_inline {
-                padding: 0;
-            }
         }
 
         .mx_AccessibleButton_kind_primary_outline {

--- a/res/css/views/elements/_AccessibleButton.scss
+++ b/res/css/views/elements/_AccessibleButton.scss
@@ -137,15 +137,11 @@ limitations under the License.
         font-size: inherit;
         font-weight: normal;
         line-height: inherit;
-    }
-
-    &.mx_AccessibleButton_kind_link {
         padding: 0;
     }
 
     &.mx_AccessibleButton_kind_link_inline {
         display: inline;
-        padding: 0 2px;
     }
 
     &.mx_AccessibleButton_kind_confirm_sm,

--- a/res/css/views/elements/_ReplyChain.scss
+++ b/res/css/views/elements/_ReplyChain.scss
@@ -22,7 +22,6 @@ limitations under the License.
 
     .mx_ReplyChain_show {
         &.mx_AccessibleButton_kind_link_inline {
-            padding: 0;
             color: unset;
             white-space: nowrap; // Enforce 'In reply to' to be a single line
 

--- a/res/css/views/elements/_ServerPicker.scss
+++ b/res/css/views/elements/_ServerPicker.scss
@@ -69,8 +69,6 @@ limitations under the License.
     }
 
     .mx_ServerPicker_change {
-        padding: 0;
-        font-size: inherit;
         grid-column: 2;
         grid-row: 2;
     }

--- a/res/css/views/messages/_ViewSourceEvent.scss
+++ b/res/css/views/messages/_ViewSourceEvent.scss
@@ -36,7 +36,6 @@ limitations under the License.
         visibility: hidden;
         // override styles from AccessibleButton
         border-radius: 0;
-        padding: 0;
         // icon
         mask-repeat: no-repeat;
         mask-position: 0 center;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -643,10 +643,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_AccessibleButton {
             color: $primary-content;
             text-decoration: underline;
-
-            &.mx_AccessibleButton_kind_link_inline {
-                padding: 0;
-            }
         }
     }
 }

--- a/res/css/views/rooms/_RoomPreviewCard.scss
+++ b/res/css/views/rooms/_RoomPreviewCard.scss
@@ -33,13 +33,6 @@ limitations under the License.
         position: relative;
         padding-left: calc(20px + $spacing-8);
 
-        .mx_AccessibleButton_kind_link {
-            display: inline;
-            padding: 0;
-            font-size: inherit;
-            line-height: inherit;
-        }
-
         &::before {
             content: "";
             position: absolute;

--- a/res/css/views/settings/_JoinRuleSettings.scss
+++ b/res/css/views/settings/_JoinRuleSettings.scss
@@ -81,8 +81,3 @@ limitations under the License.
         }
     }
 }
-
-.mx_JoinRuleSettings_linkButton {
-    padding: 0;
-    font-size: inherit;
-}

--- a/res/css/views/settings/_UpdateCheckButton.scss
+++ b/res/css/views/settings/_UpdateCheckButton.scss
@@ -16,8 +16,4 @@ limitations under the License.
 
 .mx_UpdateCheckButton_summary {
     margin-left: 16px;
-
-    .mx_AccessibleButton_kind_link {
-        padding: 0;
-    }
 }

--- a/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SecurityUserSettingsTab.scss
@@ -32,7 +32,6 @@ limitations under the License.
     }
     .mx_SettingsTab_section {
         .mx_AccessibleButton_kind_link {
-            padding: 0;
             font-size: inherit;
         }
     }

--- a/res/css/views/toasts/_NonUrgentEchoFailureToast.scss
+++ b/res/css/views/toasts/_NonUrgentEchoFailureToast.scss
@@ -30,8 +30,4 @@ limitations under the License.
     span { // includes the i18n block
         vertical-align: middle;
     }
-
-    .mx_AccessibleButton {
-        padding: 0;
-    }
 }

--- a/res/css/views/voip/_CallView.scss
+++ b/res/css/views/voip/_CallView.scss
@@ -127,10 +127,6 @@ limitations under the License.
                     width: 30px;
                     height: 30px;
                 }
-
-                .mx_AccessibleButton_hasKind {
-                    padding: 0px;
-                }
             }
         }
     }

--- a/src/async-components/views/dialogs/security/CreateKeyBackupDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateKeyBackupDialog.tsx
@@ -305,11 +305,9 @@ export default class CreateKeyBackupDialog extends React.PureComponent<IProps, I
         if (matchText) {
             passPhraseMatch = <div className="mx_CreateKeyBackupDialog_passPhraseMatch">
                 <div>{ matchText }</div>
-                <div>
-                    <AccessibleButton element="span" className="mx_linkButton" onClick={this.onSetAgainClick}>
-                        { changeText }
-                    </AccessibleButton>
-                </div>
+                <AccessibleButton kind="link" onClick={this.onSetAgainClick}>
+                    { changeText }
+                </AccessibleButton>
             </div>;
         }
         return <form onSubmit={this.onPassPhraseConfirmNextClick}>

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -656,11 +656,9 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
         if (matchText) {
             passPhraseMatch = <div>
                 <div>{ matchText }</div>
-                <div>
-                    <AccessibleButton element="span" className="mx_linkButton" onClick={this.onSetAgainClick}>
-                        { changeText }
-                    </AccessibleButton>
-                </div>
+                <AccessibleButton kind="link" onClick={this.onSetAgainClick}>
+                    { changeText }
+                </AccessibleButton>
             </div>;
         }
         return <form onSubmit={this.onPassPhraseConfirmNextClick}>

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -276,14 +276,14 @@ export default class UserMenu extends React.Component<IProps, IState> {
                 <div className="mx_UserMenu_contextMenu_header mx_UserMenu_contextMenu_guestPrompts">
                     { _t("Got an account? <a>Sign in</a>", {}, {
                         a: sub => (
-                            <AccessibleButton kind="link" onClick={this.onSignInClick}>
+                            <AccessibleButton kind="link_inline" onClick={this.onSignInClick}>
                                 { sub }
                             </AccessibleButton>
                         ),
                     }) }
                     { _t("New here? <a>Create an account</a>", {}, {
                         a: sub => (
-                            <AccessibleButton kind="link" onClick={this.onRegisterClick}>
+                            <AccessibleButton kind="link_inline" onClick={this.onRegisterClick}>
                                 { sub }
                             </AccessibleButton>
                         ),

--- a/src/components/structures/auth/ForgotPassword.tsx
+++ b/src/components/structures/auth/ForgotPassword.tsx
@@ -368,7 +368,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
                     value={_t('Send Reset Email')}
                 />
             </form>
-            <AccessibleButton kind='link_inline' className="mx_AuthBody_changeFlow" onClick={this.onLoginClick}>
+            <AccessibleButton kind='link' className="mx_AuthBody_changeFlow" onClick={this.onLoginClick}>
                 { _t('Sign in instead') }
             </AccessibleButton>
         </div>;

--- a/src/components/structures/auth/Registration.tsx
+++ b/src/components/structures/auth/Registration.tsx
@@ -580,7 +580,7 @@ export default class Registration extends React.Component<IProps, IState> {
         let goBack;
         if (this.state.doingUIAuth) {
             goBack = <AccessibleButton
-                kind='link_inline'
+                kind='link'
                 className="mx_AuthBody_changeFlow"
                 onClick={this.onGoToFormClicked}
             >
@@ -601,8 +601,7 @@ export default class Registration extends React.Component<IProps, IState> {
                         },
                     ) }</p>
                     <p><AccessibleButton
-                        element="span"
-                        className="mx_linkButton"
+                        kind="link_inline"
                         onClick={async event => {
                             const sessionLoaded = await this.onLoginClickWithCheck(event);
                             if (sessionLoaded) {
@@ -620,8 +619,7 @@ export default class Registration extends React.Component<IProps, IState> {
                     "<a>Log in</a> to your new account.", {},
                     {
                         a: (sub) => <AccessibleButton
-                            element="span"
-                            className="mx_linkButton"
+                            kind="link_inline"
                             onClick={async event => {
                                 const sessionLoaded = await this.onLoginClickWithCheck(event);
                                 if (sessionLoaded) {

--- a/src/components/views/auth/InteractiveAuthEntryComponents.tsx
+++ b/src/components/views/auth/InteractiveAuthEntryComponents.tsx
@@ -865,7 +865,7 @@ export class FallbackAuthEntry extends React.Component<IAuthEntryProps> {
         }
         return (
             <div>
-                <AccessibleButton kind='link_inline' inputRef={this.fallbackButton} onClick={this.onShowFallbackClick}>{
+                <AccessibleButton kind='link' inputRef={this.fallbackButton} onClick={this.onShowFallbackClick}>{
                     _t("Start authentication")
                 }</AccessibleButton>
                 { errorSection }

--- a/src/components/views/dialogs/BetaFeedbackDialog.tsx
+++ b/src/components/views/dialogs/BetaFeedbackDialog.tsx
@@ -44,7 +44,7 @@ const BetaFeedbackDialog: React.FC<IProps> = ({ featureId, onFinished }) => {
         }))}
     >
         <AccessibleButton
-            kind="link"
+            kind="link_inline"
             onClick={() => {
                 onFinished(false);
                 defaultDispatcher.dispatch({

--- a/src/components/views/dialogs/FeedbackDialog.tsx
+++ b/src/components/views/dialogs/FeedbackDialog.tsx
@@ -102,7 +102,7 @@ const FeedbackDialog: React.FC<IProps> = (props: IProps) => {
                 _t("PRO TIP: If you start a bug, please submit <debugLogsLink>debug logs</debugLogsLink> " +
                     "to help us track down the problem.", {}, {
                     debugLogsLink: sub => (
-                        <AccessibleButton kind="link" onClick={onDebugLogsLinkClick}>{ sub }</AccessibleButton>
+                        <AccessibleButton kind="link_inline" onClick={onDebugLogsLinkClick}>{ sub }</AccessibleButton>
                     ),
                 })
             }</p>

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -328,8 +328,8 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
                 <p>{ _t(
                     "Enter your Security Phrase or <button>use your Security Key</button> to continue.", {},
                     {
-                        button: s => <AccessibleButton className="mx_linkButton"
-                            element="span"
+                        button: s => <AccessibleButton
+                            kind="link_inline"
                             onClick={this.onUseRecoveryKeyClick}
                         >
                             { s }

--- a/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
+++ b/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
@@ -408,15 +408,13 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                     {},
                     {
                         button1: s => <AccessibleButton
-                            className="mx_linkButton"
-                            element="span"
+                            kind="link_inline"
                             onClick={this.onUseRecoveryKeyClick}
                         >
                             { s }
                         </AccessibleButton>,
                         button2: s => <AccessibleButton
-                            className="mx_linkButton"
-                            element="span"
+                            kind="link_inline"
                             onClick={this.onResetRecoveryClick}
                         >
                             { s }
@@ -470,8 +468,8 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                     "<button>set up new recovery options</button>",
                     {},
                     {
-                        button: s => <AccessibleButton className="mx_linkButton"
-                            element="span"
+                        button: s => <AccessibleButton
+                            kind="link_inline"
                             onClick={this.onResetRecoveryClick}
                         >
                             { s }

--- a/src/components/views/messages/TileErrorBoundary.tsx
+++ b/src/components/views/messages/TileErrorBoundary.tsx
@@ -76,14 +76,14 @@ export default class TileErrorBoundary extends React.Component<IProps, IState> {
 
             let submitLogsButton;
             if (SdkConfig.get().bug_report_endpoint_url) {
-                submitLogsButton = <AccessibleButton kind="link_inline" onClick={this.onBugReport}>
+                submitLogsButton = <AccessibleButton kind="link" onClick={this.onBugReport}>
                     { _t("Submit logs") }
                 </AccessibleButton>;
             }
 
             let viewSourceButton;
             if (mxEvent && SettingsStore.getValue("developerMode")) {
-                viewSourceButton = <AccessibleButton onClick={this.onViewSource} kind="link_inline">
+                viewSourceButton = <AccessibleButton onClick={this.onViewSource} kind="link">
                     { _t("View Source") }
                 </AccessibleButton>;
             }

--- a/src/components/views/messages/ViewSourceEvent.tsx
+++ b/src/components/views/messages/ViewSourceEvent.tsx
@@ -76,7 +76,7 @@ export default class ViewSourceEvent extends React.PureComponent<IProps, IState>
         return <span className={classes}>
             { content }
             <AccessibleButton
-                kind='link_inline'
+                kind='link'
                 title={_t('toggle event')}
                 className="mx_ViewSourceEvent_toggle"
                 onClick={this.onToggle}

--- a/src/components/views/rooms/NewRoomIntro.tsx
+++ b/src/components/views/rooms/NewRoomIntro.tsx
@@ -99,14 +99,14 @@ const NewRoomIntro = () => {
         let topicText;
         if (canAddTopic && topic) {
             topicText = _t("Topic: %(topic)s (<a>edit</a>)", { topic }, {
-                a: sub => <AccessibleButton kind="link" onClick={onTopicClick}>{ sub }</AccessibleButton>,
+                a: sub => <AccessibleButton kind="link_inline" onClick={onTopicClick}>{ sub }</AccessibleButton>,
             });
         } else if (topic) {
             topicText = _t("Topic: %(topic)s ", { topic });
         } else if (canAddTopic) {
             topicText = _t("<a>Add a topic</a> to help people know what it is about.", {}, {
                 a: sub => <AccessibleButton
-                    kind="link"
+                    kind="link_inline"
                     element="span"
                     onClick={onTopicClick}
                 >{ sub }</AccessibleButton>,

--- a/src/components/views/rooms/NewRoomIntro.tsx
+++ b/src/components/views/rooms/NewRoomIntro.tsx
@@ -105,11 +105,7 @@ const NewRoomIntro = () => {
             topicText = _t("Topic: %(topic)s ", { topic });
         } else if (canAddTopic) {
             topicText = _t("<a>Add a topic</a> to help people know what it is about.", {}, {
-                a: sub => <AccessibleButton
-                    kind="link_inline"
-                    element="span"
-                    onClick={onTopicClick}
-                >{ sub }</AccessibleButton>,
+                a: sub => <AccessibleButton kind="link_inline" onClick={onTopicClick}>{ sub }</AccessibleButton>,
             });
         }
 

--- a/src/components/views/settings/JoinRuleSettings.tsx
+++ b/src/components/views/settings/JoinRuleSettings.tsx
@@ -163,8 +163,7 @@ const JoinRuleSettings = ({ room, promptUpgrade, aliasWarning, onError, beforeCh
                         a: sub => <AccessibleButton
                             disabled={disabled}
                             onClick={onEditRestrictedClick}
-                            kind="link"
-                            className="mx_JoinRuleSettings_linkButton"
+                            kind="link_inline"
                         >
                             { sub }
                         </AccessibleButton>,

--- a/src/components/views/settings/UpdateCheckButton.tsx
+++ b/src/components/views/settings/UpdateCheckButton.tsx
@@ -42,7 +42,7 @@ function getStatusText(status: UpdateCheckStatus, errorDetail?: string) {
             return _t('Downloading update...');
         case UpdateCheckStatus.Ready:
             return _t("New version available. <a>Update now.</a>", {}, {
-                a: sub => <AccessibleButton kind="link" onClick={installUpdate}>{ sub }</AccessibleButton>,
+                a: sub => <AccessibleButton kind="link_inline" onClick={installUpdate}>{ sub }</AccessibleButton>,
             });
     }
 }

--- a/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
@@ -196,7 +196,10 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     { _t("Default") }
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notifications as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton
+                                                kind="link_inline"
+                                                onClick={this.onOpenSettingsClick}
+                                            >
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }
@@ -219,7 +222,10 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notified only with mentions and keywords " +
                                             "as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton
+                                                kind="link_inline"
+                                                onClick={this.onOpenSettingsClick}
+                                            >
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -162,7 +162,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                     <span className="mx_SettingsTab_subheading">{ _t("Keyboard shortcuts") }</span>
                     <div className="mx_SettingsFlag">
                         { _t("To view all keyboard shortcuts, <a>click here</a>.", {}, {
-                            a: sub => <AccessibleButton kind="link" onClick={this.onKeyboardShortcutsClicked}>
+                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onKeyboardShortcutsClicked}>
                                 { sub }
                             </AccessibleButton>,
                         }) }

--- a/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -106,7 +106,7 @@ export const SpaceFeedbackPrompt = ({ onClick }: { onClick?: () => void }) => {
     return <div className="mx_SpaceFeedbackPrompt">
         <span className="mx_SpaceFeedbackPrompt_text">{ _t("Spaces are a new feature.") }</span>
         <AccessibleButton
-            kind="link"
+            kind="link_inline"
             onClick={() => {
                 if (onClick) onClick();
                 Modal.createDialog(GenericFeatureFeedbackDialog, {

--- a/src/components/views/toasts/NonUrgentEchoFailureToast.tsx
+++ b/src/components/views/toasts/NonUrgentEchoFailureToast.tsx
@@ -32,7 +32,7 @@ export default class NonUrgentEchoFailureToast extends React.PureComponent {
                 <span className="mx_NonUrgentEchoFailureToast_icon" />
                 { _t("Your server isn't responding to some <a>requests</a>.", {}, {
                     'a': (sub) => (
-                        <AccessibleButton kind="link" onClick={this.openDialog}>{ sub }</AccessibleButton>
+                        <AccessibleButton kind="link_inline" onClick={this.openDialog}>{ sub }</AccessibleButton>
                     ),
                 }) }
             </div>

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -484,7 +484,7 @@ export default class CallView extends React.Component<IProps, IState> {
                             transferee: transfereeName,
                         },
                         {
-                            a: sub => <AccessibleButton kind="link" onClick={this.onTransferClick}>
+                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onTransferClick}>
                                 { sub }
                             </AccessibleButton>,
                         },
@@ -499,7 +499,7 @@ export default class CallView extends React.Component<IProps, IState> {
                             : _td("You held the call <a>Resume</a>"),
                         {},
                         {
-                            a: sub => <AccessibleButton kind="link" onClick={this.onCallResumeClick}>
+                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onCallResumeClick}>
                                 { sub }
                             </AccessibleButton>,
                         },

--- a/src/toasts/AnalyticsToast.tsx
+++ b/src/toasts/AnalyticsToast.tsx
@@ -109,7 +109,7 @@ export const showToast = (): void => {
         // The user had no analytics setting previously set, so we just need to prompt to opt-in, rather than
         // explaining any change.
         const learnMoreLink = (sub: string) => (
-            <AccessibleButton kind="link" onClick={onLearnMoreNoOptIn}>{ sub }</AccessibleButton>
+            <AccessibleButton kind="link_inline" onClick={onLearnMoreNoOptIn}>{ sub }</AccessibleButton>
         );
         props = {
             description: _t(


### PR DESCRIPTION
This PR:

- Remove the default spacing setting from the inline link button
- Replace `kind="link_inline"` of link buttons not embedded in a sentence with `kind="link"`. If spacing is required from the design viewpoint, the link button should be styled individually.

Inline link buttons should not have padding around them by default, as there are languages which do not have the concept of white space characters in a sentence to begin with, Chinese and Japanese for example. It should be decided by translators whether a inline link button needs spacing or not.

Review per commits is recommended.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task



<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->
















<!-- Replace -->
Preview: https://pr8238--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
