### PR TITLE
Hide live location option in threads composer

### DIFF
--- a/src/components/views/location/LocationShareMenu.tsx
+++ b/src/components/views/location/LocationShareMenu.tsx
@@ -38,8 +38,16 @@ type Props = Omit<ILocationPickerProps, 'onChoose' | 'shareType'> & {
     relation?: IEventRelation;
 };
 
-const getEnabledShareTypes = (): LocationShareType[] => {
-    const enabledShareTypes = [LocationShareType.Own, LocationShareType.Live];
+const getEnabledShareTypes = (relation): LocationShareType[] => {
+    const enabledShareTypes = [
+        LocationShareType.Own,
+    ];
+
+    // live locations cannot have a relation
+    // hide the option when composer has a relation
+    if (!relation) {
+        enabledShareTypes.push(LocationShareType.Live);
+    }
 
     if (SettingsStore.getValue("feature_location_share_pin_drop")) {
         enabledShareTypes.push(LocationShareType.Pin);
@@ -57,7 +65,7 @@ const LocationShareMenu: React.FC<Props> = ({
     relation,
 }) => {
     const matrixClient = useContext(MatrixClientContext);
-    const enabledShareTypes = getEnabledShareTypes();
+    const enabledShareTypes = getEnabledShareTypes(relation);
     const isLiveShareEnabled = useFeatureEnabled("feature_location_share_live");
 
     const multipleShareTypesEnabled = enabledShareTypes.length > 1;

--- a/test/components/views/location/LocationShareMenu-test.tsx
+++ b/test/components/views/location/LocationShareMenu-test.tsx
@@ -16,12 +16,13 @@ limitations under the License.
 
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
+import { mocked } from 'jest-mock';
 import { RoomMember } from 'matrix-js-sdk/src/models/room-member';
 import { MatrixClient } from 'matrix-js-sdk/src/client';
-import { mocked } from 'jest-mock';
-import { act } from 'react-dom/test-utils';
-import { M_ASSET, LocationAssetType } from 'matrix-js-sdk/src/@types/location';
+import { RelationType } from 'matrix-js-sdk/src/matrix';
 import { logger } from 'matrix-js-sdk/src/logger';
+import { M_ASSET, LocationAssetType } from 'matrix-js-sdk/src/@types/location';
+import { act } from 'react-dom/test-utils';
 
 import LocationShareMenu from '../../../../src/components/views/location/LocationShareMenu';
 import MatrixClientContext from '../../../../src/contexts/MatrixClientContext';
@@ -374,6 +375,16 @@ describe('<LocationShareMenu />', () => {
 
     describe('Live location share', () => {
         beforeEach(() => enableSettings(["feature_location_share_live"]));
+
+        it('does not display live location share option when composer has a relation', () => {
+            const relation = {
+                rel_type: RelationType.Thread,
+                event_id: '12345',
+            };
+            const component = getComponent({ relation });
+
+            expect(getShareTypeOption(component, LocationShareType.Live).length).toBeFalsy();
+        });
 
         it('creates beacon info event on submission', () => {
             const onFinished = jest.fn();


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->
Fixes https://github.com/vector-im/element-web/issues/22424

Live location shares are room state events and can only be shared at a room level, cannot be a reply to a thread.
Hide the live location share option in the threads composer.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Hide live location option in threads composer ([\#8746](https://github.com/matrix-org/matrix-react-sdk/pull/8746)). Fixes vector-im/element-web#22424. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->