### PR TITLE
Makes the avatar of the user menu non-draggable

### DIFF
--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -22,7 +22,6 @@ limitations under the License.
     .mx_AccessibleButton {
         display: flex;
         align-items: center;
-    }
 
     .mx_UserMenu_userAvatar {
         position: relative;
@@ -30,6 +29,7 @@ limitations under the License.
         .mx_BaseAvatar {
             pointer-events: none; // makes the avatar non-draggable
         }
+    }
     }
 
     .mx_UserMenu_name {

--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -26,6 +26,10 @@ limitations under the License.
 
     .mx_UserMenu_userAvatar {
         position: relative;
+
+        .mx_BaseAvatar {
+            pointer-events: none; // makes the avatar non-draggable
+        }
     }
 
     .mx_UserMenu_name {

--- a/res/css/structures/_UserMenu.scss
+++ b/res/css/structures/_UserMenu.scss
@@ -23,13 +23,13 @@ limitations under the License.
         display: flex;
         align-items: center;
 
-    .mx_UserMenu_userAvatar {
-        position: relative;
+        .mx_UserMenu_userAvatar {
+            position: relative;
 
-        .mx_BaseAvatar {
-            pointer-events: none; // makes the avatar non-draggable
+            .mx_BaseAvatar {
+                pointer-events: none; // makes the avatar non-draggable
+            }
         }
-    }
     }
 
     .mx_UserMenu_name {


### PR DESCRIPTION
This PR makes the avatar of the user menu non-draggable. 

Before: 

https://user-images.githubusercontent.com/3362943/172061021-c46521c6-3355-445a-9626-509702830e78.mp4

This solution cannot be applied globally as clicking `mx_BaseAvatar` triggers events some cases.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Makes the avatar of the user menu non-draggable ([\#8765](https://github.com/matrix-org/matrix-react-sdk/pull/8765)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->