### PR TITLE
Fix issue with thread notification state ignoring initial events

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -991,9 +991,7 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
             mx_EventTile_12hr: this.props.isTwelveHour,
             // Note: we keep the `sending` state class for tests, not for our styles
             mx_EventTile_sending: !isEditing && isSending,
-            mx_EventTile_highlight: (this.context.timelineRenderingType === TimelineRenderingType.Notification
-                ? false
-                : this.shouldHighlight()),
+            mx_EventTile_highlight: this.shouldHighlight(),
             mx_EventTile_selected: this.props.isSelectedEvent || this.state.contextMenu,
             mx_EventTile_continuation: isContinuation || eventType === EventType.CallInvite,
             mx_EventTile_last: this.props.last,

--- a/src/stores/notifications/ThreadNotificationState.ts
+++ b/src/stores/notifications/ThreadNotificationState.ts
@@ -31,6 +31,10 @@ export class ThreadNotificationState extends NotificationState implements IDestr
         super();
         this.thread.on(ThreadEvent.NewReply, this.handleNewThreadReply);
         this.thread.on(ThreadEvent.ViewThread, this.resetThreadNotification);
+        if (this.thread.replyToEvent) {
+            // Process the current tip event
+            this.handleNewThreadReply(this.thread, this.thread.replyToEvent);
+        }
     }
 
     public destroy(): void {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21927

js-sdk changed to batching events where possible to prevent races which broke this behaviour, very integration-testy

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issue with thread notification state ignoring initial events ([\#8417](https://github.com/matrix-org/matrix-react-sdk/pull/8417)). Fixes vector-im/element-web#21927.<!-- CHANGELOG_PREVIEW_END -->

<!-- Replace -->
Preview: https://pr8417--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
