### PR TITLE
Add option to display tooltip on link hover

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -223,6 +223,14 @@ export default abstract class BasePlatform {
     }
 
     /**
+     * Returns true if the platform requires URL previews in tooltips, otherwise false.
+     * @returns {boolean} whether the platform requires URL previews in tooltips
+     */
+    needsUrlTooltips(): boolean {
+        return false;
+    }
+
+    /**
      * Returns a promise that resolves to a string representing the current version of the application.
      */
     abstract getAppVersion(): Promise<string>;

--- a/src/components/views/messages/EditHistoryMessage.tsx
+++ b/src/components/views/messages/EditHistoryMessage.tsx
@@ -93,8 +93,16 @@ export default class EditHistoryMessage extends React.PureComponent<IProps, ISta
         }
     }
 
+    private tooltipifyLinks(): void {
+        // not present for redacted events
+        if (this.content.current) {
+            HtmlUtils.tooltipifyLinks(this.content.current.children, this.pills);
+        }
+    }
+
     public componentDidMount(): void {
         this.pillifyLinks();
+        this.tooltipifyLinks();
     }
 
     public componentWillUnmount(): void {
@@ -107,6 +115,7 @@ export default class EditHistoryMessage extends React.PureComponent<IProps, ISta
 
     public componentDidUpdate(): void {
         this.pillifyLinks();
+        this.tooltipifyLinks();
     }
 
     private renderActionBar(): JSX.Element {

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -91,6 +91,7 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
         // we should be pillify them here by doing the linkifying BEFORE the pillifying.
         pillifyLinks([this.contentRef.current], this.props.mxEvent, this.pills);
         HtmlUtils.linkifyElement(this.contentRef.current);
+        HtmlUtils.tooltipifyLinks([this.contentRef.current], this.pills);
         this.calculateUrlPreview();
 
         if (this.props.mxEvent.getContent().format === "org.matrix.custom.html") {


### PR DESCRIPTION
This makes it possible for platforms like Electron apps, which lack a built-in URL preview in the status bar, to enable tooltip previews of links.

![Screenshot 2022-04-22 at 20 46 52](https://user-images.githubusercontent.com/1137962/164776028-7a549ffd-53d6-4ae7-87f4-be2f676a1ddf.png)

This will require a corresponding change in element-web to override `needsUrlTooltips` in `ElectronPlatform`. For testing  in a browser, you can change the default value in `BasePlatform`.

One problem I wasn't able to fix yet is that when clicking a link and returning, the tooltip persists. Disabling the tooltip on focus fixes this but probably breaks accessibility. Curious if anyone has ideas on what to do here.

Relates to: vector-im/element-web#6532