### PR TITLE
Prevent overflow of grid items on a bubble with UTD generally

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -496,6 +496,13 @@ limitations under the License.
                 "shield link" auto
                 / auto  1fr;
 
+            .mx_UnknownBody,
+            .mx_EventTile_keyRequestInfo,
+            .mx_ReplyChain_wrapper,
+            .mx_ViewSourceEvent {
+                min-width: 0; // Prevent a grid blowout
+            }
+
             .mx_EventTile_e2eIcon {
                 grid-area: shield;
             }
@@ -510,7 +517,6 @@ limitations under the License.
 
             .mx_ReplyChain_wrapper {
                 grid-area: reply;
-                min-width: 0; // Prevent a grid blowout due to nowrap displayName
             }
         }
 


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/8688

This PR fixes the issue that a certain error message related to UTD in `mx_UnknownBody` of a grid layout overflows the bubble.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170288513-b78041a1-6d74-4437-982e-ce15cd45ba79.png)|![after](https://user-images.githubusercontent.com/3362943/170288497-35331776-cb27-4f7c-a353-075982c68103.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent overflow of grid items on a bubble with UTD generally ([\#8697](https://github.com/matrix-org/matrix-react-sdk/pull/8697)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->