### PR TITLE
Use AccessibleButton for 'Reset All' link button on SetupEncryptionBody

### DIFF
--- a/res/css/structures/auth/_SetupEncryptionBody.scss
+++ b/res/css/structures/auth/_SetupEncryptionBody.scss
@@ -17,9 +17,11 @@ limitations under the License.
 .mx_SetupEncryptionBody_reset {
     color: $light-fg-color;
     margin-top: $font-14px;
-}
 
-.mx_SetupEncryptionBody_reset_link {
-    @mixin ButtonResetDefault;
-    color: $alert;
+    .mx_SetupEncryptionBody_reset_link {
+        &.mx_AccessibleButton_kind_link_inline {
+            padding: 0;
+            color: $alert;
+        }
+    }
 }

--- a/src/components/structures/auth/SetupEncryptionBody.tsx
+++ b/src/components/structures/auth/SetupEncryptionBody.tsx
@@ -212,11 +212,13 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                         </div>
                         <div className="mx_SetupEncryptionBody_reset">
                             { _t("Forgotten or lost all recovery methods? <a>Reset all</a>", null, {
-                                a: (sub) => <button
+                                a: (sub) => <AccessibleButton
+                                    kind="link_inline"
+                                    className="mx_SetupEncryptionBody_reset_link"
                                     onClick={this.onResetClick}
-                                    className="mx_SetupEncryptionBody_reset_link mx_Dialog_nonDialogButton">
+                                >
                                     { sub }
-                                </button>,
+                                </AccessibleButton>,
                             }) }
                         </div>
                     </div>


### PR DESCRIPTION
cf.: https://github.com/matrix-org/matrix-react-sdk/pull/8726. See also: https://github.com/matrix-org/matrix-react-sdk/blob/e11dbae89b796d6866e45e2f98be3daaace86a63/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx#L286-L291

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/171317250-cd28f9fe-f324-4a01-9e5d-732a91843c4b.png)|![after](https://user-images.githubusercontent.com/3362943/171317240-7ae4c3b4-6b9d-4f05-b915-e85294b26a2d.png)|

- Remove ButtonResetDefault to respect the concept of cascading

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

Type: enhancement
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use AccessibleButton for 'Reset All' link button on SetupEncryptionBody ([\#8730](https://github.com/matrix-org/matrix-react-sdk/pull/8730)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->