### PR TITLE
Live location share - enable reply and react to tiles

### DIFF
--- a/res/css/components/views/messages/_MBeaconBody.scss
+++ b/res/css/components/views/messages/_MBeaconBody.scss
@@ -17,7 +17,8 @@ limitations under the License.
 .mx_MBeaconBody {
     position: relative;
     height: 220px;
-    width: 325px;
+    max-width: 325px;
+    width: 100%;
 
     border-radius: $timeline-image-border-radius;
     overflow: hidden;

--- a/src/components/views/beacon/OwnBeaconStatus.tsx
+++ b/src/components/views/beacon/OwnBeaconStatus.tsx
@@ -21,7 +21,7 @@ import { _t } from '../../../languageHandler';
 import { useOwnLiveBeacons } from '../../../utils/beacon';
 import BeaconStatus from './BeaconStatus';
 import { BeaconDisplayStatus } from './displayStatus';
-import AccessibleButton from '../elements/AccessibleButton';
+import AccessibleButton, { ButtonEvent } from '../elements/AccessibleButton';
 
 interface Props {
     displayStatus: BeaconDisplayStatus;
@@ -45,6 +45,14 @@ const OwnBeaconStatus: React.FC<Props & HTMLProps<HTMLDivElement>> = ({
         onResetLocationPublishError,
     } = useOwnLiveBeacons([beacon?.identifier]);
 
+    // eat events here to avoid 1) the map and 2) reply or thread tiles
+    // moving under the beacon status on stop/retry click
+    const preventDefaultWrapper = (callback: () => void) => (e?: ButtonEvent) => {
+        e?.stopPropagation();
+        e?.preventDefault();
+        callback();
+    };
+
     // combine display status with errors that only occur for user's own beacons
     const ownDisplayStatus = hasLocationPublishError || hasStopSharingError ?
         BeaconDisplayStatus.Error :
@@ -60,7 +68,7 @@ const OwnBeaconStatus: React.FC<Props & HTMLProps<HTMLDivElement>> = ({
         { ownDisplayStatus === BeaconDisplayStatus.Active && <AccessibleButton
             data-test-id='beacon-status-stop-beacon'
             kind='link'
-            onClick={onStopSharing}
+            onClick={preventDefaultWrapper(onStopSharing)}
             className='mx_OwnBeaconStatus_button mx_OwnBeaconStatus_destructiveButton'
             disabled={stoppingInProgress}
         >
@@ -70,7 +78,7 @@ const OwnBeaconStatus: React.FC<Props & HTMLProps<HTMLDivElement>> = ({
         { hasLocationPublishError && <AccessibleButton
             data-test-id='beacon-status-reset-wire-error'
             kind='link'
-            onClick={onResetLocationPublishError}
+            onClick={preventDefaultWrapper(onResetLocationPublishError)}
             className='mx_OwnBeaconStatus_button mx_OwnBeaconStatus_destructiveButton'
         >
             { _t('Retry') }
@@ -79,7 +87,7 @@ const OwnBeaconStatus: React.FC<Props & HTMLProps<HTMLDivElement>> = ({
         { hasStopSharingError && <AccessibleButton
             data-test-id='beacon-status-stop-beacon-retry'
             kind='link'
-            onClick={onStopSharing}
+            onClick={preventDefaultWrapper(onStopSharing)}
             className='mx_OwnBeaconStatus_button mx_OwnBeaconStatus_destructiveButton'
         >
             { _t('Retry') }

--- a/src/components/views/messages/MBeaconBody.tsx
+++ b/src/components/views/messages/MBeaconBody.tsx
@@ -87,6 +87,8 @@ const MBeaconBody: React.FC<IBodyProps> = React.forwardRef(({ mxEvent }, ref) =>
     } = useBeaconState(mxEvent);
     const mapId = useUniqueId(mxEvent.getId());
 
+    console.log('hhh', mxEvent, mxEvent.isRelation());
+
     const matrixClient = useContext(MatrixClientContext);
     const [error, setError] = useState<Error>();
     const displayStatus = getBeaconDisplayStatus(isLive, latestLocationState, error);

--- a/src/components/views/messages/MBeaconBody.tsx
+++ b/src/components/views/messages/MBeaconBody.tsx
@@ -87,8 +87,6 @@ const MBeaconBody: React.FC<IBodyProps> = React.forwardRef(({ mxEvent }, ref) =>
     } = useBeaconState(mxEvent);
     const mapId = useUniqueId(mxEvent.getId());
 
-    console.log('hhh', mxEvent, mxEvent.isRelation());
-
     const matrixClient = useContext(MatrixClientContext);
     const [error, setError] = useState<Error>();
     const displayStatus = getBeaconDisplayStatus(isLive, latestLocationState, error);

--- a/src/components/views/messages/MessageActionBar.tsx
+++ b/src/components/views/messages/MessageActionBar.tsx
@@ -21,6 +21,7 @@ import { EventStatus, MatrixEvent, MatrixEventEvent } from 'matrix-js-sdk/src/mo
 import classNames from 'classnames';
 import { MsgType, RelationType } from 'matrix-js-sdk/src/@types/event';
 import { Thread } from 'matrix-js-sdk/src/models/thread';
+import { M_BEACON_INFO } from 'matrix-js-sdk/src/@types/beacon';
 
 import type { Relations } from 'matrix-js-sdk/src/models/relations';
 import { _t } from '../../../languageHandler';
@@ -329,8 +330,14 @@ export default class MessageActionBar extends React.PureComponent<IMessageAction
 
         const inNotThreadTimeline = this.context.timelineRenderingType !== TimelineRenderingType.Thread;
 
-        const isAllowedMessageType = !this.forbiddenThreadHeadMsgType.includes(
-            this.props.mxEvent.getContent().msgtype as MsgType,
+        const isAllowedMessageType = (
+            !this.forbiddenThreadHeadMsgType.includes(
+                this.props.mxEvent.getContent().msgtype as MsgType) &&
+            /** forbid threads from live location shares
+             * until cross-platform support
+             * (PSF-1041)
+             */
+            !M_BEACON_INFO.matches(this.props.mxEvent.getType())
         );
 
         return inNotThreadTimeline && isAllowedMessageType;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -20,6 +20,7 @@ import { MatrixClient } from 'matrix-js-sdk/src/client';
 import { logger } from 'matrix-js-sdk/src/logger';
 import { M_POLL_START } from "matrix-events-sdk";
 import { M_LOCATION } from "matrix-js-sdk/src/@types/location";
+import { M_BEACON_INFO } from 'matrix-js-sdk/src/@types/beacon';
 
 import { MatrixClientPeg } from '../MatrixClientPeg';
 import shouldHideEvent from "../shouldHideEvent";
@@ -52,7 +53,8 @@ export function isContentActionable(mxEvent: MatrixEvent): boolean {
             }
         } else if (
             mxEvent.getType() === 'm.sticker' ||
-            M_POLL_START.matches(mxEvent.getType())
+            M_POLL_START.matches(mxEvent.getType()) ||
+            M_BEACON_INFO.matches(mxEvent.getType())
         ) {
             return true;
         }
@@ -277,7 +279,9 @@ export const isLocationEvent = (event: MatrixEvent): boolean => {
 
 export function canForward(event: MatrixEvent): boolean {
     return !(
-        M_POLL_START.matches(event.getType())
+        M_POLL_START.matches(event.getType()) ||
+        // disallow forwarding until psf-1044
+        M_BEACON_INFO.matches(event.getType())
     );
 }
 

--- a/test/components/views/messages/MessageActionBar-test.tsx
+++ b/test/components/views/messages/MessageActionBar-test.tsx
@@ -208,21 +208,6 @@ describe('<MessageActionBar />', () => {
         });
     });
 
-    it('kills event listeners on unmount', () => {
-        const offSpy = jest.spyOn(alicesMessageEvent, 'off').mockClear();
-        const wrapper = getComponent({ mxEvent: alicesMessageEvent });
-
-        act(() => {
-            wrapper.unmount();
-        });
-
-        expect(offSpy.mock.calls[0][0]).toEqual(MatrixEventEvent.Status);
-        expect(offSpy.mock.calls[1][0]).toEqual(MatrixEventEvent.Decrypted);
-        expect(offSpy.mock.calls[2][0]).toEqual(MatrixEventEvent.BeforeRedaction);
-
-        expect(client.decryptEventIfNeeded).toHaveBeenCalled();
-    });
-
     describe('options button', () => {
         it('renders options menu', () => {
             const { queryByLabelText } = getComponent({ mxEvent: alicesMessageEvent });

--- a/test/components/views/messages/MessageActionBar-test.tsx
+++ b/test/components/views/messages/MessageActionBar-test.tsx
@@ -15,13 +15,20 @@ limitations under the License.
 */
 
 import React from 'react';
+<<<<<<< HEAD
 import { render, fireEvent } from '@testing-library/react';
+=======
+import { mount } from 'enzyme';
+>>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 import { act } from 'react-test-renderer';
 import {
     EventType,
     EventStatus,
     MatrixEvent,
+<<<<<<< HEAD
     MatrixEventEvent,
+=======
+>>>>>>> 00723661f1 (test most basic paths in messageactionbar)
     MsgType,
     Room,
 } from 'matrix-js-sdk/src/matrix';
@@ -31,12 +38,19 @@ import {
     getMockClientWithEventEmitter,
     mockClientMethodsUser,
     mockClientMethodsEvents,
+<<<<<<< HEAD
+=======
+    findByAriaLabel,
+>>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 } from '../../../test-utils';
 import { RoomPermalinkCreator } from '../../../../src/utils/permalinks/Permalinks';
 import RoomContext, { TimelineRenderingType } from '../../../../src/contexts/RoomContext';
 import { IRoomState } from '../../../../src/components/structures/RoomView';
 import dispatcher from '../../../../src/dispatcher/dispatcher';
+<<<<<<< HEAD
 import SettingsStore from '../../../../src/settings/SettingsStore';
+=======
+>>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 
 jest.mock('../../../../src/dispatcher/dispatcher');
 

--- a/test/components/views/messages/MessageActionBar-test.tsx
+++ b/test/components/views/messages/MessageActionBar-test.tsx
@@ -15,20 +15,13 @@ limitations under the License.
 */
 
 import React from 'react';
-<<<<<<< HEAD
 import { render, fireEvent } from '@testing-library/react';
-=======
-import { mount } from 'enzyme';
->>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 import { act } from 'react-test-renderer';
 import {
     EventType,
     EventStatus,
     MatrixEvent,
-<<<<<<< HEAD
     MatrixEventEvent,
-=======
->>>>>>> 00723661f1 (test most basic paths in messageactionbar)
     MsgType,
     Room,
 } from 'matrix-js-sdk/src/matrix';
@@ -38,19 +31,12 @@ import {
     getMockClientWithEventEmitter,
     mockClientMethodsUser,
     mockClientMethodsEvents,
-<<<<<<< HEAD
-=======
-    findByAriaLabel,
->>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 } from '../../../test-utils';
 import { RoomPermalinkCreator } from '../../../../src/utils/permalinks/Permalinks';
 import RoomContext, { TimelineRenderingType } from '../../../../src/contexts/RoomContext';
 import { IRoomState } from '../../../../src/components/structures/RoomView';
 import dispatcher from '../../../../src/dispatcher/dispatcher';
-<<<<<<< HEAD
 import SettingsStore from '../../../../src/settings/SettingsStore';
-=======
->>>>>>> 00723661f1 (test most basic paths in messageactionbar)
 
 jest.mock('../../../../src/dispatcher/dispatcher');
 
@@ -220,6 +206,21 @@ describe('<MessageActionBar />', () => {
             // updated with local redaction event, delete now available
             expect(queryByLabelText('Delete')).toBeTruthy();
         });
+    });
+
+    it('kills event listeners on unmount', () => {
+        const offSpy = jest.spyOn(alicesMessageEvent, 'off').mockClear();
+        const wrapper = getComponent({ mxEvent: alicesMessageEvent });
+
+        act(() => {
+            wrapper.unmount();
+        });
+
+        expect(offSpy.mock.calls[0][0]).toEqual(MatrixEventEvent.Status);
+        expect(offSpy.mock.calls[1][0]).toEqual(MatrixEventEvent.Decrypted);
+        expect(offSpy.mock.calls[2][0]).toEqual(MatrixEventEvent.BeforeRedaction);
+
+        expect(client.decryptEventIfNeeded).toHaveBeenCalled();
     });
 
     describe('options button', () => {

--- a/test/utils/EventUtils-test.ts
+++ b/test/utils/EventUtils-test.ts
@@ -62,7 +62,11 @@ describe('EventUtils', () => {
     });
     redactedEvent.makeRedacted(redactedEvent);
 
-    const stateEvent = makeBeaconInfoEvent(userId, roomId);
+    const stateEvent = new MatrixEvent({
+        type: EventType.RoomTopic,
+        state_key: '',
+    });
+    const beaconInfoEvent = makeBeaconInfoEvent(userId, roomId);
 
     const roomMemberEvent = new MatrixEvent({
         type: EventType.RoomMember,
@@ -155,6 +159,7 @@ describe('EventUtils', () => {
             ['poll start event', pollStartEvent],
             ['event with empty content body', emptyContentBody],
             ['event with a content body', niceTextMessage],
+            ['beacon_info event', beaconInfoEvent],
         ])('returns true for %s', (_description, event) => {
             expect(isContentActionable(event)).toBe(true);
         });
@@ -323,6 +328,10 @@ describe('EventUtils', () => {
         });
         it('returns false for a poll event', () => {
             const event = makePollStartEvent('Who?', userId);
+            expect(canForward(event)).toBe(false);
+        });
+        it('returns false for a beacon_info event', () => {
+            const event = makeBeaconInfoEvent(userId, roomId);
             expect(canForward(event)).toBe(false);
         });
         it('returns true for a room message event', () => {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

- Make beacon_info events actionable
- disable threading and forwarding

<img width="458" alt="Screenshot 2022-05-30 at 17 41 00" src="https://user-images.githubusercontent.com/3055605/171025806-474ad46d-6ad3-46a6-938e-3aca21e5b79f.png">
<img width="422" alt="Screenshot 2022-05-30 at 17 40 49" src="https://user-images.githubusercontent.com/3055605/171025811-278decbb-4978-4f95-91e4-8096fe7dc97d.png">
<img width="502" alt="Screenshot 2022-05-30 at 17 40 38" src="https://user-images.githubusercontent.com/3055605/171025814-9e006efb-61a2-42d1-a702-75d942b580d3.png">



<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location share - enable reply and react to tiles ([\#8721](https://github.com/matrix-org/matrix-react-sdk/pull/8721)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->