### PR TITLE
Fix room history not being visible even if we have historical keys

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -810,13 +810,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
 
         if (!this.state.events.includes(ev)) return;
 
-        const recheckFirstVisibleEventIndex = throttle(() => {
-            const firstVisibleEventIndex = this.checkForPreJoinUISI(this.state.events);
-            if (firstVisibleEventIndex !== this.state.firstVisibleEventIndex) {
-                this.setState({ firstVisibleEventIndex });
-            }
-        }, 500, { leading: true, trailing: true });
-        recheckFirstVisibleEventIndex();
+        this.recheckFirstVisibleEventIndex();
 
         // Need to update as we don't display event tiles for events that
         // haven't yet been decrypted. The event will have just been updated
@@ -832,6 +826,13 @@ class TimelinePanel extends React.Component<IProps, IState> {
         if (this.unmounted) return;
         this.setState({ clientSyncState });
     };
+
+    private recheckFirstVisibleEventIndex = throttle((): void => {
+        const firstVisibleEventIndex = this.checkForPreJoinUISI(this.state.events);
+        if (firstVisibleEventIndex !== this.state.firstVisibleEventIndex) {
+            this.setState({ firstVisibleEventIndex });
+        }
+    }, 500, { leading: true, trailing: true });
 
     private readMarkerTimeout(readMarkerPosition: number): number {
         return readMarkerPosition === 0 ?


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/16983

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix room history not being visible even if we have historical keys ([\#8563](https://github.com/matrix-org/matrix-react-sdk/pull/8563)). Fixes vector-im/element-web#16983.<!-- CHANGELOG_PREVIEW_END -->