### PR TITLE
Fix netlify previews

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -3,7 +3,7 @@
 name: Upload Preview Build to Netlify
 on:
     workflow_run:
-        workflows: ["Layered Preview Build"]
+        workflows: ["Element Web - Build and Test"]
         types:
             - completed
 jobs:


### PR DESCRIPTION
Update the name of the workflow in the workflow_run trigger as
it was changed when adding cypress tests.

This will upload the preview build after running the cypress tests:
unsure if this is what we want or not. The preview build will be
slower to appear, but it does sort of make sense to only get a
preview buuild if the tests pass. If not, we might be able to do
this by doing a repository dispatch after the preview build.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->