### PR TITLE
Improve combining diacritics for U+20D0 to U+20F0 in Chrome

### DIFF
--- a/res/themes/legacy-light/css/_legacy-light.scss
+++ b/res/themes/legacy-light/css/_legacy-light.scss
@@ -1,16 +1,18 @@
-// XXX: check this?
 /* Nunito lacks combining diacritics, so these will fall through
-   to the next font.  Helevetica's diacritics however do not combine
+   to the next font.  Helevetica's diacritics sometimes do not combine
    nicely (on OSX, at least) and result in a huge horizontal mess.
-   Arial empirically gets it right, hence prioritising Arial here. */
+   Arial empirically gets it right, hence prioritising Arial here.
+   We also include STIXGeneral explicitly to support a wider range
+   of combining diacritics (Chrome fails without it, as per
+   https://bugs.chromium.org/p/chromium/issues/detail?id=1328898) */
 /* We fall through to Twemoji for emoji rather than falling through
    to native Emoji fonts (if any) to ensure cross-browser consistency */
 /* Noto Color Emoji contains digits, in fixed-width, therefore causing
    digits in flowed text to stand out.
    TODO: Consider putting all emoji fonts to the end rather than the front. */
-$font-family: 'Nunito', 'Twemoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Arial', 'Helvetica', sans-serif, 'Noto Color Emoji';
+$font-family: 'Nunito', 'Twemoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'STIXGeneral', 'Arial', 'Helvetica', sans-serif, 'Noto Color Emoji';
 
-$monospace-font-family: 'Inconsolata', 'Twemoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Courier', monospace, 'Noto Color Emoji';
+$monospace-font-family: 'Inconsolata', 'Twemoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'STIXGeneral', 'Courier', monospace, 'Noto Color Emoji';
 
 // unified palette
 // try to use these colors when possible

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -1,8 +1,10 @@
-// XXX: check this?
-/* Nunito lacks combining diacritics, so these will fall through
-   to the next font.  Helevetica's diacritics however do not combine
+/* Nunito and Inter lacks combining diacritics, so these will fall through
+   to the next font. Helevetica's diacritics sometimes do not combine
    nicely (on OSX, at least) and result in a huge horizontal mess.
-   Arial empirically gets it right, hence prioritising Arial here. */
+   Arial empirically gets it right, hence prioritising Arial here.
+   We also include STIXGeneral explicitly to support a wider range
+   of combining diacritics (Chrome fails without it, as per
+   https://bugs.chromium.org/p/chromium/issues/detail?id=1328898) */
 /* We fall through to Twemoji for emoji rather than falling through
    to native Emoji fonts (if any) to ensure cross-browser consistency */
 /* Noto Color Emoji contains digits, in fixed-width, therefore causing
@@ -12,6 +14,7 @@ $font-family: 'Inter',
 'Twemoji',
 'Apple Color Emoji',
 'Segoe UI Emoji',
+'STIXGeneral',
 'Arial',
 'Helvetica',
 sans-serif,
@@ -21,6 +24,7 @@ $monospace-font-family: 'Inconsolata',
 'Twemoji',
 'Apple Color Emoji',
 'Segoe UI Emoji',
+'STIXGeneral',
 'Courier',
 monospace,
 'Noto Color Emoji';


### PR DESCRIPTION
This makes all but 9 of U+20D0 to U+20F0 combine
correctly on Chrome. See also
https://bugs.chromium.org/p/chromium/issues/detail?id=1328898

Makes this test string (a series of `o` chars followed by each different combined diacritic from https://utf8-chartable.de/unicode-utf8-table.pl?start=8320&number=128):

o⃐o⃑oo⃒oo⃓o⃔o⃕o⃖o⃗o⃘o⃙o⃚o⃛o⃜o⃝o⃞o⃟o⃠o⃡o⃢o⃣o⃤o⃥o⃦o⃧o⃨o⃩o⃪o⃫o⃬o⃭o⃮o⃯o⃰

...display somewhat more correctly in Chrome as...

<img width="470" alt="Screenshot 2022-05-25 at 00 44 31" src="https://user-images.githubusercontent.com/1294269/170149645-4c5cb85c-d601-4b0a-b16c-a68984f49da1.png">

...rather than...

<img width="745" alt="Screenshot 2022-05-25 at 00 43 42" src="https://user-images.githubusercontent.com/1294269/170149637-248dacd6-d29d-417a-9889-0aa44076d592.png">

Firefox renders it as:

<img width="535" alt="Screenshot 2022-05-25 at 00 46 27" src="https://user-images.githubusercontent.com/1294269/170149777-e3db27d7-6108-4a87-bb2b-4ba293f50ea8.png">

For details on why Chrome is so different, see: https://bugs.chromium.org/p/chromium/issues/detail?id=1221097#c6


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve combining diacritics for U+20D0 to U+20F0 in Chrome ([\#8687](https://github.com/matrix-org/matrix-react-sdk/pull/8687)).<!-- CHANGELOG_PREVIEW_END -->