### PR TITLE
Fix MessageTimestamp position next to redacted messages on IRC/modern layout

### DIFF
--- a/res/css/views/messages/_ViewSourceEvent.scss
+++ b/res/css/views/messages/_ViewSourceEvent.scss
@@ -20,6 +20,7 @@ limitations under the License.
     font-size: $font-12px;
     width: 100%;
     overflow-x: auto; // Cancel overflow setting of .mx_EventTile_content
+    line-height: normal; // Align with avatar and E2E icon
 
     pre,
     code {

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -258,8 +258,12 @@ limitations under the License.
             }
 
             &:not([data-layout=bubble]) {
+                .mx_MessageTimestamp {
+                    top: 2px; // Align with avatar
+                }
+
                 .mx_EventTile_avatar {
-                    top: 1.5px;
+                    top: 0; // Align with hidden event content
                     left: calc($MessageTimestamp_width + 14px - 4px); // 14px: avatar width, 4px: align with text
                     z-index: 9; // position above the hover styling
                 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -116,6 +116,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
         .mx_EventTile_line {
             padding: 3px 0 2px; // Align with mx_EventTile_avatar and mx_EventTile_e2eIcon
+
+            .mx_MessageTimestamp {
+                top: 0;
+            }
         }
     }
 
@@ -278,7 +282,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_GenericEventListSummary:not([data-layout=bubble]) {
     .mx_EventTile_line {
         padding-left: $left-gutter;
-        line-height: normal;
 
         .mx_RedactedBody {
             line-height: 1; // remove spacing between lines


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22181

Setting `line-height: normal` (≒ [1.2, depending on the element's `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#values)) was not a proper way of aligning elements in `mx_EventTile_line` of `mx_GenericEventListSummary` on IRC/modern layout.

Before: cf. https://github.com/vector-im/element-web/issues/22181

After:

![after](https://user-images.githubusercontent.com/3362943/168411305-0602e56f-cd72-48f9-9a4f-27fe0d39cae8.png)

With hidden events:
![after1](https://user-images.githubusercontent.com/3362943/168411336-48b06bfe-8681-4aa8-98ab-8b6be8c5d396.png)


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix MessageTimestamp position next to redacted messages on IRC/modern layout ([\#8591](https://github.com/matrix-org/matrix-react-sdk/pull/8591)). Fixes vector-im/element-web#22181. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->