### PR TITLE
Set max-width for MLocationBody and MLocationBody_map by default

### DIFF
--- a/res/css/views/messages/_MLocationBody.scss
+++ b/res/css/views/messages/_MLocationBody.scss
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 .mx_MLocationBody {
+    max-width: 100%;
+
     .mx_MLocationBody_map {
+        max-width: 100%;
         width: 450px;
         height: 300px;
         z-index: 0; // keeps the entire map under the message action bar
@@ -27,15 +30,11 @@ limitations under the License.
 
 /* In the timeline, we fit the width of the container */
 .mx_EventTile_line .mx_MLocationBody .mx_MLocationBody_map {
-    width: 100%;
     max-width: 450px;
+    width: 100%;
 }
 
-.mx_EventTile[data-layout="bubble"] .mx_EventTile_line .mx_MLocationBody {
+.mx_EventTile[data-layout="bubble"] .mx_EventTile_line .mx_MLocationBody .mx_MLocationBody_map {
     max-width: 100%;
-
-    .mx_MLocationBody_map {
-        max-width: 100%;
-        width: 450px;
-    }
+    width: 450px;
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21983

To avoid map overflow due to width and height specified by `maplibregl-canvas`.
Also `max-width` is moved in front of `width` to prevent confusion (values are similar).

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

Steps to confirm the fix:

1. Open a room
2. Share location
3. Reply in thread
4. Reply to the location
5. Check that the map does not overflow the reply preview area

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set max-width for MLocationBody and MLocationBody_map by default ([\#8519](https://github.com/matrix-org/matrix-react-sdk/pull/8519)). Fixes vector-im/element-web#21983. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->