### PR TITLE
Move unread notification dots of the threads list to the expected position

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -768,8 +768,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     // Display notification dot
     &[data-notification]::before {
-        content: "";
-        position: absolute;
         width: 8px;
         height: 8px;
         border-radius: 50%;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -82,8 +82,8 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     &[data-shape=ThreadsList][data-notification]::before {
         content: "";
         position: absolute;
-        width: 10px;
-        height: 10px;
+        width: 8px;
+        height: 8px;
         border-radius: 50%;
         right: -25px; // center it in the gutter (16px margin + 4px padding + half 10px width)
         top: 4px;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -85,7 +85,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        right: -25px; // center it in the gutter (16px margin + 4px padding + half 10px width)
+        inset-inline-end: 8px;
         top: 4px;
         left: auto;
     }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -79,23 +79,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     font-size: $font-14px;
     position: relative;
 
-    &[data-shape=ThreadsList][data-notification]::before {
-        content: "";
-        position: absolute;
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        inset: 14px 8px auto auto; // 14px: align the dot with the timestamp row
-    }
-
-    &[data-shape=ThreadsList][data-notification=total]::before {
-        background-color: $room-icon-unread-color;
-    }
-
-    &[data-shape=ThreadsList][data-notification=highlight]::before {
-        background-color: $alert;
-    }
-
     .mx_ThreadSummary,
     .mx_ThreadSummaryIcon {
         margin-left: 64px;
@@ -781,6 +764,24 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         inset: 0;
         /* enough to cover all sibling elements */
         z-index: 10;
+    }
+
+    // Display notification dot
+    &[data-notification]::before {
+        content: "";
+        position: absolute;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        inset: 14px 8px auto auto; // 14px: align the dot with the timestamp row
+    }
+
+    &[data-notification=total]::before {
+        background-color: $room-icon-unread-color;
+    }
+
+    &[data-notification=highlight]::before {
+        background-color: $alert;
     }
 
     &:last-child {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -762,8 +762,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         content: "";
         position: absolute;
         inset: 0;
-        /* enough to cover all sibling elements */
-        z-index: 10;
     }
 
     // Display notification dot

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -85,9 +85,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        inset-inline-end: 8px;
-        top: 4px;
-        left: auto;
+        inset: 14px 8px auto auto; // 14px: align the dot with the timestamp row
     }
 
     &[data-shape=ThreadsList][data-notification=total]::before {
@@ -780,10 +778,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     &::before {
         content: "";
         position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
+        inset: 0;
         /* enough to cover all sibling elements */
         z-index: 10;
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22350

This PR fixes the issue that the notification dots of unread threads are displayed outside of the threads list viewport. The dots have been available but hidden from our eyes. 

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170339434-83d8a866-2ee5-47c9-9c7a-42a0ab6cde2b.png)|![after](https://user-images.githubusercontent.com/3362943/170339418-f9840ae2-4e7a-4139-8f7e-f468f43896d7.png)|

The position of the dots is specified based on the picture of https://github.com/vector-im/element-web/issues/21759. The issue could have been fixed with https://github.com/matrix-org/matrix-react-sdk/pull/8337.

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Move unread notification dots of the threads list to the expected position ([\#8700](https://github.com/matrix-org/matrix-react-sdk/pull/8700)). Fixes vector-im/element-web#22350. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->