### PR TITLE
Simplify ReplyPreview UI implementation

### DIFF
--- a/res/css/views/rooms/_ReplyPreview.scss
+++ b/res/css/views/rooms/_ReplyPreview.scss
@@ -25,30 +25,31 @@ limitations under the License.
 
     .mx_ReplyPreview_section {
         border-bottom: 1px solid $primary-hairline-color;
+        display: flex;
+        flex-flow: column;
+        row-gap: $spacing-8;
+        padding: $spacing-8 $spacing-8 0 $spacing-8;
 
         .mx_ReplyPreview_header {
-            margin: 8px;
+            display: flex;
+            justify-content: space-between;
+            column-gap: 8px;
+
             color: $primary-content;
             font-weight: 400;
             opacity: 0.4;
-        }
 
-        .mx_ReplyPreview_tile {
-            margin: 0 8px;
-        }
-
-        .mx_ReplyPreview_title {
-            float: left;
-        }
-
-        .mx_ReplyPreview_cancel {
-            float: right;
-            cursor: pointer;
-            display: flex;
-        }
-
-        .mx_ReplyPreview_clear {
-            clear: both;
+            .mx_ReplyPreview_header_cancel {
+                background-color: $primary-content;
+                mask: url('$(res)/img/cancel.svg');
+                mask-repeat: no-repeat;
+                mask-position: center;
+                mask-size: 18px;
+                width: 18px;
+                height: 18px;
+                min-width: 18px;
+                min-height: 18px;
+            }
         }
     }
 }

--- a/src/components/views/rooms/ReplyPreview.tsx
+++ b/src/components/views/rooms/ReplyPreview.tsx
@@ -22,6 +22,7 @@ import { _t } from '../../../languageHandler';
 import { RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
 import ReplyTile from './ReplyTile';
 import RoomContext, { TimelineRenderingType } from '../../../contexts/RoomContext';
+import AccessibleButton from "../elements/AccessibleButton";
 
 function cancelQuoting(context: TimelineRenderingType) {
     dis.dispatch({
@@ -44,25 +45,17 @@ export default class ReplyPreview extends React.Component<IProps> {
 
         return <div className="mx_ReplyPreview">
             <div className="mx_ReplyPreview_section">
-                <div className="mx_ReplyPreview_header mx_ReplyPreview_title">
-                    { _t('Replying') }
-                </div>
-                <div className="mx_ReplyPreview_header mx_ReplyPreview_cancel">
-                    <img
-                        className="mx_filterFlipColor"
-                        src={require("../../../../res/img/cancel.svg").default}
-                        width="18"
-                        height="18"
+                <div className="mx_ReplyPreview_header">
+                    <span>{ _t('Replying') }</span>
+                    <AccessibleButton
+                        className="mx_ReplyPreview_header_cancel"
                         onClick={() => cancelQuoting(this.context.timelineRenderingType)}
                     />
                 </div>
-                <div className="mx_ReplyPreview_clear" />
-                <div className="mx_ReplyPreview_tile">
-                    <ReplyTile
-                        mxEvent={this.props.replyToEvent}
-                        permalinkCreator={this.props.permalinkCreator}
-                    />
-                </div>
+                <ReplyTile
+                    mxEvent={this.props.replyToEvent}
+                    permalinkCreator={this.props.permalinkCreator}
+                />
             </div>
         </div>;
     }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22091

- Use AccessibleButton for cancel button, following other cases on UI
- Use flexbox for RTL compatibility and to remove `clear: both`

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Simplify ReplyPreview UI implementation ([\#8516](https://github.com/matrix-org/matrix-react-sdk/pull/8516)). Fixes vector-im/element-web#22091. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->