### PR TITLE
Set spacing declarations to elements in mx_EventTile_mediaLine

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -935,11 +935,18 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             }
         }
 
-        .mx_MFileBody,
-        .mx_MImageBody {
-            display: block; // Apply margin to span element
-            margin-inline-start: var(--ThreadView_group_spacing-start);
-            margin-inline-end: var(--ThreadView_group_spacing-end);
+        .mx_EventTile_mediaLine {
+            // such as MImageBody
+            > div,
+            // such as MAudioBody and MFileBody
+            > span {
+                margin-inline-start: var(--ThreadView_group_spacing-start);
+                margin-inline-end: var(--ThreadView_group_spacing-end);
+            }
+
+            > span {
+                display: block; // Apply the margin declarations to span element
+            }
         }
 
         .mx_ReplyChain_wrapper {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -938,12 +938,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_EventTile_mediaLine {
             // such as MImageBody
             > div,
-            // such as MAudioBody and MFileBody
             > span {
                 margin-inline-start: var(--ThreadView_group_spacing-start);
                 margin-inline-end: var(--ThreadView_group_spacing-end);
             }
 
+            // such as MAudioBody and MFileBody
             > span {
                 display: block; // Apply the margin declarations to span element
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22307
This is a follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/8664.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/169675853-f2d697c2-a21b-46c0-befd-e74cee55e619.png)|![after](https://user-images.githubusercontent.com/3362943/169675851-c67b61bc-4956-4021-8a76-126cbfe536d7.png)|

This fix should keep working until something except `div` or `span` would be used to wrap an child element in `mx_EventTile_mediaLine`.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set spacing declarations to elements in mx_EventTile_mediaLine ([\#8665](https://github.com/matrix-org/matrix-react-sdk/pull/8665)). Fixes vector-im/element-web#22307. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->