### PR TITLE
Adjust EditMessageComposer style declarations

### DIFF
--- a/res/css/views/rooms/_EditMessageComposer.scss
+++ b/res/css/views/rooms/_EditMessageComposer.scss
@@ -19,7 +19,7 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     max-width: 100%; // disable overflow
-    width: fit-content;
+    width: auto;
     gap: 5px;
     padding: 3px;
 

--- a/res/css/views/rooms/_EditMessageComposer.scss
+++ b/res/css/views/rooms/_EditMessageComposer.scss
@@ -18,11 +18,10 @@ limitations under the License.
 .mx_EditMessageComposer {
     display: flex;
     flex-direction: column;
+    max-width: 100%; // disable overflow
+    width: fit-content;
     gap: 5px;
     padding: 3px;
-
-    // Make sure the formatting bar is visible
-    overflow: visible !important; // override mx_EventTile_content
 
     .mx_BasicMessageComposer_input {
         border-radius: 4px;
@@ -38,12 +37,15 @@ limitations under the License.
 
     .mx_EditMessageComposer_buttons {
         display: flex;
-        flex-direction: row;
+        flex-flow: row wrap-reverse; // display "Save" over "Cancel"
         justify-content: flex-end;
         gap: 5px;
+        margin-inline-start: auto;
 
         .mx_AccessibleButton {
-            padding: 5px 40px;
+            flex: 1;
+            box-sizing: border-box;
+            min-width: 100px; // magic number to align the edge of the button with the input area
         }
     }
 }

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -65,6 +65,11 @@ limitations under the License.
 
     .mx_EventTile_content {
         margin-right: 0;
+
+        &.mx_EditMessageComposer {
+            // Make sure the formatting bar is visible
+            overflow: visible;
+        }
     }
 
     &.mx_EventTile_continuation {

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -65,11 +65,6 @@ limitations under the License.
 
     .mx_EventTile_content {
         margin-right: 0;
-
-        &.mx_EditMessageComposer {
-            // Make sure the formatting bar is visible
-            overflow: visible;
-        }
     }
 
     &.mx_EventTile_continuation {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -51,6 +51,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         mask-image: url('$(res)/img/element-icons/circle-sending.svg');
     }
 
+    .mx_EventTile_content {
+        &.mx_EditMessageComposer {
+            // Make sure the formatting bar is visible
+            overflow: visible;
+        }
+    }
+
     &[data-layout=group] {
         .mx_EventTile_line {
             line-height: var(--GroupLayout-EventTile-line-height);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22231

- `max-width: 100%` to avoid flexbox from overflowing
- `flex-flow: row wrap-reverse` to display "Save" over "Cancel" button
- `margin-inline-start: auto` to move those buttons to the right side
- `flex: 1` to set the same width for the buttons
- `min-width: 100px` to align the edge of the button with text area

Wrapping the buttons should be preferred here as the width of the buttons depends on the length of the strings.

Editing margin between the left edge and the input area on bubble message layout is out of scope (it's been there due to a declaration with `!important` inside `.ThreadView`)

The space between the buttons and the right edge of the input area should be taken care of with https://github.com/matrix-org/matrix-react-sdk/pull/8632.

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/168847455-1dd39a37-6044-41a1-83b0-25df4ae71201.png)|![after1](https://user-images.githubusercontent.com/3362943/168847422-ad5ba937-237f-4144-b094-fc7983f03279.png)|
|![before2](https://user-images.githubusercontent.com/3362943/168847469-5c534fa2-dd2a-4b84-8d7a-18aa46dd622c.png)|![after2](https://user-images.githubusercontent.com/3362943/168847437-7f6f6300-cdd9-4d87-9aae-7ae114e0aba9.png)|
|![before](https://user-images.githubusercontent.com/3362943/168852045-70ba827b-fc29-43fb-a1b8-750d2577f3b9.png)|![after](https://user-images.githubusercontent.com/3362943/168852003-011b522a-bda1-45f2-b392-cece24f7106f.png)|
|![before1](https://user-images.githubusercontent.com/3362943/168852055-3e6ee261-435f-4752-bde2-4fa855921cfd.png)|![after1](https://user-images.githubusercontent.com/3362943/168852034-6c3dda7d-ecc5-4618-9c92-7208613d0e41.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Adjust EditMessageComposer style declarations ([\#8631](https://github.com/matrix-org/matrix-react-sdk/pull/8631)). Fixes vector-im/element-web#22231. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->