### PR TITLE
Add a confirmation when ignoring a user

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -373,15 +373,25 @@ const UserOptionsSection: React.FC<{
     // Only allow the user to ignore the user if its not ourselves
     // same goes for jumping to read receipt
     if (!isMe) {
-        const onIgnoreToggle = () => {
+        const onIgnoreToggle = async () => {
             const ignoredUsers = cli.getIgnoredUsers();
             if (isIgnored) {
                 const index = ignoredUsers.indexOf(member.userId);
                 if (index !== -1) ignoredUsers.splice(index, 1);
             } else {
+                // ask the user to confirm
+                const [accepted] = await Modal.createTrackedDialog("Confirm Ignore User", "", QuestionDialog, {
+                    title: _t("Do you want to ignore this user?"),
+                    description: _t(
+                        "You won't see messages from %(targetName)s anymore. Are you sure you want to ignore them?",
+                        { targetName: member.name },
+                    ),
+                }).finished;
+                if (!accepted) return;
                 ignoredUsers.push(member.userId);
             }
 
+            // noinspection ES6MissingAwait
             cli.setIgnoredUsers(ignoredUsers);
         };
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2008,6 +2008,8 @@
     "%(count)s sessions|one": "%(count)s session",
     "Hide sessions": "Hide sessions",
     "Message": "Message",
+    "Do you want to ignore this user?": "Do you want to ignore this user?",
+    "You won't see messages from %(targetName)s anymore. Are you sure you want to ignore them?": "You won't see messages from %(targetName)s anymore. Are you sure you want to ignore them?",
     "Jump to read receipt": "Jump to read receipt",
     "Mention": "Mention",
     "Share Link to User": "Share Link to User",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/14746

Doesn't apply when un-ignoring.

I don't believe we have a utility for checking if a dialog opened, and an end-to-end test feels ways overkill on this, so no tests for now. If someone has a pointer to a test which checks for a dialog then happy to write appropriate tests.

![image](https://user-images.githubusercontent.com/1190097/168734187-81dcc15f-f460-4876-a3bd-d0dca4b6156a.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a confirmation when ignoring a user ([\#8620](https://github.com/matrix-org/matrix-react-sdk/pull/8620)). Fixes vector-im/element-web#14746.<!-- CHANGELOG_PREVIEW_END -->