### PR TITLE
Update local aliases checks to use stable API

### DIFF
--- a/src/components/views/room_settings/AliasSettings.tsx
+++ b/src/components/views/room_settings/AliasSettings.tsx
@@ -139,12 +139,11 @@ export default class AliasSettings extends React.Component<IProps, IState> {
         this.setState({ localAliasesLoading: true });
         try {
             const mxClient = this.context;
+
             let localAliases = [];
-            if (await mxClient.doesServerSupportUnstableFeature("org.matrix.msc2432")) {
-                const response = await mxClient.unstableGetLocalAliases(this.props.roomId);
-                if (Array.isArray(response.aliases)) {
-                    localAliases = response.aliases;
-                }
+            const response = await mxClient.getLocalAliases(this.props.roomId);
+            if (Array.isArray(response?.aliases)) {
+                localAliases = response.aliases;
             }
             this.setState({ localAliases });
 

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -220,16 +220,9 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
 
     private async hasAliases(): Promise<boolean> {
         const cli = this.context;
-        if (await cli.doesServerSupportUnstableFeature("org.matrix.msc2432")) {
-            const response = await cli.unstableGetLocalAliases(this.props.roomId);
-            const localAliases = response.aliases;
-            return Array.isArray(localAliases) && localAliases.length !== 0;
-        } else {
-            const room = cli.getRoom(this.props.roomId);
-            const aliasEvents = room.currentState.getStateEvents(EventType.RoomAliases) || [];
-            const hasAliases = !!aliasEvents.find((ev) => (ev.getContent().aliases || []).length > 0);
-            return hasAliases;
-        }
+        const response = await cli.getLocalAliases(this.props.roomId);
+        const localAliases = response.aliases;
+        return Array.isArray(localAliases) && localAliases.length !== 0;
     }
 
     private renderJoinRule() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22337
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/2402**

The version check was removed from this given v1.1 has been out for a while now. See https://github.com/vector-im/element-web/issues/22346 for further context on how/if we should define a minimum supported version.

----

Notes: Fix local aliases section of room settings not working for some homeservers (ie: running Dendrite).

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix local aliases section of room settings not working for some homeservers (ie ([\#8698](https://github.com/matrix-org/matrix-react-sdk/pull/8698)). Fixes vector-im/element-web#22337.<!-- CHANGELOG_PREVIEW_END -->