### PR TITLE
Fix dropdown button size for picture-in-picture CallView

### DIFF
--- a/res/css/views/voip/CallView/_CallViewButtons.scss
+++ b/res/css/views/voip/CallView/_CallViewButtons.scss
@@ -24,6 +24,8 @@ limitations under the License.
 }
 
 .mx_CallViewButtons {
+    --CallViewButtons_dropdownButton-size: 16px;
+
     position: absolute;
     display: flex;
     justify-content: center;
@@ -65,8 +67,8 @@ limitations under the License.
         }
 
         &.mx_CallViewButtons_dropdownButton {
-            width: 16px;
-            height: 16px;
+            width: var(--CallViewButtons_dropdownButton-size);
+            height: var(--CallViewButtons_dropdownButton-size);
 
             position: absolute;
             right: 0;

--- a/res/css/views/voip/_CallView.scss
+++ b/res/css/views/voip/_CallView.scss
@@ -165,6 +165,11 @@ limitations under the License.
                 width: 34px;
                 height: 34px;
 
+                &.mx_CallViewButtons_dropdownButton {
+                    width: var(--CallViewButtons_dropdownButton-size);
+                    height: var(--CallViewButtons_dropdownButton-size);
+                }
+
                 &::before {
                     width: 22px;
                     height: 22px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22316

This PR fixes the dropdown button covering the microphone and camera buttons on picture-in-picture call view.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170059327-7a47ac79-3ae2-43d3-b00a-3309942e7e9b.png)|![after](https://user-images.githubusercontent.com/3362943/170059290-948d1ba5-b00e-4d79-8155-da06252dad67.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix dropdown button size for picture-in-picture CallView ([\#8680](https://github.com/matrix-org/matrix-react-sdk/pull/8680)). Fixes vector-im/element-web#22316. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->