### PR TITLE
Don't consider threads for breaking continuation until actually created

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -56,6 +56,7 @@ import { getEventDisplayInfo } from "../../utils/EventRenderingUtils";
 import { IReadReceiptInfo } from "../views/rooms/ReadReceiptMarker";
 import { haveRendererForEvent } from "../../events/EventTileFactory";
 import { editorRoomKey } from "../../Editing";
+import { hasThreadSummary } from "../../utils/EventUtils";
 
 const CONTINUATION_MAX_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const continuedTypes = [EventType.Sticker, EventType.RoomMessage];
@@ -65,10 +66,6 @@ const groupedEvents = [
     EventType.RoomServerAcl,
     EventType.RoomPinnedEvents,
 ];
-
-function hasThreadSummary(event: MatrixEvent): boolean {
-    return event.isThreadRoot && event?.getThread().length && !!event.getThread().replyToEvent;
-}
 
 // check if there is a previous event and it has the same sender as this event
 // and the types are the same/is in continuedTypes and the time between them is <= CONTINUATION_MAX_INTERVAL

--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -67,7 +67,7 @@ const groupedEvents = [
 ];
 
 function hasThreadSummary(event: MatrixEvent): boolean {
-    return event.isThreadRoot && event.getThread().length && !!event.getThread().replyToEvent;
+    return event.isThreadRoot && event?.getThread().length && !!event.getThread().replyToEvent;
 }
 
 // check if there is a previous event and it has the same sender as this event

--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -66,6 +66,10 @@ const groupedEvents = [
     EventType.RoomPinnedEvents,
 ];
 
+function hasThreadSummary(event: MatrixEvent): boolean {
+    return event.isThreadRoot && event.getThread().length && !!event.getThread().replyToEvent;
+}
+
 // check if there is a previous event and it has the same sender as this event
 // and the types are the same/is in continuedTypes and the time between them is <= CONTINUATION_MAX_INTERVAL
 export function shouldFormContinuation(
@@ -96,7 +100,7 @@ export function shouldFormContinuation(
 
     // Thread summaries in the main timeline should break up a continuation on both sides
     if (threadsEnabled &&
-        (mxEvent.isThreadRoot || prevEvent.isThreadRoot) &&
+        (hasThreadSummary(mxEvent) || hasThreadSummary(prevEvent)) &&
         timelineRenderingType !== TimelineRenderingType.Thread
     ) {
         return false;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -280,3 +280,7 @@ export function canForward(event: MatrixEvent): boolean {
         M_POLL_START.matches(event.getType())
     );
 }
+
+export function hasThreadSummary(event: MatrixEvent): boolean {
+    return event.isThreadRoot && event.getThread()?.length && !!event.getThread().replyToEvent;
+}

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -733,9 +733,10 @@ describe("shouldFormContinuation", () => {
         expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(true);
         expect(shouldFormContinuation(threadRoot, message3, false, true)).toEqual(true);
 
-        const thread = {};
-        thread.length = 1;
-        thread.replyToEvent = {};
+        const thread = {
+            length: 1,
+            replyToEvent: {},
+        };
         jest.spyOn(threadRoot, "getThread").mockReturnValue(thread);
         expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(false);
         expect(shouldFormContinuation(threadRoot, message3, false, true)).toEqual(false);

--- a/test/components/structures/MessagePanel-test.js
+++ b/test/components/structures/MessagePanel-test.js
@@ -699,7 +699,7 @@ describe('MessagePanel', function() {
 });
 
 describe("shouldFormContinuation", () => {
-    it("does not form continuations from thread roots", () => {
+    it("does not form continuations from thread roots which have summaries", () => {
         const message1 = TestUtilsMatrix.mkMessage({
             event: true,
             room: "!room:id",
@@ -730,6 +730,13 @@ describe("shouldFormContinuation", () => {
         });
 
         expect(shouldFormContinuation(message1, message2, false, true)).toEqual(true);
+        expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(true);
+        expect(shouldFormContinuation(threadRoot, message3, false, true)).toEqual(true);
+
+        const thread = {};
+        thread.length = 1;
+        thread.replyToEvent = {};
+        jest.spyOn(threadRoot, "getThread").mockReturnValue(thread);
         expect(shouldFormContinuation(message2, threadRoot, false, true)).toEqual(false);
         expect(shouldFormContinuation(threadRoot, message3, false, true)).toEqual(false);
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22164

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't consider threads for breaking continuation until actually created ([\#8581](https://github.com/matrix-org/matrix-react-sdk/pull/8581)). Fixes vector-im/element-web#22164.<!-- CHANGELOG_PREVIEW_END -->