### PR TITLE
Replace message composer menu with IconizedContextMenu

### DIFF
--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -178,12 +178,6 @@ limitations under the License.
     }
 }
 
-.mx_ContextualMenu {
-    .mx_MessageComposer_button {
-        padding-left: calc(var(--size) + 6px);
-    }
-}
-
 .mx_MessageComposer_button {
     --size: 26px;
     position: relative;
@@ -192,20 +186,16 @@ limitations under the License.
     line-height: var(--size);
     width: auto;
     padding-left: var(--size);
+    border-radius: 50%;
+    margin-right: 6px;
 
-    &:not(.mx_CallContextMenu_item) {
-        border-radius: 50%;
-        margin-right: 6px;
-
-        &:last-child {
-            margin-right: auto;
-        }
+    &:last-child {
+        margin-right: auto;
     }
 
     &::before {
         content: '';
         position: absolute;
-
         top: 3px;
         left: 3px;
         height: 20px;
@@ -398,19 +388,4 @@ limitations under the License.
     .mx_MessageComposer_e2eIcon {
         left: 0;
     }
-}
-
-.mx_MessageComposer_Menu .mx_CallContextMenu_item {
-    display: flex;
-    align-items: center;
-    max-width: unset;
-    margin: 7px 7px 7px 16px; // space out the buttons
-}
-
-.mx_MessageComposer_Menu .mx_ContextualMenu {
-    min-width: 150px;
-    width: max-content;
-    padding: 5px 10px 5px 0;
-    box-shadow: 0px 2px 9px rgba(0, 0, 0, 0.25);
-    border-radius: 8px;
 }

--- a/src/components/views/location/LocationButton.tsx
+++ b/src/components/views/location/LocationButton.tsx
@@ -58,7 +58,6 @@ export const LocationButton: React.FC<IProps> = ({ roomId, sender, menuPosition,
 
     const className = classNames(
         "mx_MessageComposer_button",
-        "mx_MessageComposer_location",
         {
             "mx_MessageComposer_button_highlight": menuDisplayed,
         },
@@ -67,6 +66,7 @@ export const LocationButton: React.FC<IProps> = ({ roomId, sender, menuPosition,
     return <React.Fragment>
         <CollapsibleButton
             className={className}
+            iconClassName="mx_MessageComposer_location"
             onClick={openMenu}
             title={_t("Location")}
         />

--- a/src/components/views/rooms/CollapsibleButton.tsx
+++ b/src/components/views/rooms/CollapsibleButton.tsx
@@ -20,27 +20,27 @@ import classNames from 'classnames';
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
 import { MenuItem } from "../../structures/ContextMenu";
 import { OverflowMenuContext } from './MessageComposerButtons';
+import { IconizedContextMenuOption } from '../context_menus/IconizedContextMenu';
 
 interface ICollapsibleButtonProps extends ComponentProps<typeof MenuItem> {
     title: string;
+    iconClassName: string;
 }
 
-export const CollapsibleButton = ({ title, children, className, ...props }: ICollapsibleButtonProps) => {
+export const CollapsibleButton = ({ title, children, className, iconClassName, ...props }: ICollapsibleButtonProps) => {
     const inOverflowMenu = !!useContext(OverflowMenuContext);
     if (inOverflowMenu) {
-        return <MenuItem
+        return <IconizedContextMenuOption
             {...props}
-            className={classNames("mx_CallContextMenu_item", className)}
-        >
-            { title }
-            { children }
-        </MenuItem>;
+            iconClassName={iconClassName}
+            label={title}
+        />;
     }
 
     return <AccessibleTooltipButton
         {...props}
         title={title}
-        className={className}
+        className={classNames(className, iconClassName)}
     >
         { children }
     </AccessibleTooltipButton>;

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -38,6 +38,7 @@ import MatrixClientContext from '../../../contexts/MatrixClientContext';
 import RoomContext from '../../../contexts/RoomContext';
 import { useDispatcher } from "../../../hooks/useDispatcher";
 import { chromeFileInputFix } from "../../../utils/BrowserWorkarounds";
+import IconizedContextMenu, { IconizedContextMenuOptionList } from '../context_menus/IconizedContextMenu';
 
 interface IProps {
     addEmoji: (emoji: string) => boolean;
@@ -108,15 +109,18 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             title={_t("More options")}
         /> }
         { props.isMenuOpen && (
-            <ContextMenu
+            <IconizedContextMenu
                 onFinished={props.toggleButtonMenu}
                 {...props.menuPosition}
                 wrapperClassName="mx_MessageComposer_Menu"
+                compact={true}
             >
                 <OverflowMenuContext.Provider value={props.toggleButtonMenu}>
-                    { moreButtons }
+                    <IconizedContextMenuOptionList>
+                        { moreButtons }
+                    </IconizedContextMenuOptionList>
                 </OverflowMenuContext.Provider>
-            </ContextMenu>
+            </IconizedContextMenu>
         ) }
     </UploadButtonContextProvider>;
 };
@@ -158,7 +162,6 @@ const EmojiButton: React.FC<IEmojiButtonProps> = ({ addEmoji, menuPosition }) =>
 
     const className = classNames(
         "mx_MessageComposer_button",
-        "mx_MessageComposer_emoji",
         {
             "mx_MessageComposer_button_highlight": menuDisplayed,
         },
@@ -169,6 +172,7 @@ const EmojiButton: React.FC<IEmojiButtonProps> = ({ addEmoji, menuPosition }) =>
     return <React.Fragment>
         <CollapsibleButton
             className={className}
+            iconClassName="mx_MessageComposer_emoji"
             onClick={openMenu}
             title={_t("Emoji")}
         />
@@ -254,7 +258,8 @@ const UploadButton = () => {
     };
 
     return <CollapsibleButton
-        className="mx_MessageComposer_button mx_MessageComposer_upload"
+        className="mx_MessageComposer_button"
+        iconClassName="mx_MessageComposer_upload"
         onClick={onClick}
         title={_t('Attachment')}
     />;
@@ -266,7 +271,8 @@ function showStickersButton(props: IProps): ReactElement {
             ? <CollapsibleButton
                 id='stickersButton'
                 key="controls_stickers"
-                className="mx_MessageComposer_button mx_MessageComposer_stickers"
+                className="mx_MessageComposer_button"
+                iconClassName="mx_MessageComposer_stickers"
                 onClick={() => props.setStickerPickerOpen(!props.isStickerPickerOpen)}
                 title={props.isStickerPickerOpen ? _t("Hide stickers") : _t("Sticker")}
             />
@@ -281,7 +287,8 @@ function voiceRecordingButton(props: IProps, narrow: boolean): ReactElement {
             ? null
             : <CollapsibleButton
                 key="voice_message_send"
-                className="mx_MessageComposer_button mx_MessageComposer_voiceMessage"
+                className="mx_MessageComposer_button"
+                iconClassName="mx_MessageComposer_voiceMessage"
                 onClick={props.onRecordStartEndClick}
                 title={_t("Voice Message")}
             />
@@ -345,7 +352,8 @@ class PollButton extends React.PureComponent<IPollButtonProps> {
 
         return (
             <CollapsibleButton
-                className="mx_MessageComposer_button mx_MessageComposer_poll"
+                className="mx_MessageComposer_button"
+                iconClassName="mx_MessageComposer_poll"
                 onClick={this.onCreateClick}
                 title={_t("Poll")}
             />


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/6216686/167132125-41304bf9-82cc-4d21-a950-07bec948354e.gif) | ![after](https://user-images.githubusercontent.com/6216686/167132141-9af37e77-b55f-4808-bd6f-13b94eadc748.gif) |

Notes: The message composer menu now looks like all other menus

Closes vector-im/element-web#22046

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * The message composer menu now looks like all other menus ([\#8518](https://github.com/matrix-org/matrix-react-sdk/pull/8518)). Fixes vector-im/element-web#22046. Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->