### PR TITLE
Merge styles of mx_EventTile_content for maintainability

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -392,6 +392,45 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_edited {
     cursor: pointer;
 }
+
+.markdown-body {
+    font-family: inherit !important;
+    white-space: normal !important;
+    line-height: inherit !important;
+    color: inherit; // inherit the colour from the dark or light theme by default (but not for code blocks)
+    font-size: $font-14px;
+
+    pre,
+    code {
+        font-family: $monospace-font-family !important;
+        background-color: $codeblock-background-color;
+    }
+
+    // this selector wrongly applies to code blocks too but we will unset it in the next one
+    code {
+        white-space: pre-wrap; // don't collapse spaces in inline code blocks
+    }
+
+    pre code {
+        white-space: pre; // we want code blocks to be scrollable and not wrap
+
+        >* {
+            display: inline;
+        }
+    }
+
+    pre {
+        // have to use overlay rather than auto otherwise Linux and Windows
+        // Chrome gets very confused about vertical spacing:
+        // https://github.com/vector-im/vector-web/issues/754
+        overflow-x: overlay;
+        overflow-y: visible;
+
+        &::-webkit-scrollbar-corner {
+            background: transparent;
+        }
+    }
+}
 }
 
 .mx_EventTile_e2eIcon {
@@ -467,45 +506,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         overflow: hidden;
         text-overflow: ellipsis;
         display: -webkit-box;
-    }
-}
-
-.mx_EventTile_content .markdown-body {
-    font-family: inherit !important;
-    white-space: normal !important;
-    line-height: inherit !important;
-    color: inherit; // inherit the colour from the dark or light theme by default (but not for code blocks)
-    font-size: $font-14px;
-
-    pre,
-    code {
-        font-family: $monospace-font-family !important;
-        background-color: $codeblock-background-color;
-    }
-
-    // this selector wrongly applies to code blocks too but we will unset it in the next one
-    code {
-        white-space: pre-wrap; // don't collapse spaces in inline code blocks
-    }
-
-    pre code {
-        white-space: pre; // we want code blocks to be scrollable and not wrap
-
-        >* {
-            display: inline;
-        }
-    }
-
-    pre {
-        // have to use overlay rather than auto otherwise Linux and Windows
-        // Chrome gets very confused about vertical spacing:
-        // https://github.com/vector-im/vector-web/issues/754
-        overflow-x: overlay;
-        overflow-y: visible;
-
-        &::-webkit-scrollbar-corner {
-            background: transparent;
-        }
     }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -380,20 +380,17 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 }
 
 .mx_EventTile_content {
-.mx_EventTile_edited {
-    user-select: none;
-    font-size: $font-12px;
-    color: $roomtopic-color;
-    display: inline-block;
-    margin-left: 9px;
-    cursor: pointer;
-}
+.mx_EventTile_edited,
 .mx_EventTile_pendingModeration {
     user-select: none;
     font-size: $font-12px;
     color: $roomtopic-color;
     display: inline-block;
     margin-left: 9px;
+}
+
+.mx_EventTile_edited {
+    cursor: pointer;
 }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -379,13 +379,15 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 }
 
-.mx_EventTile_content .mx_EventTile_edited {
+.mx_EventTile_content {
+.mx_EventTile_edited {
     user-select: none;
     font-size: $font-12px;
     color: $roomtopic-color;
     display: inline-block;
     margin-left: 9px;
     cursor: pointer;
+}
 }
 
 .mx_EventTile_content .mx_EventTile_pendingModeration {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -411,14 +411,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         white-space: pre-wrap; // don't collapse spaces in inline code blocks
     }
 
-    pre code {
-        white-space: pre; // we want code blocks to be scrollable and not wrap
-
-        >* {
-            display: inline;
-        }
-    }
-
     pre {
         // have to use overlay rather than auto otherwise Linux and Windows
         // Chrome gets very confused about vertical spacing:
@@ -428,6 +420,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
         &::-webkit-scrollbar-corner {
             background: transparent;
+        }
+
+        code {
+            white-space: pre; // we want code blocks to be scrollable and not wrap
+
+            > * {
+                display: inline;
+            }
         }
     }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -373,6 +373,28 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             font-size: 1.5em;
             border-bottom: none !important; // override GFM
         }
+
+        a {
+            color: $accent-alt;
+        }
+
+        blockquote {
+            border-left: 2px solid $blockquote-bar-color;
+            border-radius: 2px;
+            padding: 0 10px;
+        }
+
+        /*
+        // actually, removing the Italic TTF provides
+        // better results seemingly
+
+        // compensate for Nunito italics being terrible
+        // https://github.com/google/fonts/issues/1726
+        em {
+            transform: skewX(-14deg);
+            display: inline-block;
+        }
+        */
     }
 }
 
@@ -595,28 +617,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_body .mx_EventTile_pre_container:hover .mx_EventTile_expandButton {
     visibility: visible;
 }
-
-.mx_EventTile_content .markdown-body a {
-    color: $accent-alt;
-}
-
-.mx_EventTile_content .markdown-body blockquote {
-    border-left: 2px solid $blockquote-bar-color;
-    border-radius: 2px;
-    padding: 0 10px;
-}
-
-/*
-// actually, removing the Italic TTF provides
-// better results seemingly
-
-// compensate for Nunito italics being terrible
-// https://github.com/google/fonts/issues/1726
-.mx_EventTile_content .markdown-body em {
-    transform: skewX(-14deg);
-    display: inline-block;
-}
-*/
 
 /* end of overrides */
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -356,6 +356,23 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 }
             }
         }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-family: inherit !important;
