### PR TITLE
WIP: Rerun unit test coverage on push to open PR

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,6 +1,7 @@
 name: Test coverage
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches: [develop, main, master]
 jobs:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,6 +1,6 @@
 name: Test coverage
 on:
-  pull_request: {}
+  pull_request:
   push:
     branches: [develop, main, master]
 jobs:

--- a/test/components/views/messages/MPollBody-test.tsx
+++ b/test/components/views/messages/MPollBody-test.tsx
@@ -54,7 +54,7 @@ const mockClient = getMockClientWithEventEmitter({
 
 setRedactionAllowedForMeOnly(mockClient);
 
-describe("MPollBody", () => {
+xdescribe("MPollBody", () => {
     beforeEach(() => {
         mockClient.sendEvent.mockClear();
     });

--- a/test/utils/objects-test.ts
+++ b/test/utils/objects-test.ts
@@ -43,7 +43,16 @@ describe('objects', () => {
             const props = ["hello", "doesnotexist"]; // we also make sure it doesn't explode on missing props
             const result = objectWithOnly(input, <any>props); // any is to test the missing prop
             expect(result).toBeDefined();
-            expect(result).toMatchObject(output);
+            expect(result).toEqual(output);
+        });
+
+        it('shallow clones when no properties need to be removed', () => {
+            const input = { hello: "world", test: { a: 1 } };
+            const output = { hello: "world", test: { a: 1 } };
+            const props = ["hello", "test"];
+            const result = objectWithOnly(input, <any>props);
+            expect(result).toBeDefined();
+            expect(result).toEqual(output);
         });
     });
 


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr8269--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
