### PR TITLE
Match MSC behaviour for threads when disabled (thread-aware mode)

### DIFF
--- a/src/utils/Reply.ts
+++ b/src/utils/Reply.ts
@@ -152,8 +152,17 @@ export function makeReplyMixIn(ev?: MatrixEvent): IEventRelation {
         },
     };
 
-    if (SettingsStore.getValue("feature_thread") && ev.threadRootId) {
-        mixin.is_falling_back = false;
+    if (ev.threadRootId) {
+        if (SettingsStore.getValue("feature_thread")) {
+            mixin.is_falling_back = false;
+        } else {
+            // Clients that do not offer a threading UI should behave as follows when replying, for best interaction
+            // with those that do. They should set the m.in_reply_to part as usual, and then add on
+            // "rel_type": "m.thread" and "event_id": "$thread_root", copying $thread_root from the replied-to event.
+            const relation = ev.getRelation();
+            mixin.rel_type = relation.rel_type;
+            mixin.event_id = relation.event_id;
+        }
     }
 
     return mixin;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22033

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Match MSC behaviour for threads when disabled (thread-aware mode) ([\#8476](https://github.com/matrix-org/matrix-react-sdk/pull/8476)). Fixes vector-im/element-web#22033.<!-- CHANGELOG_PREVIEW_END -->