### PR TITLE
Make style of RR and RecentlyViewedButton consistent

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -730,6 +730,16 @@ legend {
     width: 24px;
 }
 
+@define-mixin ContextMenu_label {
+    display: grid;
+
+    > div {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+}
+
 @define-mixin ContextMenu_description {
     font-size: $font-12px;
     line-height: $font-15px;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -716,9 +716,7 @@ legend {
 
     .mx_ContextMenu_Header {
         margin: 0 0 $spacing-12 0;
-
-        // shouldn’t be actually focusable
-        outline: none;
+        user-select: none;
     }
 
     .mx_ContextMenu_MenuItem {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -700,9 +700,14 @@ legend {
     max-height: 400px;
     border: 1px solid rgba($primary-content, .1);
     border-radius: 8px;
-    box-shadow: 0 8px 4px rgba(0, 0, 0, 0.08);
+    box-shadow: 4px 4px 12px 0 $menu-box-shadow-color;
     display: flex;
     flex-direction: column;
+    background-color: $menu-bg-color;
+    color: $primary-content;
+    font-size: $font-14px;
+    position: absolute;
+    z-index: 5001;
 
     .mx_ContextMenu_Header {
         margin: 0 0 $spacing-12 0;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -725,6 +725,14 @@ legend {
     margin: 0 0 12px 0;
 }
 
+@define-mixin ContextMenu_row {
+    overflow-y: auto;
+
+    * {
+        margin-inline-end: 4px;
+    }
+}
+
 @define-mixin ContextMenu_avatar {
     margin-inline-end: 8px;
     width: 24px;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -719,22 +719,20 @@ legend {
         user-select: none;
     }
 
-    .mx_ContextMenu_MenuItem {
-        overflow-y: auto;
-
+    .mx_AutoHideScrollbar {
         > * {
             margin-inline-end: $spacing-4;
         }
 
-        .mx_ContextMenu_MenuItem_label {
+        .mx_ContextMenu_label {
             display: grid;
 
-            .mx_ContextMenu_MenuItem_label_item {
+            .mx_ContextMenu_label_item {
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
 
-                &.mx_ContextMenu_MenuItem_label_item--desc {
+                &.mx_ContextMenu_label_item--desc {
                     font-size: $font-12px;
                     line-height: $font-15px;
                     color: $secondary-content;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -730,6 +730,12 @@ legend {
                 text-overflow: ellipsis;
             }
         }
+
+        .mx_ContextMenu_MenuItem_description {
+            font-size: $font-12px;
+            line-height: $font-15px;
+            color: $secondary-content;
+        }
     }
 
     .mx_AccessibleButton {
@@ -753,12 +759,6 @@ legend {
 @define-mixin ContextMenu_avatar {
     margin-inline-end: 8px;
     width: 24px;
-}
-
-@define-mixin ContextMenu_description {
-    font-size: $font-12px;
-    line-height: $font-15px;
-    color: $secondary-content;
 }
 
 @define-mixin ListResetDefault {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -692,13 +692,18 @@ legend {
     }
 }
 
+@define-mixin ContextMenu_border {
+    border: 1px solid rgba($primary-content, .1);
+}
+
 @define-mixin ContextMenu {
+    @mixin ContextMenu_border;
+
     padding: $spacing-16;
     padding-inline-end: $spacing-8;
     width: max-content;
     max-width: 240px;
     max-height: 400px;
-    border: 1px solid rgba($primary-content, .1);
     border-radius: 8px;
     box-shadow: 4px 4px 12px 0 $menu-box-shadow-color;
     display: flex;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -715,10 +715,19 @@ legend {
             background-color: $panel-actions;
         }
     }
+
+    .mx_BaseAvatar {
+        margin-inline-end: $spacing-4;
+    }
 }
 
 @define-mixin ContextMenu_title {
     margin: 0 0 12px 0;
+}
+
+@define-mixin ContextMenu_avatar {
+    margin-inline-end: 8px;
+    width: 24px;
 }
 
 @define-mixin ListResetDefault {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -702,6 +702,19 @@ legend {
     box-shadow: 0 8px 4px rgba(0, 0, 0, 0.08);
     display: flex;
     flex-direction: column;
+
+    .mx_AccessibleButton {
+        margin-top: 2px;
+        padding: 4px;
+        display: flex;
+        align-items: center;
+        border-radius: 8px;
+        min-height: 34px;
+
+        &:hover {
+            background-color: $panel-actions;
+        }
+    }
 }
 
 @define-mixin ContextMenu_title {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -703,6 +703,13 @@ legend {
     display: flex;
     flex-direction: column;
 
+    .mx_ContextMenu_Header {
+        margin: 0 0 12px 0;
+
+        // shouldn’t be actually focusable
+        outline: none;
+    }
+
     .mx_AccessibleButton {
         margin-top: 2px;
         padding: 4px;
@@ -719,10 +726,6 @@ legend {
     .mx_BaseAvatar {
         margin-inline-end: $spacing-4;
     }
-}
-
-@define-mixin ContextMenu_title {
-    margin: 0 0 12px 0;
 }
 
 @define-mixin ContextMenu_row {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -704,6 +704,10 @@ legend {
     flex-direction: column;
 }
 
+@define-mixin ContextMenu_title {
+    margin: 0 0 12px 0;
+}
+
 @define-mixin ListResetDefault {
     list-style: none;
     padding: 0;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -723,22 +723,6 @@ legend {
         > * {
             margin-inline-end: $spacing-4;
         }
-
-        .mx_ContextMenu_label {
-            display: grid;
-
-            .mx_ContextMenu_label_item {
-                overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-
-                &.mx_ContextMenu_label_item--desc {
-                    font-size: $font-12px;
-                    line-height: $font-15px;
-                    color: $secondary-content;
-                }
-            }
-        }
     }
 
     .mx_AccessibleButton {
@@ -757,6 +741,22 @@ legend {
         .mx_BaseAvatar {
             width: 24px;
             margin-inline-end: $spacing-8;
+        }
+
+        .mx_ContextMenu_label {
+            display: grid;
+
+            .mx_ContextMenu_label_item {
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+
+                &.mx_ContextMenu_label_item--desc {
+                    font-size: $font-12px;
+                    line-height: $font-15px;
+                    color: $secondary-content;
+                }
+            }
         }
     }
 }

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -692,6 +692,18 @@ legend {
     }
 }
 
+@define-mixin ContextMenu {
+    padding: 16px 8px 16px 16px;
+    width: max-content;
+    max-width: 240px;
+    max-height: 400px;
+    border: 1px solid rgba($primary-content, .1);
+    border-radius: 8px;
+    box-shadow: 0 8px 4px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+}
+
 @define-mixin ListResetDefault {
     list-style: none;
     padding: 0;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -721,17 +721,17 @@ legend {
         .mx_ContextMenu_MenuItem_label {
             display: grid;
 
-            > div {
+            .mx_ContextMenu_MenuItem_label_item {
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
-            }
-        }
 
-        .mx_ContextMenu_MenuItem_description {
-            font-size: $font-12px;
-            line-height: $font-15px;
-            color: $secondary-content;
+                &.mx_ContextMenu_MenuItem_label_item--desc {
+                    font-size: $font-12px;
+                    line-height: $font-15px;
+                    color: $secondary-content;
+                }
+            }
         }
     }
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -710,6 +710,18 @@ legend {
         outline: none;
     }
 
+    .mx_ContextMenu_MenuItem {
+        overflow-y: auto;
+
+        .mx_AutoHideScrollbar {
+            margin-inline-end: 0;
+        }
+
+        * {
+            margin-inline-end: 4px;
+        }
+    }
+
     .mx_AccessibleButton {
         margin-top: 2px;
         padding: 4px;
@@ -725,14 +737,6 @@ legend {
 
     .mx_BaseAvatar {
         margin-inline-end: $spacing-4;
-    }
-}
-
-@define-mixin ContextMenu_row {
-    overflow-y: auto;
-
-    * {
-        margin-inline-end: 4px;
     }
 }
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -713,11 +713,7 @@ legend {
     .mx_ContextMenu_MenuItem {
         overflow-y: auto;
 
-        .mx_AutoHideScrollbar {
-            margin-inline-end: 0;
-        }
-
-        * {
+        > * {
             margin-inline-end: 4px;
         }
 
@@ -751,14 +747,11 @@ legend {
         }
     }
 
+    .mx_DecoratedRoomAvatar,
     .mx_BaseAvatar {
-        margin-inline-end: $spacing-4;
+        width: 24px;
+        margin-inline-end: 8px;
     }
-}
-
-@define-mixin ContextMenu_avatar {
-    margin-inline-end: 8px;
-    width: 24px;
 }
 
 @define-mixin ListResetDefault {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -693,7 +693,8 @@ legend {
 }
 
 @define-mixin ContextMenu {
-    padding: 16px 8px 16px 16px;
+    padding: $spacing-16;
+    padding-inline-end: $spacing-8;
     width: max-content;
     max-width: 240px;
     max-height: 400px;
@@ -704,7 +705,7 @@ legend {
     flex-direction: column;
 
     .mx_ContextMenu_Header {
-        margin: 0 0 12px 0;
+        margin: 0 0 $spacing-12 0;
 
         // shouldn’t be actually focusable
         outline: none;
@@ -714,7 +715,7 @@ legend {
         overflow-y: auto;
 
         > * {
-            margin-inline-end: 4px;
+            margin-inline-end: $spacing-4;
         }
 
         .mx_ContextMenu_MenuItem_label {
@@ -735,8 +736,8 @@ legend {
     }
 
     .mx_AccessibleButton {
-        margin-top: 2px;
-        padding: 4px;
+        margin-top: 2px; // TODO: spacing variable
+        padding: $spacing-4;
         display: flex;
         align-items: center;
         border-radius: 8px;
@@ -750,7 +751,7 @@ legend {
     .mx_DecoratedRoomAvatar,
     .mx_BaseAvatar {
         width: 24px;
-        margin-inline-end: 8px;
+        margin-inline-end: $spacing-8;
     }
 }
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -720,6 +720,16 @@ legend {
         * {
             margin-inline-end: 4px;
         }
+
+        .mx_ContextMenu_MenuItem_label {
+            display: grid;
+
+            > div {
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+        }
     }
 
     .mx_AccessibleButton {
@@ -743,16 +753,6 @@ legend {
 @define-mixin ContextMenu_avatar {
     margin-inline-end: 8px;
     width: 24px;
-}
-
-@define-mixin ContextMenu_label {
-    display: grid;
-
-    > div {
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
 }
 
 @define-mixin ContextMenu_description {

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -730,6 +730,12 @@ legend {
     width: 24px;
 }
 
+@define-mixin ContextMenu_description {
+    font-size: $font-12px;
+    line-height: $font-15px;
+    color: $secondary-content;
+}
+
 @define-mixin ListResetDefault {
     list-style: none;
     padding: 0;

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -752,12 +752,12 @@ legend {
         &:hover {
             background-color: $panel-actions;
         }
-    }
 
-    .mx_DecoratedRoomAvatar,
-    .mx_BaseAvatar {
-        width: 24px;
-        margin-inline-end: $spacing-8;
+        .mx_DecoratedRoomAvatar,
+        .mx_BaseAvatar {
+            width: 24px;
+            margin-inline-end: $spacing-8;
+        }
     }
 }
 

--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -723,38 +723,38 @@ legend {
         > * {
             margin-inline-end: $spacing-4;
         }
-    }
 
-    .mx_AccessibleButton {
-        margin-top: 2px; // TODO: spacing variable
-        padding: $spacing-4;
-        display: flex;
-        align-items: center;
-        border-radius: 8px;
-        min-height: 34px;
+        .mx_AccessibleButton {
+            margin-top: 2px; // TODO: spacing variable
+            padding: $spacing-4;
+            display: flex;
+            align-items: center;
+            border-radius: 8px;
+            min-height: 34px;
 
-        &:hover {
-            background-color: $panel-actions;
-        }
+            &:hover {
+                background-color: $panel-actions;
+            }
 
-        .mx_DecoratedRoomAvatar,
-        .mx_BaseAvatar {
-            width: 24px;
-            margin-inline-end: $spacing-8;
-        }
+            .mx_DecoratedRoomAvatar,
+            .mx_BaseAvatar {
+                width: 24px;
+                margin-inline-end: $spacing-8;
+            }
 
-        .mx_ContextMenu_label {
-            display: grid;
+            .mx_ContextMenu_label {
+                display: grid;
 
-            .mx_ContextMenu_label_item {
-                overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
+                .mx_ContextMenu_label_item {
+                    overflow: hidden;
+                    white-space: nowrap;
+                    text-overflow: ellipsis;
 
-                &.mx_ContextMenu_label_item--desc {
-                    font-size: $font-12px;
-                    line-height: $font-15px;
-                    color: $secondary-content;
+                    &.mx_ContextMenu_label_item--desc {
+                        font-size: $font-12px;
+                        line-height: $font-15px;
+                        color: $secondary-content;
+                    }
                 }
             }
         }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -96,8 +96,6 @@ limitations under the License.
         }
 
         .mx_ReadReceiptGroup_name {
-            @mixin ContextMenu_label;
-
             .mx_ReadReceiptGroup_secondary {
                 @mixin ContextMenu_description;
             }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -108,14 +108,14 @@ limitations under the License.
             overflow: hidden;
 
             p {
-                margin: 2px 0;
+                margin: 0;
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
             }
 
             .mx_ReadReceiptGroup_secondary {
-                color: $secondary-content;
+                @mixin ContextMenu_description;
             }
         }
     }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -95,6 +95,10 @@ limitations under the License.
         outline: none;
     }
 
+    .mx_ReadReceiptGroup_receipts {
+        @mixin ContextMenu_row;
+    }
+
     .mx_ReadReceiptGroup_person {
         .mx_BaseAvatar {
             @mixin ContextMenu_avatar;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -95,4 +95,6 @@ limitations under the License.
     overflow-y: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    box-sizing: border-box;
+    border: 1px solid rgba($primary-content, .1);
 }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -94,8 +94,14 @@ limitations under the License.
 .mx_Tooltip--ReadReceiptGroup {
     @mixin ContextMenu_border;
 
-    overflow-y: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     box-sizing: border-box;
+    max-width: calc(220px - 10px); // 10px: 4px padding * 2 + 2px border
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+
+    .mx_Tooltip--ReadReceiptGroup_label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -66,7 +66,7 @@ limitations under the License.
     }
 }
 
-.mx_ReadReceiptGroup_popup {
+.mx_ContextMenu--ReadReceiptGroup {
     @mixin ContextMenu;
 
     max-height: 300px;
@@ -91,7 +91,7 @@ limitations under the License.
     }
 }
 
-.mx_ReadReceiptGroup_person--tooltip {
+.mx_Tooltip--ReadReceiptGroup {
     overflow-y: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -85,13 +85,9 @@ limitations under the License.
         bottom: 8px;
     }
 
-    .mx_ReadReceiptGroup_title {
-        @mixin ContextMenu_title;
-
+    .mx_ContextMenu_Header--ReadReceiptGroup {
         font-size: 12px;
         line-height: 15px;
-        // shouldn’t be actually focusable
-        outline: none;
     }
 
     .mx_ReadReceiptGroup_receipts {

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -67,11 +67,10 @@ limitations under the License.
 }
 
 .mx_ReadReceiptGroup_popup {
+    @mixin ContextMenu;
+
     max-height: 300px;
     width: 220px;
-    border-radius: 8px;
-    display: flex;
-    flex-direction: column;
     text-align: left;
     font-size: 12px;
     line-height: 15px;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -78,11 +78,11 @@ limitations under the License.
     right: 0;
 
     &.mx_ContextualMenu_top {
-        top: 8px;
+        top: $spacing-8;
     }
 
     &.mx_ContextualMenu_bottom {
-        bottom: 8px;
+        bottom: $spacing-8;
     }
 
     .mx_ContextMenu_Header--ReadReceiptGroup {

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -95,45 +95,29 @@ limitations under the License.
         outline: none;
     }
 
-    .mx_AutoHideScrollbar {
-        .mx_ReadReceiptGroup_person {
+    .mx_ReadReceiptGroup_person {
+        .mx_BaseAvatar {
+            margin: 6px 8px;
+            align-self: center;
+            justify-self: center;
+        }
+
+        .mx_ReadReceiptGroup_name {
             display: flex;
-            flex-direction: row;
-            padding: 4px;
-            margin: 0 12px;
-            border-radius: 8px;
+            flex-direction: column;
+            flex-grow: 1;
+            flex-shrink: 1;
+            overflow: hidden;
 
-            &:hover {
-                background: $menu-selected-color;
-            }
-
-            &:last-child {
-                margin-bottom: 8px;
-            }
-
-            .mx_BaseAvatar {
-                margin: 6px 8px;
-                align-self: center;
-                justify-self: center;
-            }
-
-            .mx_ReadReceiptGroup_name {
-                display: flex;
-                flex-direction: column;
-                flex-grow: 1;
-                flex-shrink: 1;
+            p {
+                margin: 2px 0;
+                text-overflow: ellipsis;
                 overflow: hidden;
+                white-space: nowrap;
+            }
 
-                p {
-                    margin: 2px 0;
-                    text-overflow: ellipsis;
-                    overflow: hidden;
-                    white-space: nowrap;
-                }
-
-                .mx_ReadReceiptGroup_secondary {
-                    color: $secondary-content;
-                }
+            .mx_ReadReceiptGroup_secondary {
+                color: $secondary-content;
             }
         }
     }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -92,9 +92,10 @@ limitations under the License.
 }
 
 .mx_Tooltip--ReadReceiptGroup {
+    @mixin ContextMenu_border;
+
     overflow-y: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     box-sizing: border-box;
-    border: 1px solid rgba($primary-content, .1);
 }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -90,10 +90,6 @@ limitations under the License.
         line-height: 15px;
     }
 
-    .mx_ReadReceiptGroup_receipts {
-        @mixin ContextMenu_row;
-    }
-
     .mx_ReadReceiptGroup_person {
         .mx_BaseAvatar {
             @mixin ContextMenu_avatar;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -90,7 +90,6 @@ limitations under the License.
 
         font-size: 12px;
         line-height: 15px;
-        font-weight: 600;
         // shouldn’t be actually focusable
         outline: none;
     }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -101,18 +101,7 @@ limitations under the License.
         }
 
         .mx_ReadReceiptGroup_name {
-            display: flex;
-            flex-direction: column;
-            flex-grow: 1;
-            flex-shrink: 1;
-            overflow: hidden;
-
-            p {
-                margin: 0;
-                text-overflow: ellipsis;
-                overflow: hidden;
-                white-space: nowrap;
-            }
+            @mixin ContextMenu_label;
 
             .mx_ReadReceiptGroup_secondary {
                 @mixin ContextMenu_description;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -94,12 +94,6 @@ limitations under the License.
         .mx_BaseAvatar {
             @mixin ContextMenu_avatar;
         }
-
-        .mx_ReadReceiptGroup_name {
-            .mx_ReadReceiptGroup_secondary {
-                @mixin ContextMenu_description;
-            }
-        }
     }
 }
 

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -86,9 +86,10 @@ limitations under the License.
     }
 
     .mx_ReadReceiptGroup_title {
+        @mixin ContextMenu_title;
+
         font-size: 12px;
         line-height: 15px;
-        margin: 16px 16px 8px;
         font-weight: 600;
         // shouldn’t be actually focusable
         outline: none;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -89,12 +89,6 @@ limitations under the License.
         font-size: 12px;
         line-height: 15px;
     }
-
-    .mx_ReadReceiptGroup_person {
-        .mx_BaseAvatar {
-            @mixin ContextMenu_avatar;
-        }
-    }
 }
 
 .mx_ReadReceiptGroup_person--tooltip {

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -71,7 +71,6 @@ limitations under the License.
 
     max-height: 300px;
     width: 220px;
-    text-align: left;
     font-size: 12px;
     line-height: 15px;
 

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -97,6 +97,7 @@ limitations under the License.
     max-width: calc(220px - 10px); // 10px: 4px padding * 2 + 2px border
     margin-inline-start: 0;
     margin-inline-end: 0;
+    line-height: unset; // Unset the value of mx_Tooltip
 
     .mx_Tooltip--ReadReceiptGroup_label {
         overflow: hidden;

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -97,9 +97,7 @@ limitations under the License.
 
     .mx_ReadReceiptGroup_person {
         .mx_BaseAvatar {
-            margin: 6px 8px;
-            align-self: center;
-            justify-self: center;
+            @mixin ContextMenu_avatar;
         }
 
         .mx_ReadReceiptGroup_name {

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -16,4 +16,7 @@ limitations under the License.
 
 .mx_ContextMenu--RecentlyViewedButton {
     @mixin ContextMenu;
+
+    box-shadow: 0 8px 4px rgba(0, 0, 0, 0.08);
+    position: relative;
 }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -26,10 +26,6 @@ limitations under the License.
             }
         }
 
-        .mx_RecentlyViewedButton_entry_label {
-            @mixin ContextMenu_label;
-        }
-
         .mx_RecentlyViewedButton_entry_spaces {
             @mixin ContextMenu_description;
         }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -15,15 +15,7 @@ limitations under the License.
 */
 
 .mx_RecentlyViewedButton_ContextMenu {
-    padding: 16px 8px 16px 16px;
-    width: max-content;
-    max-width: 240px;
-    max-height: 400px;
-    border: 1px solid rgba($primary-content, .1);
-    border-radius: 8px;
-    box-shadow: 0 8px 4px rgba(0, 0, 0, 0.08);
-    display: flex;
-    flex-direction: column;
+    @mixin ContextMenu;
 
     > h4 {
         margin: 0 0 12px 0;

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -31,8 +31,7 @@ limitations under the License.
 
     .mx_AccessibleButton {
         .mx_DecoratedRoomAvatar {
-            margin-right: 8px;
-            width: 24px;
+            @mixin ContextMenu_avatar;
 
             .mx_BaseAvatar {
                 width: inherit;

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -22,11 +22,7 @@ limitations under the License.
     }
 
     > div {
-        overflow-y: auto;
-
-        * {
-            margin-right: 4px;
-        }
+        @mixin ContextMenu_row;
     }
 
     .mx_AccessibleButton {

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_RecentlyViewedButton_ContextMenu {
+.mx_ContextMenu--RecentlyViewedButton {
     @mixin ContextMenu;
 }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -30,17 +30,6 @@ limitations under the License.
     }
 
     .mx_AccessibleButton {
-        margin-top: 2px;
-        padding: 4px;
-        display: flex;
-        align-items: center;
-        border-radius: 8px;
-        min-height: 34px;
-
-        &:hover {
-            background-color: $panel-actions;
-        }
-
         .mx_DecoratedRoomAvatar {
             margin-right: 8px;
             width: 24px;

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -17,10 +17,6 @@ limitations under the License.
 .mx_RecentlyViewedButton_ContextMenu {
     @mixin ContextMenu;
 
-    > h4 {
-        @mixin ContextMenu_title;
-    }
-
     > div {
         @mixin ContextMenu_row;
     }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -17,10 +17,6 @@ limitations under the License.
 .mx_RecentlyViewedButton_ContextMenu {
     @mixin ContextMenu;
 
-    > div {
-        @mixin ContextMenu_row;
-    }
-
     .mx_AccessibleButton {
         .mx_DecoratedRoomAvatar {
             @mixin ContextMenu_avatar;

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -25,9 +25,5 @@ limitations under the License.
                 width: inherit;
             }
         }
-
-        .mx_RecentlyViewedButton_entry_spaces {
-            @mixin ContextMenu_description;
-        }
     }
 }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -49,9 +49,7 @@ limitations under the License.
         }
 
         .mx_RecentlyViewedButton_entry_spaces {
-            font-size: $font-12px;
-            line-height: $font-15px;
-            color: $secondary-content;
+            @mixin ContextMenu_description;
         }
     }
 }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -18,7 +18,7 @@ limitations under the License.
     @mixin ContextMenu;
 
     > h4 {
-        margin: 0 0 12px 0;
+        @mixin ContextMenu_title;
     }
 
     > div {

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -16,14 +16,4 @@ limitations under the License.
 
 .mx_RecentlyViewedButton_ContextMenu {
     @mixin ContextMenu;
-
-    .mx_AccessibleButton {
-        .mx_DecoratedRoomAvatar {
-            @mixin ContextMenu_avatar;
-
-            .mx_BaseAvatar {
-                width: inherit;
-            }
-        }
-    }
 }

--- a/res/css/views/rooms/_RecentlyViewedButton.scss
+++ b/res/css/views/rooms/_RecentlyViewedButton.scss
@@ -39,13 +39,7 @@ limitations under the License.
         }
 
         .mx_RecentlyViewedButton_entry_label {
-            display: grid;
-
-            > div {
-                overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-            }
+            @mixin ContextMenu_label;
         }
 
         .mx_RecentlyViewedButton_entry_spaces {

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -231,9 +231,9 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
                 resizeMethod="crop"
                 hideTitle
             />
-            <div className="mx_ContextMenu_MenuItem_label mx_ReadReceiptGroup_name">
+            <div className="mx_ContextMenu_MenuItem_label">
                 <div>{ roomMember.name }</div>
-                <div className="mx_ReadReceiptGroup_secondary">
+                <div className="mx_ContextMenu_MenuItem_description">
                     { formatDate(new Date(ts), isTwelveHour) }
                 </div>
             </div>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -190,10 +190,10 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
         tooltipClassName: "mx_Tooltip--ReadReceiptGroup",
         label: (
             <>
-                <div className="mx_Tooltip_title">
+                <div className="mx_Tooltip_title mx_Tooltip--ReadReceiptGroup_label">
                     { roomMember?.rawDisplayName ?? userId }
                 </div>
-                <div className="mx_Tooltip_sub">
+                <div className="mx_Tooltip_sub mx_Tooltip--ReadReceiptGroup_label">
                     { userId }
                 </div>
             </>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -251,7 +251,7 @@ function SectionHeader({ className, children }: PropsWithChildren<ISectionHeader
     const [onFocus] = useRovingTabIndex(ref);
 
     return (
-        <h3
+        <h4
             className={className}
             role="menuitem"
             onFocus={onFocus}
@@ -259,6 +259,6 @@ function SectionHeader({ className, children }: PropsWithChildren<ISectionHeader
             ref={ref}
         >
             { children }
-        </h3>
+        </h4>
     );
 }

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -230,10 +230,10 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
                 hideTitle
             />
             <div className="mx_ReadReceiptGroup_name">
-                <p>{ roomMember?.name ?? userId }</p>
-                <p className="mx_ReadReceiptGroup_secondary">
+                <div>{ roomMember?.name ?? userId }</div>
+                <div className="mx_ReadReceiptGroup_secondary">
                     { formatDate(new Date(ts), isTwelveHour) }
-                </p>
+                </div>
             </div>
             { tooltip }
         </MenuItem>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -128,7 +128,7 @@ export function ReadReceiptGroup(
         const buttonRect = button.current.getBoundingClientRect();
         contextMenu = (
             <ContextMenu
-                menuClassName="mx_ReadReceiptGroup_popup"
+                menuClassName="mx_ContextMenu--ReadReceiptGroup"
                 onFinished={closeMenu}
                 {...aboveLeftOf(buttonRect)}>
                 <SectionHeader className="mx_ContextMenu_Header mx_ContextMenu_Header--ReadReceiptGroup">
@@ -187,7 +187,7 @@ interface ReadReceiptPersonProps extends IReadReceiptProps {
 function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick }: ReadReceiptPersonProps) {
     const [{ showTooltip, hideTooltip }, tooltip] = useTooltip({
         alignment: Alignment.TopCenter,
-        tooltipClassName: "mx_ReadReceiptGroup_person--tooltip",
+        tooltipClassName: "mx_Tooltip--ReadReceiptGroup",
         label: (
             <>
                 <div className="mx_Tooltip_title">

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -231,8 +231,8 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
                 resizeMethod="crop"
                 hideTitle
             />
-            <div className="mx_ReadReceiptGroup_name">
-                <div>{ roomMember?.name ?? userId }</div>
+            <div className="mx_ContextMenu_MenuItem_label mx_ReadReceiptGroup_name">
+                <div>{ roomMember.name }</div>
                 <div className="mx_ReadReceiptGroup_secondary">
                     { formatDate(new Date(ts), isTwelveHour) }
                 </div>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -134,7 +134,7 @@ export function ReadReceiptGroup(
                 <SectionHeader className="mx_ContextMenu_Header mx_ContextMenu_Header--ReadReceiptGroup">
                     { _t("Seen by %(count)s people", { count: readReceipts.length }) }
                 </SectionHeader>
-                <div className="mx_ReadReceiptGroup_receipts">
+                <div className="mx_ContextMenu_MenuItem">
                     <AutoHideScrollbar>
                         { readReceipts.map(receipt => (
                             <ReadReceiptPerson

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -134,18 +134,16 @@ export function ReadReceiptGroup(
                 <SectionHeader className="mx_ContextMenu_Header mx_ContextMenu_Header--ReadReceiptGroup">
                     { _t("Seen by %(count)s people", { count: readReceipts.length }) }
                 </SectionHeader>
-                <div className="mx_ContextMenu_MenuItem">
-                    <AutoHideScrollbar>
-                        { readReceipts.map(receipt => (
-                            <ReadReceiptPerson
-                                key={receipt.userId}
-                                {...receipt}
-                                isTwelveHour={isTwelveHour}
-                                onAfterClick={closeMenu}
-                            />
-                        )) }
-                    </AutoHideScrollbar>
-                </div>
+                <AutoHideScrollbar>
+                    { readReceipts.map(receipt => (
+                        <ReadReceiptPerson
+                            key={receipt.userId}
+                            {...receipt}
+                            isTwelveHour={isTwelveHour}
+                            onAfterClick={closeMenu}
+                        />
+                    )) }
+                </AutoHideScrollbar>
             </ContextMenu>
         );
     }
@@ -230,9 +228,9 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
                 resizeMethod="crop"
                 hideTitle
             />
-            <div className="mx_ContextMenu_MenuItem_label">
-                <div className="mx_ContextMenu_MenuItem_label_item">{ roomMember?.name ?? userId }</div>
-                <div className="mx_ContextMenu_MenuItem_label_item mx_ContextMenu_MenuItem_label_item--desc">
+            <div className="mx_ContextMenu_label">
+                <div className="mx_ContextMenu_label_item">{ roomMember?.name ?? userId }</div>
+                <div className="mx_ContextMenu_label_item mx_ContextMenu_label_item--desc">
                     { formatDate(new Date(ts), isTwelveHour) }
                 </div>
             </div>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -231,8 +231,8 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
                 hideTitle
             />
             <div className="mx_ContextMenu_MenuItem_label">
-                <div>{ roomMember.name }</div>
-                <div className="mx_ContextMenu_MenuItem_description">
+                <div className="mx_ContextMenu_MenuItem_label_item">{ roomMember?.name ?? userId }</div>
+                <div className="mx_ContextMenu_MenuItem_label_item mx_ContextMenu_MenuItem_label_item--desc">
                     { formatDate(new Date(ts), isTwelveHour) }
                 </div>
             </div>

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -131,19 +131,21 @@ export function ReadReceiptGroup(
                 menuClassName="mx_ReadReceiptGroup_popup"
                 onFinished={closeMenu}
                 {...aboveLeftOf(buttonRect)}>
-                <AutoHideScrollbar>
-                    <SectionHeader className="mx_ReadReceiptGroup_title">
-                        { _t("Seen by %(count)s people", { count: readReceipts.length }) }
-                    </SectionHeader>
-                    { readReceipts.map(receipt => (
-                        <ReadReceiptPerson
-                            key={receipt.userId}
-                            {...receipt}
-                            isTwelveHour={isTwelveHour}
-                            onAfterClick={closeMenu}
-                        />
-                    )) }
-                </AutoHideScrollbar>
+                <SectionHeader className="mx_ReadReceiptGroup_title">
+                    { _t("Seen by %(count)s people", { count: readReceipts.length }) }
+                </SectionHeader>
+                <div className="mx_ReadReceiptGroup_receipts">
+                    <AutoHideScrollbar>
+                        { readReceipts.map(receipt => (
+                            <ReadReceiptPerson
+                                key={receipt.userId}
+                                {...receipt}
+                                isTwelveHour={isTwelveHour}
+                                onAfterClick={closeMenu}
+                            />
+                        )) }
+                    </AutoHideScrollbar>
+                </div>
             </ContextMenu>
         );
     }

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -131,7 +131,7 @@ export function ReadReceiptGroup(
                 menuClassName="mx_ReadReceiptGroup_popup"
                 onFinished={closeMenu}
                 {...aboveLeftOf(buttonRect)}>
-                <SectionHeader className="mx_ReadReceiptGroup_title">
+                <SectionHeader className="mx_ContextMenu_Header mx_ContextMenu_Header--ReadReceiptGroup">
                     { _t("Seen by %(count)s people", { count: readReceipts.length }) }
                 </SectionHeader>
                 <div className="mx_ReadReceiptGroup_receipts">

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -202,7 +202,6 @@ function ReadReceiptPerson({ userId, roomMember, ts, isTwelveHour, onAfterClick 
 
     return (
         <MenuItem
-            className="mx_ReadReceiptGroup_person"
             onClick={() => {
                 dis.dispatch({
                     action: Action.ViewUser,

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -33,7 +33,9 @@ const RecentlyViewedButton = () => {
     const crumbs = useEventEmitterState(BreadcrumbsStore.instance, UPDATE_EVENT, () => BreadcrumbsStore.instance.rooms);
 
     const content = <div className="mx_RecentlyViewedButton_ContextMenu">
-        <h4>{ _t("Recently viewed") }</h4>
+        <h4 className="mx_ContextMenu_Header">
+            { _t("Recently viewed") }
+        </h4>
         <div>
             { crumbs.map(crumb => {
                 const contextDetails = roomContextDetailsText(crumb);

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -32,7 +32,7 @@ const RecentlyViewedButton = () => {
     const tooltipRef = useRef<InteractiveTooltip>();
     const crumbs = useEventEmitterState(BreadcrumbsStore.instance, UPDATE_EVENT, () => BreadcrumbsStore.instance.rooms);
 
-    const content = <div className="mx_RecentlyViewedButton_ContextMenu">
+    const content = <div className="mx_ContextMenu--RecentlyViewedButton">
         <h4 className="mx_ContextMenu_Header">
             { _t("Recently viewed") }
         </h4>

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -55,7 +55,7 @@ const RecentlyViewedButton = () => {
                     <DecoratedRoomAvatar room={crumb} avatarSize={24} tooltipProps={{ tabIndex: -1 }} />
                     <span className="mx_ContextMenu_MenuItem_label">
                         <div>{ crumb.name }</div>
-                        { contextDetails && <div className="mx_RecentlyViewedButton_entry_spaces">
+                        { contextDetails && <div className="mx_ContextMenu_MenuItem_description">
                             { contextDetails }
                         </div> }
                     </span>

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -27,6 +27,7 @@ import { Action } from "../../../dispatcher/actions";
 import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { roomContextDetailsText } from "../../../utils/i18n-helpers";
+import AutoHideScrollbar from "../../structures/AutoHideScrollbar";
 
 const RecentlyViewedButton = () => {
     const tooltipRef = useRef<InteractiveTooltip>();
@@ -36,7 +37,7 @@ const RecentlyViewedButton = () => {
         <h4 className="mx_ContextMenu_Header">
             { _t("Recently viewed") }
         </h4>
-        <div className="mx_ContextMenu_MenuItem">
+        <AutoHideScrollbar>
             { crumbs.map(crumb => {
                 const contextDetails = roomContextDetailsText(crumb);
 
@@ -53,16 +54,16 @@ const RecentlyViewedButton = () => {
                     }}
                 >
                     <DecoratedRoomAvatar room={crumb} avatarSize={24} tooltipProps={{ tabIndex: -1 }} />
-                    <span className="mx_ContextMenu_MenuItem_label">
-                        <div className="mx_ContextMenu_MenuItem_label_item">{ crumb.name }</div>
+                    <span className="mx_ContextMenu_label">
+                        <div className="mx_ContextMenu_label_item">{ crumb.name }</div>
                         { contextDetails && <div
-                            className="mx_ContextMenu_MenuItem_label_item mx_ContextMenu_MenuItem_label_item--desc">
+                            className="mx_ContextMenu_label_item mx_ContextMenu_label_item--desc">
                             { contextDetails }
                         </div> }
                     </span>
                 </MenuItem>;
             }) }
-        </div>
+        </AutoHideScrollbar>
     </div>;
 
     return <InteractiveTooltip content={content} direction={Direction.Right} ref={tooltipRef}>

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -54,8 +54,9 @@ const RecentlyViewedButton = () => {
                 >
                     <DecoratedRoomAvatar room={crumb} avatarSize={24} tooltipProps={{ tabIndex: -1 }} />
                     <span className="mx_ContextMenu_MenuItem_label">
-                        <div>{ crumb.name }</div>
-                        { contextDetails && <div className="mx_ContextMenu_MenuItem_description">
+                        <div className="mx_ContextMenu_MenuItem_label_item">{ crumb.name }</div>
+                        { contextDetails && <div
+                            className="mx_ContextMenu_MenuItem_label_item mx_ContextMenu_MenuItem_label_item--desc">
                             { contextDetails }
                         </div> }
                     </span>

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -53,7 +53,7 @@ const RecentlyViewedButton = () => {
                     }}
                 >
                     <DecoratedRoomAvatar room={crumb} avatarSize={24} tooltipProps={{ tabIndex: -1 }} />
-                    <span className="mx_RecentlyViewedButton_entry_label">
+                    <span className="mx_ContextMenu_MenuItem_label">
                         <div>{ crumb.name }</div>
                         { contextDetails && <div className="mx_RecentlyViewedButton_entry_spaces">
                             { contextDetails }

--- a/src/components/views/rooms/RecentlyViewedButton.tsx
+++ b/src/components/views/rooms/RecentlyViewedButton.tsx
@@ -36,7 +36,7 @@ const RecentlyViewedButton = () => {
         <h4 className="mx_ContextMenu_Header">
             { _t("Recently viewed") }
         </h4>
-        <div>
+        <div className="mx_ContextMenu_MenuItem">
             { crumbs.map(crumb => {
                 const contextDetails = roomContextDetailsText(crumb);
 


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21898

This PR inherits font size of the header (`Seen by ... people`), the user ID, and the clock from the current implementation. Input on their size and spacing between elements would be greatly appreciated.

Dark theme:

https://user-images.githubusercontent.com/3362943/165489784-8904f9ab-9ba4-4f50-8bed-b2026c186128.mp4

Light theme:

https://user-images.githubusercontent.com/3362943/165489810-d5be0591-1537-4730-bfb3-5356e2fc8312.mp4

On the tooltip should a long user name not overflow:

![after1](https://user-images.githubusercontent.com/3362943/165491530-646e79c2-9871-4715-9532-10304950592c.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
