### PR TITLE
Tidy style rules of TimelineCard up

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -85,6 +85,16 @@ limitations under the License.
         .mx_EventTile_msgOption {
             margin-right: 2px;
         }
+
+        &.mx_EventTile_info {
+            .mx_EventTile_line {
+                padding-left: 36px;
+            }
+
+            .mx_EventTile_avatar {
+                left: 18px;
+            }
+        }
     }
 
     .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {
@@ -110,14 +120,6 @@ limitations under the License.
 
     .mx_EventTile_readAvatars {
         top: -10px;
-    }
-
-    .mx_EventTile:not([data-layout="bubble"]).mx_EventTile_info .mx_EventTile_line {
-        padding-left: 36px;
-    }
-
-    .mx_EventTile:not([data-layout="bubble"]).mx_EventTile_info .mx_EventTile_avatar {
-        left: 18px;
     }
 
     .mx_WhoIsTypingTile {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -55,9 +55,11 @@ limitations under the License.
         margin-right: 0;
     }
 
-    .mx_EventTile:not([data-layout="bubble"]) .mx_EventTile_line {
-        padding-left: 36px;
-        padding-right: 36px;
+    .mx_EventTile:not([data-layout="bubble"]) {
+        .mx_EventTile_line {
+            padding-left: 36px;
+            padding-right: 36px;
+        }
     }
 
     .mx_EventTile:not([data-layout="bubble"]) .mx_ReactionsRow {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -65,12 +65,12 @@ limitations under the License.
             padding-left: 36px;
             padding-right: 36px;
         }
-    }
 
-    .mx_EventTile:not([data-layout="bubble"]) .mx_ThreadInfo {
-        margin-left: 36px;
-        margin-right: 0;
-        max-width: min(calc(100% - 36px), 600px);
+        .mx_ThreadInfo {
+            margin-left: 36px;
+            margin-right: 0;
+            max-width: min(calc(100% - 36px), 600px);
+        }
     }
 
     .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -97,8 +97,16 @@ limitations under the License.
         }
     }
 
-    .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {
-        margin-left: 36px;
+    .mx_GroupLayout {
+        .mx_EventTile {
+            > .mx_DisambiguatedProfile {
+                margin-left: 36px;
+            }
+
+            .mx_EventTile_line {
+                padding-bottom: 8px;
+            }
+        }
     }
 
     .mx_CallEvent_wrapper {
@@ -112,10 +120,6 @@ limitations under the License.
     .mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line,
     .mx_GenericEventListSummary:not([data-layout=bubble]) > .mx_GenericEventListSummary_unstyledList > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
         padding-left: 36px;
-    }
-
-    .mx_GroupLayout .mx_EventTile .mx_EventTile_line {
-        padding-bottom: 8px;
     }
 
     .mx_EventTile_readAvatars {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -76,6 +76,11 @@ limitations under the License.
             top: 12px;
             left: -3px;
         }
+
+        .mx_MessageTimestamp {
+            right: -4px;
+            left: auto;
+        }
     }
 
     .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {
@@ -88,11 +93,6 @@ limitations under the License.
         .mx_CallEvent {
             margin: 4px;
         }
-    }
-
-    .mx_EventTile:not([data-layout="bubble"]) .mx_MessageTimestamp {
-        right: -4px;
-        left: auto;
     }
 
     .mx_EventTile:not([data-layout="bubble"]) .mx_EventTile_msgOption {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -81,6 +81,10 @@ limitations under the License.
             right: -4px;
             left: auto;
         }
+
+        .mx_EventTile_msgOption {
+            margin-right: 2px;
+        }
     }
 
     .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {
@@ -93,10 +97,6 @@ limitations under the License.
         .mx_CallEvent {
             margin: 4px;
         }
-    }
-
-    .mx_EventTile:not([data-layout="bubble"]) .mx_EventTile_msgOption {
-        margin-right: 2px;
     }
 
     .mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line,

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -60,11 +60,11 @@ limitations under the License.
             padding-left: 36px;
             padding-right: 36px;
         }
-    }
 
-    .mx_EventTile:not([data-layout="bubble"]) .mx_ReactionsRow {
-        padding-left: 36px;
-        padding-right: 36px;
+        .mx_ReactionsRow {
+            padding-left: 36px;
+            padding-right: 36px;
+        }
     }
 
     .mx_EventTile:not([data-layout="bubble"]) .mx_ThreadInfo {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -71,15 +71,15 @@ limitations under the License.
             margin-right: 0;
             max-width: min(calc(100% - 36px), 600px);
         }
+
+        .mx_EventTile_avatar {
+            top: 12px;
+            left: -3px;
+        }
     }
 
     .mx_GroupLayout .mx_EventTile > .mx_DisambiguatedProfile {
         margin-left: 36px;
-    }
-
-    .mx_EventTile:not([data-layout="bubble"]) .mx_EventTile_avatar {
-        top: 12px;
-        left: -3px;
     }
 
     .mx_CallEvent_wrapper {


### PR DESCRIPTION
This PR organizes style rules of `_TimelineCard.scss` structurally, in order to make it easier to debug style inconsistencies between the thread timeline and chat timeline on the right panel on https://github.com/vector-im/element-web/issues/21774.

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
