### PR TITLE
Fix indentation of mx_EventTile_body inside ThreadView on Modern layout

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -886,12 +886,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         width: 100%;
 
         .mx_EventTile_content,
-        .mx_EventTile_body,
         .mx_HiddenBody,
         .mx_RedactedBody,
         .mx_UnknownBody,
         .mx_MPollBody,
         .mx_MLocationBody,
+        .mx_MLocationBody_error,
+        .mx_MLocationBody_fallback,
         .mx_ReplyChain_wrapper,
         .mx_ReactionsRow {
             margin-left: $spacing-start;
@@ -903,6 +904,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             .mx_MImageBody {
                 margin: 0;
             }
+        }
+
+        .mx_MLocationBody_error {
+            // See: mx_EventTile_tileError of _EventTile.scss
+            display: block;
+            text-align: start;
         }
 
         .mx_ReplyChain_wrapper {

--- a/src/components/views/messages/MLocationBody.tsx
+++ b/src/components/views/messages/MLocationBody.tsx
@@ -97,11 +97,13 @@ export const LocationBodyFallbackContent: React.FC<{ event: MatrixEvent, error: 
         (_t('Shared a location: ') + event.getContent()?.body);
 
     return <div className="mx_EventTile_body">
-        <span className={errorType !== LocationShareError.MapStyleUrlNotConfigured ? "mx_EventTile_tileError" : ''}>
+        <span className={errorType !== LocationShareError.MapStyleUrlNotConfigured
+            ? "mx_EventTile_tileError mx_MLocationBody_error"
+            : ''
+        }>
             { message }
         </span>
-        <br />
-        { locationFallback }
+        <div className="mx_MLocationBody_fallback">{ locationFallback }</div>
     </div>;
 };
 
@@ -155,4 +157,3 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
         }
     </div>;
 };
-

--- a/test/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
+++ b/test/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
@@ -5,12 +5,15 @@ exports[`MLocationBody <MLocationBody> with error displays correct fallback cont
   className="mx_EventTile_body"
 >
   <span
-    className="mx_EventTile_tileError"
+    className="mx_EventTile_tileError mx_MLocationBody_error"
   >
     Unable to load map: This homeserver is not configured correctly to display maps, or the configured map server may be unreachable.
   </span>
-  <br />
-  Shared a location: Found at geo:51.5076,-0.1276 at 2021-12-21T12:22+0000
+  <div
+    className="mx_MLocationBody_fallback"
+  >
+    Shared a location: Found at geo:51.5076,-0.1276 at 2021-12-21T12:22+0000
+  </div>
 </div>
 `;
 
@@ -23,8 +26,11 @@ exports[`MLocationBody <MLocationBody> with error displays correct fallback cont
   >
     Unable to load map: This homeserver is not configured to display maps.
   </span>
-  <br />
-  Shared a location: Found at geo:51.5076,-0.1276 at 2021-12-21T12:22+0000
+  <div
+    className="mx_MLocationBody_fallback"
+  >
+    Shared a location: Found at geo:51.5076,-0.1276 at 2021-12-21T12:22+0000
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21997
The bug was introduced with https://github.com/matrix-org/matrix-react-sdk/pull/8442/files#diff-bd83194d78de871bc4ad1c4e8d43102c4368481bbb90705152d3d17fea813919R892.

Steps to confirm the fix:

1. Create a test room
2. Create a test thread
3. Send a message on the thread
4. Share location
5. Check that the message is not intended
6. Check that the error message is intended
7. Check that the fallback message is intended 

![after](https://user-images.githubusercontent.com/3362943/166097689-b8df7f5d-61a7-478c-acb4-127455152690.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix indentation of mx_EventTile_body inside ThreadView on Modern layout ([\#8450](https://github.com/matrix-org/matrix-react-sdk/pull/8450)). Fixes vector-im/element-web#21997. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->