### PR TITLE
Prevent the banner text from being selected, replacing the spacing values with the variable

### DIFF
--- a/res/css/views/messages/_MImageBody.scss
+++ b/res/css/views/messages/_MImageBody.scss
@@ -19,12 +19,12 @@ $timeline-image-border-radius: 8px;
 
 .mx_MImageBody_banner {
     position: absolute;
-    bottom: 4px;
-    left: 4px;
-    padding: 4px;
+    bottom: $spacing-4;
+    left: $spacing-4;
+    padding: $spacing-4;
     border-radius: $timeline-image-border-radius;
     font-size: $font-15px;
-
+    user-select: none; // prevent banner text from being selected
     pointer-events: none; // let the cursor go through to the media underneath
 
     // Trying to match the width of the image is surprisingly difficult, so arbitrarily break it off early.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22442

This PR:
- adds `user-select: none;` to prevent banner text from being selected
- replaces the hard coded values for spacing with a variable

Before:

https://user-images.githubusercontent.com/3362943/172036317-dd0b5101-7e91-4ed2-82aa-36a27f877897.mp4

After:

https://user-images.githubusercontent.com/3362943/172036300-963ad252-93b1-4b55-b6ce-fd9988c79282.mp4

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent the banner text from being selected, replacing the spacing values with the variable ([\#8756](https://github.com/matrix-org/matrix-react-sdk/pull/8756)). Fixes vector-im/element-web#22442. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->