### PR TITLE
Fix RightPanelStore handling first room on app launch wrong

### DIFF
--- a/src/stores/right-panel/RightPanelStore.ts
+++ b/src/stores/right-panel/RightPanelStore.ts
@@ -34,6 +34,7 @@ import {
 import { ActionPayload } from "../../dispatcher/payloads";
 import { Action } from "../../dispatcher/actions";
 import { ActiveRoomChangedPayload } from "../../dispatcher/payloads/ActiveRoomChangedPayload";
+import { RoomViewStore } from "../RoomViewStore";
 
 /**
  * A class for tracking the state of the right panel between layouts and
@@ -55,6 +56,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
     }
 
     protected async onReady(): Promise<any> {
+        this.viewedRoomId = RoomViewStore.instance.getRoomId();
         this.matrixClient.on(CryptoEvent.VerificationRequest, this.onVerificationRequestUpdate);
         this.loadCacheFromSettings();
         this.emitAndUpdateSettings();
@@ -348,6 +350,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
     };
 
     private handleViewedRoomChange(oldRoomId: Optional<string>, newRoomId: Optional<string>) {
+        if (!this.mxClient) return; // not ready, onReady will handle the first room
         this.viewedRoomId = newRoomId;
         // load values from byRoomCache with the viewedRoomId.
         this.loadCacheFromSettings();


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21741

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix RightPanelStore handling first room on app launch wrong ([\#8370](https://github.com/matrix-org/matrix-react-sdk/pull/8370)). Fixes vector-im/element-web#21741.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8370--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
