### PR TITLE
Fix text event covering the avatar on a thread

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -229,9 +229,14 @@ limitations under the License.
                 line-height: $line-height;
 
                 .mx_EventTile_content,
-                .mx_RedactedBody {
-                    width: auto;
+                .mx_RedactedBody,
+                .mx_TextualEvent {
                     margin-inline-start: calc(var(--ThreadView_group_spacing-start) + 14px + 6px); // 14px: avatar width, 6px: 20px - 14px
+                    width: auto;
+                }
+
+                .mx_EventTile_content,
+                .mx_RedactedBody {
                     font-size: $line-height;
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22379

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/170809612-02b79b82-1b2a-4279-a92d-db309d82e0a2.png)|![after](https://user-images.githubusercontent.com/3362943/170809603-4139a5d5-fb75-4f3a-a172-8f7577f8bfc1.png)|

- Add the inline start margin and width declarations to TextualEvent

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix text event covering the avatar on a thread ([\#8710](https://github.com/matrix-org/matrix-react-sdk/pull/8710)). Fixes vector-im/element-web#22379. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->