### PR TITLE
Revert "Fix wide image overflowing from the thumbnail container (#8663)"

### DIFF
--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -54,23 +54,12 @@ $timeline-image-border-radius: 8px;
     }
 }
 
-.mx_MImageBody {
-    .mx_MImageBody_thumbnail_container {
-        border-radius: $timeline-image-border-radius;
+.mx_MImageBody_thumbnail_container {
+    border-radius: $timeline-image-border-radius;
 
-        // Necessary for the border radius to apply correctly to the placeholder
-        overflow: hidden;
-        contain: paint;
-
-        // Override inline max-width value to avoid overflow
-        max-width: 100% !important;
-
-        .mx_MImageBody_thumbnail {
-            // Apply the border radius to an image directly.
-            // This is necessary for images smaller than the placeholder.
-            border-radius: $timeline-image-border-radius;
-        }
-    }
+    // Necessary for the border radius to apply correctly to the placeholder
+    overflow: hidden;
+    contain: paint;
 }
 
 .mx_MImageBody_thumbnail {


### PR DESCRIPTION
This reverts #8663 to fix at least a couple of image-related regressions, such as the bubble effect on consecutive images being broken, and flat images having an extra wide container:

Before|After
-|-
![Screenshot 2022-05-27 at 12-55-47 Element 1 Test room](https://user-images.githubusercontent.com/48614497/170744542-899bf13d-c5e8-403a-9ebe-c6f61650c96b.png)|![Screenshot 2022-05-27 at 12-55-18 Element 1 Test room](https://user-images.githubusercontent.com/48614497/170744539-ddf844b1-7d0a-40bf-baed-6c7f97ae1c46.png)

Regresses https://github.com/vector-im/element-web/issues/22303

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Fix wide image overflowing from the thumbnail container (#8663)" ([\#8709](https://github.com/matrix-org/matrix-react-sdk/pull/8709)).<!-- CHANGELOG_PREVIEW_END -->