### PR TITLE
Fix gha concurrency conditions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -2,6 +2,9 @@ name: Pull Request
 on:
   pull_request_target:
     types: [ opened, edited, labeled, unlabeled, synchronize ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
 jobs:
   changelog:
     name: Preview Changelog

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 jobs:
   prdetails:


### PR DESCRIPTION
`pull_request_target` and `workflow_run` always run with ref = develop

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->