### PR TITLE
When selecting reply in thread on a thread response open existing thread

### DIFF
--- a/src/components/views/messages/MessageActionBar.tsx
+++ b/src/components/views/messages/MessageActionBar.tsx
@@ -232,8 +232,19 @@ export default class MessageActionBar extends React.PureComponent<IMessageAction
                 action: Action.ViewUserSettings,
                 initialTabId: UserTab.Labs,
             });
+        } else if (this.props.mxEvent.isThreadRelation) {
+            showThread({
+                rootEvent: this.props.mxEvent.getThread().rootEvent,
+                initialEvent: this.props.mxEvent,
+                scroll_into_view: true,
+                highlighted: true,
+                push: isCard,
+            });
         } else {
-            showThread({ rootEvent: this.props.mxEvent, push: isCard });
+            showThread({
+                rootEvent: this.props.mxEvent,
+                push: isCard,
+            });
         }
     };
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21743

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * When selecting reply in thread on a thread response open existing thread ([\#8291](https://github.com/matrix-org/matrix-react-sdk/pull/8291)). Fixes vector-im/element-web#21743.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8291--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
