### PR TITLE
Remove width setting for RoomView_messageListWrapper on the thread panel

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -149,12 +149,6 @@ limitations under the License.
         }
     }
 
-    .mx_RoomView_messagePanel { // To avoid the rule from being applied to .mx_ThreadPanel_empty
-        .mx_RoomView_messageListWrapper {
-            width: calc(100% + 6px); // 8px - 2px
-        }
-    }
-
     .mx_RoomView_MessageList {
         padding-inline-start: $spacing-8;
         padding-inline-end: $spacing-8;


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/8337
Fixes https://github.com/vector-im/element-web/issues/22079

This PR removes the width setting for thread panel which has set the spacing between the right border and the event tile.

![after](https://user-images.githubusercontent.com/3362943/166871787-1aeb9f95-cd4c-49d2-9dd0-f266e7490e0d.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove width setting for RoomView_messageListWrapper on the thread panel ([\#8503](https://github.com/matrix-org/matrix-react-sdk/pull/8503)). Fixes vector-im/element-web#22079. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->