### PR TITLE
Fix rendering of hidden events

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -951,7 +951,7 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
             isLeftAlignedBubbleMessage,
             noBubbleEvent,
             isSeeingThroughMessageHiddenForModeration,
-        } = getEventDisplayInfo(this.props.mxEvent, this.shouldHideEvent());
+        } = getEventDisplayInfo(this.props.mxEvent, this.context.showHiddenEvents, this.shouldHideEvent());
         const { isQuoteExpanded } = this.state;
 
         // This shouldn't happen: the caller should check we support this type


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/8313 regressed hidden events to render like this:

![hidden](https://user-images.githubusercontent.com/48614497/163511636-8fe19d15-73a5-4433-91ae-cf7884d1ca02.png)

Type: defect

Notes: none
element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8334--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
