### PR TITLE
Adjust message timestamp position on TimelineCard in non-bubble layouts

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -87,8 +87,8 @@ limitations under the License.
 
         .mx_MessageTimestamp {
             position: absolute; // for modern layout and IRC layout
-            right: -4px;
-            left: auto;
+            inset-inline-start: auto;
+            inset-inline-end: 0;
         }
 
         .mx_EventTile_msgOption {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22426

This PR adjusts message timestamp position on TimelineCard in non-bubble layouts by removing the obsolete `right` value.

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/171665257-b1b2ecf7-34e9-4937-9a0b-a53342a31908.png)|![after1](https://user-images.githubusercontent.com/3362943/171665208-b29446be-4a59-4b01-a222-838337e9b38b.png)|
|![before2](https://user-images.githubusercontent.com/3362943/171665273-6e627bcc-9f69-4a78-87fe-4b67074a0471.png)|![after2](https://user-images.githubusercontent.com/3362943/171665242-2d054ed8-9a44-4e51-af1e-b00875af3017.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Adjust message timestamp position on TimelineCard in non-bubble layouts ([\#8745](https://github.com/matrix-org/matrix-react-sdk/pull/8745)). Fixes vector-im/element-web#22426. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->