### PR TITLE
Reduce gutter with the new read receipt UI

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -419,12 +419,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_ThreadSummaryIcon,
         .mx_EventTile_line {
             /* ideally should be 100px, but 95px gives us a max thumbnail size of 800x600, which is nice */
-            margin-right: 110px;
+            margin-right: 80px;
             min-height: $font-14px;
         }
 
         .mx_ThreadSummary {
-            max-width: min(calc(100% - $left-gutter - 110px), 600px); // leave space on both left & right gutters
+            max-width: min(calc(100% - $left-gutter - 80px), 600px); // leave space on both left & right gutters
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21890

### 👎 Before

<img width="712" alt="Screen Shot 2022-06-01 at 15 48 44" src="https://user-images.githubusercontent.com/769871/171435037-e959106e-b6c6-45cf-bb75-86e912d79152.png">

### 👍  After

<img width="699" alt="Screen Shot 2022-06-01 at 15 55 13" src="https://user-images.githubusercontent.com/769871/171435071-a7e830d3-cb96-4ebb-961e-901ec84259fb.png">



<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Reduce gutter with the new read receipt UI ([\#8736](https://github.com/matrix-org/matrix-react-sdk/pull/8736)). Fixes vector-im/element-web#21890.<!-- CHANGELOG_PREVIEW_END -->