### PR TITLE
Move style rules related to ThreadPanel from EventTile

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -122,11 +122,6 @@ limitations under the License.
     &.mx_ThreadView {
         max-height: 100%;
 
-        .mx_ThreadView_List {
-            flex: 1;
-            overflow: scroll;
-        }
-
         // Inside a thread timeline only
         .mx_GenericEventListSummary {
             &:not([data-layout=bubble]) > .mx_EventTile_line {

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -122,6 +122,11 @@ limitations under the License.
     &.mx_ThreadView {
         max-height: 100%;
 
+        .mx_ThreadView_List {
+            flex: 1;
+            overflow: scroll;
+        }
+
         // Inside a thread timeline only
         .mx_GenericEventListSummary {
             &:not([data-layout=bubble]) > .mx_EventTile_line {
@@ -138,6 +143,10 @@ limitations under the License.
             .mx_FileDropTarget {
                 border-radius: 8px;
             }
+        }
+
+        .mx_MessageComposer_sendMessage {
+            margin-right: 0;
         }
     }
 

--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -120,6 +120,8 @@ limitations under the License.
     }
 
     &.mx_ThreadView {
+        max-height: 100%;
+
         // Inside a thread timeline only
         .mx_GenericEventListSummary {
             &:not([data-layout=bubble]) > .mx_EventTile_line {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -846,10 +846,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     --ThreadView_group_spacing-start: 56px; // 56px: 64px - 8px (padding)
     --ThreadView_group_spacing-end: 8px; // same as padding
 
-    display: flex;
-    flex-direction: column;
-    max-height: 100%;
-
     .mx_ThreadView_List {
         flex: 1;
         overflow: scroll;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -846,11 +846,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     --ThreadView_group_spacing-start: 56px; // 56px: 64px - 8px (padding)
     --ThreadView_group_spacing-end: 8px; // same as padding
 
-    .mx_ThreadView_List {
-        flex: 1;
-        overflow: scroll;
-    }
-
     .mx_EventTile_roomName {
         display: none;
     }
@@ -977,9 +972,5 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 }
             }
         }
-    }
-
-    .mx_MessageComposer_sendMessage {
-        margin-right: 0;
     }
 }


### PR DESCRIPTION
Manage style rules related to the thread panel on `_ThreadPanel.scss` instead of `_EventTile.scss`. This PR also removes redundant declarations on ThreadView, which is expected to be implemented to ThreadPanel only.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->