### PR TITLE
Fix user name overflow on bubble message

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -91,9 +91,12 @@ limitations under the License.
     .mx_DisambiguatedProfile,
     .mx_EventTile_line {
         width: fit-content;
-        max-width: 70%;
         // fixed line height to prevent emoji from being taller than text
         line-height: $font-18px;
+    }
+
+    .mx_DisambiguatedProfile {
+        max-width: 100%;
     }
 
     > .mx_DisambiguatedProfile {
@@ -214,6 +217,7 @@ limitations under the License.
         margin: 0 -12px 0 -9px;
         border-top-left-radius: var(--cornerRadius);
         border-top-right-radius: var(--cornerRadius);
+        max-width: 70%;
 
         // the selector here is quite weird because timestamps can appear linked & unlinked and in different places
         // in the DOM depending on the specific rendering context
@@ -433,17 +437,22 @@ limitations under the License.
             "shield body" auto
             "shield link" auto
             / auto  1fr;
+
         .mx_EventTile_e2eIcon {
             grid-area: shield;
         }
+
         .mx_UnknownBody {
             grid-area: body;
         }
+
         .mx_EventTile_keyRequestInfo {
             grid-area: link;
         }
+
         .mx_ReplyChain_wrapper {
             grid-area: reply;
+            overflow: hidden; // for DisambiguatedProfile
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21914

This PR fixes user name overflow on bubble message.

Before:

![before](https://user-images.githubusercontent.com/3362943/165101424-885644ab-d5bb-40e3-a803-eb29160b8967.png)

After:

![after](https://user-images.githubusercontent.com/3362943/165101385-c43e78c7-c778-405d-9671-f18f8caad300.png)

The color of the ellipsis is out of scope of this PR.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix user name overflow on bubble message ([\#8405](https://github.com/matrix-org/matrix-react-sdk/pull/8405)). Fixes vector-im/element-web#21914. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->