### PR TITLE
Extract Tag to its own component

### DIFF
--- a/res/css/views/elements/_TagComposer.scss
+++ b/res/css/views/elements/_TagComposer.scss
@@ -29,7 +29,9 @@ limitations under the License.
             margin-left: 16px; // distance from <Field>
         }
 
-        .mx_Field, .mx_Field input, .mx_AccessibleButton {
+        .mx_Field,
+        .mx_Field input,
+        .mx_AccessibleButton {
             // So they look related to each other by feeling the same
             border-radius: 8px;
         }
@@ -39,39 +41,49 @@ limitations under the License.
         display: flex;
         flex-wrap: wrap;
         margin-top: 12px; // this plus 12px from the tags makes 24px from the input
+    }
 
-        .mx_TagComposer_tag {
-            padding: 6px 8px 8px 12px;
-            position: relative;
-            margin-right: 12px;
-            margin-top: 12px;
+    .mx_Tag {
+        margin-right: 12px;
+        margin-top: 12px;
+    }
+}
 
-            // Cheaty way to get an opacified variable colour background
-            &::before {
-                content: '';
-                border-radius: 20px;
-                background-color: $tertiary-content;
-                opacity: 0.15;
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
+.mx_Tag {
 
-                // Pass through the pointer otherwise we have effectively put a whole div
-                // on top of the component, which makes it hard to interact with buttons.
-                pointer-events: none;
-            }
-        }
+    font-size: $font-15px;
 
-        .mx_AccessibleButton {
-            background-image: url('$(res)/img/subtract.svg');
-            width: 16px;
-            height: 16px;
-            margin-left: 8px;
-            display: inline-block;
+    display: inline-flex;
+    align-items: center;
+
+    gap: 8px;
+    padding: 8px;
+    border-radius: 8px;
+
+    color: $primary-content;
+    background: $quinary-content;
+
+    >svg:first-child {
+        width: 1em;
+        color: $secondary-content;
+        transform: scale(1.25);
+        transform-origin: center;
+    }
+
+    .mx_Tag_delete {
+        border-radius: 50%;
+        text-align: center;
+        width: 1.066666em; // 16px;
+        height: 1.066666em;
+        line-height: 1em;
+        color: $secondary-content;
+        background: $system;
+        position: relative;
+
+        &::before {
+            content: "✕";
+            font-size: 0.7em;
             vertical-align: middle;
-            cursor: pointer;
         }
     }
 }

--- a/res/css/views/elements/_TagComposer.scss
+++ b/res/css/views/elements/_TagComposer.scss
@@ -80,9 +80,8 @@ limitations under the License.
         background: $system;
         position: relative;
 
-        &::before {
-            content: "✕";
-            font-size: 0.7em;
+        svg {
+            width: .5em;
             vertical-align: middle;
         }
     }

--- a/src/components/views/elements/Tag.tsx
+++ b/src/components/views/elements/Tag.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from "react";
 
 import AccessibleButton from "./AccessibleButton";
+import { Icon as CancelRounded } from "../../../../res/img/element-icons/cancel-rounded.svg";
 
 interface IProps {
     icon?: () => JSX.Element;
@@ -35,7 +36,9 @@ export const Tag = ({
         { icon?.() }
         { label }
         { onDeleteClick && (
-            <AccessibleButton className="mx_Tag_delete" onClick={onDeleteClick} disabled={disabled} />
+            <AccessibleButton className="mx_Tag_delete" onClick={onDeleteClick} disabled={disabled}>
+                <CancelRounded />
+            </AccessibleButton>
         ) }
     </div>;
 };

--- a/src/components/views/elements/Tag.tsx
+++ b/src/components/views/elements/Tag.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+
+import AccessibleButton from "./AccessibleButton";
+
+interface IProps {
+    icon?: () => JSX.Element;
+    label: string;
+    onDeleteClick?: () => void;
+    disabled?: boolean;
+}
+
+export const Tag = ({
+    icon,
+    label,
+    onDeleteClick,
+    disabled = false,
+}: IProps) => {
+    return <div className='mx_Tag'>
+        { icon?.() }
+        { label }
+        { onDeleteClick && (
+            <AccessibleButton className="mx_Tag_delete" onClick={onDeleteClick} disabled={disabled} />
+        ) }
+    </div>;
+};

--- a/src/components/views/elements/TagComposer.tsx
+++ b/src/components/views/elements/TagComposer.tsx
@@ -19,6 +19,7 @@ import React, { ChangeEvent, FormEvent } from "react";
 import Field from "./Field";
 import { _t } from "../../../languageHandler";
 import AccessibleButton from "./AccessibleButton";
+import { Tag } from "./Tag";
 
 interface IProps {
     tags: string[];
@@ -80,10 +81,13 @@ export default class TagComposer extends React.PureComponent<IProps, IState> {
                 </AccessibleButton>
             </form>
             <div className='mx_TagComposer_tags'>
-                { this.props.tags.map((t, i) => (<div className='mx_TagComposer_tag' key={i}>
-                    <span>{ t }</span>
-                    <AccessibleButton onClick={this.onRemove.bind(this, t)} disabled={this.props.disabled} />
-                </div>)) }
+                { this.props.tags.map((t, i) => (
+                    <Tag
+                        label={t}
+                        key={t}
+                        onDeleteClick={this.onRemove.bind(this, t)}
+                        disabled={this.props.disabled} />
+                )) }
             </div>
         </div>;
     }


### PR DESCRIPTION
In preparation for https://github.com/vector-im/element-web/issues/21354

This extracts `Tag` to its own component and consolidates the implementation to match the [Figma design](https://www.figma.com/file/X7PvFE7f73mI7pJ9WLM61l/%5BWeb%5D-%5BSearch%5D?node-id=248%3A21139)

The screenshots below have been extracted from the "Notifications" section of the settings, and is currently the only place where those are used

### 💅 After 
<img width="315" alt="Screen Shot 2022-04-13 at 15 24 45" src="https://user-images.githubusercontent.com/769871/163203502-31f1e31f-0ab2-4f11-919a-1499e2e2e8e5.png">

### 🏚 Before
<img width="536" alt="Screen Shot 2022-04-13 at 15 25 02" src="https://user-images.githubusercontent.com/769871/163203509-04f153cb-6eb6-41d5-afcd-2e15eb8e9a90.png">


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8309--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
