### PR TITLE
Live location sharing - refresh beacon timers on tab becoming active

### DIFF
--- a/src/components/views/beacon/LeftPanelLiveShareWarning.tsx
+++ b/src/components/views/beacon/LeftPanelLiveShareWarning.tsx
@@ -63,12 +63,10 @@ const getLabel = (hasStoppingErrors: boolean, hasLocationErrors: boolean): strin
 
 const useLivenessMonitor = (liveBeaconIds: BeaconIdentifier[], beacons: Map<BeaconIdentifier, Beacon>): void => {
     useEffect(() => {
-        console.log('hhh does this fire too much?');
         // chromium sets the minimum timer interval to 1000ms
         // for inactive tabs
         // refresh beacon monitors when the tab becomes active again
         const onPageVisibilityChanged = () => {
-            console.log('hhh onPageVisibilityChanged', document.visibilityState, liveBeaconIds);
             if (document.visibilityState === 'visible') {
                 liveBeaconIds.map(identifier => beacons.get(identifier)?.monitorLiveness());
             }

--- a/src/components/views/beacon/LeftPanelLiveShareWarning.tsx
+++ b/src/components/views/beacon/LeftPanelLiveShareWarning.tsx
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import classNames from 'classnames';
-import React from 'react';
-import { BeaconIdentifier, Room } from 'matrix-js-sdk/src/matrix';
+import React, { useEffect } from 'react';
+import { Beacon, BeaconIdentifier, Room } from 'matrix-js-sdk/src/matrix';
 
 import { useEventEmitterState } from '../../../hooks/useEventEmitter';
 import { _t } from '../../../languageHandler';
@@ -61,6 +61,27 @@ const getLabel = (hasStoppingErrors: boolean, hasLocationErrors: boolean): strin
     return _t('You are sharing your live location');
 };
 
+const useLivenessMonitor = (liveBeaconIds: BeaconIdentifier[], beacons: Map<BeaconIdentifier, Beacon>): void => {
+    useEffect(() => {
+        console.log('hhh does this fire too much?');
+        // chromium sets the minimum timer interval to 1000ms
+        // for inactive tabs
+        // refresh beacon monitors when the tab becomes active again
+        const onPageVisibilityChanged = () => {
+            console.log('hhh onPageVisibilityChanged', document.visibilityState, liveBeaconIds);
+            if (document.visibilityState === 'visible') {
+                liveBeaconIds.map(identifier => beacons.get(identifier)?.monitorLiveness());
+            }
+        };
+        if (liveBeaconIds.length) {
+            document.addEventListener("visibilitychange", onPageVisibilityChanged);
+        }
+        () => {
+            document.removeEventListener("visibilitychange", onPageVisibilityChanged);
+        };
+    }, [liveBeaconIds, beacons]);
+};
+
 const LeftPanelLiveShareWarning: React.FC<Props> = ({ isMinimized }) => {
     const isMonitoringLiveLocation = useEventEmitterState(
         OwnBeaconStore.instance,
@@ -90,6 +111,8 @@ const LeftPanelLiveShareWarning: React.FC<Props> = ({ isMinimized }) => {
 
     const hasLocationPublishErrors = !!beaconIdsWithLocationPublishError.length;
     const hasStoppingErrors = !!beaconIdsWithStoppingError.length;
+
+    useLivenessMonitor(liveBeaconIds, OwnBeaconStore.instance.beacons);
 
     if (!isMonitoringLiveLocation) {
         return null;

--- a/test/components/views/beacon/LeftPanelLiveShareWarning-test.tsx
+++ b/test/components/views/beacon/LeftPanelLiveShareWarning-test.tsx
@@ -34,6 +34,7 @@ jest.mock('../../../../src/stores/OwnBeaconStore', () => {
         public getBeaconById = jest.fn();
         public getLiveBeaconIds = jest.fn().mockReturnValue([]);
         public readonly beaconUpdateErrors = new Map<BeaconIdentifier, Error>();
+        public readonly beacons = new Map<BeaconIdentifier, Beacon>();
     }
     return {
         // @ts-ignore
@@ -193,6 +194,24 @@ describe('<LeftPanelLiveShareWarning />', () => {
             component.setProps({});
 
             expect(component.html()).toBe(null);
+        });
+
+        it('refreshes beacon liveness monitors when pagevisibilty changes to visible', () => {
+            OwnBeaconStore.instance.beacons.set(beacon1.identifier, beacon1);
+            OwnBeaconStore.instance.beacons.set(beacon2.identifier, beacon2);
+            const beacon1MonitorSpy = jest.spyOn(beacon1, 'monitorLiveness');
+            const beacon2MonitorSpy = jest.spyOn(beacon1, 'monitorLiveness');
+
+            jest.spyOn(document, 'addEventListener').mockImplementation(
+                (_e, listener) => (listener as EventListener)(new Event('')),
+            );
+
+            expect(beacon1MonitorSpy).not.toHaveBeenCalled();
+
+            getComponent();
+
+            expect(beacon1MonitorSpy).toHaveBeenCalled();
+            expect(beacon2MonitorSpy).toHaveBeenCalled();
         });
 
         describe('stopping errors', () => {

--- a/test/components/views/beacon/LeftPanelLiveShareWarning-test.tsx
+++ b/test/components/views/beacon/LeftPanelLiveShareWarning-test.tsx
@@ -104,6 +104,10 @@ describe('<LeftPanelLiveShareWarning />', () => {
             mocked(OwnBeaconStore.instance).getLiveBeaconIds.mockReturnValue([beacon2.identifier, beacon1.identifier]);
         });
 
+        afterAll(() => {
+            jest.spyOn(document, 'addEventListener').mockRestore();
+        });
+
         it('renders correctly when not minimized', () => {
             const component = getComponent();
             expect(component).toMatchSnapshot();


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Beacon's expiry time is monitored by timeouts. Chromium optimises by servicing timers less often in inactive tabs. This means that while a tab is inactive, its timers get out of sync and the beacon can pass its expiry without the liveness monitor updating correctly - leading to '0s remaining' UI like this:
![image](https://user-images.githubusercontent.com/3055605/167102242-6f5f923e-177d-431a-ac75-57fb9901c431.png)

To solve this, refresh the monitor timeouts when reactivating a tab.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Live location sharing - refresh beacon timers on tab becoming active ([\#8515](https://github.com/matrix-org/matrix-react-sdk/pull/8515)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->