### PR TITLE
Don't show image metadata banner in replies

### DIFF
--- a/res/css/views/messages/_MImageReplyBody.scss
+++ b/res/css/views/messages/_MImageReplyBody.scss
@@ -20,6 +20,10 @@ limitations under the License.
     .mx_MImageBody_thumbnail_container {
         flex: 1;
         margin-right: 4px;
+
+        .mx_MImageBody_banner {
+            display: none;
+        }
     }
 
     .mx_MImageReplyBody_info {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22214
Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->