### PR TITLE
Remove obsolete declarations for buttons on EditMessageComposer on ThreadView

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -977,9 +977,4 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     .mx_EditMessageComposer {
         margin-left: 30px !important; // align start of first letter with that of the event body
     }
-
-    .mx_EditMessageComposer_buttons {
-        padding-right: 11px; // align with right edge of input
-        margin-right: 0; // align with right edge of background
-    }
 }


### PR DESCRIPTION
Those declarations are no longer necessary to align the buttons with the right edge of the input area and background.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/168856904-d7442ee0-7315-454e-bac5-b24d318ef0f5.png)|![after](https://user-images.githubusercontent.com/3362943/168856850-7829fc2b-1dbf-4790-b070-70bab52fc2e7.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
Notes: Remove padding from the buttons on edit message composer of a event tile on a thread

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove padding from the buttons on edit message composer of a event tile on a thread ([\#8632](https://github.com/matrix-org/matrix-react-sdk/pull/8632)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->