### PR TITLE
Live location sharing - set replaces relation when stopping beacon

### DIFF
--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -20,6 +20,7 @@ import {
     BeaconIdentifier,
     BeaconEvent,
     MatrixEvent,
+    RelationType,
     Room,
     RoomMember,
     RoomState,
@@ -447,11 +448,20 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
             ...update,
         };
 
-        const updateContent = makeBeaconInfoContent(timeout,
+        const newContent = makeBeaconInfoContent(timeout,
             live,
             description,
             assetType,
-            timestamp);
+            timestamp,
+        );
+        const updateContent = {
+            ...newContent,
+            "m.new_content": newContent,
+            "m.relates_to": {
+                "rel_type": RelationType.Replace,
+                "event_id": beacon.beaconInfoId,
+            },
+        };
 
         await this.matrixClient.unstable_setLiveBeacon(beacon.roomId, updateContent);
     };

--- a/test/stores/OwnBeaconStore-test.ts
+++ b/test/stores/OwnBeaconStore-test.ts
@@ -20,6 +20,7 @@ import {
     BeaconEvent,
     getBeaconInfoIdentifier,
     MatrixEvent,
+    RelationType,
     RoomStateEvent,
     RoomMember,
 } from "matrix-js-sdk/src/matrix";
@@ -472,6 +473,14 @@ describe('OwnBeaconStore', () => {
             const expectedUpdateContent = {
                 ...prevEventContent,
                 live: false,
+                ["m.new_content"]: {
+                    ...prevEventContent,
+                    live: false,
+                },
+                ["m.relates_to"]: {
+                    event_id: alicesRoom1BeaconInfo.getId(),
+                    rel_type: RelationType.Replace,
+                },
             };
             expect(mockClient.unstable_setLiveBeacon).toHaveBeenCalledWith(
                 room1Id,
@@ -641,6 +650,14 @@ describe('OwnBeaconStore', () => {
             const expectedUpdateContent = {
                 ...prevEventContent,
                 live: false,
+                ["m.new_content"]: {
+                    ...prevEventContent,
+                    live: false,
+                },
+                ["m.relates_to"]: {
+                    event_id: alicesRoom1BeaconInfo.getId(),
+                    rel_type: RelationType.Replace,
+                },
             };
             expect(mockClient.unstable_setLiveBeacon).toHaveBeenCalledWith(
                 room1Id,
@@ -666,6 +683,14 @@ describe('OwnBeaconStore', () => {
             const expectedUpdateContent = {
                 ...prevEventContent,
                 live: false,
+                ["m.new_content"]: {
+                    ...prevEventContent,
+                    live: false,
+                },
+                ["m.relates_to"]: {
+                    event_id: alicesRoom1BeaconInfo.getId(),
+                    rel_type: RelationType.Replace,
+                },
             };
             expect(mockClient.unstable_setLiveBeacon).toHaveBeenCalledWith(
                 room1Id,


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Use a replaces relation when stopping a beacon so it can be replaced correctly in the timeline.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8266--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
