### PR TITLE
Fix beta indicator dot causing excessive CPU usage

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -694,6 +694,16 @@ $left-gutter: 64px;
     visibility: visible;
 }
 
+// Inverse of the above to *disable* the animation on any indicators. This approach
+// is less pretty, but is easier to target because otherwise we need to define the
+// animation for when it's shown which means duplicating the style definition in
+// multiple places.
+.mx_EventTile:not(:hover):not(.mx_EventTile_actionBarFocused):not([data-whatinput='keyboard'] :focus-within):not(.focus-visible:focus-within) {
+    .mx_MessageActionBar .mx_Indicator {
+        animation: none;
+    }
+}
+
 @media only screen and (max-width: 480px) {
 
     .mx_EventTile_line,


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21793

See diff for rationale. Sorry about your eyes when reading that style selector.

I did look at making the animation itself be lighter weight, but that doesn't seem feasible if we want to keep the same effect. 

🚨⚠ **auto-merge is enabled**

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix beta indicator dot causing excessive CPU usage ([\#8340](https://github.com/matrix-org/matrix-react-sdk/pull/8340)). Fixes vector-im/element-web#21793.<!-- CHANGELOG_PREVIEW_END -->