### PR TITLE
Fix thread summary overflow on narrow message panel on bubble message layout

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -704,7 +704,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
 .mx_MessagePanel_narrow .mx_ThreadSummary {
     min-width: initial;
-    max-width: initial;
+    max-width: 100%; // prevent overflow
     width: initial;
 }
 


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22097

This PR fixes the bug that thread summary button overflows from `mx_EventTile` on narrow message panel on bubble message layout.

![after](https://user-images.githubusercontent.com/3362943/167173149-735a3380-e4bb-4e68-96a7-45bb116e43f4.png)

Steps to confirm the fix:

1. Change the layout to bubble message layout (note: the issue does not appear on modern layout)
2. Create a test user
3. Create a test room
4. Create a thread with the test user
5. Share the location
6. Open the room from your main account
7. Check that the thread preview on the summary button does not overflow from `mx_EventTile`

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix thread summary overflow on narrow message panel on bubble message layout ([\#8520](https://github.com/matrix-org/matrix-react-sdk/pull/8520)). Fixes vector-im/element-web#22097. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->