### PR TITLE
Organize rules of GenericEventListSummary on bubble layout

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -608,11 +608,11 @@ limitations under the License.
     // Align with left edge of bubble tiles
     padding: 0 49px;
 }
-}
+
 
 // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
 // that breaks ScrollPanel's reliance upon offsetTop so we have to have a bit more finesse.
-.mx_GenericEventListSummary[data-expanded=true][data-layout=bubble] {
+&[data-expanded=true] {
     display: flex;
     flex-direction: column;
     margin: 0;
@@ -634,6 +634,8 @@ limitations under the License.
         }
     }
 }
+}
+
 
 // increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
 .mx_GenericEventListSummary[data-layout=bubble][data-expanded=false] + .mx_EventTile[data-layout=bubble][data-self=true] {

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -603,9 +603,11 @@ limitations under the License.
     }
 }
 
-.mx_GenericEventListSummary[data-expanded=false][data-layout=bubble] {
+.mx_GenericEventListSummary[data-layout=bubble] {
+    &[data-expanded=false] {
     // Align with left edge of bubble tiles
     padding: 0 49px;
+}
 }
 
 // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -601,9 +601,7 @@ limitations under the License.
         content: "";
         clear: both;
     }
-}
 
-.mx_GenericEventListSummary[data-layout=bubble] {
     &[data-expanded=false] {
     // Align with left edge of bubble tiles
     padding: 0 49px;

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -603,39 +603,39 @@ limitations under the License.
     }
 
     &[data-expanded=false] {
-    // Align with left edge of bubble tiles
-    padding: 0 49px;
+        // Align with left edge of bubble tiles
+        padding: 0 49px;
 
-    // increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
-    + .mx_EventTile[data-layout=bubble][data-self=true] {
-        margin-top: 20px;
-    }
-}
-
-// ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
-// that breaks ScrollPanel's reliance upon offsetTop so we have to have a bit more finesse.
-&[data-expanded=true] {
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-
-    .mx_EventTile_info {
-        padding: 2px 0;
-        margin-right: 0;
-
-        .mx_MessageActionBar {
-            right: 48px; // align with that of right-column bubbles
-        }
-
-        .mx_ReadReceiptGroup {
-            right: -18px; // match alignment to RRs of chat bubbles
-        }
-
-        &::before {
-            right: 0; // match alignment of the hover background to that of chat bubbles
+        // increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
+        + .mx_EventTile[data-layout=bubble][data-self=true] {
+            margin-top: 20px;
         }
     }
-}
+
+    // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
+    // that breaks ScrollPanel's reliance upon offsetTop so we have to have a bit more finesse.
+    &[data-expanded=true] {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+
+        .mx_EventTile_info {
+            padding: 2px 0;
+            margin-right: 0;
+
+            .mx_MessageActionBar {
+                right: 48px; // align with that of right-column bubbles
+            }
+
+            .mx_ReadReceiptGroup {
+                right: -18px; // match alignment to RRs of chat bubbles
+            }
+
+            &::before {
+                right: 0; // match alignment of the hover background to that of chat bubbles
+            }
+        }
+    }
 }
 
 /* events that do not require bubble layout */

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -607,8 +607,12 @@ limitations under the License.
     &[data-expanded=false] {
     // Align with left edge of bubble tiles
     padding: 0 49px;
-}
 
+    // increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
+    + .mx_EventTile[data-layout=bubble][data-self=true] {
+        margin-top: 20px;
+    }
+}
 
 // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
 // that breaks ScrollPanel's reliance upon offsetTop so we have to have a bit more finesse.
@@ -634,12 +638,6 @@ limitations under the License.
         }
     }
 }
-}
-
-
-// increase margin between ELS and the next Event to not have our user avatar overlap the expand/collapse button
-.mx_GenericEventListSummary[data-layout=bubble][data-expanded=false] + .mx_EventTile[data-layout=bubble][data-self=true] {
-    margin-top: 20px;
 }
 
 /* events that do not require bubble layout */


### PR DESCRIPTION
This PR organizes rules of `GenericEventListSummary` on `_EventBubbleTile.scss` to clarify the hierarchy. 

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->