### PR TITLE
Align EventTile_line with display name on message bubble

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -111,8 +111,10 @@ limitations under the License.
 
     .mx_DisambiguatedProfile,
     .mx_EventTile_line {
+        --EventBubbleTile_line-max-width: 70%;
+
         width: fit-content;
-        max-width: var(--EventBubbleTile_line-max-width);
+        max-width: var(--EventBubbleTile_line-max-width); // Align message bubble and displayName
         line-height: $font-18px; // fixed line height to prevent emoji from being taller than text
     }
 
@@ -264,7 +266,6 @@ limitations under the License.
 
     .mx_EventTile_line {
         --EventBubbleTile_line-margin-inline-end: -12px;
-        --EventBubbleTile_line-max-width: 70%;
 
         position: relative;
         display: flex;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22343

This PR fixes the issue that display name overflows the event tile line's width.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170269428-02d347b4-607d-4e39-88f0-ac7a420ac0cf.png)|![after](https://user-images.githubusercontent.com/3362943/170269373-529f14e8-ac06-44ba-98ee-a097cac03a7c.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Align EventTile_line with display name on message bubble ([\#8692](https://github.com/matrix-org/matrix-react-sdk/pull/8692)). Fixes vector-im/element-web#22343. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->