### PR TITLE
Fix a grid blowout due to nowrap displayName on a bubble with UTD

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -493,17 +493,22 @@ limitations under the License.
             "shield body" auto
             "shield link" auto
             / auto  1fr;
+
         .mx_EventTile_e2eIcon {
             grid-area: shield;
         }
+
         .mx_UnknownBody {
             grid-area: body;
         }
+
         .mx_EventTile_keyRequestInfo {
             grid-area: link;
         }
+
         .mx_ReplyChain_wrapper {
             grid-area: reply;
+            min-width: 0; // Prevent a grid blowout due to nowrap displayName
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21914

This PR fixes the issue that the display name overflows the bubble on `&.mx_EventTile_bad > .mx_EventTile_line` which uses grid layout. The [previous PR](https://github.com/matrix-org/matrix-react-sdk/pull/8405) for the issue was not really proper.

To confirm the fix, you would need to have a reply to the event tile of UTD. Please note that the issue is not reproduced on normal bubbles.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170179445-8687092b-ed3f-4c12-a9cd-7e52989df087.png)|![after](https://user-images.githubusercontent.com/3362943/170179440-a6e27b08-97a6-4b17-a0ba-e76e47a58c39.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix a grid blowout due to nowrap displayName on a bubble with UTD ([\#8688](https://github.com/matrix-org/matrix-react-sdk/pull/8688)). Fixes vector-im/element-web#21914. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->