### PR TITLE
Use a default for `ignoreHover` when not supplied

### DIFF
--- a/src/components/views/elements/TooltipTarget.tsx
+++ b/src/components/views/elements/TooltipTarget.tsx
@@ -43,7 +43,7 @@ const TooltipTarget: React.FC<IProps> = ({
     ...rest
 }) => {
     const [isFocused, focusProps] = useFocus();
-    const [isHovering, hoverProps] = useHover(ignoreHover);
+    const [isHovering, hoverProps] = useHover(ignoreHover || (() => false));
 
     // No need to fill up the DOM with hidden tooltip elements. Only add the
     // tooltip when we're hovering over the item (performance)


### PR DESCRIPTION
It is considered optional by the component props, so let's treat it as optional.

Fixes this thing in the console:

```
react-dom.development.js?61bb:4091 
        
       Uncaught TypeError: ignoreHover is not a function
    at onMouseMove (useHover.ts?ef9e:28:28)
    at HTMLUnknownElement.callCallback (react-dom.development.js?61bb:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?61bb:3994:1)
    at invokeGuardedCallback (react-dom.development.js?61bb:4056:1)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js?61bb:4070:1)
    at executeDispatch (react-dom.development.js?61bb:8243:1)
    at processDispatchQueueItemsInOrder (react-dom.development.js?61bb:8275:1)
    at processDispatchQueue (react-dom.development.js?61bb:8288:1)
    at dispatchEventsForPlugins (react-dom.development.js?61bb:8299:1)
    at eval (react-dom.development.js?61bb:8508:1)
```

----

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->