### PR TITLE
Make the pill on the basic message composer compatible with display name in RTL languages

### DIFF
--- a/res/css/views/elements/_Pill.scss
+++ b/res/css/views/elements/_Pill.scss
@@ -48,8 +48,8 @@ limitations under the License.
 
     &::before,
     .mx_BaseAvatar {
-        margin-left: -0.3em; // Otherwise the gap is too large
-        margin-right: 0.2em;
+        margin-inline-start: -0.3em; // Otherwise the gap is too large
+        margin-inline-end: 0.2em;
     }
 
     a& {

--- a/res/css/views/rooms/_BasicMessageComposer.scss
+++ b/res/css/views/rooms/_BasicMessageComposer.scss
@@ -51,7 +51,9 @@ limitations under the License.
         }
 
         &.mx_BasicMessageComposer_input_shouldShowPillAvatar {
-            span.mx_UserPill, span.mx_RoomPill, span.mx_SpacePill {
+            span.mx_UserPill,
+            span.mx_RoomPill,
+            span.mx_SpacePill {
                 user-select: all;
                 position: relative;
                 cursor: unset; // We don't want indicate clickability
@@ -66,7 +68,7 @@ limitations under the License.
                     content: var(--avatar-letter);
                     width: $font-16px;
                     height: $font-16px;
-                    margin-right: 0.24rem;
+                    margin-inline-end: 0.24rem;
                     background: var(--avatar-background), $background;
                     color: $avatar-initial-color;
                     background-repeat: no-repeat;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22445

This PR makes the pill on the basic message composer compatible with display name in RTL languages by using logical properties.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/172043316-67846259-35dc-446d-8b5b-818a70828a0a.png)|![after](https://user-images.githubusercontent.com/3362943/172043310-20c9c9ca-b039-4b29-ba27-d80bd8896eac.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make the pill on the basic message composer compatible with display name in RTL languages ([\#8758](https://github.com/matrix-org/matrix-react-sdk/pull/8758)). Fixes vector-im/element-web#22445. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->