### PR TITLE
Fix position of wide images on IRC / modern layout

### DIFF
--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -64,9 +64,6 @@ $timeline-image-border-radius: 8px;
 
         min-height: $font-44px;
         min-width: $font-44px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
 
         // Override inline max-width value to avoid overflow
         max-width: 100% !important;

--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -62,9 +62,6 @@ $timeline-image-border-radius: 8px;
         overflow: hidden;
         contain: paint;
 
-        min-height: $font-44px;
-        min-width: $font-44px;
-
         // Override inline max-width value to avoid overflow
         max-width: 100% !important;
 

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -158,6 +158,7 @@ limitations under the License.
 
     .mx_MImageBody {
     .mx_MImageBody_thumbnail_container {
+        justify-content: center;
         min-height: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
         min-width: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
     }

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -156,9 +156,11 @@ limitations under the License.
         padding-right: 48px;
     }
 
+    .mx_MImageBody {
     .mx_MImageBody_thumbnail_container {
         min-height: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
         min-width: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
+    }
     }
 
     .mx_CallEvent {

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -157,11 +157,11 @@ limitations under the License.
     }
 
     .mx_MImageBody {
-    .mx_MImageBody_thumbnail_container {
-        justify-content: center;
-        min-height: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
-        min-width: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
-    }
+        .mx_MImageBody_thumbnail_container {
+            justify-content: center;
+            min-height: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
+            min-width: calc(1.8rem + var(--gutterSize) + var(--gutterSize));
+        }
     }
 
     .mx_CallEvent {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -61,8 +61,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     .mx_MImageBody {
         .mx_MImageBody_thumbnail_container {
             display: flex;
-            justify-content: center;
-            align-items: center;
+            align-items: center; // on every layout
         }
     }
 
@@ -275,6 +274,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         margin-right: 34px;
 
         .mx_MImageBody_thumbnail_container {
+            justify-content: flex-start;
             min-height: $font-44px;
             min-width: $font-44px;
         }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -58,6 +58,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
+    .mx_MImageBody {
+        .mx_MImageBody_thumbnail_container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    }
+
     &[data-layout=group] {
         .mx_EventTile_line {
             line-height: var(--GroupLayout-EventTile-line-height);

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -273,6 +273,11 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     .mx_MImageBody {
         margin-right: 34px;
+
+        .mx_MImageBody_thumbnail_container {
+            min-height: $font-44px;
+            min-width: $font-44px;
+        }
     }
 
     .mx_EventTile_e2eIcon {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22309

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/169687649-70faeb81-9a12-47b2-ad7d-0e01dcdcb371.png)|![after](https://user-images.githubusercontent.com/3362943/169687643-e38e0480-ef48-445a-acf3-4c9acaf84145.png)|

- Move declarations related to position from _MImageBody.scss to _EventTile.scss
- Move min-height and min-width declarations from _MImageBody.scss to _EventTile.scss
- Apply 'justify-content: center' to bubble layout only

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix position of wide images on IRC / modern layout ([\#8667](https://github.com/matrix-org/matrix-react-sdk/pull/8667)). Fixes vector-im/element-web#22309. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->