### PR TITLE
Increase composer line height to avoid cutting off emoji

### DIFF
--- a/res/css/views/rooms/_SendMessageComposer.scss
+++ b/res/css/views/rooms/_SendMessageComposer.scss
@@ -20,7 +20,7 @@ limitations under the License.
     flex-direction: column;
     font-size: $font-14px;
     // fixed line height to prevent emoji from being taller than text
-    line-height: calc(1.2 * $font-14px);
+    line-height: $font-18px;
     justify-content: center;
     margin-right: 6px;
     // don't grow wider than available space


### PR DESCRIPTION
Unsure whether this needs design review, 1.8rem is the value it should've been all along because that's the actual max height in the presence of emoji

Emoji personally don't get cut off on my system prior to this change, but this should solve it for others who do see that.

Before|After
-|-
![Screenshot 2022-05-13 at 11-15-47 Element Test room](https://user-images.githubusercontent.com/48614497/168314437-8e013099-97a4-413c-af7f-8d2b4964cbe0.png)|![Screenshot 2022-05-13 at 11-14-18 Element Test room](https://user-images.githubusercontent.com/48614497/168314434-18d89104-d73d-4e0c-8709-26ba56363fbe.png)

Closes https://github.com/vector-im/element-web/issues/22170.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Increase composer line height to avoid cutting off emoji ([\#8583](https://github.com/matrix-org/matrix-react-sdk/pull/8583)). Fixes vector-im/element-web#22170.<!-- CHANGELOG_PREVIEW_END -->