### PR TITLE
Live location share - show loading UI for beacons with start timestamp in the future (PSF-1081)

### DIFF
--- a/src/components/views/beacon/displayStatus.ts
+++ b/src/components/views/beacon/displayStatus.ts
@@ -25,14 +25,17 @@ export enum BeaconDisplayStatus {
 export const getBeaconDisplayStatus = (
     isLive: boolean,
     latestLocationState?: BeaconLocationState,
-    error?: Error): BeaconDisplayStatus => {
+    error?: Error,
+    waitingToStart?: boolean): BeaconDisplayStatus => {
     if (error) {
         return BeaconDisplayStatus.Error;
+    }
+    if (waitingToStart) {
+        return BeaconDisplayStatus.Loading;
     }
     if (!isLive) {
         return BeaconDisplayStatus.Stopped;
     }
-
     if (!latestLocationState) {
         return BeaconDisplayStatus.Loading;
     }

--- a/src/utils/beacon/duration.ts
+++ b/src/utils/beacon/duration.ts
@@ -39,3 +39,10 @@ export const sortBeaconsByLatestExpiry = (left: Beacon, right: Beacon): number =
 // aka sort by timestamp descending
 export const sortBeaconsByLatestCreation = (left: Beacon, right: Beacon): number =>
     right.beaconInfo.timestamp - left.beaconInfo.timestamp;
+
+// a beacon's starting timestamp can be in the future
+// (either from small deviations in system clock times, or on purpose from another client)
+// a beacon is only live between its start timestamp and expiry
+// detect when a beacon is waiting to become live
+export const isBeaconWaitingToStart = (beacon: Beacon): boolean =>
+    !beacon.isLive && beacon.beaconInfo.timestamp > Date.now() && getBeaconExpiryTimestamp(beacon) > Date.now();

--- a/test/components/views/messages/MBeaconBody-test.tsx
+++ b/test/components/views/messages/MBeaconBody-test.tsx
@@ -111,6 +111,18 @@ describe('<MBeaconBody />', () => {
         expect(component.text()).toEqual("Live location ended");
     });
 
+    it('renders loading beacon UI for a beacon that has not started yet', () => {
+        const beaconInfoEvent = makeBeaconInfoEvent(aliceId,
+            roomId,
+            // puts this beacons start timestamp in the future
+            { isLive: true, timestamp: now + 60000, timeout: 500 },
+            '$alice-room1-1',
+        );
+        makeRoomWithStateEvents([beaconInfoEvent], { roomId, mockClient });
+        const component = getComponent({ mxEvent: beaconInfoEvent });
+        expect(component.text()).toEqual("Loading live location...");
+    });
+
     it('does not open maximised map when on click when beacon is stopped', () => {
         const beaconInfoEvent = makeBeaconInfoEvent(aliceId,
             roomId,


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Fixes: https://github.com/vector-im/element-web/issues/22437

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location share - show loading UI for beacons with start timestamp in the future

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
