### PR TITLE
Live location sharing - handle safari cocoa core data timestamps

### DIFF
--- a/src/utils/beacon/geolocation.ts
+++ b/src/utils/beacon/geolocation.ts
@@ -86,8 +86,13 @@ export const genericPositionFromGeolocation = (geoPosition: GeolocationPosition)
     const {
         latitude, longitude, altitude, accuracy,
     } = geoPosition.coords;
+
     return {
-        timestamp: geoPosition.timestamp,
+        // safari reports geolocation timestamps as Apple Cocoa Core Data timestamp
+        // or ms since 1/1/2001 instead of the regular epoch
+        // they also use local time, not utc
+        // to simplify, just use Date.now()
+        timestamp: Date.now(),
         latitude, longitude, altitude, accuracy,
     };
 };


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Safari reports geolocation timestamps in an arcane apple format - illustrated here: https://jsfiddle.net/vRRdE/2/

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->