### PR TITLE
Normalize inline spacing of image and file button on ThreadView

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -243,10 +243,12 @@ limitations under the License.
     }
 
     .mx_EventTile_line {
+        --EventBubbleTile_line-margin-inline-end: -12px;
+
         position: relative;
         display: flex;
         gap: 5px;
-        margin: 0 -12px 0 -9px;
+        margin: 0 var(--EventBubbleTile_line-margin-inline-end) 0 -9px;
         border-top-left-radius: var(--cornerRadius);
         border-top-right-radius: var(--cornerRadius);
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -935,6 +935,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             }
         }
 
+        .mx_MFileBody,
+        .mx_MImageBody {
+            display: block; // Apply margin to span element
+            margin-inline-start: var(--ThreadView_group_spacing-start);
+            margin-inline-end: var(--ThreadView_group_spacing-end);
+        }
+
         .mx_ReplyChain_wrapper {
             .mx_MLocationBody {
                 margin-inline-start: 0;
@@ -965,16 +972,9 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 }
             }
         }
-
-        .mx_EventTile_mediaLine {
-            padding-inline-start: var(--ThreadView_group_spacing-start);
-        }
     }
 
     .mx_EventTile_mediaLine {
-        padding-inline-start: var(--BaseCard_EventTile-spacing-horizontal);
-        padding-right: 50px;
-
         .mx_MImageBody {
             margin: 0;
             padding: 0;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -895,7 +895,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             margin-inline-end: var(--BaseCard_EventTile-spacing-horizontal);
 
             .mx_EventTile_line.mx_EventTile_mediaLine {
-                padding: 0 !important;
+                padding: 0;
                 max-width: 100%;
 
                 .mx_MFileBody {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -907,7 +907,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 align-items: flex-end;
 
                 .mx_EventTile_line.mx_EventTile_mediaLine {
-                    margin: 0 -13px 0 0; // align with normal messages
+                    margin: 0 var(--EventBubbleTile_line-margin-inline-end) 0 0; // align with normal messages
                 }
             }
         }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -974,13 +974,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
-    .mx_EventTile_mediaLine {
-        .mx_MImageBody {
-            margin: 0;
-            padding: 0;
-        }
-    }
-
     .mx_MessageComposer_sendMessage {
         margin-right: 0;
     }


### PR DESCRIPTION
This PR replaces padding of an image and a file button on group layout on ThreadView with margin.

Purple: padding
Yellow: margin

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/169664252-fbe25644-98f8-48f5-988b-55014904d3f5.png)|![after](https://user-images.githubusercontent.com/3362943/169664250-a0c51c04-8137-471b-8a3a-96dfff87696d.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->