### PR TITLE
Fix unresponsive notification toggles

### DIFF
--- a/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
+++ b/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
@@ -22,7 +22,7 @@ import SettingsHandler from "./SettingsHandler";
  */
 export default abstract class AbstractLocalStorageSettingsHandler extends SettingsHandler {
     // Shared cache between all subclass instances
-    private static itemCache = new Map<string, any>();
+    private static itemCache = new Map<string, string>();
     private static objectCache = new Map<string, object>();
     private static storageListenerBound = false;
 
@@ -51,7 +51,7 @@ export default abstract class AbstractLocalStorageSettingsHandler extends Settin
         }
     }
 
-    protected getItem(key: string): any {
+    protected getItem(key: string): string {
         if (!AbstractLocalStorageSettingsHandler.itemCache.has(key)) {
             const value = localStorage.getItem(key);
             AbstractLocalStorageSettingsHandler.itemCache.set(key, value);
@@ -59,6 +59,14 @@ export default abstract class AbstractLocalStorageSettingsHandler extends Settin
         }
 
         return AbstractLocalStorageSettingsHandler.itemCache.get(key);
+    }
+
+    protected getBoolean(key: string): boolean | null {
+        const item = this.getItem(key);
+        if (item === "true") return true;
+        if (item === "false") return false;
+        // Fall back to the next config level
+        return null;
     }
 
     protected getObject<T extends object>(key: string): T | null {
@@ -76,9 +84,13 @@ export default abstract class AbstractLocalStorageSettingsHandler extends Settin
         return AbstractLocalStorageSettingsHandler.objectCache.get(key) as T;
     }
 
-    protected setItem(key: string, value: any): void {
+    protected setItem(key: string, value: string): void {
         AbstractLocalStorageSettingsHandler.itemCache.set(key, value);
         localStorage.setItem(key, value);
+    }
+
+    protected setBoolean(key: string, value: boolean | null): void {
+        this.setItem(key, `${value}`);
     }
 
     protected setObject(key: string, value: object): void {

--- a/src/settings/handlers/DeviceSettingsHandler.ts
+++ b/src/settings/handlers/DeviceSettingsHandler.ts
@@ -43,17 +43,11 @@ export default class DeviceSettingsHandler extends AbstractLocalStorageSettingsH
 
         // Special case notifications
         if (settingName === "notificationsEnabled") {
-            const value = this.getItem("notifications_enabled");
-            if (typeof(value) === "string") return value === "true";
-            return null; // wrong type or otherwise not set
+            return this.getBoolean("notifications_enabled");
         } else if (settingName === "notificationBodyEnabled") {
-            const value = this.getItem("notifications_body_enabled");
-            if (typeof(value) === "string") return value === "true";
-            return null; // wrong type or otherwise not set
+            return this.getBoolean("notifications_body_enabled");
         } else if (settingName === "audioNotificationsEnabled") {
-            const value = this.getItem("audio_notifications_enabled");
-            if (typeof(value) === "string") return value === "true";
-            return null; // wrong type or otherwise not set
+            return this.getBoolean("audio_notifications_enabled");
         }
 
         const settings = this.getSettings() || {};
@@ -68,15 +62,15 @@ export default class DeviceSettingsHandler extends AbstractLocalStorageSettingsH
 
         // Special case notifications
         if (settingName === "notificationsEnabled") {
-            this.setItem("notifications_enabled", newValue);
+            this.setBoolean("notifications_enabled", newValue);
             this.watchers.notifyUpdate(settingName, null, SettingLevel.DEVICE, newValue);
             return Promise.resolve();
         } else if (settingName === "notificationBodyEnabled") {
-            this.setItem("notifications_body_enabled", newValue);
+            this.setBoolean("notifications_body_enabled", newValue);
             this.watchers.notifyUpdate(settingName, null, SettingLevel.DEVICE, newValue);
             return Promise.resolve();
         } else if (settingName === "audioNotificationsEnabled") {
-            this.setItem("audio_notifications_enabled", newValue);
+            this.setBoolean("audio_notifications_enabled", newValue);
             this.watchers.notifyUpdate(settingName, null, SettingLevel.DEVICE, newValue);
             return Promise.resolve();
         }
@@ -126,15 +120,11 @@ export default class DeviceSettingsHandler extends AbstractLocalStorageSettingsH
             return false;
         }
 
-        const value = this.getItem("mx_labs_feature_" + featureName);
-        if (value === "true") return true;
-        if (value === "false") return false;
-        // Try to read the next config level for the feature.
-        return null;
+        return this.getBoolean("mx_labs_feature_" + featureName);
     }
 
     private writeFeature(featureName: string, enabled: boolean | null) {
-        this.setItem("mx_labs_feature_" + featureName, `${enabled}`);
+        this.setBoolean("mx_labs_feature_" + featureName, enabled);
         this.watchers.notifyUpdate(featureName, null, SettingLevel.DEVICE, enabled);
     }
 }


### PR DESCRIPTION
These were broken for a couple of reasons: the notification settings view wasn't watching the settings properly, and the local storage settings class was inconsistent about what types it returned, giving values like `false` or `"false"` depending on whether the setting was in the cache.

Closes https://github.com/vector-im/element-web/issues/22109.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix unresponsive notification toggles ([\#8549](https://github.com/matrix-org/matrix-react-sdk/pull/8549)). Fixes vector-im/element-web#22109.<!-- CHANGELOG_PREVIEW_END -->