### PR TITLE
fix: use fake timers and restore mocks in MatrixClientPeg test

### DIFF
--- a/test/MatrixClientPeg-test.ts
+++ b/test/MatrixClientPeg-test.ts
@@ -17,10 +17,12 @@ limitations under the License.
 import { advanceDateAndTime, stubClient } from "./test-utils";
 import { MatrixClientPeg as peg } from "../src/MatrixClientPeg";
 
+jest.useFakeTimers();
+
 describe("MatrixClientPeg", () => {
     afterEach(() => {
         localStorage.clear();
-        advanceDateAndTime(0);
+        jest.restoreAllMocks();
     });
 
     it("setJustRegisteredUserId", () => {
@@ -32,7 +34,7 @@ describe("MatrixClientPeg", () => {
         expect(peg.userRegisteredWithinLastHours(0)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(1)).toBe(true);
         expect(peg.userRegisteredWithinLastHours(24)).toBe(true);
-        advanceDateAndTime(1 * 60 * 60 * 1000);
+        advanceDateAndTime(1 * 60 * 60 * 1000 + 1);
         expect(peg.userRegisteredWithinLastHours(0)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(1)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(24)).toBe(true);
@@ -50,7 +52,7 @@ describe("MatrixClientPeg", () => {
         expect(peg.userRegisteredWithinLastHours(0)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(1)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(24)).toBe(false);
-        advanceDateAndTime(1 * 60 * 60 * 1000);
+        advanceDateAndTime(1 * 60 * 60 * 1000 + 1);
         expect(peg.userRegisteredWithinLastHours(0)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(1)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(24)).toBe(false);


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

This test was failing for me intermittently locally.
Some other tests had failed for me and other M1 macbook users on timing issues before, and I suspect this is the same. 

The code sets a timestamp to `Date.now()`, advances time by exactly one hour and then expects `timestamp - Date.now()` to be more than 1 hour.
On CI `timestamp - Date.now()` was evaluating to a **little over** 1 hour - eg `1.0000044444444445` on CI
https://buildkite.com/matrix-dot-org/matrix-react-sdk/builds/23364#60e54e22-4fca-4801-b799-232930ce4ef3
Locally this was evaluating to exactly 1hour, or slightly under.

Changes:
- add a ms of delay to the time advance in the test, so it will reliably evaluate to > 1
- use jest's fake timers -  tests were trying to advance fake time already and causing warning
- restore mocks after each test, `advanceDateAndTime(0)` was not restoring `Date.now()` advancement to 0, meaning `Date.now()` and `new Date().getTime()` as used in the peg were out of sync.


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8356--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
