### PR TITLE
Remove ListResetDefault

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -739,9 +739,3 @@ legend {
     mask-repeat: no-repeat;
     mask-size: contain;
 }
-
-@define-mixin ListResetDefault {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}

--- a/res/css/components/views/beacon/_DialogSidebar.scss
+++ b/res/css/components/views/beacon/_DialogSidebar.scss
@@ -53,7 +53,9 @@ limitations under the License.
 }
 
 .mx_DialogSidebar_list {
-    @mixin ListResetDefault;
+    list-style: none;
+    padding: 0;
+    margin: 0;
     flex: 1 1 0;
     width: 100%;
     overflow: auto;


### PR DESCRIPTION
The mixin is used only here once. Also to reset lists, they should be globally reset with selectors instead of applying the mixin ad-hoc, in order to protect the lists from unexpected style inconsistencies.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->