### PR TITLE
Reuse DeviceContextMenu for video room lobbies

### DIFF
--- a/src/MediaDeviceHandler.ts
+++ b/src/MediaDeviceHandler.ts
@@ -33,6 +33,8 @@ export type IMediaDevices = Record<MediaDeviceKindEnum, Array<MediaDeviceInfo>>;
 
 export enum MediaDeviceHandlerEvent {
     AudioOutputChanged = "audio_output_changed",
+    AudioInputChanged = "audio_input_changed",
+    VideoInputChanged = "video_input_changed",
 }
 
 export default class MediaDeviceHandler extends EventEmitter {
@@ -92,7 +94,8 @@ export default class MediaDeviceHandler extends EventEmitter {
      */
     public async setAudioInput(deviceId: string): Promise<void> {
         SettingsStore.setValue("webrtc_audioinput", null, SettingLevel.DEVICE, deviceId);
-        return MatrixClientPeg.get().getMediaHandler().setAudioInput(deviceId);
+        await MatrixClientPeg.get().getMediaHandler().setAudioInput(deviceId);
+        this.emit(MediaDeviceHandlerEvent.AudioInputChanged, deviceId);
     }
 
     /**
@@ -102,7 +105,8 @@ export default class MediaDeviceHandler extends EventEmitter {
      */
     public async setVideoInput(deviceId: string): Promise<void> {
         SettingsStore.setValue("webrtc_videoinput", null, SettingLevel.DEVICE, deviceId);
-        return MatrixClientPeg.get().getMediaHandler().setVideoInput(deviceId);
+        await MatrixClientPeg.get().getMediaHandler().setVideoInput(deviceId);
+        this.emit(MediaDeviceHandlerEvent.VideoInputChanged, deviceId);
     }
 
     public async setDevice(deviceId: string, kind: MediaDeviceKindEnum): Promise<void> {

--- a/src/stores/VideoChannelStore.ts
+++ b/src/stores/VideoChannelStore.ts
@@ -109,7 +109,12 @@ export default class VideoChannelStore extends AsyncStoreWithClient<null> {
         localStorage.setItem("mx_videoMuted", value.toString());
     }
 
-    public connect = async (roomId: string, audioDevice: MediaDeviceInfo, videoDevice: MediaDeviceInfo) => {
+    public connect = async (
+        roomId: string,
+        audioOutput: MediaDeviceInfo,
+        audioInput: MediaDeviceInfo,
+        videoInput: MediaDeviceInfo,
+    ) => {
         if (this.activeChannel) await this.disconnect();
 
         const jitsi = getVideoChannel(roomId);
@@ -172,8 +177,9 @@ export default class VideoChannelStore extends AsyncStoreWithClient<null> {
             },
         );
         messaging.transport.send(ElementWidgetActions.JoinCall, {
-            audioDevice: audioDevice?.label,
-            videoDevice: videoDevice?.label,
+            audioOutput: audioOutput?.label,
+            audioInput: audioInput?.label,
+            videoInput: videoInput?.label,
         });
         try {
             await waitForJoin;

--- a/test/stores/VideoChannelStore-test.ts
+++ b/test/stores/VideoChannelStore-test.ts
@@ -113,7 +113,7 @@ describe("VideoChannelStore", () => {
         expect(store.roomId).toBeFalsy();
         expect(store.connected).toEqual(false);
 
-        store.connect("!1:example.org", null, null);
+        store.connect("!1:example.org", null, null, null);
         await confirmConnect();
         expect(store.roomId).toEqual("!1:example.org");
         expect(store.connected).toEqual(true);
@@ -126,7 +126,7 @@ describe("VideoChannelStore", () => {
     });
 
     it("waits for messaging when connecting", async () => {
-        store.connect("!1:example.org", null, null);
+        store.connect("!1:example.org", null, null, null);
         WidgetMessagingStore.instance.storeMessaging(widget, "!1:example.org", messaging);
         widgetReady();
         await confirmConnect();


### PR DESCRIPTION
**Depends on https://github.com/vector-im/element-web/pull/22116**

![devices](https://user-images.githubusercontent.com/48614497/167338169-01fadd82-9a46-40a6-a698-1f7a045941d7.png)

Notes: Allow selecting custom audio outputs when connected to a video room, visually indicate selected devices, and save video room device selections between sessions

Closes https://github.com/vector-im/element-web/issues/22085