### PR TITLE
Normalize the name of buttons on MessageActionBar

### DIFF
--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -142,11 +142,11 @@ limitations under the License.
     mask-image: url('$(res)/img/element-icons/collapse-message.svg');
 }
 
-.mx_MessageActionBar_viewInRoom::after {
+.mx_MessageActionBar_viewInRoomButton::after {
     mask-image: url('$(res)/img/element-icons/view-in-room.svg');
 }
 
-.mx_MessageActionBar_copyLinkToThread::after {
+.mx_MessageActionBar_copyLinkButton::after {
     mask-image: url('$(res)/img/element-icons/link.svg');
 }
 

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1372,13 +1372,13 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
                         </div>
                         <Toolbar className="mx_MessageActionBar" aria-label={_t("Message Actions")} aria-live="off">
                             <RovingAccessibleTooltipButton
-                                className="mx_MessageActionBar_maskButton mx_MessageActionBar_viewInRoom"
+                                className="mx_MessageActionBar_maskButton mx_MessageActionBar_viewInRoomButton"
                                 onClick={this.viewInRoom}
                                 title={_t("View in room")}
                                 key="view_in_room"
                             />
                             <RovingAccessibleTooltipButton
-                                className="mx_MessageActionBar_maskButton mx_MessageActionBar_copyLinkToThread"
+                                className="mx_MessageActionBar_maskButton mx_MessageActionBar_copyLinkButton"
                                 onClick={this.copyLinkToThread}
                                 title={_t("Copy link to thread")}
                                 key="copy_link_to_thread"


### PR DESCRIPTION
- `..._viewInRoom` -> `..._viewInRoomButton` (add `Button` as the suffix)
- `..._copyLinkToThread` -> `..._copyLinkButton` (remove `ToThread` for another place and add `Button` as the suffix)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none


...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->
