### PR TITLE
Tidy up mx_InviteDialog_dialPad style rules

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -380,14 +380,14 @@ limitations under the License.
     border-left: none;
 }
 }
-}
 
-.mx_InviteDialog_dialPad .mx_DialPad {
+.mx_DialPad {
     row-gap: 16px;
     column-gap: 48px;
 
     margin-left: auto;
     margin-right: auto;
+}
 }
 
 .mx_InviteDialog_transferConsultConnect {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -346,9 +346,9 @@ limitations under the License.
 .mx_InviteDialog_helpText {
     margin: 0;
 
-.mx_AccessibleButton_kind_link {
-    padding: 0;
-}
+    .mx_AccessibleButton_kind_link {
+        padding: 0;
+    }
 }
 
 .mx_InviteDialog_dialPad {
@@ -357,37 +357,37 @@ limitations under the License.
     margin-left: auto;
     margin-right: auto;
 
-.mx_InviteDialog_dialPadField {
-    border-top: 0;
-    border-left: 0;
-    border-right: 0;
-    border-radius: 0;
-    margin-top: 0;
-    border-color: $quaternary-content;
+    .mx_InviteDialog_dialPadField {
+        border-top: 0;
+        border-left: 0;
+        border-right: 0;
+        border-radius: 0;
+        margin-top: 0;
+        border-color: $quaternary-content;
 
-    &:focus-within {
-        border-color: $accent;
+        &:focus-within {
+            border-color: $accent;
+        }
+
+        input {
+            font-size: 18px;
+            font-weight: 600;
+            padding-top: 0;
+        }
+
+        .mx_Field_postfix {
+            /* Remove border separator between postfix and field content */
+            border-left: none;
+        }
     }
 
-    input {
-        font-size: 18px;
-        font-weight: 600;
-        padding-top: 0;
+    .mx_DialPad {
+        row-gap: 16px;
+        column-gap: 48px;
+
+        margin-left: auto;
+        margin-right: auto;
     }
-
-.mx_Field_postfix {
-    /* Remove border separator between postfix and field content */
-    border-left: none;
-}
-}
-
-.mx_DialPad {
-    row-gap: 16px;
-    column-gap: 48px;
-
-    margin-left: auto;
-    margin-right: auto;
-}
 }
 
 .mx_InviteDialog_transferConsultConnect {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -351,7 +351,8 @@ limitations under the License.
 }
 }
 
-.mx_InviteDialog_dialPad .mx_InviteDialog_dialPadField {
+.mx_InviteDialog_dialPad {
+.mx_InviteDialog_dialPadField {
     border-top: 0;
     border-left: 0;
     border-right: 0;
@@ -364,6 +365,7 @@ limitations under the License.
         font-weight: 600;
         padding-top: 0;
     }
+}
 }
 
 .mx_InviteDialog_dialPad .mx_InviteDialog_dialPadField:focus-within {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -369,12 +369,12 @@ limitations under the License.
         font-weight: 600;
         padding-top: 0;
     }
-}
-}
 
-.mx_InviteDialog_dialPadField .mx_Field_postfix {
+.mx_Field_postfix {
     /* Remove border separator between postfix and field content */
     border-left: none;
+}
+}
 }
 
 .mx_InviteDialog_dialPad {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -345,10 +345,10 @@ limitations under the License.
 
 .mx_InviteDialog_helpText {
     margin: 0;
-}
 
-.mx_InviteDialog_helpText .mx_AccessibleButton_kind_link {
+.mx_AccessibleButton_kind_link {
     padding: 0;
+}
 }
 
 .mx_InviteDialog_dialPad .mx_InviteDialog_dialPadField {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -354,13 +354,11 @@ limitations under the License.
 .mx_InviteDialog_dialPad {
     width: 224px;
     margin-top: 16px;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline: auto;
 
     .mx_InviteDialog_dialPadField {
         border-top: 0;
-        border-left: 0;
-        border-right: 0;
+        border-inline: 0;
         border-radius: 0;
         margin-top: 0;
         border-color: $quaternary-content;
@@ -384,9 +382,7 @@ limitations under the License.
     .mx_DialPad {
         row-gap: 16px;
         column-gap: 48px;
-
-        margin-left: auto;
-        margin-right: auto;
+        margin-inline: auto;
     }
 }
 

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -352,6 +352,11 @@ limitations under the License.
 }
 
 .mx_InviteDialog_dialPad {
+    width: 224px;
+    margin-top: 16px;
+    margin-left: auto;
+    margin-right: auto;
+
 .mx_InviteDialog_dialPadField {
     border-top: 0;
     border-left: 0;
@@ -375,13 +380,6 @@ limitations under the License.
     border-left: none;
 }
 }
-}
-
-.mx_InviteDialog_dialPad {
-    width: 224px;
-    margin-top: 16px;
-    margin-left: auto;
-    margin-right: auto;
 }
 
 .mx_InviteDialog_dialPad .mx_DialPad {

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -353,7 +353,7 @@ limitations under the License.
 
 .mx_InviteDialog_dialPad {
     width: 224px;
-    margin-top: 16px;
+    margin-top: $spacing-16;
     margin-inline: auto;
 
     .mx_InviteDialog_dialPadField {
@@ -380,8 +380,8 @@ limitations under the License.
     }
 
     .mx_DialPad {
-        row-gap: 16px;
-        column-gap: 48px;
+        row-gap: $spacing-16;
+        column-gap: 48px; // TODO: Use a spacing variable
         margin-inline: auto;
     }
 }

--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -360,16 +360,16 @@ limitations under the License.
     margin-top: 0;
     border-color: $quaternary-content;
 
+    &:focus-within {
+        border-color: $accent;
+    }
+
     input {
         font-size: 18px;
         font-weight: 600;
         padding-top: 0;
     }
 }
-}
-
-.mx_InviteDialog_dialPad .mx_InviteDialog_dialPadField:focus-within {
-    border-color: $accent;
 }
 
 .mx_InviteDialog_dialPadField .mx_Field_postfix {


### PR DESCRIPTION
From the current implementation the hierarchy between `mx_InviteDialog_dialPadField` and `mx_DialPad` is not clear, so it is left as it is.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->