### PR TITLE
Don't form continuations on either side of a thread root

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -92,9 +92,13 @@ export function shouldFormContinuation(
         mxEvent.sender.name !== prevEvent.sender.name ||
         mxEvent.sender.getMxcAvatarUrl() !== prevEvent.sender.getMxcAvatarUrl()) return false;
 
-    // Thread summaries in the main timeline should break up a continuation
-    if (threadsEnabled && prevEvent.isThreadRoot &&
-        timelineRenderingType !== TimelineRenderingType.Thread) return false;
+    // Thread summaries in the main timeline should break up a continuation on both sides
+    if (threadsEnabled &&
+        (mxEvent.isThreadRoot || prevEvent.isThreadRoot) &&
+        timelineRenderingType !== TimelineRenderingType.Thread
+    ) {
+        return false;
+    }
 
     // if we don't have tile for previous event then it was shown by showHiddenEvents and has no SenderProfile
     if (!haveRendererForEvent(prevEvent, showHiddenEvents)) return false;

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -705,6 +705,6 @@ describe("shouldFormContinuation", () => {
 
         expect(shouldFormContinuation(message1, message2, false, true)).toEqual(true);
         expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(false);
-        expect(shouldFormContinuation(threadRoot, message3,false, true)).toEqual(false);
+        expect(shouldFormContinuation(threadRoot, message3, false, true)).toEqual(false);
     });
 });

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -674,6 +674,20 @@ describe('MessagePanel', function() {
 
 describe("shouldFormContinuation", () => {
     it("does not form continuations from thread roots", () => {
+        const message1 = TestUtilsMatrix.mkMessage({
+            event: true,
+            room: "!room:id",
+            user: "@user:id",
+            msg: "Here is a message in the main timeline",
+        });
+
+        const message2 = TestUtilsMatrix.mkMessage({
+            event: true,
+            room: "!room:id",
+            user: "@user:id",
+            msg: "And here's another message in the main timeline",
+        });
+
         const threadRoot = TestUtilsMatrix.mkMessage({
             event: true,
             room: "!room:id",
@@ -682,14 +696,15 @@ describe("shouldFormContinuation", () => {
         });
         jest.spyOn(threadRoot, "isThreadRoot", "get").mockReturnValue(true);
 
-        const message = TestUtilsMatrix.mkMessage({
+        const message3 = TestUtilsMatrix.mkMessage({
             event: true,
             room: "!room:id",
             user: "@user:id",
-            msg: "And here's another message in the main timeline",
+            msg: "And here's another message in the main timeline after the thread root",
         });
 
-        expect(shouldFormContinuation(threadRoot, message, false, true)).toEqual(false);
-        expect(shouldFormContinuation(message, threadRoot, false, true)).toEqual(true);
+        expect(shouldFormContinuation(message1, message2, false, true)).toEqual(true);
+        expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(false);
+        expect(shouldFormContinuation(threadRoot, message3,false, true)).toEqual(false);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20908

![image](https://user-images.githubusercontent.com/2403652/165249733-9c8bea79-6bcc-49fd-835b-c531895042f7.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't form continuations on either side of a thread root ([\#8408](https://github.com/matrix-org/matrix-react-sdk/pull/8408)). Fixes vector-im/element-web#20908.<!-- CHANGELOG_PREVIEW_END -->




<!-- Replace -->
Preview: https://pr8408--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
