### PR TITLE
stop the bottom edge of buttons getting clipped in devtools

### DIFF
--- a/res/css/views/dialogs/_DevtoolsDialog.scss
+++ b/res/css/views/dialogs/_DevtoolsDialog.scss
@@ -26,7 +26,6 @@ limitations under the License.
 }
 
 .mx_DevTools_content {
-    margin: 10px 0;
     overflow-y: auto;
     height: calc(100% - 124px); // 58px for buttons + 50px for header + 8px margin around
 }


### PR DESCRIPTION
Fixes this...

<img width="200" alt="Screenshot 2022-04-24 at 13 52 20" src="https://user-images.githubusercontent.com/1294269/164989698-1af844ca-9a24-45bf-b375-c176ea5442a7.png">

...and gives us a bit more screen real-estate too for devtools.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * stop the bottom edge of buttons getting clipped in devtools ([\#8400](https://github.com/matrix-org/matrix-react-sdk/pull/8400)).<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8400--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
