### PR TITLE
Clarify logout key backup warning dialog

### DIFF
--- a/src/components/views/dialogs/LogoutDialog.tsx
+++ b/src/components/views/dialogs/LogoutDialog.tsx
@@ -134,6 +134,12 @@ export default class LogoutDialog extends React.Component<IProps, IState> {
                     "Encrypted messages are secured with end-to-end encryption. " +
                     "Only you and the recipient(s) have the keys to read these messages.",
                 ) }</p>
+                <p>{ _t(
+                    "When you sign out, these keys will be deleted from this device, " +
+                    "which means you won't be able to read encrypted messages unless you " +
+                    "have the keys for them on your other devices, or backed them up to the " +
+                    "server.",
+                ) }</p>
                 <p>{ _t("Back up your keys before signing out to avoid losing them.") }</p>
             </div>;
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2651,6 +2651,7 @@
     "Leave some rooms": "Leave some rooms",
     "Leave space": "Leave space",
     "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.": "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.",
+    "When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.": "When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.",
     "Start using Key Backup": "Start using Key Backup",
     "I don't want my encrypted messages": "I don't want my encrypted messages",
     "Manually export keys": "Manually export keys",


### PR DESCRIPTION
*As originally proposed in https://github.com/matrix-org/matrix-react-sdk/pull/5363 by @notramo*

---

Clarify logout key backup warning dialog

Added details to the logout key backup warning dialog on
why access to encrypted messages will be lost.

Fix https://github.com/vector-im/element-web/issues/15565

Before | After
--- | ---
<img width="772" alt="" src="https://user-images.githubusercontent.com/558581/171523302-67ac698b-67bf-4ce9-9b81-b14b0456807b.png"> | <img width="778" alt="" src="https://user-images.githubusercontent.com/558581/171523301-25e7d5ab-a989-4eb0-946d-3659c7109e56.png">



<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
