### PR TITLE
Slightly better presentation of read receipts to screen reader users

### DIFF
--- a/src/components/views/rooms/ReadReceiptGroup.tsx
+++ b/src/components/views/rooms/ReadReceiptGroup.tsx
@@ -199,10 +199,12 @@ export function ReadReceiptGroup(
 
     return (
         <div className="mx_EventTile_msgOption">
-            <div className="mx_ReadReceiptGroup">
+            <div className="mx_ReadReceiptGroup" role="group" aria-label={_t("Read receipts")}>
                 <AccessibleButton
                     className="mx_ReadReceiptGroup_button"
                     inputRef={button}
+                    aria-label={tooltipText}
+                    aria-haspopup="true"
                     onClick={openMenu}
                     onMouseOver={showTooltip}
                     onMouseLeave={hideTooltip}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1765,6 +1765,7 @@
     "%(members)s and %(last)s": "%(members)s and %(last)s",
     "Seen by %(count)s people|other": "Seen by %(count)s people",
     "Seen by %(count)s people|one": "Seen by %(count)s person",
+    "Read receipts": "Read receipts",
     "Recently viewed": "Recently viewed",
     "Replying": "Replying",
     "Room %(name)s": "Room %(name)s",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22293
Signed-off-by: Peter Vágner <pvdeejay@gmail.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Slightly better presentation of read receipts to screen reader users ([\#8662](https://github.com/matrix-org/matrix-react-sdk/pull/8662)). Fixes vector-im/element-web#22293. Contributed by @pvagner.<!-- CHANGELOG_PREVIEW_END -->