### PR TITLE
Fixes reaction row rendering out of view on message bubbles

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -193,6 +193,7 @@ limitations under the License.
             float: right;
             clear: right;
             display: flex;
+            flex-wrap: wrap;
 
             /* Moving the "add reaction button" before the reactions */
             > :last-child {


### PR DESCRIPTION
Fixes:  [vector-im/element-web#22093](https://github.com/vector-im/element-web/issues/22093)

Issue reported by @frakic 

Signed-off-by: Yaya Usman [yaya-usman@users.noreply.github.com](mailto:yaya-usman@users.noreply.github.com) 

**Before:**
![Capture2](https://user-images.githubusercontent.com/38439166/167422390-a3050aec-7c94-4e59-82e3-aa203b881f22.PNG)


**After:** 
![Capture1](https://user-images.githubusercontent.com/38439166/167506627-cc6e0589-afc3-4105-887e-0bee91de9bc1.PNG)



Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fixes reaction row rendering out of view on message bubbles ([\#8542](https://github.com/matrix-org/matrix-react-sdk/pull/8542)). Contributed by @yaya-usman.<!-- CHANGELOG_PREVIEW_END -->