### PR TITLE
Add a way to toggle `ScrollPanel` and `TimelinePanel` debug logs

### DIFF
--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -17,13 +17,12 @@ limitations under the License.
 import React, { createRef, CSSProperties, ReactNode, KeyboardEvent } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
 
+import SettingsStore from '../../settings/SettingsStore';
 import Timer from '../../utils/Timer';
 import AutoHideScrollbar from "./AutoHideScrollbar";
 import { getKeyBindingsManager } from "../../KeyBindingsManager";
 import ResizeNotifier from "../../utils/ResizeNotifier";
 import { KeyBindingAction } from "../../accessibility/KeyboardShortcuts";
-
-const DEBUG_SCROLL = false;
 
 // The amount of extra scroll distance to allow prior to unfilling.
 // See getExcessHeight.
@@ -36,12 +35,10 @@ const UNFILL_REQUEST_DEBOUNCE_MS = 200;
 // much while the content loads.
 const PAGE_SIZE = 400;
 
-let debuglog;
-if (DEBUG_SCROLL) {
-    // using bind means that we get to keep useful line numbers in the console
-    debuglog = logger.log.bind(console, "ScrollPanel debuglog:");
-} else {
-    debuglog = function() {};
+const debuglog = function() {
+    if(SettingsStore.getValue("debug_scroll_panel")) {
+        logger.log.call(console, "ScrollPanel debuglog:", ...arguments);
+    }
 }
 
 interface IProps {

--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -36,10 +36,10 @@ const UNFILL_REQUEST_DEBOUNCE_MS = 200;
 const PAGE_SIZE = 400;
 
 const debuglog = (...args: any[]) => {
-    if(SettingsStore.getValue("debug_scroll_panel")) {
+    if (SettingsStore.getValue("debug_scroll_panel")) {
         logger.log.call(console, "ScrollPanel debuglog:", ...args);
     }
-}
+};
 
 interface IProps {
     /* stickyBottom: if set to true, then once the user hits the bottom of

--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -35,9 +35,9 @@ const UNFILL_REQUEST_DEBOUNCE_MS = 200;
 // much while the content loads.
 const PAGE_SIZE = 400;
 
-const debuglog = function() {
+const debuglog = (...args: any[]) => {
     if(SettingsStore.getValue("debug_scroll_panel")) {
-        logger.log.call(console, "ScrollPanel debuglog:", ...arguments);
+        logger.log.call(console, "ScrollPanel debuglog:", ...args);
     }
 }
 

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -61,9 +61,9 @@ const READ_RECEIPT_INTERVAL_MS = 500;
 
 const READ_MARKER_DEBOUNCE_MS = 100;
 
-const debuglog = function() {
+const debuglog = (...args: any[]) => {
     if(SettingsStore.getValue("debug_timeline_panel")) {
-        logger.log.call(console, "TimelinePanel debuglog:", ...arguments);
+        logger.log.call(console, "TimelinePanel debuglog:", ...args);
     }
 }
 

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -61,12 +61,10 @@ const READ_RECEIPT_INTERVAL_MS = 500;
 
 const READ_MARKER_DEBOUNCE_MS = 100;
 
-const DEBUG = false;
-
-let debuglog = function(...s: any[]) {};
-if (DEBUG) {
-    // using bind means that we get to keep useful line numbers in the console
-    debuglog = logger.log.bind(console, "TimelinePanel debuglog:");
+const debuglog = function() {
+    if(SettingsStore.getValue("debug_timeline_panel")) {
+        logger.log.call(console, "TimelinePanel debuglog:", ...arguments);
+    }
 }
 
 interface IProps {

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -62,10 +62,10 @@ const READ_RECEIPT_INTERVAL_MS = 500;
 const READ_MARKER_DEBOUNCE_MS = 100;
 
 const debuglog = (...args: any[]) => {
-    if(SettingsStore.getValue("debug_timeline_panel")) {
+    if (SettingsStore.getValue("debug_timeline_panel")) {
         logger.log.call(console, "TimelinePanel debuglog:", ...args);
     }
-}
+};
 
 interface IProps {
     // The js-sdk EventTimelineSet object for the timeline sequence we are

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -949,6 +949,14 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: false,
     },
+    "debug_scroll_panel": {
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        default: false,
+    },
+    "debug_timeline_panel": {
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        default: false,
+    },
     [UIFeature.RoomHistorySettings]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,


### PR DESCRIPTION
Add a way to toggle `ScrollPanel` and `TimelinePanel` debug logs while using the app. Previously, the debug logs could only be turned on at build time which doesn't work if you're reproducing bugs in production (`app.element.io` `develop.element.io`).

Part of https://github.com/vector-im/element-web/issues/21532. This does solve the direct use case mentioned in that issue but the approach we're taking here doesn't scale well to debug logs in many components because we need a setting for each one. This works for now but would like to explore the options mentioned in the issue to make this more scalable and user-friendly if we need to capture more logs from someone.

To better debug timeline issues when they crop up.

Turn on:
```js
mxSettingsStore.setValue('debug_scroll_panel', null, 'device', true);
mxSettingsStore.setValue('debug_timeline_panel', null, 'device', true);
```

Turn off:
```js
mxSettingsStore.setValue('debug_scroll_panel', null, 'device', false);
mxSettingsStore.setValue('debug_timeline_panel', null, 'device', false);
```

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a way to toggle `ScrollPanel` and `TimelinePanel` debug logs ([\#8513](https://github.com/matrix-org/matrix-react-sdk/pull/8513)). Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->