### PR TITLE
Fix bubble layout in thread view

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -954,7 +954,6 @@ $threadInfoLineHeight: calc(2 * $font-12px);
     .mx_EventTile {
         display: flex;
         flex-direction: column;
-        padding-top: 14px; // due to layout differences, this odd number matches the 18px padding-top of main tl events
 
         .mx_EventTile_line {
             padding-left: 0;
@@ -970,6 +969,10 @@ $threadInfoLineHeight: calc(2 * $font-12px);
             padding-left: 0;
             padding-right: 0;
         }
+    }
+
+    .mx_EventTile:not([data-layout=bubble]) {
+        padding-top: 14px; // due to layout differences, this odd number matches the 18px padding-top of main tl events
     }
 
     .mx_EventTile[data-layout=bubble] {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21689

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

Currently:
![before](https://user-images.githubusercontent.com/3362943/162158446-4465521f-9433-41b7-8912-1b19bf4a6331.png)

Yellow: margin
Purple: padding

With this PR:

On the bubble layout:
![after1](https://user-images.githubusercontent.com/3362943/162158410-3b172287-6899-426b-a607-4478c8c3ea58.png)
![after2](https://user-images.githubusercontent.com/3362943/162158431-bf969ba9-f30d-4bd9-8285-eed99be56bc3.png)

On the modern layout:
![after](https://user-images.githubusercontent.com/3362943/162167073-13fecbce-ffe0-484b-84c4-8d63b00f94b0.png)

The lines inside the thread view is to show `padding-top: 0 !important`.

There are several ways to remove the padding, but I guess this way should be consistent with other rules.

type: defect

Notes: none
element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8249--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
