### PR TITLE
Align media and reactions row on thread panel

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -55,14 +55,19 @@ limitations under the License.
         margin-right: 0;
     }
 
-    .mx_EventTile:not([data-layout="bubble"]) .mx_EventTile_line {
-        padding-left: 36px;
-        padding-right: 36px;
-    }
+    .mx_EventTile:not([data-layout="bubble"]) {
+        .mx_EventTile_line {
+            padding-left: 36px;
+            padding-right: 36px;
+        }
 
-    .mx_EventTile:not([data-layout="bubble"]) .mx_ReactionsRow {
-        padding-left: 36px;
-        padding-right: 36px;
+        .mx_ReactionsRow {
+            padding: 0;
+
+            // See margin setting of ReactionsRow on _EventTile.scss
+            margin-left: 36px;
+            margin-right: 8px;
+        }
     }
 
     .mx_EventTile:not([data-layout="bubble"]) .mx_ThreadInfo {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1012,7 +1012,8 @@ $threadInfoLineHeight: calc(2 * $font-12px);
         .mx_RedactedBody,
         .mx_UnknownBody,
         .mx_MPollBody,
-        .mx_ReplyChain_wrapper {
+        .mx_ReplyChain_wrapper,
+        .mx_ReactionsRow {
             margin-left: 48px;
             margin-right: 8px;
 
@@ -1022,11 +1023,6 @@ $threadInfoLineHeight: calc(2 * $font-12px);
             .mx_MImageBody {
                 margin: 0;
             }
-        }
-
-        .mx_ReactionsRow {
-            margin-left: 36px;
-            margin-right: 8px;
         }
 
         .mx_MessageTimestamp {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1005,6 +1005,7 @@ $threadInfoLineHeight: calc(2 * $font-12px);
     }
 
     .mx_EventTile[data-layout=group] {
+        $spacing-start: 48px;
         width: 100%;
 
         .mx_EventTile_content,
@@ -1014,7 +1015,7 @@ $threadInfoLineHeight: calc(2 * $font-12px);
         .mx_MPollBody,
         .mx_ReplyChain_wrapper,
         .mx_ReactionsRow {
-            margin-left: 48px;
+            margin-left: $spacing-start;
             margin-right: 8px;
 
             .mx_EventTile_content,
@@ -1048,10 +1049,14 @@ $threadInfoLineHeight: calc(2 * $font-12px);
                 }
             }
         }
+
+        .mx_EventTile_mediaLine {
+            padding-inline-start: $spacing-start;
+        }
     }
 
     .mx_EventTile_mediaLine {
-        padding-left: 36px !important;
+        padding-left: 36px;
         padding-right: 50px;
 
         .mx_MImageBody {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21780

Steps to confirm the fix:
1. Change the layout to the modern layout
2. Send a message in a room
3. Reply in thread
4. Send a test image
5. Send a couple of reactions
6. Check that the image and the reactions row are aligned

![after](https://user-images.githubusercontent.com/3362943/163263662-f32cc4d8-887b-42c8-b466-3eaf5b9242c5.png)


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8312--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
