### PR TITLE
Prevent possible regressions of EventTile structurally

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -502,8 +502,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 
     &::before {
-        mask-repeat: no-repeat;
-        mask-position: center;
         mask-size: 80%;
     }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -606,23 +606,22 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 }
 }
 
-&.mx_EventTile_copyButton {
+.mx_EventTile_copyButton {
     mask-image: url($copy-button-url);
 }
 
-&.mx_EventTile_collapseButton,
-&.mx_EventTile_expandButton {
+.mx_EventTile_collapseButton,
+.mx_EventTile_expandButton {
     mask-position: center;
     mask-repeat: no-repeat;
 }
 
-&.mx_EventTile_collapseButton {
+.mx_EventTile_collapseButton {
     mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
 }
 
-&.mx_EventTile_expandButton {
+.mx_EventTile_expandButton {
     mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
-}
 }
 
 .mx_EventTile_body .mx_EventTile_pre_container {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -506,24 +506,25 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         mask-position: center;
         mask-size: 80%;
     }
-}
 
-.mx_EventTile_e2eIcon_warning {
+    &.mx_EventTile_e2eIcon_warning,
+    &.mx_EventTile_e2eIcon_normal {
+        opacity: 1;
+    }
+
+&.mx_EventTile_e2eIcon_warning {
     &::after {
         mask-image: url('$(res)/img/e2e/warning.svg');
         background-color: $alert;
     }
-
-    opacity: 1;
 }
 
-.mx_EventTile_e2eIcon_normal {
+&.mx_EventTile_e2eIcon_normal {
     &::after {
         mask-image: url('$(res)/img/e2e/normal.svg');
         background-color: $header-panel-text-primary-color;
     }
-
-    opacity: 1;
+}
 }
 
 /* Various markdown overrides */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -617,13 +617,15 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 }
 }
 
-.mx_EventTile_body .mx_EventTile_pre_container:focus-within .mx_EventTile_copyButton,
-.mx_EventTile_body .mx_EventTile_pre_container:hover .mx_EventTile_copyButton,
-.mx_EventTile_body .mx_EventTile_pre_container:focus-within .mx_EventTile_collapseButton,
-.mx_EventTile_body .mx_EventTile_pre_container:hover .mx_EventTile_collapseButton,
-.mx_EventTile_body .mx_EventTile_pre_container:focus-within .mx_EventTile_expandButton,
-.mx_EventTile_body .mx_EventTile_pre_container:hover .mx_EventTile_expandButton {
+.mx_EventTile_body .mx_EventTile_pre_container {
+    &:focus-within .mx_EventTile_copyButton,
+    &:hover .mx_EventTile_copyButton,
+    &:focus-within .mx_EventTile_collapseButton,
+    &:hover .mx_EventTile_collapseButton,
+    &:focus-within .mx_EventTile_expandButton,
+    &:hover .mx_EventTile_expandButton {
     visibility: visible;
+}
 }
 
 /* end of overrides */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -620,13 +620,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_body .mx_EventTile_pre_container {
     &:focus-within,
     &:hover {
-        .mx_EventTile_copyButton {
-            visibility: visible;
-        }
-    }
-
-    &:focus-within,
-    &:hover {
+        .mx_EventTile_copyButton,
         .mx_EventTile_collapseButton {
             visibility: visible;
         }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -580,6 +580,24 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     height: 19px;
 }
 
+.mx_EventTile_copyButton {
+    mask-image: url($copy-button-url);
+}
+
+.mx_EventTile_collapseButton,
+.mx_EventTile_expandButton {
+    mask-position: center;
+    mask-repeat: no-repeat;
+}
+
+.mx_EventTile_collapseButton {
+    mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
+}
+
+.mx_EventTile_expandButton {
+    mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
+}
+
 .mx_EventTile_pre_container {
     // For correct positioning of _copyButton (See TextualBody)
     position: relative;
@@ -604,24 +622,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     mask-size: 75%;
 }
 }
-}
-
-.mx_EventTile_copyButton {
-    mask-image: url($copy-button-url);
-}
-
-.mx_EventTile_collapseButton,
-.mx_EventTile_expandButton {
-    mask-position: center;
-    mask-repeat: no-repeat;
-}
-
-.mx_EventTile_collapseButton {
-    mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
-}
-
-.mx_EventTile_expandButton {
-    mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
 }
 
 .mx_EventTile_body .mx_EventTile_pre_container {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -632,10 +632,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
-    &:focus-within .mx_EventTile_expandButton,
-    &:hover .mx_EventTile_expandButton {
-    visibility: visible;
-}
+    &:focus-within,
+    &:hover {
+        .mx_EventTile_expandButton {
+            visibility: visible;
+        }
+    }
 }
 
 /* end of overrides */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -572,6 +572,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     border: 1px solid $tertiary-content;
 }
 