+            color: inherit;
+        }
+
+        /* Make h1 and h2 the same size as h3. */
+        h1,
+        h2 {
+            font-size: 1.5em;
+            border-bottom: none !important; // override GFM
+        }
     }
 }
 
@@ -577,23 +594,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_body .mx_EventTile_pre_container:focus-within .mx_EventTile_expandButton,
 .mx_EventTile_body .mx_EventTile_pre_container:hover .mx_EventTile_expandButton {
     visibility: visible;
-}
-
-.mx_EventTile_content .markdown-body h1,
-.mx_EventTile_content .markdown-body h2,
-.mx_EventTile_content .markdown-body h3,
-.mx_EventTile_content .markdown-body h4,
-.mx_EventTile_content .markdown-body h5,
-.mx_EventTile_content .markdown-body h6 {
-    font-family: inherit !important;
-    color: inherit;
-}
-
-/* Make h1 and h2 the same size as h3. */
-.mx_EventTile_content .markdown-body h1,
-.mx_EventTile_content .markdown-body h2 {
-    font-size: 1.5em;
-    border-bottom: none !important; // override GFM
 }
 
 .mx_EventTile_content .markdown-body a {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -294,15 +294,69 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     padding-left: calc($left-gutter + 20px); // override padding-left $left-gutter
 }
 
-/* all the overflow-y: hidden; are to trap Zalgos -
-   but they introduce an implicit overflow-x: auto.
-   so make that explicitly hidden too to avoid random
-   horizontal scrollbars occasionally appearing, like in
-   https://github.com/vector-im/vector-web/issues/1154 */
 .mx_EventTile_content {
+    /*
+    all the overflow-y: hidden; are to trap Zalgos -
+    but they introduce an implicit overflow-x: auto.
+    so make that explicitly hidden too to avoid random
+    horizontal scrollbars occasionally appearing, like in
+    https://github.com/vector-im/vector-web/issues/1154
+    */
     overflow-y: hidden;
     overflow-x: hidden;
     margin-right: 34px;
+
+    .mx_EventTile_edited,
+    .mx_EventTile_pendingModeration {
+        user-select: none;
+        font-size: $font-12px;
+        color: $roomtopic-color;
+        display: inline-block;
+        margin-left: 9px;
+    }
+
+    .mx_EventTile_edited {
+        cursor: pointer;
+    }
+
+    .markdown-body {
+        font-family: inherit !important;
+        white-space: normal !important;
+        line-height: inherit !important;
+        color: inherit; // inherit the colour from the dark or light theme by default (but not for code blocks)
+        font-size: $font-14px;
+
+        pre,
+        code {
+            font-family: $monospace-font-family !important;
+            background-color: $codeblock-background-color;
+        }
+
+        // this selector wrongly applies to code blocks too but we will unset it in the next one
+        code {
+            white-space: pre-wrap; // don't collapse spaces in inline code blocks
+        }
+
+        pre {
+            // have to use overlay rather than auto otherwise Linux and Windows
+            // Chrome gets very confused about vertical spacing:
+            // https://github.com/vector-im/vector-web/issues/754
+            overflow-x: overlay;
+            overflow-y: visible;
+
+            &::-webkit-scrollbar-corner {
+                background: transparent;
+            }
+
+            code {
+                white-space: pre; // we want code blocks to be scrollable and not wrap
+
+                > * {
+                    display: inline;
+                }
+            }
+        }
+    }
 }
 
 /* Spoiler stuff */
@@ -377,60 +431,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     .mx_Emoji {
         font-size: inherit !important;
     }
-}
-
-.mx_EventTile_content {
-.mx_EventTile_edited,
-.mx_EventTile_pendingModeration {
-    user-select: none;
-    font-size: $font-12px;
-    color: $roomtopic-color;
-    display: inline-block;
-    margin-left: 9px;
-}
-
-.mx_EventTile_edited {
-    cursor: pointer;
-}
-
-.markdown-body {
-    font-family: inherit !important;
-    white-space: normal !important;
-    line-height: inherit !important;
-    color: inherit; // inherit the colour from the dark or light theme by default (but not for code blocks)
-    font-size: $font-14px;
-
-    pre,
-    code {
-        font-family: $monospace-font-family !important;
-        background-color: $codeblock-background-color;
-    }
-
-    // this selector wrongly applies to code blocks too but we will unset it in the next one
-    code {
-        white-space: pre-wrap; // don't collapse spaces in inline code blocks
-    }
-
-    pre {
-        // have to use overlay rather than auto otherwise Linux and Windows
-        // Chrome gets very confused about vertical spacing:
-        // https://github.com/vector-im/vector-web/issues/754
-        overflow-x: overlay;
-        overflow-y: visible;
-
-        &::-webkit-scrollbar-corner {
-            background: transparent;
-        }
-
-        code {
-            white-space: pre; // we want code blocks to be scrollable and not wrap
-
-            > * {
-                display: inline;
-            }
-        }
-    }
-}
 }
 
 .mx_EventTile_e2eIcon {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -332,7 +332,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             background-color: $codeblock-background-color;
         }
 
-        // this selector wrongly applies to code blocks too but we will unset it in the next one
         code {
             white-space: pre-wrap; // don't collapse spaces in inline code blocks
         }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -388,14 +388,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     margin-left: 9px;
     cursor: pointer;
 }
-}
-
-.mx_EventTile_content .mx_EventTile_pendingModeration {
+.mx_EventTile_pendingModeration {
     user-select: none;
     font-size: $font-12px;
     color: $roomtopic-color;
     display: inline-block;
     margin-left: 9px;
+}
 }
 
 .mx_EventTile_e2eIcon {


### PR DESCRIPTION
This PR merges styles of `mx_EventTile_content` and its child elements for maintainability.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->