### PR TITLE
Removed share button from deleted message

### DIFF
--- a/src/components/views/messages/MessageActionBar.tsx
+++ b/src/components/views/messages/MessageActionBar.tsx
@@ -482,8 +482,11 @@ export default class MessageActionBar extends React.PureComponent<IMessageAction
         }
 
         // aria-live=off to not have this read out automatically as navigating around timeline, gets repetitive.
-        return <Toolbar className="mx_MessageActionBar" aria-label={_t("Message Actions")} aria-live="off">
-            { toolbarOpts }
-        </Toolbar>;
+        return <React.Fragment>
+                {!mxEvent.isRedacted() ? 
+                <Toolbar className="mx_MessageActionBar" aria-label={_t("Message Actions")} aria-live="off">
+                { toolbarOpts }
+                </Toolbar> : <React.Fragment/>}
+        </React.Fragment>;
     }
 }


### PR DESCRIPTION
Fixes issue---- https://github.com/vector-im/element-web/issues/21785

### **Problem**
 If a message is deleted, it stays in the chat space as deleted, also it can be shared as shown in the image below:

**Before--->**

https://user-images.githubusercontent.com/67657066/163726454-5e012030-f75f-4f67-9296-8bfcd1cbfc3a.mp4






**After--->**

https://user-images.githubusercontent.com/67657066/163726404-094c1d32-ede3-4e1c-bfd9-d069b2b01b7e.mp4



<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->