### PR TITLE
Apply the same max-width to image tile on the thread timeline as message bubble

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -112,9 +112,8 @@ limitations under the License.
     .mx_DisambiguatedProfile,
     .mx_EventTile_line {
         width: fit-content;
-        max-width: 70%;
-        // fixed line height to prevent emoji from being taller than text
-        line-height: $font-18px;
+        max-width: var(--EventBubbleTile_line-max-width);
+        line-height: $font-18px; // fixed line height to prevent emoji from being taller than text
     }
 
     // other users profile on bubble layout
@@ -262,6 +261,7 @@ limitations under the License.
 
     .mx_EventTile_line {
         --EventBubbleTile_line-margin-inline-end: -12px;
+        --EventBubbleTile_line-max-width: 70%;
 
         position: relative;
         display: flex;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -886,8 +886,9 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             margin-inline-end: var(--BaseCard_EventTile-spacing-horizontal);
 
             .mx_EventTile_line.mx_EventTile_mediaLine {
-                padding: 0;
-                max-width: 100%;
+                padding-block: 0;
+                padding-inline-start: 0;
+                max-width: var(--EventBubbleTile_line-max-width);
 
                 .mx_MFileBody {
                     width: 100%;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22313

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/169700931-6232e76d-426c-40df-87d2-bd14f14e4057.png)|![after](https://user-images.githubusercontent.com/3362943/169700923-c3394368-cf66-40f1-accb-b6383a5901cc.png)|

This PR replaces the hard-coded width value with a variable in order to align the image on the thread timeline with message bubbles.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Apply the same max-width to image tile on the thread timeline as message bubble ([\#8669](https://github.com/matrix-org/matrix-react-sdk/pull/8669)). Fixes vector-im/element-web#22313. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->