### PR TITLE
Set line-height: 1 to RedactedBody inside GenericEventListSummary for IRC/modern layout

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -53,7 +53,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &[data-layout=group] {
         .mx_EventTile_line {
-            line-height: $font-22px; // See: mx_EventTile_reply on _GroupLayout.scss
+            line-height: var(--GroupLayout-EventTile-line-height);
         }
     }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -50,6 +50,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     .mx_EventTile_receiptSending::before {
         mask-image: url('$(res)/img/element-icons/circle-sending.svg');
     }
+
+    &[data-layout=group] {
+        .mx_EventTile_line {
+            line-height: $font-22px; // See: mx_EventTile_reply on _GroupLayout.scss
+        }
+    }
 }
 
 .mx_EventTile:not([data-layout=bubble]) {
@@ -263,8 +269,15 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 }
 
-.mx_GenericEventListSummary:not([data-layout=bubble]) .mx_EventTile_line {
-    padding-left: $left-gutter;
+.mx_GenericEventListSummary:not([data-layout=bubble]) {
+    .mx_EventTile_line {
+        padding-left: $left-gutter;
+        line-height: normal;
+
+        .mx_RedactedBody {
+            line-height: 1; // remove spacing between lines
+        }
+    }
 }
 
 .mx_EventTile:not([data-layout=bubble]).mx_EventTile_info .mx_EventTile_line,

--- a/res/css/views/rooms/_GroupLayout.scss
+++ b/res/css/views/rooms/_GroupLayout.scss
@@ -18,6 +18,8 @@ limitations under the License.
 $left-gutter: 64px;
 
 .mx_GroupLayout {
+    --GroupLayout-EventTile-line-height: $font-22px;
+
     .mx_EventTile {
         > .mx_DisambiguatedProfile {
             line-height: $font-20px;
@@ -40,7 +42,7 @@ $left-gutter: 64px;
         }
 
         .mx_EventTile_reply {
-            line-height: $font-22px;
+            line-height: var(--GroupLayout-EventTile-line-height);
         }
     }
 }

--- a/res/css/views/rooms/_GroupLayout.scss
+++ b/res/css/views/rooms/_GroupLayout.scss
@@ -53,7 +53,8 @@ $left-gutter: 64px;
     .mx_EventTile {
         padding-top: 4px;
 
-        .mx_EventTile_line, .mx_EventTile_reply {
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
             padding-top: 0;
             padding-bottom: 0;
         }
@@ -62,9 +63,12 @@ $left-gutter: 64px;
             // same as the padding for non-compact .mx_EventTile.mx_EventTile_info
             padding-top: 0px;
             font-size: $font-13px;
-            .mx_EventTile_line, .mx_EventTile_reply {
+
+            .mx_EventTile_line,
+            .mx_EventTile_reply {
                 line-height: $font-20px;
             }
+
             .mx_EventTile_avatar {
                 top: 4px;
             }
@@ -77,10 +81,13 @@ $left-gutter: 64px;
         &.mx_EventTile_emote {
             // add a bit more space for emotes so that avatars don't collide
             padding-top: 8px;
+
             .mx_EventTile_avatar {
                 top: 2px;
             }
-            .mx_EventTile_line, .mx_EventTile_reply {
+
+            .mx_EventTile_line,
+            .mx_EventTile_reply {
                 padding-top: 0px;
                 padding-bottom: 1px;
             }
@@ -88,7 +95,9 @@ $left-gutter: 64px;
 
         &.mx_EventTile_emote.mx_EventTile_continuation {
             padding-top: 0;
-            .mx_EventTile_line, .mx_EventTile_reply {
+
+            .mx_EventTile_line,
+            .mx_EventTile_reply {
                 padding-top: 0px;
                 padding-bottom: 0px;
             }

--- a/res/css/views/rooms/_GroupLayout.scss
+++ b/res/css/views/rooms/_GroupLayout.scss
@@ -33,9 +33,13 @@ $left-gutter: 64px;
             position: absolute; // for modern layout
         }
 
-        .mx_EventTile_line, .mx_EventTile_reply {
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
             padding-top: 1px;
             padding-bottom: 3px;
+        }
+
+        .mx_EventTile_reply {
             line-height: $font-22px;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22112

Set `line-height: 1` to `mx_RedactedBody` inside `mx_GenericEventListSummary` for IRC/modern layout.

Specifying `mx_EventTile_line`'s line-height in `mx_GroupLayout` is too strong for `mx_GenericEventListSummary`. It should be specified in `_EventTile.scss` instead.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set line-height: 1 to RedactedBody inside GenericEventListSummary for IRC/modern layout ([\#8529](https://github.com/matrix-org/matrix-react-sdk/pull/8529)). Fixes vector-im/element-web#22112. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->