### PR TITLE
Fix soft crash around threads when room isn't yet in store

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -402,8 +402,7 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
     }
 
     private setupNotificationListener = (thread: Thread): void => {
-        const room = MatrixClientPeg.get().getRoom(this.props.mxEvent.getRoomId());
-        const notifications = RoomNotificationStateStore.instance.getThreadsRoomState(room);
+        const notifications = RoomNotificationStateStore.instance.getThreadsRoomState(thread.room);
 
         this.threadState = notifications.getThreadRoomState(thread);
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22047

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix soft crash around threads when room isn't yet in store ([\#8496](https://github.com/matrix-org/matrix-react-sdk/pull/8496)). Fixes vector-im/element-web#22047.<!-- CHANGELOG_PREVIEW_END -->