### PR TITLE
Order receipts with the most recent on the right

### DIFF
--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -56,7 +56,7 @@ export function determineAvatarPosition(index: number, count: number, max: numbe
     if (index < max) {
         return {
             hidden: false,
-            position: Math.min(count, max) - index - 1,
+            position: index,
         };
     } else {
         return {

--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -52,7 +52,7 @@ interface IAvatarPosition {
     position: number;
 }
 
-export function determineAvatarPosition(index: number, count: number, max: number): IAvatarPosition {
+export function determineAvatarPosition(index: number, max: number): IAvatarPosition {
     if (index < max) {
         return {
             hidden: false,
@@ -133,7 +133,7 @@ export function ReadReceiptGroup(
     }
 
     const avatars = readReceipts.map((receipt, index) => {
-        const { hidden, position } = determineAvatarPosition(index, readReceipts.length, maxAvatars);
+        const { hidden, position } = determineAvatarPosition(index, maxAvatars);
 
         const userId = receipt.userId;
         let readReceiptInfo: IReadReceiptInfo;

--- a/test/components/views/rooms/ReadReceiptGroup-test.tsx
+++ b/test/components/views/rooms/ReadReceiptGroup-test.tsx
@@ -37,43 +37,43 @@ describe("ReadReceiptGroup", () => {
         // We want to fill slots so the first avatar is in the right-most slot without leaving any slots at the left
         // unoccupied.
         it("to handle the non-overflowing case correctly", () => {
-            expect(determineAvatarPosition(0, 1, 4))
+            expect(determineAvatarPosition(0, 4))
                 .toEqual({ hidden: false, position: 0 });
 
-            expect(determineAvatarPosition(0, 2, 4))
+            expect(determineAvatarPosition(0, 4))
                 .toEqual({ hidden: false, position: 0 });
-            expect(determineAvatarPosition(1, 2, 4))
+            expect(determineAvatarPosition(1, 4))
                 .toEqual({ hidden: false, position: 1 });
 
-            expect(determineAvatarPosition(0, 3, 4))
+            expect(determineAvatarPosition(0, 4))
                 .toEqual({ hidden: false, position: 0 });
-            expect(determineAvatarPosition(1, 3, 4))
+            expect(determineAvatarPosition(1, 4))
                 .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(2, 3, 4))
+            expect(determineAvatarPosition(2, 4))
                 .toEqual({ hidden: false, position: 2 });
 
-            expect(determineAvatarPosition(0, 4, 4))
+            expect(determineAvatarPosition(0, 4))
                 .toEqual({ hidden: false, position: 0 });
-            expect(determineAvatarPosition(1, 4, 4))
+            expect(determineAvatarPosition(1, 4))
                 .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(2, 4, 4))
+            expect(determineAvatarPosition(2, 4))
                 .toEqual({ hidden: false, position: 2 });
-            expect(determineAvatarPosition(3, 4, 4))
+            expect(determineAvatarPosition(3, 4))
                 .toEqual({ hidden: false, position: 3 });
         });
 
         it("to handle the overflowing case correctly", () => {
-            expect(determineAvatarPosition(0, 6, 4))
+            expect(determineAvatarPosition(0, 4))
                 .toEqual({ hidden: false, position: 0 });
-            expect(determineAvatarPosition(1, 6, 4))
+            expect(determineAvatarPosition(1, 4))
                 .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(2, 6, 4))
+            expect(determineAvatarPosition(2, 4))
                 .toEqual({ hidden: false, position: 2 });
-            expect(determineAvatarPosition(3, 6, 4))
+            expect(determineAvatarPosition(3, 4))
                 .toEqual({ hidden: false, position: 3 });
-            expect(determineAvatarPosition(4, 6, 4))
+            expect(determineAvatarPosition(4, 4))
                 .toEqual({ hidden: true, position: 0 });
-            expect(determineAvatarPosition(5, 6, 4))
+            expect(determineAvatarPosition(5, 4))
                 .toEqual({ hidden: true, position: 0 });
         });
     });

--- a/test/components/views/rooms/ReadReceiptGroup-test.tsx
+++ b/test/components/views/rooms/ReadReceiptGroup-test.tsx
@@ -34,43 +34,43 @@ describe("ReadReceiptGroup", () => {
     describe("AvatarPosition", () => {
         // The avatar slots are numbered from right to left
         // That means currently, we’ve got the slots | 3 | 2 | 1 | 0 | each with 10px distance to the next one.
-        // We want to fill slots so the first avatar is in the left-most slot without leaving any slots at the right
+        // We want to fill slots so the first avatar is in the right-most slot without leaving any slots at the left
         // unoccupied.
         it("to handle the non-overflowing case correctly", () => {
             expect(determineAvatarPosition(0, 1, 4))
                 .toEqual({ hidden: false, position: 0 });
 
             expect(determineAvatarPosition(0, 2, 4))
-                .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(1, 2, 4))
                 .toEqual({ hidden: false, position: 0 });
+            expect(determineAvatarPosition(1, 2, 4))
+                .toEqual({ hidden: false, position: 1 });
 
             expect(determineAvatarPosition(0, 3, 4))
-                .toEqual({ hidden: false, position: 2 });
+                .toEqual({ hidden: false, position: 0 });
             expect(determineAvatarPosition(1, 3, 4))
                 .toEqual({ hidden: false, position: 1 });
             expect(determineAvatarPosition(2, 3, 4))
-                .toEqual({ hidden: false, position: 0 });
+                .toEqual({ hidden: false, position: 2 });
 
             expect(determineAvatarPosition(0, 4, 4))
-                .toEqual({ hidden: false, position: 3 });
-            expect(determineAvatarPosition(1, 4, 4))
-                .toEqual({ hidden: false, position: 2 });
-            expect(determineAvatarPosition(2, 4, 4))
-                .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(3, 4, 4))
                 .toEqual({ hidden: false, position: 0 });
+            expect(determineAvatarPosition(1, 4, 4))
+                .toEqual({ hidden: false, position: 1 });
+            expect(determineAvatarPosition(2, 4, 4))
+                .toEqual({ hidden: false, position: 2 });
+            expect(determineAvatarPosition(3, 4, 4))
+                .toEqual({ hidden: false, position: 3 });
         });
 
         it("to handle the overflowing case correctly", () => {
             expect(determineAvatarPosition(0, 6, 4))
-                .toEqual({ hidden: false, position: 3 });
-            expect(determineAvatarPosition(1, 6, 4))
-                .toEqual({ hidden: false, position: 2 });
-            expect(determineAvatarPosition(2, 6, 4))
-                .toEqual({ hidden: false, position: 1 });
-            expect(determineAvatarPosition(3, 6, 4))
                 .toEqual({ hidden: false, position: 0 });
+            expect(determineAvatarPosition(1, 6, 4))
+                .toEqual({ hidden: false, position: 1 });
+            expect(determineAvatarPosition(2, 6, 4))
+                .toEqual({ hidden: false, position: 2 });
+            expect(determineAvatarPosition(3, 6, 4))
+                .toEqual({ hidden: false, position: 3 });
             expect(determineAvatarPosition(4, 6, 4))
                 .toEqual({ hidden: true, position: 0 });
             expect(determineAvatarPosition(5, 6, 4))


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22044

<hr>

![2022-05-05_13-05](https://user-images.githubusercontent.com/25768714/166910896-ff68554d-1b11-4efe-908a-3d7abe320429.png)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Order receipts with the most recent on the right ([\#8506](https://github.com/matrix-org/matrix-react-sdk/pull/8506)). Fixes vector-im/element-web#22044.<!-- CHANGELOG_PREVIEW_END -->