### PR TITLE
Make the empty thread panel fill BaseCard

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -316,6 +316,8 @@ limitations under the License.
     bottom: 0;
     left: 0;
     padding: 20px;
+    box-sizing: border-box; // Include padding and border
+    width: 100%;
 
     h2 {
         color: $primary-content;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22338

Use `border-box` to make maintaining the layout more intuitive. Otherwise you would have to specify the width like `calc(100% - 20px *2)`, which is unfriendly.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170249228-ed743dfd-c5ff-47f3-936f-969f75182b89.png)|![after](https://user-images.githubusercontent.com/3362943/170249212-d06cd478-3d8a-4f3f-bc4b-6a164bfcda0a.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make the empty thread panel fill BaseCard ([\#8690](https://github.com/matrix-org/matrix-react-sdk/pull/8690)). Fixes vector-im/element-web#22338. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->