### PR TITLE
Show notifications even when Element is focused

### DIFF
--- a/src/Notifier.ts
+++ b/src/Notifier.ts
@@ -95,9 +95,6 @@ export const Notifier = {
         if (!plaf.supportsNotifications() || !plaf.maySendNotifications()) {
             return;
         }
-        if (global.document.hasFocus()) {
-            return;
-        }
 
         let msg = this.notificationMessageForEvent(ev);
         if (!msg) return;


### PR DESCRIPTION
This makes Element show notifications for messages even when it is the
focused application.

Before this change, Element would not show any notifications while
focused on the app. This causes confusion to end-users, especially if
the room where the notification came in is in a different space.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->
```
Signed-off-by: Sumner Evans <sumner@beeper.com>
```

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: 

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Show notifications even when Element is focused ([\#8590](https://github.com/matrix-org/matrix-react-sdk/pull/8590)). Contributed by @sumnerevans.<!-- CHANGELOG_PREVIEW_END -->