### PR TITLE
Set color-scheme property in themes

### DIFF
--- a/res/themes/dark/css/_dark.scss
+++ b/res/themes/dark/css/_dark.scss
@@ -269,6 +269,10 @@ $selected-color: $room-highlight-color;
 }
 // ********************
 
+body {
+    color-scheme: dark;
+}
+
 // Nasty hacks to apply a filter to arbitrary monochrome artwork to make it
 // better match the theme.  Typically applied to dark grey 'off' buttons or
 // light grey 'on' buttons.

--- a/res/themes/legacy-dark/css/_legacy-dark.scss
+++ b/res/themes/legacy-dark/css/_legacy-dark.scss
@@ -242,6 +242,10 @@ $location-live-secondary-color: #deddfd;
     text-decoration: none;
 }
 
+body {
+    color-scheme: dark;
+}
+
 // Nasty hacks to apply a filter to arbitrary monochrome artwork to make it
 // better match the theme.  Typically applied to dark grey 'off' buttons or
 // light grey 'on' buttons.

--- a/res/themes/legacy-light/css/_legacy-light.scss
+++ b/res/themes/legacy-light/css/_legacy-light.scss
@@ -347,6 +347,10 @@ $location-live-secondary-color: #deddfd;
     text-decoration: none;
 }
 
+body {
+    color-scheme: light;
+}
+
 // diff highlight colors
 .hljs-addition {
     background: #dfd;

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -378,6 +378,10 @@ $location-live-secondary-color: #deddfd;
     text-decoration: none;
 }
 
+body {
+    color-scheme: light;
+}
+
 // ********************
 
 // diff highlight colors


### PR DESCRIPTION
This ensures that native browser elements are styled appropriately for the theme.

Here's what the jump to date picker looks like in dark mode in Chrome:

Before|After
-|-
![before](https://user-images.githubusercontent.com/48614497/167524071-72f0a3d8-b66b-425d-ab8b-8b77c7cb4239.png)|![after](https://user-images.githubusercontent.com/48614497/167524072-26a8d22f-3971-431c-b60d-58af0aeda588.png)

Closes https://github.com/vector-im/element-web/issues/22124.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set color-scheme property in themes ([\#8547](https://github.com/matrix-org/matrix-react-sdk/pull/8547)). Fixes vector-im/element-web#22124.<!-- CHANGELOG_PREVIEW_END -->