### PR TITLE
clarify `/jumptodate` argument

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -321,7 +321,7 @@ export const Commands = [
     }),
     new Command({
         command: 'jumptodate',
-        args: '<date>',
+        args: '<YYYY-MM-DD>',
         description: _td('Jump to the given date in the timeline (YYYY-MM-DD)'),
         isEnabled: () => SettingsStore.getValue("feature_jump_to_date"),
         runFn: function(roomId, args) {

--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -322,7 +322,7 @@ export const Commands = [
     new Command({
         command: 'jumptodate',
         args: '<YYYY-MM-DD>',
-        description: _td('Jump to the given date in the timeline (YYYY-MM-DD)'),
+        description: _td('Jump to the given date in the timeline'),
         isEnabled: () => SettingsStore.getValue("feature_jump_to_date"),
         runFn: function(roomId, args) {
             if (args) {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -421,7 +421,7 @@
     "Sends a message as html, without interpreting it as markdown": "Sends a message as html, without interpreting it as markdown",
     "Upgrades a room to a new version": "Upgrades a room to a new version",
     "You do not have the required permissions to use this command.": "You do not have the required permissions to use this command.",
-    "Jump to the given date in the timeline (YYYY-MM-DD)": "Jump to the given date in the timeline (YYYY-MM-DD)",
+    "Jump to the given date in the timeline": "Jump to the given date in the timeline",
     "We were unable to understand the given date (%(inputDate)s). Try using the format YYYY-MM-DD.": "We were unable to understand the given date (%(inputDate)s). Try using the format YYYY-MM-DD.",
     "Changes your display nickname": "Changes your display nickname",
     "Changes your display nickname in the current room only": "Changes your display nickname in the current room only",


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

I realise that the description gives this info. However I argue that
1. obviously `jumptodate` takes a date argument
2. the specific format `YYYY-MM-DD` is clearly a date
3. other commands take an `mxc_url` argument, which they say in the `args` field instead of a more abstract concept like `picture` and explain only in the description that it wants an mxc

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
Signed-off-by: Kim Brose <kim.brose@rwth-aachen.de>

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->