### PR TITLE
Remove an obsolete declaration for DisambiguatedProfile of EventTile on modern layout

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -110,14 +110,6 @@ limitations under the License.
         }
     }
 
-    .mx_GroupLayout {
-        .mx_EventTile {
-            > .mx_DisambiguatedProfile {
-                margin-left: 36px;
-            }
-        }
-    }
-
     .mx_CallEvent_wrapper {
         justify-content: center;
         margin: auto 5px;


### PR DESCRIPTION
The margin is specified with `.mx_TimelineCard .mx_EventTile:not([data-layout="bubble"]) .mx_DisambiguatedProfile`, which makes this declaration redundant.

![before](https://user-images.githubusercontent.com/3362943/168426297-d86789be-37a5-4b41-93f5-8b31eed7750f.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->