### PR TITLE
Display emotes like normal messages

### DIFF
--- a/res/css/views/messages/_MEmoteBody.scss
+++ b/res/css/views/messages/_MEmoteBody.scss
@@ -17,7 +17,3 @@ limitations under the License.
 .mx_MEmoteBody {
     white-space: pre-wrap;
 }
-
-.mx_MEmoteBody_sender {
-    cursor: pointer;
-}

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -129,12 +129,6 @@ $irc-line-height: $font-18px;
         }
     }
 
-    .mx_EventTile_emote {
-        > .mx_EventTile_avatar {
-            margin-left: calc(var(--name-width) + $icon-width + $right-padding);
-        }
-    }
-
     blockquote {
         margin: 0;
     }

--- a/src/components/views/messages/EditHistoryMessage.tsx
+++ b/src/components/views/messages/EditHistoryMessage.tsx
@@ -156,12 +156,8 @@ export default class EditHistoryMessage extends React.PureComponent<IProps, ISta
                 );
             }
             if (mxEvent.getContent().msgtype === "m.emote") {
-                const name = mxEvent.sender ? mxEvent.sender.name : mxEvent.getSender();
                 contentContainer = (
-                    <div className="mx_EventTile_content" ref={this.content}>*&nbsp;
-                        <span className="mx_MEmoteBody_sender">{ name }</span>
-                        &nbsp;{ contentElements }
-                    </div>
+                    <div className="mx_EventTile_content" ref={this.content}>*&nbsp;{ contentElements }</div>
                 );
             } else {
                 contentContainer = <div className="mx_EventTile_content" ref={this.content}>{ contentElements }</div>;

--- a/src/components/views/messages/SenderProfile.tsx
+++ b/src/components/views/messages/SenderProfile.tsx
@@ -16,11 +16,10 @@
 
 import React from 'react';
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
-import { MsgType } from "matrix-js-sdk/src/@types/event";
 
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import DisambiguatedProfile from "./DisambiguatedProfile";
-import RoomContext, { TimelineRenderingType } from '../../../contexts/RoomContext';
+import RoomContext from '../../../contexts/RoomContext';
 import SettingsStore from "../../../settings/SettingsStore";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 
@@ -35,7 +34,6 @@ export default class SenderProfile extends React.PureComponent<IProps> {
 
     render() {
         const { mxEvent, onClick } = this.props;
-        const msgtype = mxEvent.getContent().msgtype;
 
         let member = mxEvent.sender;
         if (SettingsStore.getValue("feature_use_only_current_profiles")) {

--- a/src/components/views/messages/SenderProfile.tsx
+++ b/src/components/views/messages/SenderProfile.tsx
@@ -47,12 +47,6 @@ export default class SenderProfile extends React.PureComponent<IProps> {
 
         return <RoomContext.Consumer>
             { roomContext => {
-                if (msgtype === MsgType.Emote &&
-                    roomContext.timelineRenderingType !== TimelineRenderingType.ThreadsList
-                ) {
-                    return null; // emote message must include the name so don't duplicate it
-                }
-
                 return (
                     <DisambiguatedProfile
                         fallbackName={mxEvent.getSender() || ""}

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -408,15 +408,6 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
         this.forceUpdate();
     };
 
-    private onEmoteSenderClick = (): void => {
-        const mxEvent = this.props.mxEvent;
-        dis.dispatch<ComposerInsertPayload>({
-            action: Action.ComposerInsert,
-            userId: mxEvent.getSender(),
-            timelineRenderingType: this.context.timelineRenderingType,
-        });
-    };
-
     /**
      * This acts as a fallback in-app navigation handler for any body links that
      * were ignored as part of linkification because they were already links
@@ -631,13 +622,6 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
                     onClick={this.onBodyLinkClick}
                 >
                     *&nbsp;
-                    <span
-                        className="mx_MEmoteBody_sender"
-                        onClick={this.onEmoteSenderClick}
-                    >
-                        { mxEvent.sender ? mxEvent.sender.name : mxEvent.getSender() }
-                    </span>
-                    &nbsp;
                     { body }
                     { widgets }
                 </div>

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -23,7 +23,6 @@ import { isEventLike, LegacyMsgType, M_MESSAGE, MessageEvent } from "matrix-even
 import * as HtmlUtils from '../../../HtmlUtils';
 import { formatDate } from '../../../DateUtils';
 import Modal from '../../../Modal';
-import dis from '../../../dispatcher/dispatcher';
 import { _t } from '../../../languageHandler';
 import * as ContextMenu from '../../structures/ContextMenu';
 import { ChevronFace, toRightOf } from '../../structures/ContextMenu';
@@ -34,8 +33,6 @@ import { isPermalinkHost, tryTransformPermalinkToLocalHref } from "../../../util
 import { copyPlaintext } from "../../../utils/strings";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
 import UIStore from "../../../stores/UIStore";
-import { ComposerInsertPayload } from "../../../dispatcher/payloads/ComposerInsertPayload";
-import { Action } from "../../../dispatcher/actions";
 import GenericTextContextMenu from "../context_menus/GenericTextContextMenu";
 import Spoiler from "../elements/Spoiler";
 import QuestionDialog from "../dialogs/QuestionDialog";

--- a/src/utils/EventRenderingUtils.ts
+++ b/src/utils/EventRenderingUtils.ts
@@ -78,7 +78,6 @@ export function getEventDisplayInfo(mxEvent: MatrixEvent, showHiddenEvents: bool
     );
     // Some non-info messages want to be rendered in the appropriate bubble column but without the bubble background
     const noBubbleEvent = (
-        (eventType === EventType.RoomMessage && msgtype === MsgType.Emote) ||
         M_POLL_START.matches(eventType) ||
         M_LOCATION.matches(eventType) ||
         M_BEACON_INFO.matches(eventType) ||

--- a/src/utils/EventRenderingUtils.ts
+++ b/src/utils/EventRenderingUtils.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
-import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
+import { EventType } from "matrix-js-sdk/src/@types/event";
 import { M_POLL_START } from "matrix-events-sdk";
 import { M_LOCATION } from "matrix-js-sdk/src/@types/location";
 import { M_BEACON_INFO } from "matrix-js-sdk/src/@types/beacon";


### PR DESCRIPTION
### Default layout before

![Screenshot 2022-04-26 at 20 46 26](https://user-images.githubusercontent.com/1137962/165371762-658d21f7-831b-4fa2-927c-abea88084aef.png)

### Default layout after

![Screenshot 2022-04-26 at 20 45 54](https://user-images.githubusercontent.com/1137962/165371784-3c4f145f-c9d4-4b90-a688-548661fca095.png)

### Bubbles layout before

![Screenshot 2022-04-27 at 08 06 04](https://user-images.githubusercontent.com/1137962/165452672-9384d13f-1b98-4b6b-8d84-91679fb80065.png)

### Bubbles layout after

![Screenshot 2022-04-27 at 08 04 31](https://user-images.githubusercontent.com/1137962/165452670-4a01beeb-407c-44bf-97c3-1e179f1fb141.png)

### IRC layout before

![Screenshot 2022-04-27 at 08 06 58](https://user-images.githubusercontent.com/1137962/165452673-222025a2-0c84-4b2a-b96e-bb56f034adda.png)

### IRC layout after

![Screenshot 2022-04-27 at 08 09 09](https://user-images.githubusercontent.com/1137962/165452675-33d655bb-37ee-47d6-ac84-65e6a3f86347.png)

### Advantages

- Time is visible (default layout)
- User name gives visual hint that it is clickable (default & IRC layout)
- Reading flow not broken because style is consistent with normal messages (all layouts)

### Disadvantages

- Slightly more vertical space needed (default & bubble layout)

Fixes: vector-im/element-web#2284

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Display emotes like normal messages ([\#8420](https://github.com/matrix-org/matrix-react-sdk/pull/8420)). Fixes vector-im/element-web#2284. Contributed by @Johennes.<!-- CHANGELOG_PREVIEW_END -->







<!-- Replace -->
Preview: https://pr8420--matrix-react-sdk.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
