### PR TITLE
Fix 'Logout' inline link on the splash screen

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -2012,9 +2012,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                     <div className="mx_MatrixChat_splash">
                         { errorBox }
                         <Spinner />
-                        <AccessibleButton kind='link_inline' className="mx_MatrixChat_splashButtons" onClick={this.onLogoutClick}>
-                            { _t('Logout') }
-                        </AccessibleButton>
+                        <div className="mx_MatrixChat_splashButtons">
+                            <AccessibleButton kind='link_inline' onClick={this.onLogoutClick}>
+                                { _t('Logout') }
+                            </AccessibleButton>
+                        </div>
                     </div>
                 );
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22449

This PR makes the only `Logout` text on the splash screen clickable.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/172092133-c5a8188d-fa2d-42f0-bf98-fa3dd92c73b2.png)|![after](https://user-images.githubusercontent.com/3362943/172092110-e636fa59-af7d-4eda-ac45-d5a1c91f71df.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix 'Logout' inline link on the splash screen ([\#8770](https://github.com/matrix-org/matrix-react-sdk/pull/8770)). Fixes vector-im/element-web#22449. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->