### PR TITLE
Use AccessibleButton for 'In reply to' link button on ReplyChain

### DIFF
--- a/res/css/views/elements/_ReplyChain.scss
+++ b/res/css/views/elements/_ReplyChain.scss
@@ -15,20 +15,19 @@ limitations under the License.
 */
 
 .mx_ReplyChain {
-    margin-top: 0;
-    margin-left: 0;
-    margin-right: 0;
-    margin-bottom: 8px;
-    padding: 0 10px;
+    margin: 0 0 $spacing-8 0;
+    padding: 0 10px; // TODO: Use a spacing variable
     border-left: 2px solid $accent;
     border-radius: 2px;
 
     .mx_ReplyChain_show {
-        @mixin ButtonResetDefault;
-        color: inherit;
+        &.mx_AccessibleButton_kind_link_inline {
+            padding: 0;
+            color: unset;
 
-        &:hover {
-            color: $links;
+            &:hover {
+                color: $links;
+            }
         }
     }
 

--- a/src/components/views/elements/ReplyChain.tsx
+++ b/src/components/views/elements/ReplyChain.tsx
@@ -32,7 +32,7 @@ import { Action } from "../../../dispatcher/actions";
 import Spinner from './Spinner';
 import ReplyTile from "../rooms/ReplyTile";
 import Pill, { PillType } from './Pill';
-import { ButtonEvent } from './AccessibleButton';
+import AccessibleButton, { ButtonEvent } from './AccessibleButton';
 import { getParentEventId, shouldDisplayReply } from '../../../utils/Reply';
 import RoomContext from "../../../contexts/RoomContext";
 import { MatrixClientPeg } from '../../../MatrixClientPeg';
@@ -217,9 +217,13 @@ export default class ReplyChain extends React.Component<IProps, IState> {
                 {
                     _t('<a>In reply to</a> <pill>', {}, {
                         'a': (sub) => (
-                            <button onClick={this.onQuoteClick} className="mx_ReplyChain_show">
+                            <AccessibleButton
+                                kind="link_inline"
+                                className="mx_ReplyChain_show"
+                                onClick={this.onQuoteClick}
+                            >
                                 { sub }
-                            </button>
+                            </AccessibleButton>
                         ),
                         'pill': (
                             <Pill


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22407

![Untitled](https://user-images.githubusercontent.com/3362943/171226786-ad6e08e9-e5f9-40c7-84b2-ec28fcfcf4ab.png)

- Remove `ButtonResetDefault` mixin to respect the concept of cascading

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use AccessibleButton for 'In reply to' link button on ReplyChain ([\#8726](https://github.com/matrix-org/matrix-react-sdk/pull/8726)). Fixes vector-im/element-web#22407. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->