### PR TITLE
Fix crash on null idp for SSO buttons

### DIFF
--- a/src/Login.ts
+++ b/src/Login.ts
@@ -51,7 +51,7 @@ export interface IIdentityProvider {
 export interface ISSOFlow {
     type: "m.login.sso" | "m.login.cas";
     // eslint-disable-next-line camelcase
-    identity_providers: IIdentityProvider[];
+    identity_providers?: IIdentityProvider[];
 }
 
 export type LoginFlow = ISSOFlow | IPasswordFlow;

--- a/src/components/views/elements/SSOButtons.tsx
+++ b/src/components/views/elements/SSOButtons.tsx
@@ -29,7 +29,7 @@ import { mediaFromMxc } from "../../../customisations/Media";
 import { PosthogAnalytics } from "../../../PosthogAnalytics";
 
 interface ISSOButtonProps extends Omit<IProps, "flow"> {
-    idp: IIdentityProvider;
+    idp?: IIdentityProvider;
     mini?: boolean;
 }
 
@@ -84,7 +84,7 @@ const SSOButton: React.FC<ISSOButtonProps> = ({
     const label = idp ? _t("Continue with %(provider)s", { provider: idp.name }) : _t("Sign in with single sign-on");
 
     const onClick = () => {
-        const authenticationType = getAuthenticationType(idp.brand);
+        const authenticationType = getAuthenticationType(idp?.brand ?? "");
         PosthogAnalytics.instance.setAuthenticationType(authenticationType);
         PlatformPeg.get().startSingleSignOn(matrixClient, loginType, fragmentAfterLogin, idp?.id);
     };

--- a/test/components/structures/auth/Login-test.tsx
+++ b/test/components/structures/auth/Login-test.tsx
@@ -159,6 +159,6 @@ describe('Login', function() {
         await flushPromises();
 
         const ssoButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(root, "mx_SSOButton");
-        expect(ssoButtons.length).toBe(1);    
+        expect(ssoButtons.length).toBe(1);
     });
 });

--- a/test/components/structures/auth/Login-test.tsx
+++ b/test/components/structures/auth/Login-test.tsx
@@ -146,4 +146,19 @@ describe('Login', function() {
         const ssoButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(root, "mx_SSOButton");
         expect(ssoButtons.length).toBe(3);
     });
+
+    it("should show single SSO button if identity_providers is null", async () => {
+        mockClient.loginFlows.mockResolvedValue({
+            flows: [{
+                "type": "m.login.sso",
+            }],
+        });
+
+        const root = render();
+
+        await flushPromises();
+
+        const ssoButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(root, "mx_SSOButton");
+        expect(ssoButtons.length).toBe(1);    
+    });
 });


### PR DESCRIPTION
A bug was introduced by https://github.com/matrix-org/matrix-react-sdk/commit/1ed68a718fb42bef60be791c6dccee1a855fc014#diff-025d41cb3581dfddd068b4d99a816d5fe78066a023952b7d24a1d074bfd58690L64 whereby the optional `identity_providers` field for `m.login.sso` became mandatory.

This PR: improves the typings for relevant parts; fixes the specific error; adds a test case for null identity_providers.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix crash on null idp for SSO buttons ([\#8650](https://github.com/matrix-org/matrix-react-sdk/pull/8650)). Contributed by @hughns.<!-- CHANGELOG_PREVIEW_END -->