### PR TITLE
Hide recently_viewed dropdown when other modal opens

### DIFF
--- a/res/css/views/elements/_InteractiveTooltip.scss
+++ b/res/css/views/elements/_InteractiveTooltip.scss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_InteractiveTooltip_wrapper {
     position: fixed;
-    z-index: 5000;
+    z-index: 4000;
 }
 
 .mx_InteractiveTooltip {

--- a/res/css/views/elements/_InteractiveTooltip.scss
+++ b/res/css/views/elements/_InteractiveTooltip.scss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_InteractiveTooltip_wrapper {
     position: fixed;
-    z-index: 4000;
+    z-index: 3999;
 }
 
 .mx_InteractiveTooltip {


### PR DESCRIPTION
Fixes:  [vector-im/element-web#21847](https://github.com/vector-im/element-web/issues/21847)

Issue reported by @gsouquet 

Signed-off-by: Yaya Usman [yaya-usman@users.noreply.github.com](mailto:yaya-usman@users.noreply.github.com) 

**Before:**
![before-gif](https://user-images.githubusercontent.com/38439166/167405431-bf674977-56e8-4f03-9321-98c9f9c1e8fd.gif)


**After:** 
![after-gif](https://user-images.githubusercontent.com/38439166/167405462-02c989b1-8770-40c4-8ace-59c1d59a68ab.gif)



Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Hide recently_viewed dropdown when other modal opens ([\#8538](https://github.com/matrix-org/matrix-react-sdk/pull/8538)). Contributed by @yaya-usman.<!-- CHANGELOG_PREVIEW_END -->