### PR TITLE
Disable the message action bar when hovering over the 1px border between threads on the list

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -838,6 +838,7 @@ $threadInfoLineHeight: calc(2 * $font-12px);
         height: 1px;
         bottom: calc(-1 * var(--topOffset));
         background-color: $quinary-content;
+        pointer-events: none; // disable the message action bar on hover
     }
 
     &::before {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21955

This PR fixes the issue that the message action bar appears when hovering over the 1px border between threads in the threads list.

Before this PR:

https://user-images.githubusercontent.com/3362943/165530708-bed3aed2-cc76-4336-89c1-3ef98d7179ff.mp4

![before](https://user-images.githubusercontent.com/3362943/165530722-e378b92b-1178-4b53-9215-cb9def56c801.png)

After this PR:

https://user-images.githubusercontent.com/3362943/165530687-7e75d3b5-10a3-4f08-bd98-d8780f3ac523.mp4

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Disable the message action bar when hovering over the 1px border between threads on the list ([\#8429](https://github.com/matrix-org/matrix-react-sdk/pull/8429)). Fixes vector-im/element-web#21955. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->