### PR TITLE
Fix regression around the room list treeview keyboard a11y

### DIFF
--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -616,11 +616,8 @@ export default class RoomList extends React.PureComponent<IProps, IState> {
     public focus(): void {
         // focus the first focusable element in this aria treeview widget
         const treeItems = this.treeRef.current?.querySelectorAll<HTMLElement>('[role="treeitem"]');
-        if (treeItems) {
-            return;
-        }
-        [...treeItems]
-            .find(e => e.offsetParent !== null)?.focus();
+        if (!treeItems) return;
+        [...treeItems].find(e => e.offsetParent !== null)?.focus();
     }
 
     public render() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21436
Regressed by 6e143c313ed139b5599f252dc53350886363b6c9

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix regression around the room list treeview keyboard a11y ([\#8385](https://github.com/matrix-org/matrix-react-sdk/pull/8385)). Fixes vector-im/element-web#21436.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8385--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
