### PR TITLE
fix: ensure metaspace changes correctly notify listeners

### DIFF
--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -1072,6 +1072,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
                 ?.["m.room_versions"]?.["org.matrix.msc3244.room_capabilities"]?.["restricted"];
         });
 
+        const oldMetaSpaces = this._enabledMetaSpaces;
         const enabledMetaSpaces = SettingsStore.getValue("Spaces.enabledMetaSpaces");
         this._enabledMetaSpaces = metaSpaceOrder.filter(k => enabledMetaSpaces[k]);
 
@@ -1079,6 +1080,11 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
         this.sendUserProperties();
 
         this.rebuildSpaceHierarchy(); // trigger an initial update
+        // rebuildSpaceHierarchy will only send an update if the spaces have changed.
+        // If only the meta spaces have changed, we need to send an update ourselves.
+        if (arrayHasDiff(oldMetaSpaces, this._enabledMetaSpaces)) {
+            this.emit(UPDATE_TOP_LEVEL_SPACES, this.spacePanelSpaces, this.enabledMetaSpaces);
+        }
 
         // restore selected state from last session if any and still valid
         const lastSpaceId = window.localStorage.getItem(ACTIVE_SPACE_LS_KEY);


### PR DESCRIPTION
Type: Defect
Closes: https://github.com/vector-im/element-web/issues/21006

The previous flow of events:

1. SpaceStore is created. `enabledMetaSpaces` and `spacePanelSpaces` are empty
2. Sometimes SpacePanel is initialized at this point already and loads the empty `enabledMetaSpaces` and `spacePanelSpaces` from the SpaceStore.
3. SpaceStore loads the actual lists and updates `enabledMetaSpaces` and `spacePanelSpaces`. **Only if `spacePanelSpaces` has changed, SpaceStore will notify the SpacePanel**
4. SpacePanel updates the lists
5. Sometimes SpacePanel is initialized only at this point and loads the current `enabledMetaSpaces` and `spacePanelSpaces` from the SpaceStore.
6. If at any later point `enabledMetaSpaces` or `spacePanelSpaces` change, SpaceStore notifies the SpacePanel, which updates itself.

Note the race condition (SpacePanel initializing either at point 2 or 5) and the actual logic bug (bold, in point 3).

This PR fixes that logic bug, causing SpaceStore to notify its listeners, including the SpacePanel, during onReady even if only metaSpaces have been loaded.