### PR TITLE
Remove unused code for weblate->counterpart conversion

### DIFF
--- a/__mocks__/browser-request.js
+++ b/__mocks__/browser-request.js
@@ -1,9 +1,45 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const en = require("../src/i18n/strings/en_EN");
 const de = require("../src/i18n/strings/de_DE");
 const lv = {
     "Save": "Saglabāt",
     "Uploading %(filename)s and %(count)s others|one": "Качване на %(filename)s и %(count)s друг",
 };
+
+function weblateToCounterpart(inTrs) {
+    const outTrs = {};
+
+    for (const key of Object.keys(inTrs)) {
+        const keyParts = key.split('|', 2);
+        if (keyParts.length === 2) {
+            let obj = outTrs[keyParts[0]];
+            if (obj === undefined) {
+                obj = {};
+                outTrs[keyParts[0]] = obj;
+            }
+            obj[keyParts[1]] = inTrs[key];
+        } else {
+            outTrs[key] = inTrs[key];
+        }
+    }
+
+    return outTrs;
+}
 
 // Mock the browser-request for the languageHandler tests to return
 // Fake languages.json containing references to en_EN, de_DE and lv
@@ -13,7 +49,7 @@ const lv = {
 module.exports = jest.fn((opts, cb) => {
     const url = opts.url || opts.uri;
     if (url && url.endsWith("languages.json")) {
-        cb(undefined, {status: 200}, JSON.stringify({
+        cb(undefined, { status: 200 }, JSON.stringify({
             "en": {
                 "fileName": "en_EN.json",
                 "label": "English",
@@ -24,16 +60,16 @@ module.exports = jest.fn((opts, cb) => {
             },
             "lv": {
                 "fileName": "lv.json",
-                "label": "Latvian"
-            }
+                "label": "Latvian",
+            },
         }));
     } else if (url && url.endsWith("en_EN.json")) {
-        cb(undefined, {status: 200}, JSON.stringify(en));
+        cb(undefined, { status: 200 }, JSON.stringify(weblateToCounterpart(en)));
     } else if (url && url.endsWith("de_DE.json")) {
-        cb(undefined, {status: 200}, JSON.stringify(de));
+        cb(undefined, { status: 200 }, JSON.stringify(weblateToCounterpart(de)));
     } else if (url && url.endsWith("lv.json")) {
-        cb(undefined, {status: 200}, JSON.stringify(lv));
+        cb(undefined, { status: 200 }, JSON.stringify(weblateToCounterpart(lv)));
     } else {
-        cb(true, {status: 404}, "");
+        cb(true, { status: 404 }, "");
     }
 });

--- a/src/languageHandler.tsx
+++ b/src/languageHandler.tsx
@@ -556,27 +556,13 @@ function getLangsJson(): Promise<object> {
     });
 }
 
-function weblateToCounterpart(inTrs: object): object {
-    const outTrs = {};
-
-    for (const key of Object.keys(inTrs)) {
-        const keyParts = key.split('|', 2);
-        if (keyParts.length === 2) {
-            let obj = outTrs[keyParts[0]];
-            if (obj === undefined) {
-                obj = {};
-                outTrs[keyParts[0]] = obj;
-            }
-            obj[keyParts[1]] = inTrs[key];
-        } else {
-            outTrs[key] = inTrs[key];
-        }
-    }
-
-    return outTrs;
+interface ICounterpartTranslation {
+    [key: string]: string | {
+        [pluralisation: string]: string;
+    };
 }
 
-async function getLanguageRetry(langPath: string, num = 3): Promise<object> {
+async function getLanguageRetry(langPath: string, num = 3): Promise<ICounterpartTranslation> {
     return retry(() => getLanguage(langPath), num, e => {
         logger.log("Failed to load i18n", langPath);
         logger.error(e);
@@ -584,7 +570,7 @@ async function getLanguageRetry(langPath: string, num = 3): Promise<object> {
     });
 }
 
-function getLanguage(langPath: string): Promise<object> {
+function getLanguage(langPath: string): Promise<ICounterpartTranslation> {
     return new Promise((resolve, reject) => {
         request(
             { method: "GET", url: langPath },
@@ -597,7 +583,7 @@ function getLanguage(langPath: string): Promise<object> {
                     reject(new Error(`Failed to load ${langPath}, got ${response.status}`));
                     return;
                 }
-                resolve(weblateToCounterpart(JSON.parse(body)));
+                resolve(JSON.parse(body));
             },
         );
     });


### PR DESCRIPTION
Happens at build time instead now (in copy-res)

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
