### PR TITLE
Replace "link" with "link_inline" for inline link buttons

### DIFF
--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -365,14 +365,14 @@ export default class UserMenu extends React.Component<IProps, IState> {
                 <div className="mx_UserMenu_contextMenu_header mx_UserMenu_contextMenu_guestPrompts">
                     { _t("Got an account? <a>Sign in</a>", {}, {
                         a: sub => (
-                            <AccessibleButton kind="link" onClick={this.onSignInClick}>
+                            <AccessibleButton kind="link_inline" onClick={this.onSignInClick}>
                                 { sub }
                             </AccessibleButton>
                         ),
                     }) }
                     { _t("New here? <a>Create an account</a>", {}, {
                         a: sub => (
-                            <AccessibleButton kind="link" onClick={this.onRegisterClick}>
+                            <AccessibleButton kind="link_inline" onClick={this.onRegisterClick}>
                                 { sub }
                             </AccessibleButton>
                         ),

--- a/src/components/views/dialogs/BetaFeedbackDialog.tsx
+++ b/src/components/views/dialogs/BetaFeedbackDialog.tsx
@@ -44,7 +44,7 @@ const BetaFeedbackDialog: React.FC<IProps> = ({ featureId, onFinished }) => {
         }))}
     >
         <AccessibleButton
-            kind="link"
+            kind="link_inline"
             onClick={() => {
                 onFinished(false);
                 defaultDispatcher.dispatch({

--- a/src/components/views/dialogs/FeedbackDialog.tsx
+++ b/src/components/views/dialogs/FeedbackDialog.tsx
@@ -102,7 +102,7 @@ const FeedbackDialog: React.FC<IProps> = (props: IProps) => {
                 _t("PRO TIP: If you start a bug, please submit <debugLogsLink>debug logs</debugLogsLink> " +
                     "to help us track down the problem.", {}, {
                     debugLogsLink: sub => (
-                        <AccessibleButton kind="link" onClick={onDebugLogsLinkClick}>{ sub }</AccessibleButton>
+                        <AccessibleButton kind="link_inline" onClick={onDebugLogsLinkClick}>{ sub }</AccessibleButton>
                     ),
                 })
             }</p>

--- a/src/components/views/rooms/NewRoomIntro.tsx
+++ b/src/components/views/rooms/NewRoomIntro.tsx
@@ -100,14 +100,14 @@ const NewRoomIntro = () => {
         let topicText;
         if (canAddTopic && topic) {
             topicText = _t("Topic: %(topic)s (<a>edit</a>)", { topic }, {
-                a: sub => <AccessibleButton kind="link" onClick={onTopicClick}>{ sub }</AccessibleButton>,
+                a: sub => <AccessibleButton kind="link_inline" onClick={onTopicClick}>{ sub }</AccessibleButton>,
             });
         } else if (topic) {
             topicText = _t("Topic: %(topic)s ", { topic });
         } else if (canAddTopic) {
             topicText = _t("<a>Add a topic</a> to help people know what it is about.", {}, {
                 a: sub => <AccessibleButton
-                    kind="link"
+                    kind="link_inline"
                     element="span"
                     onClick={onTopicClick}
                 >{ sub }</AccessibleButton>,

--- a/src/components/views/settings/JoinRuleSettings.tsx
+++ b/src/components/views/settings/JoinRuleSettings.tsx
@@ -163,7 +163,7 @@ const JoinRuleSettings = ({ room, promptUpgrade, aliasWarning, onError, beforeCh
                         a: sub => <AccessibleButton
                             disabled={disabled}
                             onClick={onEditRestrictedClick}
-                            kind="link"
+                            kind="link_inline"
                             className="mx_JoinRuleSettings_linkButton"
                         >
                             { sub }

--- a/src/components/views/settings/UpdateCheckButton.tsx
+++ b/src/components/views/settings/UpdateCheckButton.tsx
@@ -42,7 +42,7 @@ function getStatusText(status: UpdateCheckStatus, errorDetail?: string) {
             return _t('Downloading update...');
         case UpdateCheckStatus.Ready:
             return _t("New version available. <a>Update now.</a>", {}, {
-                a: sub => <AccessibleButton kind="link" onClick={installUpdate}>{ sub }</AccessibleButton>,
+                a: sub => <AccessibleButton kind="link_inline" onClick={installUpdate}>{ sub }</AccessibleButton>,
             });
     }
 }

--- a/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
@@ -195,7 +195,7 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     { _t("Default") }
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notifications as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onOpenSettingsClick}>
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }
@@ -218,7 +218,7 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notified only with mentions and keywords " +
                                             "as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onOpenSettingsClick}>
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }

--- a/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
@@ -195,7 +195,10 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     { _t("Default") }
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notifications as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton
+                                                kind="link_inline"
+                                                onClick={this.onOpenSettingsClick}
+                                            >
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }
@@ -218,7 +221,10 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
                                     <div className="mx_NotificationSettingsTab_microCopy">
                                         { _t("Get notified only with mentions and keywords " +
                                             "as set up in your <a>settings</a>", {}, {
-                                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onOpenSettingsClick}>
+                                            a: sub => <AccessibleButton
+                                                kind="link_inline"
+                                                onClick={this.onOpenSettingsClick}
+                                            >
                                                 { sub }
                                             </AccessibleButton>,
                                         }) }

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -265,7 +265,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                     <span className="mx_SettingsTab_subheading">{ _t("Keyboard shortcuts") }</span>
                     <div className="mx_SettingsFlag">
                         { _t("To view all keyboard shortcuts, <a>click here</a>.", {}, {
-                            a: sub => <AccessibleButton kind="link" onClick={this.onKeyboardShortcutsClicked}>
+                            a: sub => <AccessibleButton kind="link_inline" onClick={this.onKeyboardShortcutsClicked}>
                                 { sub }
                             </AccessibleButton>,
                         }) }

--- a/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -106,7 +106,7 @@ export const SpaceFeedbackPrompt = ({ onClick }: { onClick?: () => void }) => {
     return <div className="mx_SpaceFeedbackPrompt">
         <span className="mx_SpaceFeedbackPrompt_text">{ _t("Spaces are a new feature.") }</span>
         <AccessibleButton
-            kind="link"
+            kind="link_inline"
             onClick={() => {
                 if (onClick) onClick();
                 Modal.createTrackedDialog("Spaces Feedback", "", GenericFeatureFeedbackDialog, {

--- a/src/components/views/toasts/NonUrgentEchoFailureToast.tsx
+++ b/src/components/views/toasts/NonUrgentEchoFailureToast.tsx
@@ -32,7 +32,7 @@ export default class NonUrgentEchoFailureToast extends React.PureComponent {
                 <span className="mx_NonUrgentEchoFailureToast_icon" />
                 { _t("Your server isn't responding to some <a>requests</a>.", {}, {
                     'a': (sub) => (
-                        <AccessibleButton kind="link" onClick={this.openDialog}>{ sub }</AccessibleButton>
+                        <AccessibleButton kind="link_inline" onClick={this.openDialog}>{ sub }</AccessibleButton>
                     ),
                 }) }
             </div>

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -429,7 +429,7 @@ export default class CallView extends React.Component<IProps, IState> {
                         transferee: transfereeName,
                     },
                     {
-                        a: sub => <AccessibleButton kind="link" onClick={this.onTransferClick}>
+                        a: sub => <AccessibleButton kind="link_inline" onClick={this.onTransferClick}>
                             { sub }
                         </AccessibleButton>,
                     },
@@ -441,7 +441,7 @@ export default class CallView extends React.Component<IProps, IState> {
                 const holdString = CallHandler.instance.hasAnyUnheldCall() ?
                     _td("You held the call <a>Switch</a>") : _td("You held the call <a>Resume</a>");
                 onHoldText = _t(holdString, {}, {
-                    a: sub => <AccessibleButton kind="link" onClick={this.onCallResumeClick}>
+                    a: sub => <AccessibleButton kind="link_inline" onClick={this.onCallResumeClick}>
                         { sub }
                     </AccessibleButton>,
                 });

--- a/src/toasts/AnalyticsToast.tsx
+++ b/src/toasts/AnalyticsToast.tsx
@@ -98,7 +98,7 @@ const getAnonymousDescription = (): ReactNode => {
         },
         {
             "UsageDataLink": (sub) => (
-                <AccessibleButton kind="link" onClick={onUsageDataClicked}>{ sub }</AccessibleButton>
+                <AccessibleButton kind="link_inline" onClick={onUsageDataClicked}>{ sub }</AccessibleButton>
             ),
             "PolicyLink": (sub) => cookiePolicyUrl ? (
                 <a target="_blank" href={cookiePolicyUrl}>{ sub }</a>
@@ -136,7 +136,7 @@ export const showPseudonymousAnalyticsOptInToast = (analyticsOptIn: boolean): vo
         // The user had no analytics setting previously set, so we just need to prompt to opt-in, rather than
         // explaining any change.
         const learnMoreLink = (sub) => (
-            <AccessibleButton kind="link" onClick={onLearnMoreNoOptIn}>{ sub }</AccessibleButton>
+            <AccessibleButton kind="link_inline" onClick={onLearnMoreNoOptIn}>{ sub }</AccessibleButton>
         );
         props = {
             description: _t(


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

The link buttons as inline text should have `kind="link_inline"`. If a styling rule of `.mx_AccessibleButton_kind_link` is necessary, each link button should be styled separately. 

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr8258--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
