### PR TITLE
Convert `setupNotificationListener` to an unbound function

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -401,14 +401,14 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
         room?.on(ThreadEvent.New, this.onNewThread);
     }
 
-    private setupNotificationListener = (thread: Thread): void => {
+    private setupNotificationListener(thread: Thread): void {
         const notifications = RoomNotificationStateStore.instance.getThreadsRoomState(thread.room);
 
         this.threadState = notifications.getThreadRoomState(thread);
 
         this.threadState.on(NotificationStateEvents.Update, this.onThreadStateUpdate);
         this.onThreadStateUpdate();
-    };
+    }
 
     private onThreadStateUpdate = (): void => {
         let threadNotification = null;


### PR DESCRIPTION
This isn't called by an event handler directly, so shouldn't need to be bound. Equally, this shouldn't cause any problems.

This is a long-shot attempt at completing https://github.com/vector-im/element-web/issues/22141

----

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->