### PR TITLE
Use visibility property for DisambiguatedProfile

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -230,11 +230,11 @@ limitations under the License.
         }
 
         .mx_DisambiguatedProfile {
-            display: none;
+            visibility: hidden;
         }
 
         .mx_ReplyTile .mx_DisambiguatedProfile {
-            display: block;
+            visibility: visible;
         }
 
         .mx_ReactionsRow {


### PR DESCRIPTION
Using `display: block` may contradict with other values of the display property.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->