### PR TITLE
Integrate thread panel's header style declarations with those of BaseCard

### DIFF
--- a/res/css/views/right_panel/_BaseCard.scss
+++ b/res/css/views/right_panel/_BaseCard.scss
@@ -25,6 +25,8 @@ limitations under the License.
     flex: 1;
 
     .mx_BaseCard_header {
+        --BaseCard_header_button-margin: 12px;
+
         margin: 4px 0;
 
         > h2 {
@@ -36,12 +38,13 @@ limitations under the License.
             white-space: nowrap;
         }
 
-        .mx_BaseCard_back, .mx_BaseCard_close {
+        .mx_BaseCard_back,
+        .mx_BaseCard_close {
             position: absolute;
             background-color: rgba(141, 151, 165, 0.2);
             height: 20px;
             width: 20px;
-            margin: 12px;
+            margin: var(--BaseCard_header_button-margin);
             top: 0;
             border-radius: 50%;
 

--- a/res/css/views/right_panel/_BaseCard.scss
+++ b/res/css/views/right_panel/_BaseCard.scss
@@ -25,9 +25,9 @@ limitations under the License.
     flex: 1;
 
     .mx_BaseCard_header {
-        --BaseCard_header_button-margin: 12px;
+        --BaseCard_header_button-margin: $spacing-12;
 
-        margin: 4px 0;
+        margin: $spacing-4 0;
 
         > h2 {
             margin: 0 44px;

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -74,12 +74,11 @@ limitations under the License.
         }
 
         .mx_MessageActionBar_maskButton {
-            --size: 24px;
-            width: var(--size);
-            height: var(--size);
+            width: var(--ThreadPanel_header-button-size);
+            height: var(--ThreadPanel_header-button-size);
 
             &::after {
-                mask-size: var(--size);
+                mask-size: var(--ThreadPanel_header-button-size);
                 mask-image: url("$(res)/img/element-icons/message/overflow-large.svg");
             }
         }

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -23,7 +23,7 @@ limitations under the License.
     overflow: visible;
 
     .mx_BaseCard_header {
-        margin-bottom: 12px;
+        margin-bottom: $spacing-12;
 
         .mx_BaseCard_close,
         .mx_BaseCard_back {

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 .mx_ThreadPanel {
+    --ThreadPanel_header-button-size: 24px;
+
     display: flex;
     flex-direction: column;
     height: 100px;
@@ -25,22 +27,26 @@ limitations under the License.
 
         .mx_BaseCard_close,
         .mx_BaseCard_back {
-            width: 24px;
-            height: 24px;
+            width: var(--ThreadPanel_header-button-size);
+            height: var(--ThreadPanel_header-button-size);
         }
 
         .mx_BaseCard_back {
-            left: -4px;
+            margin-inline-start: calc(var(--BaseCard_header_button-margin) - 4px);
         }
 
         .mx_BaseCard_close {
-            right: -4px;
+            margin-inline-end: calc(var(--BaseCard_header_button-margin) - 4px);
         }
     }
 
     .mx_BaseCard_back ~ .mx_ThreadPanel__header {
         width: calc(100% - 60px);
-        margin-left: 30px;
+        margin-inline-start: var(--ThreadPanel_header-button-size);
+
+        span {
+            margin-inline-start: 6px;
+        }
     }
 
     .mx_ThreadPanel__header {

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -84,31 +84,6 @@ limitations under the License.
         }
     }
 
-    .mx_ThreadPanel_button {
-        width: 20px;
-        height: 20px;
-        margin-top: -3px;
-        margin-bottom: auto;
-        position: relative;
-
-        &::before {
-            top: 2px;
-            left: 2px;
-            content: '';
-            width: 16px;
-            height: 16px;
-            position: absolute;
-            mask-position: center;
-            mask-size: contain;
-            mask-repeat: no-repeat;
-            background: $primary-content;
-        }
-
-        &.mx_ThreadPanel_OptionsButton::before {
-            mask-image: url('$(res)/img/element-icons/context-menu.svg');
-        }
-    }
-
     .mx_AutoHideScrollbar,
     .mx_RoomView_messagePanelSpinner {
         background-color: $background;


### PR DESCRIPTION
|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/169373689-8c720231-d356-4537-9dcb-95c72352ca4c.png)|![after](https://user-images.githubusercontent.com/3362943/169373678-b4c4c4ad-4265-43e3-9b62-fd7c76b4ac85.png)|

- Use a variable for margin of buttons on `mx_BaseCard_header`
- Reduce default margin instead of setting negative left and right values
- Set margin to span in order to ensure spacing between the back button and the span (6px: 30px - 24px)
- Use the same variable to the mask button
- Use spacing variables
- Remove obsolete declarations - `.mx_ThreadPanel_button`

Style declarations of `TimelineCard` (chat panel with a maximized widget) are going to be checked after this PR.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->