### PR TITLE
Log errors in english

### DIFF
--- a/src/AddThreepid.ts
+++ b/src/AddThreepid.ts
@@ -63,7 +63,7 @@ export default class AddThreepid {
             return res;
         }, function(err) {
             if (err.errcode === 'M_THREEPID_IN_USE') {
-                err.message = _t('This email address is already in use');
+                err.message = 'This email address is already in use';
             } else if (err.httpStatus) {
                 err.message = err.message + ` (Status ${err.httpStatus})`;
             }
@@ -91,7 +91,7 @@ export default class AddThreepid {
                 return res;
             }, function(err) {
                 if (err.errcode === 'M_THREEPID_IN_USE') {
-                    err.message = _t('This email address is already in use');
+                    err.message = 'This email address is already in use';
                 } else if (err.httpStatus) {
                     err.message = err.message + ` (Status ${err.httpStatus})`;
                 }

--- a/src/components/views/dialogs/SetEmailDialog.tsx
+++ b/src/components/views/dialogs/SetEmailDialog.tsx
@@ -86,7 +86,7 @@ export default class SetEmailDialog extends React.Component<IProps, IState> {
             logger.error("Unable to add email address " + emailAddress + " " + err);
             Modal.createTrackedDialog('Unable to add email address', '', ErrorDialog, {
                 title: _t("Unable to add email address"),
-                description: ((err && err.message) ? err.message : _t("Operation failed")),
+                description: ((err && err.message) ? _t(err.message) : _t("Operation failed")),
             });
         });
         this.setState({ emailBusy: true });

--- a/src/components/views/settings/ChangePassword.tsx
+++ b/src/components/views/settings/ChangePassword.tsx
@@ -165,11 +165,11 @@ export default class ChangePassword extends React.Component<IProps, IState> {
     private checkPassword(oldPass: string, newPass: string, confirmPass: string): {error: string} {
         if (newPass !== confirmPass) {
             return {
-                error: _t("New passwords don't match"),
+                error: "New passwords don't match",
             };
         } else if (!newPass || newPass.length === 0) {
             return {
-                error: _t("Passwords can't be empty"),
+                error: "Passwords can't be empty",
             };
         }
     }

--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.tsx
@@ -249,14 +249,14 @@ export default class GeneralUserSettingsTab extends React.Component<IProps, ISta
         // TODO: Figure out a design that doesn't involve replacing the current dialog
         let errMsg = err.error || err.message || "";
         if (err.httpStatus === 403) {
-            errMsg = _t("Failed to change password. Is your password correct?");
+            errMsg = "Failed to change password. Is your password correct?";
         } else if (!errMsg) {
             errMsg += ` (HTTP status ${err.httpStatus})`;
         }
         logger.error("Failed to change password: " + errMsg);
         Modal.createTrackedDialog('Failed to change password', '', ErrorDialog, {
             title: _t("Error"),
-            description: errMsg,
+            description: _t(errMsg),
         });
     };
 


### PR DESCRIPTION
When using element.io in languages other than English, a few errors in console get logged in the native language as addressed by issue [#9597](https://github.com/vector-im/element-web/issues/9597)

Summary of Changes done : 

- Changed all `err.message` to English
- Added `_t()` in Modal Descriptions . eg., `description: _t(errMsg)`

Signed Off by : Reshma <reshmashaik3011@gmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Log errors in english ([\#8508](https://github.com/matrix-org/matrix-react-sdk/pull/8508)). Contributed by @TheReshma.<!-- CHANGELOG_PREVIEW_END -->