### PR TITLE
Fix fallback value for missing invite power level

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -942,7 +942,7 @@ function useRoomPermissions(cli: MatrixClient, room: Room, user: RoomMember): IR
         }
 
         setRoomPermissions({
-            canInvite: me.powerLevel >= (powerLevels.invite ?? 50),
+            canInvite: me.powerLevel >= (powerLevels.invite ?? 0),
             canEdit: modifyLevelMax >= 0,
             modifyLevelMax,
         });

--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -262,7 +262,7 @@ export default class RolesRoomSettingsTab extends React.Component<IProps> {
             },
             "invite": {
                 desc: _t('Invite users'),
-                defaultValue: 50,
+                defaultValue: 0,
             },
             "state_default": {
                 desc: _t('Change settings'),


### PR DESCRIPTION
The spec was recently amended to document that invites actually fall back to a default of 0, rather than 50 (since this is what Synapse was doing all along): https://github.com/matrix-org/matrix-spec/pull/1021

---

Notes: Fix a bug where the required power level for inviting somebody would be shown as 'Moderator' when in fact every regular user with power level >= 0 could send an invite.

Signed-off-by: Jonas Platte <jplatte+git@posteo.de>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr8335--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
