### PR TITLE
Fix oblong avatars in video room lobbies

### DIFF
--- a/res/css/views/avatars/_BaseAvatar.scss
+++ b/res/css/views/avatars/_BaseAvatar.scss
@@ -47,6 +47,7 @@ limitations under the License.
 
 .mx_BaseAvatar_image {
     object-fit: cover;
+    aspect-ratio: 1;
     border-radius: 125px;
     vertical-align: top;
     background-color: $background;


### PR DESCRIPTION
Fixes this fun visual bug that Nad encountered, because of his non-square avatar:

<img width="861" alt="Screenshot 2022-05-11 at 17 05 52" src="https://user-images.githubusercontent.com/48614497/167901182-2c0fd1a3-42e9-4b8b-a748-5df6e37b83ec.png">

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix oblong avatars in video room lobbies ([\#8565](https://github.com/matrix-org/matrix-react-sdk/pull/8565)).<!-- CHANGELOG_PREVIEW_END -->