+.mx_EventTile_button {
+    display: inline-block;
+    visibility: hidden;
+    cursor: pointer;
+    width: 19px;
+    height: 19px;
+}
+
 .mx_EventTile_pre_container {
     // For correct positioning of _copyButton (See TextualBody)
     position: relative;
@@ -584,13 +592,8 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 // Inserted adjacent to <pre> blocks, (See TextualBody)
 .mx_EventTile_button {
     position: absolute;
-    display: inline-block;
-    visibility: hidden;
-    cursor: pointer;
     top: 8px;
     right: 8px;
-    width: 19px;
-    height: 19px;
     background-color: $message-action-bar-fg-color;
 
 &.mx_EventTile_buttonBottom {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -632,31 +632,31 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
 .mx_EventTile_keyRequestInfo {
     font-size: $font-12px;
-}
 
 .mx_EventTile_keyRequestInfo_text {
     opacity: 0.5;
-}
 
-.mx_EventTile_keyRequestInfo_text .mx_AccessibleButton {
+.mx_AccessibleButton {
     @mixin ButtonResetDefault;
     color: $primary-content;
     text-decoration: underline;
     cursor: pointer;
+}
+}
 }
 
 .mx_EventTile_keyRequestInfo_tooltip_contents p {
     text-align: auto;
     margin-left: 3px;
     margin-right: 3px;
-}
 
-.mx_EventTile_keyRequestInfo_tooltip_contents p:first-child {
+&:first-child {
     margin-top: 0px;
 }
 
-.mx_EventTile_keyRequestInfo_tooltip_contents p:last-child {
+&:last-child {
     margin-bottom: 0px;
+}
 }
 
 .mx_EventTile_tileError {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -592,28 +592,28 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     width: 19px;
     height: 19px;
     background-color: $message-action-bar-fg-color;
-}
 
-.mx_EventTile_buttonBottom {
+&.mx_EventTile_buttonBottom {
     top: 33px;
 }
 
-.mx_EventTile_copyButton {
+&.mx_EventTile_copyButton {
     mask-image: url($copy-button-url);
 }
 
-.mx_EventTile_collapseButton {
+&.mx_EventTile_collapseButton {
     mask-size: 75%;
     mask-position: center;
     mask-repeat: no-repeat;
     mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
 }
 
-.mx_EventTile_expandButton {
+&.mx_EventTile_expandButton {
     mask-size: 75%;
     mask-position: center;
     mask-repeat: no-repeat;
     mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
+}
 }
 
 .mx_EventTile_body .mx_EventTile_pre_container:focus-within .mx_EventTile_copyButton,

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -572,7 +572,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
 .mx_EventTile_button {
     display: inline-block;
-    visibility: hidden;
     cursor: pointer;
 }
 
@@ -600,9 +599,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &:focus-within,
     &:hover {
-        .mx_EventTile_copyButton,
-        .mx_EventTile_collapseButton,
-        .mx_EventTile_expandButton {
+        .mx_EventTile_button {
             visibility: visible;
         }
     }
@@ -618,6 +615,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         right: 8px;
         width: 19px;
         height: 19px;
+        visibility: hidden;
         background-color: $message-action-bar-fg-color;
 
         &.mx_EventTile_buttonBottom {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -618,8 +618,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 }
 
 .mx_EventTile_body .mx_EventTile_pre_container {
-    &:focus-within .mx_EventTile_copyButton,
-    &:hover .mx_EventTile_copyButton,
+    &:focus-within,
+    &:hover {
+        .mx_EventTile_copyButton {
+            visibility: visible;
+        }
+    }
+
     &:focus-within .mx_EventTile_collapseButton,
     &:hover .mx_EventTile_collapseButton,
     &:focus-within .mx_EventTile_expandButton,

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -567,10 +567,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 }
 
-.mx_EventTile_collapsedCodeBlock {
-    max-height: 30vh;
-}
-
 .mx_EventTile:hover .mx_EventTile_body pre,
 .mx_EventTile.focus-visible:focus-within .mx_EventTile_body pre {
     border: 1px solid $tertiary-content;
@@ -579,6 +575,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_pre_container {
     // For correct positioning of _copyButton (See TextualBody)
     position: relative;
+
+.mx_EventTile_collapsedCodeBlock {
+    max-height: 30vh;
+}
 }
 
 // Inserted adjacent to <pre> blocks, (See TextualBody)

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -408,19 +408,19 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_spoiler {
     cursor: pointer;
 
-.mx_EventTile_spoiler_reason {
-    color: $event-timestamp-color;
-    font-size: $font-11px;
-}
+    .mx_EventTile_spoiler_reason {
+        color: $event-timestamp-color;
+        font-size: $font-11px;
+    }
 
-.mx_EventTile_spoiler_content {
-    filter: blur(5px) saturate(0.1) sepia(1);
-    transition-duration: 0.5s;
-}
+    .mx_EventTile_spoiler_content {
+        filter: blur(5px) saturate(0.1) sepia(1);
+        transition-duration: 0.5s;
+    }
 
-&.visible > .mx_EventTile_spoiler_content {
-    filter: none;
-}
+    &.visible > .mx_EventTile_spoiler_content {
+        filter: none;
+    }
 }
 
 .mx_RoomView_timeline_rr_enabled {
@@ -512,19 +512,19 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         opacity: 1;
     }
 
-&.mx_EventTile_e2eIcon_warning {
-    &::after {
-        mask-image: url('$(res)/img/e2e/warning.svg');
-        background-color: $alert;
+    &.mx_EventTile_e2eIcon_warning {
+        &::after {
+            mask-image: url('$(res)/img/e2e/warning.svg');
+            background-color: $alert;
+        }
     }
-}
 
-&.mx_EventTile_e2eIcon_normal {
-    &::after {
-        mask-image: url('$(res)/img/e2e/normal.svg');
-        background-color: $header-panel-text-primary-color;
+    &.mx_EventTile_e2eIcon_normal {
+        &::after {
+            mask-image: url('$(res)/img/e2e/normal.svg');
+            background-color: $header-panel-text-primary-color;
+        }
     }
-}
 }
 
 /* Various markdown overrides */
@@ -611,26 +611,26 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
-.mx_EventTile_collapsedCodeBlock {
-    max-height: 30vh;
-}
+    .mx_EventTile_collapsedCodeBlock {
+        max-height: 30vh;
+    }
 
-// Inserted adjacent to <pre> blocks, (See TextualBody)
-.mx_EventTile_button {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    background-color: $message-action-bar-fg-color;
+    // Inserted adjacent to <pre> blocks, (See TextualBody)
+    .mx_EventTile_button {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background-color: $message-action-bar-fg-color;
 
-&.mx_EventTile_buttonBottom {
-    top: 33px;
-}
+        &.mx_EventTile_buttonBottom {
+            top: 33px;
+        }
 
-&.mx_EventTile_collapseButton,
-&.mx_EventTile_expandButton {
-    mask-size: 75%;
-}
-}
+        &.mx_EventTile_collapseButton,
+        &.mx_EventTile_expandButton {
+            mask-size: 75%;
+        }
+    }
 }
 
 /* end of overrides */
@@ -638,16 +638,16 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_keyRequestInfo {
     font-size: $font-12px;
 
-.mx_EventTile_keyRequestInfo_text {
-    opacity: 0.5;
+    .mx_EventTile_keyRequestInfo_text {
+        opacity: 0.5;
 
-.mx_AccessibleButton {
-    @mixin ButtonResetDefault;
-    color: $primary-content;
-    text-decoration: underline;
-    cursor: pointer;
-}
-}
+        .mx_AccessibleButton {
+            @mixin ButtonResetDefault;
+            color: $primary-content;
+            text-decoration: underline;
+            cursor: pointer;
+        }
+    }
 }
 
 .mx_EventTile_keyRequestInfo_tooltip_contents p {
@@ -655,13 +655,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     margin-left: 3px;
     margin-right: 3px;
 
-&:first-child {
-    margin-top: 0px;
-}
+    &:first-child {
+        margin-top: 0px;
+    }
 
-&:last-child {
-    margin-bottom: 0px;
-}
+    &:last-child {
+        margin-bottom: 0px;
+    }
 }
 
 .mx_EventTile_tileError {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -510,18 +510,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         opacity: 1;
     }
 
-    &.mx_EventTile_e2eIcon_warning {
-        &::after {
-            mask-image: url('$(res)/img/e2e/warning.svg');
-            background-color: $alert;
-        }
+    &.mx_EventTile_e2eIcon_warning::after {
+        mask-image: url('$(res)/img/e2e/warning.svg');
+        background-color: $alert;
     }
 
-    &.mx_EventTile_e2eIcon_normal {
-        &::after {
-            mask-image: url('$(res)/img/e2e/normal.svg');
-            background-color: $header-panel-text-primary-color;
-        }
+    &.mx_EventTile_e2eIcon_normal::after {
+        mask-image: url('$(res)/img/e2e/normal.svg');
+        background-color: $header-panel-text-primary-color;
     }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -576,8 +576,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     display: inline-block;
     visibility: hidden;
     cursor: pointer;
-    width: 19px;
-    height: 19px;
 }
 
 .mx_EventTile_copyButton {
@@ -620,6 +618,8 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         position: absolute;
         top: 8px;
         right: 8px;
+        width: 19px;
+        height: 19px;
         background-color: $message-action-bar-fg-color;
 
         &.mx_EventTile_buttonBottom {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -598,9 +598,18 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
 }
 
-.mx_EventTile_pre_container {
+.mx_EventTile_body .mx_EventTile_pre_container {
     // For correct positioning of _copyButton (See TextualBody)
     position: relative;
+
+    &:focus-within,
+    &:hover {
+        .mx_EventTile_copyButton,
+        .mx_EventTile_collapseButton,
+        .mx_EventTile_expandButton {
+            visibility: visible;
+        }
+    }
 
 .mx_EventTile_collapsedCodeBlock {
     max-height: 30vh;
@@ -622,17 +631,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     mask-size: 75%;
 }
 }
-}
-
-.mx_EventTile_body .mx_EventTile_pre_container {
-    &:focus-within,
-    &:hover {
-        .mx_EventTile_copyButton,
-        .mx_EventTile_collapseButton,
-        .mx_EventTile_expandButton {
-            visibility: visible;
-        }
-    }
 }
 
 /* end of overrides */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -407,7 +407,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 /* Spoiler stuff */
 .mx_EventTile_spoiler {
     cursor: pointer;
-}
 
 .mx_EventTile_spoiler_reason {
     color: $event-timestamp-color;
@@ -419,8 +418,9 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     transition-duration: 0.5s;
 }
 
-.mx_EventTile_spoiler.visible > .mx_EventTile_spoiler_content {
+&.visible > .mx_EventTile_spoiler_content {
     filter: none;
+}
 }
 
 .mx_RoomView_timeline_rr_enabled {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -601,17 +601,18 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     mask-image: url($copy-button-url);
 }
 
-&.mx_EventTile_collapseButton {
-    mask-size: 75%;
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
-}
-
+&.mx_EventTile_collapseButton,
 &.mx_EventTile_expandButton {
     mask-size: 75%;
     mask-position: center;
     mask-repeat: no-repeat;
+}
+
+&.mx_EventTile_collapseButton {
+    mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
+}
+
+&.mx_EventTile_expandButton {
     mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
 }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -625,8 +625,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
-    &:focus-within .mx_EventTile_collapseButton,
-    &:hover .mx_EventTile_collapseButton,
+    &:focus-within,
+    &:hover {
+        .mx_EventTile_collapseButton {
+            visibility: visible;
+        }
+    }
+
     &:focus-within .mx_EventTile_expandButton,
     &:hover .mx_EventTile_expandButton {
     visibility: visible;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -587,7 +587,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile_collapsedCodeBlock {
     max-height: 30vh;
 }
-}
 
 // Inserted adjacent to <pre> blocks, (See TextualBody)
 .mx_EventTile_button {
@@ -600,13 +599,19 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     top: 33px;
 }
 
+&.mx_EventTile_collapseButton,
+&.mx_EventTile_expandButton {
+    mask-size: 75%;
+}
+}
+}
+
 &.mx_EventTile_copyButton {
     mask-image: url($copy-button-url);
 }
 
 &.mx_EventTile_collapseButton,
 &.mx_EventTile_expandButton {
-    mask-size: 75%;
     mask-position: center;
     mask-repeat: no-repeat;
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -621,13 +621,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     &:focus-within,
     &:hover {
         .mx_EventTile_copyButton,
-        .mx_EventTile_collapseButton {
-            visibility: visible;
-        }
-    }
-
-    &:focus-within,
-    &:hover {
+        .mx_EventTile_collapseButton,
         .mx_EventTile_expandButton {
             visibility: visible;
         }


### PR DESCRIPTION
This PR intends to prevent possible regressions related to EventTile structurally by reducing top-level declarations, which are vulnerable to regressions, and setting proper exposure to the declarations.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
