### PR TITLE
Slightly improve the look of the `Message edits` dialog

### DIFF
--- a/res/css/views/dialogs/_MessageEditHistoryDialog.scss
+++ b/res/css/views/dialogs/_MessageEditHistoryDialog.scss
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_MessageEditHistoryDialog .mx_Dialog_header > .mx_Dialog_title {
-    text-align: center;
-}
-
 .mx_MessageEditHistoryDialog {
     display: flex;
     flex-direction: column;

--- a/res/css/views/dialogs/_MessageEditHistoryDialog.scss
+++ b/res/css/views/dialogs/_MessageEditHistoryDialog.scss
@@ -56,17 +56,31 @@ limitations under the License.
     }
 
     .mx_EventTile {
+        padding-top: 0 !important; // Override mx_EventTile:not([data-layout=bubble])
+
         .mx_MessageTimestamp {
             position: absolute;
         }
-    }
 
-    .mx_EventTile_line, .mx_EventTile_content {
-        margin-right: 0px;
+        .mx_EventTile_line {
+            padding-top: 1px;
+            padding-bottom: 3px;
+
+            line-height: $font-22px;
+
+            .mx_EventTile_content {
+                margin-right: 0px;
+            }
+        }
     }
 
     .mx_MessageActionBar .mx_AccessibleButton {
-        font-size: $font-10px;
-        padding: 0 8px;
+        display: flex;
+        align-items: center;
+
+        padding-inline-start: $spacing-8;
+        padding-inline-end: $spacing-8;
+
+        font-size: $font-15px;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22410

<hr>

![2022-06-05_17-26](https://user-images.githubusercontent.com/25768714/172057914-e6310d79-c358-47a8-9ac8-fe981fcabfa1.png)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Slightly improve the look of the `Message edits` dialog ([\#8763](https://github.com/matrix-org/matrix-react-sdk/pull/8763)). Fixes vector-im/element-web#22410.<!-- CHANGELOG_PREVIEW_END -->