### PR TITLE
Fix issue with underfilled timelines when barren of content

### DIFF
--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -731,7 +731,7 @@ export default class ScrollPanel extends React.Component<IProps> {
         const contentHeight = this.getMessagesHeight();
         // Only round to the nearest page when we're basing the height off the content, not off the scrollNode height
         // otherwise it'll cause too much overscroll which makes it possible to entirely scroll content off-screen.
-        if (contentHeight < sn.clientHeight - PAGE_SIZE) {
+        if (contentHeight < sn.clientHeight) {
             this.minListHeight = sn.clientHeight;
         } else {
             this.minListHeight = Math.ceil(contentHeight / PAGE_SIZE) * PAGE_SIZE;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21930

Originally thought giving it a buffer region of a page would help smooth over updates as you resize but it instead created a region which was underfilled causing the messages to float in the middle, not sticking to top or bottom (bottom being expected in BACAT)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issue with underfilled timelines when barren of content ([\#8432](https://github.com/matrix-org/matrix-react-sdk/pull/8432)). Fixes vector-im/element-web#21930.<!-- CHANGELOG_PREVIEW_END -->