### PR TITLE
Avoid a reflow when setting caret position on an empty composer

### DIFF
--- a/src/editor/caret.ts
+++ b/src/editor/caret.ts
@@ -43,6 +43,8 @@ function setDocumentRangeSelection(editor: HTMLDivElement, model: EditorModel, r
 }
 
 export function setCaretPosition(editor: HTMLDivElement, model: EditorModel, caretPosition: IPosition) {
+    if (model.isEmpty) return; // selection can't possibly be wrong, so avoid a reflow
+
     const range = document.createRange();
     const { node, offset } = getNodeAndOffsetForPosition(editor, model, caretPosition);
     range.setStart(node, offset);


### PR DESCRIPTION
This saves an extra ~12 ms on each room switch, because we can.

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Avoid a reflow when setting caret position on an empty composer ([\#8348](https://github.com/matrix-org/matrix-react-sdk/pull/8348)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8348--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
