### PR TITLE
Fix poll overflowing a reply tile on bubble message layout

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -406,6 +406,7 @@ limitations under the License.
 
     .mx_MPollBody {
         width: 550px; // to prevent timestamp overlapping summary text
+        max-width: 100%; // prevent overflowing a reply tile
 
         .mx_MPollBody_totalVotes {
             // align summary text with corner timestamp


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22005

This PR fixes poll options overflowing a reply tile on bubble message layout.

Steps to confirm the fix:
1. Change the layout to bubble message layout
2. Create a poll
3. Reply to the poll

![after](https://user-images.githubusercontent.com/3362943/166146585-cb7da4e4-c1ff-4ac4-9689-08ce96c2f9be.png)

https://user-images.githubusercontent.com/3362943/166146536-75990651-c6d2-4053-b762-687e1ff6eea1.mp4

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix poll overflowing a reply tile on bubble message layout ([\#8459](https://github.com/matrix-org/matrix-react-sdk/pull/8459)). Fixes vector-im/element-web#22005. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->