### PR TITLE
Make sure MessageTimestamp is not hidden by EventTile_line on TimelineCard

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -55,6 +55,7 @@ limitations under the License.
         &.mx_EventTile_info .mx_EventTile_line,
         .mx_EventTile_line {
             padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-horizontal);
+            padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
 
             .mx_EventTile_e2eIcon {
                 inset-inline-start: 8px;


### PR DESCRIPTION
This PR makes sure that `MessageTimestamp` on TimelineCard is not hidden by `EventTile_line`, whose content can be an image, location map, etc. 

The issue can also be reproduced on a text message where text-justify effect is activated (eg. a message which is not wrapped with white space characters). 

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/171696120-06524bd9-5acd-46a8-bb07-80b98e2e5fed.png)|![after1](https://user-images.githubusercontent.com/3362943/171695518-3b216e76-e0a0-4493-af0b-f0c3f60d4297.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make sure MessageTimestamp is not hidden by EventTile_line on TimelineCard ([\#8748](https://github.com/matrix-org/matrix-react-sdk/pull/8748)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->