### PR TITLE
Show full thread message in hover title on thread summary

### DIFF
--- a/src/components/views/rooms/ThreadSummary.tsx
+++ b/src/components/views/rooms/ThreadSummary.tsx
@@ -104,7 +104,7 @@ export const ThreadMessagePreview = ({ thread, showDisplayname = false }: IPrevi
         { showDisplayname && <div className="mx_ThreadSummary_sender">
             { lastReply.sender?.name ?? lastReply.getSender() }
         </div> }
-        <div className="mx_ThreadSummary_content">
+        <div className="mx_ThreadSummary_content" title={preview}>
             <span className="mx_ThreadSummary_message-preview">
                 { preview }
             </span>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22037

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Show full thread message in hover title on thread summary ([\#8568](https://github.com/matrix-org/matrix-react-sdk/pull/8568)). Fixes vector-im/element-web#22037.<!-- CHANGELOG_PREVIEW_END -->