### PR TITLE
Fix reading of cached room device setting values

### DIFF
--- a/src/settings/handlers/RoomDeviceSettingsHandler.ts
+++ b/src/settings/handlers/RoomDeviceSettingsHandler.ts
@@ -69,7 +69,7 @@ export default class RoomDeviceSettingsHandler extends AbstractLocalStorageSetti
     }
 
     private read(key: string): any {
-        return this.getItem(key);
+        return this.getObject(key);
     }
 
     private getKey(settingName: string, roomId: string): string {

--- a/test/settings/handlers/RoomDeviceSettingsHandler-test.ts
+++ b/test/settings/handlers/RoomDeviceSettingsHandler-test.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import RoomDeviceSettingsHandler from "../../../src/settings/handlers/RoomDeviceSettingsHandler";
+import { WatchManager } from "../../../src/settings/WatchManager";
+
+describe("RoomDeviceSettingsHandler", () => {
+    it("should correctly read cached values", () => {
+        const watchers = new WatchManager();
+        const handler = new RoomDeviceSettingsHandler(watchers);
+
+        const settingName = "RightPanel.phases";
+        const roomId = "!room:server";
+        const value = {
+            isOpen: true,
+            history: [{}],
+        };
+
+        handler.setValue(settingName, roomId, value);
+        expect(handler.getValue(settingName, roomId)).toEqual(value);
+    });
+});


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix reading of cached room device setting values ([\#8491](https://github.com/matrix-org/matrix-react-sdk/pull/8491)).<!-- CHANGELOG_PREVIEW_END -->