### PR TITLE
Improve _ShareType.scss

### DIFF
--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -44,8 +44,6 @@ limitations under the License.
 }
 
 .mx_ShareType_option {
-    @mixin ButtonResetDefault;
-
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -53,14 +51,18 @@ limitations under the License.
     justify-content: flex-start;
     padding: $spacing-8 $spacing-20;
     margin-top: $spacing-12;
+    background: none;
 
-    color: $primary-content;
     border: 1px solid $quinary-content;
     border-radius: 8px;
 
     font-size: $font-15px;
+    font-family: inherit;
+    line-height: inherit;
+    color: $primary-content;
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
         border-color: $accent;
     }
 }

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -45,6 +45,7 @@ limitations under the License.
 
 .mx_ShareType_option {
     width: 100%;
+    box-sizing: border-box; // avoid the buttons from overflowing. otherwise: calc(100% - padding * 2)
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -27,14 +27,13 @@ limitations under the License.
 
     .mx_ShareType_wrapper_options {
         display: flex;
-        flex-flow: column;
+        flex-direction: column;
         row-gap: $spacing-12;
         width: 100%;
         margin-top: $spacing-12;
 
         .mx_ShareType_option {
             display: flex;
-            flex-direction: row;
             align-items: center;
             justify-content: flex-start;
             padding: $spacing-8 $spacing-20;

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -24,24 +24,6 @@ limitations under the License.
     padding: 60px $spacing-12 $spacing-32;
 
     color: $primary-content;
-}
-
-.mx_ShareType_badge {
-    height: 60px;
-    width: 60px;
-    margin-bottom: $spacing-20;
-    background-color: $accent;
-    border-radius: 50%;
-    border: 14px solid $accent;
-    // colors icon
-    color: white;
-    box-sizing: border-box;
-}
-
-.mx_ShareType_heading {
-    padding-bottom: $spacing-32;
-    text-align: center;
-}
 
 .mx_ShareType_option {
     width: 100%;
@@ -66,6 +48,24 @@ limitations under the License.
     &:focus {
         border-color: $accent;
     }
+}
+}
+
+.mx_ShareType_badge {
+    height: 60px;
+    width: 60px;
+    margin-bottom: $spacing-20;
+    background-color: $accent;
+    border-radius: 50%;
+    border: 14px solid $accent;
+    // colors icon
+    color: white;
+    box-sizing: border-box;
+}
+
+.mx_ShareType_heading {
+    padding-bottom: $spacing-32;
+    text-align: center;
 }
 
 .mx_ShareType_option-icon {

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -25,15 +25,19 @@ limitations under the License.
 
     color: $primary-content;
 
-    .mx_ShareType_option {
+    .mx_ShareType_wrapper_options {
+        display: flex;
+        flex-flow: column;
+        row-gap: $spacing-12;
         width: 100%;
-        box-sizing: border-box; // avoid the buttons from overflowing. otherwise: calc(100% - padding * 2)
+        margin-top: $spacing-12;
+
+    .mx_ShareType_option {
         display: flex;
         flex-direction: row;
         align-items: center;
         justify-content: flex-start;
         padding: $spacing-8 $spacing-20;
-        margin-top: $spacing-12;
         background: none;
 
         border: 1px solid $quinary-content;
@@ -48,6 +52,7 @@ limitations under the License.
         &:focus {
             border-color: $accent;
         }
+    }
     }
 }
 

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -32,27 +32,27 @@ limitations under the License.
         width: 100%;
         margin-top: $spacing-12;
 
-    .mx_ShareType_option {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: flex-start;
-        padding: $spacing-8 $spacing-20;
-        background: none;
+        .mx_ShareType_option {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-start;
+            padding: $spacing-8 $spacing-20;
+            background: none;
 
-        border: 1px solid $quinary-content;
-        border-radius: 8px;
+            border: 1px solid $quinary-content;
+            border-radius: 8px;
 
-        font-size: $font-15px;
-        font-family: inherit;
-        line-height: inherit;
-        color: $primary-content;
+            font-size: $font-15px;
+            font-family: inherit;
+            line-height: inherit;
+            color: $primary-content;
 
-        &:hover,
-        &:focus {
-            border-color: $accent;
+            &:hover,
+            &:focus {
+                border-color: $accent;
+            }
         }
-    }
     }
 }
 

--- a/res/css/components/views/location/_ShareType.scss
+++ b/res/css/components/views/location/_ShareType.scss
@@ -25,30 +25,30 @@ limitations under the License.
 
     color: $primary-content;
 
-.mx_ShareType_option {
-    width: 100%;
-    box-sizing: border-box; // avoid the buttons from overflowing. otherwise: calc(100% - padding * 2)
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    padding: $spacing-8 $spacing-20;
-    margin-top: $spacing-12;
-    background: none;
+    .mx_ShareType_option {
+        width: 100%;
+        box-sizing: border-box; // avoid the buttons from overflowing. otherwise: calc(100% - padding * 2)
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+        padding: $spacing-8 $spacing-20;
+        margin-top: $spacing-12;
+        background: none;
 
-    border: 1px solid $quinary-content;
-    border-radius: 8px;
+        border: 1px solid $quinary-content;
+        border-radius: 8px;
 
-    font-size: $font-15px;
-    font-family: inherit;
-    line-height: inherit;
-    color: $primary-content;
+        font-size: $font-15px;
+        font-family: inherit;
+        line-height: inherit;
+        color: $primary-content;
 
-    &:hover,
-    &:focus {
-        border-color: $accent;
+        &:hover,
+        &:focus {
+            border-color: $accent;
+        }
     }
-}
 }
 
 .mx_ShareType_badge {

--- a/src/components/views/location/ShareType.tsx
+++ b/src/components/views/location/ShareType.tsx
@@ -78,6 +78,7 @@ const ShareType: React.FC<Props> = ({
     return <div className='mx_ShareType'>
         <LocationIcon className='mx_ShareType_badge' />
         <Heading className='mx_ShareType_heading' size='h3'>{ _t("What location type do you want to share?") }</Heading>
+        <div className='mx_ShareType_wrapper_options'>
         { enabledShareTypes.map((type) =>
             <ShareTypeOption
                 key={type}
@@ -87,6 +88,7 @@ const ShareType: React.FC<Props> = ({
                 data-test-id={`share-location-option-${type}`}
             />,
         ) }
+        </div>
     </div>;
 };
 

--- a/src/components/views/location/ShareType.tsx
+++ b/src/components/views/location/ShareType.tsx
@@ -51,6 +51,7 @@ type ShareTypeOptionProps = HTMLAttributes<Element> & { label: string, shareType
 const ShareTypeOption: React.FC<ShareTypeOptionProps> = ({
     onClick, label, shareType, ...rest
 }) => <AccessibleButton
+    element='button'
     className='mx_ShareType_option'
     onClick={onClick}
     {...rest}>

--- a/src/components/views/location/ShareType.tsx
+++ b/src/components/views/location/ShareType.tsx
@@ -79,15 +79,15 @@ const ShareType: React.FC<Props> = ({
         <LocationIcon className='mx_ShareType_badge' />
         <Heading className='mx_ShareType_heading' size='h3'>{ _t("What location type do you want to share?") }</Heading>
         <div className='mx_ShareType_wrapper_options'>
-        { enabledShareTypes.map((type) =>
-            <ShareTypeOption
-                key={type}
-                onClick={() => setShareType(type)}
-                label={labels[type]}
-                shareType={type}
-                data-test-id={`share-location-option-${type}`}
-            />,
-        ) }
+            { enabledShareTypes.map((type) =>
+                <ShareTypeOption
+                    key={type}
+                    onClick={() => setShareType(type)}
+                    label={labels[type]}
+                    shareType={type}
+                    data-test-id={`share-location-option-${type}`}
+                />,
+            ) }
         </div>
     </div>;
 };

--- a/src/components/views/location/ShareType.tsx
+++ b/src/components/views/location/ShareType.tsx
@@ -51,7 +51,6 @@ type ShareTypeOptionProps = HTMLAttributes<Element> & { label: string, shareType
 const ShareTypeOption: React.FC<ShareTypeOptionProps> = ({
     onClick, label, shareType, ...rest
 }) => <AccessibleButton
-    element='button'
     className='mx_ShareType_option'
     onClick={onClick}
     {...rest}>

--- a/test/components/views/location/LocationShareMenu-test.tsx
+++ b/test/components/views/location/LocationShareMenu-test.tsx
@@ -128,7 +128,7 @@ describe('<LocationShareMenu />', () => {
     });
 
     const getShareTypeOption = (component: ReactWrapper, shareType: LocationShareType) =>
-        findByTagAndTestId(component, `share-location-option-${shareType}`, 'div');
+        findByTagAndTestId(component, `share-location-option-${shareType}`, 'button');
 
     const getBackButton = (component: ReactWrapper) =>
         findByTagAndTestId(component, 'share-dialog-buttons-back', 'button');

--- a/test/components/views/location/LocationShareMenu-test.tsx
+++ b/test/components/views/location/LocationShareMenu-test.tsx
@@ -128,7 +128,7 @@ describe('<LocationShareMenu />', () => {
     });
 
     const getShareTypeOption = (component: ReactWrapper, shareType: LocationShareType) =>
-        findByTagAndTestId(component, `share-location-option-${shareType}`, 'button');
+        findByTagAndTestId(component, `share-location-option-${shareType}`, 'div');
 
     const getBackButton = (component: ReactWrapper) =>
         findByTagAndTestId(component, 'share-dialog-buttons-back', 'button');


### PR DESCRIPTION
|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/171472382-45578b77-6c19-4f08-a7b0-1a9c249c397a.png)|![after](https://user-images.githubusercontent.com/3362943/171475225-30efefaa-b06d-4c26-a220-de2fb73dd0ae.png)|

- Stop setting declarations more than needed. The mixin complicates the style inheritance structure, hides declarations which possibly specify elements in a wrong way, and also wastes resources.
- Protect the buttons from being regressed unexpectedly by setting enough specificity to prevent a regression. Please note that every top level block is treated equally among all files.
- ~~Remove element='button' from `AccessibleButton`, which is a redundant setting. If it should be a button HTML element, it is AccessibleButton that should be fixed.~~ -> should be addressed with another PR.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->