### PR TITLE
Add the option to disable hardware acceleration

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -291,15 +291,15 @@ export default abstract class BasePlatform {
         throw new Error("Unimplemented");
     }
 
-    public supportsDisableHardwareAcceleration(): boolean {
+    public supportsHardwareAcceleration(): boolean {
         return false;
     }
 
-    public async getDisableHardwareAcceleration(): Promise<boolean> {
-        return false;
+    public async getHardwareAccelerationEnabled(): Promise<boolean> {
+        return true;
     }
 
-    public async setDisableHardwareAcceleration(enabled: boolean): Promise<void> {
+    public async setHardwareAccelerationEnabled(enabled: boolean): Promise<void> {
         throw new Error("Unimplemented");
     }
 

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -291,7 +291,7 @@ export default abstract class BasePlatform {
         throw new Error("Unimplemented");
     }
 
-    public supportsHardwareAcceleration(): boolean {
+    public supportsTogglingHardwareAcceleration(): boolean {
         return false;
     }
 

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -291,15 +291,15 @@ export default abstract class BasePlatform {
         throw new Error("Unimplemented");
     }
 
-    supportsDisableHardwareAcceleration(): boolean {
+    public supportsDisableHardwareAcceleration(): boolean {
         return false;
     }
 
-    async getDisableHardwareAcceleration(): Promise<boolean> {
+    public async getDisableHardwareAcceleration(): Promise<boolean> {
         return false;
     }
 
-    async setDisableHardwareAcceleration(enabled: boolean): Promise<void> {
+    public async setDisableHardwareAcceleration(enabled: boolean): Promise<void> {
         throw new Error("Unimplemented");
     }
 

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -291,6 +291,18 @@ export default abstract class BasePlatform {
         throw new Error("Unimplemented");
     }
 
+    supportsDisableHardwareAcceleration(): boolean {
+        return false;
+    }
+
+    async getDisableHardwareAcceleration(): Promise<boolean> {
+        return false;
+    }
+
+    async setDisableHardwareAcceleration(enabled: boolean): Promise<void> {
+        throw new Error("Unimplemented");
+    }
+
     /**
      * Get our platform specific EventIndexManager.
      *

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -157,7 +157,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             minimizeToTray = await platform.getMinimizeToTrayEnabled();
         }
 
-        const hardwareAccelerationSupported = platform.supportsHardwareAcceleration();
+        const hardwareAccelerationSupported = platform.supportsTogglingHardwareAcceleration();
         let enableHardwareAcceleration = false;
         if (hardwareAccelerationSupported) {
             enableHardwareAcceleration = await platform.getHardwareAccelerationEnabled();

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -29,6 +29,7 @@ import dis from "../../../../../dispatcher/dispatcher";
 import { UserTab } from "../../../dialogs/UserTab";
 import { OpenToTabPayload } from "../../../../../dispatcher/payloads/OpenToTabPayload";
 import { Action } from "../../../../../dispatcher/actions";
+import SdkConfig from "../../../../../SdkConfig";
 
 interface IProps {
     closeSettingsFn(success: boolean): void;
@@ -265,10 +266,13 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
 
         let hardwareAccelerationOption = null;
         if (this.state.togglingHardwareAccelerationSupported) {
+            const appName = SdkConfig.get().brand;
             hardwareAccelerationOption = <LabelledToggleSwitch
                 value={this.state.enableHardwareAcceleration}
                 onChange={this.onHardwareAccelerationChange}
-                label={_t('Enable hardware acceleration (restart %(appName)s to take effect)')} />;
+                label={_t('Enable hardware acceleration (restart %(appName)s to take effect)', {
+                    appName,
+                })} />;
         }
 
         return (

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -43,8 +43,8 @@ interface IState {
     alwaysShowMenuBar: boolean;
     minimizeToTraySupported: boolean;
     minimizeToTray: boolean;
-    hardwareAccelerationSupported: boolean;
-    hardwareAcceleration: boolean;
+    togglingHardwareAccelerationSupported: boolean;
+    enableHardwareAcceleration: boolean;
     autocompleteDelay: string;
     readMarkerInViewThresholdMs: string;
     readMarkerOutOfViewThresholdMs: string;
@@ -119,8 +119,8 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBarSupported: false,
             minimizeToTray: true,
             minimizeToTraySupported: false,
-            hardwareAcceleration: true,
-            hardwareAccelerationSupported: false,
+            enableHardwareAcceleration: true,
+            togglingHardwareAccelerationSupported: false,
             autocompleteDelay:
                 SettingsStore.getValueAt(SettingLevel.DEVICE, 'autocompleteDelay').toString(10),
             readMarkerInViewThresholdMs:
@@ -157,9 +157,9 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             minimizeToTray = await platform.getMinimizeToTrayEnabled();
         }
 
-        const hardwareAccelerationSupported = platform.supportsTogglingHardwareAcceleration();
+        const togglingHardwareAccelerationSupported = platform.supportsTogglingHardwareAcceleration();
         let enableHardwareAcceleration = false;
-        if (hardwareAccelerationSupported) {
+        if (togglingHardwareAccelerationSupported) {
             enableHardwareAcceleration = await platform.getHardwareAccelerationEnabled();
         }
 
@@ -172,7 +172,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBar,
             minimizeToTraySupported,
             minimizeToTray,
-            hardwareAccelerationSupported,
+            togglingHardwareAccelerationSupported,
             enableHardwareAcceleration,
         });
     }
@@ -264,7 +264,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         }
 
         let hardwareAccelerationOption = null;
-        if (this.state.hardwareAccelerationSupported) {
+        if (this.state.togglingHardwareAccelerationSupported) {
             hardwareAccelerationOption = <LabelledToggleSwitch
                 value={this.state.enableHardwareAcceleration}
                 onChange={this.onHardwareAccelerationChange}

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -158,7 +158,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         }
 
         const togglingHardwareAccelerationSupported = platform.supportsTogglingHardwareAcceleration();
-        let enableHardwareAcceleration = false;
+        let enableHardwareAcceleration = true;
         if (togglingHardwareAccelerationSupported) {
             enableHardwareAcceleration = await platform.getHardwareAccelerationEnabled();
         }

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -43,6 +43,8 @@ interface IState {
     alwaysShowMenuBar: boolean;
     minimizeToTraySupported: boolean;
     minimizeToTray: boolean;
+    disableHardwareAccelerationSupported: boolean;
+    disableHardwareAcceleration: boolean;
     autocompleteDelay: string;
     readMarkerInViewThresholdMs: string;
     readMarkerOutOfViewThresholdMs: string;
@@ -117,6 +119,8 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBarSupported: false,
             minimizeToTray: true,
             minimizeToTraySupported: false,
+            disableHardwareAcceleration: false,
+            disableHardwareAccelerationSupported: false,
             autocompleteDelay:
                 SettingsStore.getValueAt(SettingLevel.DEVICE, 'autocompleteDelay').toString(10),
             readMarkerInViewThresholdMs:
@@ -153,6 +157,12 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             minimizeToTray = await platform.getMinimizeToTrayEnabled();
         }
 
+        const disableHardwareAccelerationSupported = platform.supportsDisableHardwareAcceleration();
+        let disableHardwareAcceleration = false;
+        if (disableHardwareAccelerationSupported) {
+            disableHardwareAcceleration = await platform.getDisableHardwareAcceleration();
+        }
+
         this.setState({
             autoLaunch,
             autoLaunchSupported,
@@ -162,6 +172,8 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBar,
             minimizeToTraySupported,
             minimizeToTray,
+            disableHardwareAccelerationSupported,
+            disableHardwareAcceleration,
         });
     }
 
@@ -179,6 +191,11 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
 
     private onMinimizeToTrayChange = (checked: boolean) => {
         PlatformPeg.get().setMinimizeToTrayEnabled(checked).then(() => this.setState({ minimizeToTray: checked }));
+    };
+
+    private onDisableHardwareAccelerationChange = (checked: boolean) => {
+        PlatformPeg.get().setDisableHardwareAcceleration(checked).then(
+            () => this.setState({ disableHardwareAcceleration: checked }));
     };
 
     private onAutocompleteDelayChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -246,6 +263,14 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                 label={_t('Show tray icon and minimise window to it on close')} />;
         }
 
+        let disableHardwareAccelerationOption = null;
+        if (this.state.disableHardwareAccelerationSupported) {
+            disableHardwareAccelerationOption = <LabelledToggleSwitch
+                value={this.state.disableHardwareAcceleration}
+                onChange={this.onDisableHardwareAccelerationChange}
+                label={_t('Disable hardware acceleration (requires restart to take effect)')} />;
+        }
+
         return (
             <div className="mx_SettingsTab mx_PreferencesUserSettingsTab">
                 <div className="mx_SettingsTab_heading">{ _t("Preferences") }</div>
@@ -303,6 +328,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                     <span className="mx_SettingsTab_subheading">{ _t("General") }</span>
                     { this.renderGroup(PreferencesUserSettingsTab.GENERAL_SETTINGS) }
                     { minimizeToTrayOption }
+                    { disableHardwareAccelerationOption }
                     { autoHideMenuOption }
                     { autoLaunchOption }
                     { warnBeforeExitOption }

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -268,7 +268,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             hardwareAccelerationOption = <LabelledToggleSwitch
                 value={this.state.enableHardwareAcceleration}
                 onChange={this.onHardwareAccelerationChange}
-                label={_t('Enable hardware acceleration (requires restart to take effect)')} />;
+                label={_t('Enable hardware acceleration (restart %(appName)s to take effect)')} />;
         }
 
         return (

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -43,8 +43,8 @@ interface IState {
     alwaysShowMenuBar: boolean;
     minimizeToTraySupported: boolean;
     minimizeToTray: boolean;
-    disableHardwareAccelerationSupported: boolean;
-    disableHardwareAcceleration: boolean;
+    hardwareAccelerationSupported: boolean;
+    hardwareAcceleration: boolean;
     autocompleteDelay: string;
     readMarkerInViewThresholdMs: string;
     readMarkerOutOfViewThresholdMs: string;
@@ -119,8 +119,8 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBarSupported: false,
             minimizeToTray: true,
             minimizeToTraySupported: false,
-            disableHardwareAcceleration: false,
-            disableHardwareAccelerationSupported: false,
+            hardwareAcceleration: true,
+            hardwareAccelerationSupported: false,
             autocompleteDelay:
                 SettingsStore.getValueAt(SettingLevel.DEVICE, 'autocompleteDelay').toString(10),
             readMarkerInViewThresholdMs:
@@ -157,10 +157,10 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             minimizeToTray = await platform.getMinimizeToTrayEnabled();
         }
 
-        const disableHardwareAccelerationSupported = platform.supportsDisableHardwareAcceleration();
-        let disableHardwareAcceleration = false;
-        if (disableHardwareAccelerationSupported) {
-            disableHardwareAcceleration = await platform.getDisableHardwareAcceleration();
+        const hardwareAccelerationSupported = platform.supportsHardwareAcceleration();
+        let enableHardwareAcceleration = false;
+        if (hardwareAccelerationSupported) {
+            enableHardwareAcceleration = await platform.getHardwareAccelerationEnabled();
         }
 
         this.setState({
@@ -172,8 +172,8 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
             alwaysShowMenuBar,
             minimizeToTraySupported,
             minimizeToTray,
-            disableHardwareAccelerationSupported,
-            disableHardwareAcceleration,
+            hardwareAccelerationSupported,
+            enableHardwareAcceleration,
         });
     }
 
@@ -193,9 +193,9 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         PlatformPeg.get().setMinimizeToTrayEnabled(checked).then(() => this.setState({ minimizeToTray: checked }));
     };
 
-    private onDisableHardwareAccelerationChange = (checked: boolean) => {
-        PlatformPeg.get().setDisableHardwareAcceleration(checked).then(
-            () => this.setState({ disableHardwareAcceleration: checked }));
+    private onHardwareAccelerationChange = (checked: boolean) => {
+        PlatformPeg.get().setHardwareAccelerationEnabled(checked).then(
+            () => this.setState({ enableHardwareAcceleration: checked }));
     };
 
     private onAutocompleteDelayChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -263,12 +263,12 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                 label={_t('Show tray icon and minimise window to it on close')} />;
         }
 
-        let disableHardwareAccelerationOption = null;
-        if (this.state.disableHardwareAccelerationSupported) {
-            disableHardwareAccelerationOption = <LabelledToggleSwitch
-                value={this.state.disableHardwareAcceleration}
-                onChange={this.onDisableHardwareAccelerationChange}
-                label={_t('Disable hardware acceleration (requires restart to take effect)')} />;
+        let hardwareAccelerationOption = null;
+        if (this.state.hardwareAccelerationSupported) {
+            hardwareAccelerationOption = <LabelledToggleSwitch
+                value={this.state.enableHardwareAcceleration}
+                onChange={this.onHardwareAccelerationChange}
+                label={_t('Enable hardware acceleration (requires restart to take effect)')} />;
         }
 
         return (
@@ -328,7 +328,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                     <span className="mx_SettingsTab_subheading">{ _t("General") }</span>
                     { this.renderGroup(PreferencesUserSettingsTab.GENERAL_SETTINGS) }
                     { minimizeToTrayOption }
-                    { disableHardwareAccelerationOption }
+                    { hardwareAccelerationOption }
                     { autoHideMenuOption }
                     { autoLaunchOption }
                     { warnBeforeExitOption }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1500,7 +1500,7 @@
     "Warn before quitting": "Warn before quitting",
     "Always show the window menu bar": "Always show the window menu bar",
     "Show tray icon and minimise window to it on close": "Show tray icon and minimise window to it on close",
-    "Disable hardware acceleration (requires restart to take effect)": "Disable hardware acceleration (requires restart to take effect)",
+    "Enable hardware acceleration (requires restart to take effect)": "Enable hardware acceleration (requires restart to take effect)",
     "Preferences": "Preferences",
     "Room list": "Room list",
     "Keyboard shortcuts": "Keyboard shortcuts",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1500,6 +1500,7 @@
     "Warn before quitting": "Warn before quitting",
     "Always show the window menu bar": "Always show the window menu bar",
     "Show tray icon and minimise window to it on close": "Show tray icon and minimise window to it on close",
+    "Disable hardware acceleration (requires restart to take effect)": "Disable hardware acceleration (requires restart to take effect)",
     "Preferences": "Preferences",
     "Room list": "Room list",
     "Keyboard shortcuts": "Keyboard shortcuts",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1500,7 +1500,7 @@
     "Warn before quitting": "Warn before quitting",
     "Always show the window menu bar": "Always show the window menu bar",
     "Show tray icon and minimise window to it on close": "Show tray icon and minimise window to it on close",
-    "Enable hardware acceleration (requires restart to take effect)": "Enable hardware acceleration (requires restart to take effect)",
+    "Enable hardware acceleration (restart %(appName)s to take effect)": "Enable hardware acceleration (restart %(appName)s to take effect)",
     "Preferences": "Preferences",
     "Room list": "Room list",
     "Keyboard shortcuts": "Keyboard shortcuts",


### PR DESCRIPTION
UI config to disable hardware acceleration. Only visible in Element Desktop.

Will not have any effect without https://github.com/vector-im/element-desktop/pull/365

This is motivated by https://github.com/vector-im/element-web/issues/13648 - people want it to work around blurry font  issues on Windows, and general hardware issues. Discord and other Electron apps commonly support it.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add the option to disable hardware acceleration ([\#8655](https://github.com/matrix-org/matrix-react-sdk/pull/8655)). Contributed by @novocaine.<!-- CHANGELOG_PREVIEW_END -->