### PR TITLE
Stop spaces from displaying as rooms in new breadcrumbs

### DIFF
--- a/res/css/views/avatars/_BaseAvatar.scss
+++ b/res/css/views/avatars/_BaseAvatar.scss
@@ -29,6 +29,8 @@ limitations under the License.
     user-select: none;
 
     &.mx_RoomAvatar_isSpaceRoom {
+        mask-image: unset !important; // override mx_DecoratedRoomAvatar_cutout
+
         &.mx_BaseAvatar_image, .mx_BaseAvatar_image {
             border-radius: 8px;
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22165

<hr>

![2022-05-14_11-01](https://user-images.githubusercontent.com/25768714/168418914-91ede0f9-bb1f-47d2-916e-6d30cb6997dd.png)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Stop spaces from displaying as rooms in new breadcrumbs ([\#8595](https://github.com/matrix-org/matrix-react-sdk/pull/8595)). Fixes vector-im/element-web#22165.<!-- CHANGELOG_PREVIEW_END -->