### PR TITLE
Fixes right panel composer look and feel

### DIFF
--- a/res/css/views/right_panel/_ThreadPanel.scss
+++ b/res/css/views/right_panel/_ThreadPanel.scss
@@ -197,9 +197,18 @@ limitations under the License.
     .mx_MessageComposer {
         background-color: $background;
         border-radius: 8px;
-        margin-top: 8px;
-        padding: 0 8px;
+        margin-top: $spacing-8;
+        padding: $spacing-8;
         box-sizing: border-box;
+
+        .mx_ReplyPreview {
+            padding-top: 0;
+            padding-left: $spacing-8;
+            padding-right: $spacing-8;
+            margin-left: calc(-1 * $spacing-8);
+            margin-right: calc(-1 * $spacing-8);
+            border-color: transparent;
+        }
     }
 
     .mx_MessageTimestamp {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22459
 
<table>
<tr>
	<td> 🤮 Before
	<td> 💅 After
<tr>
	<td> <img width="478" alt="Screen Shot 2022-06-08 at 09 39 54" src="https://user-images.githubusercontent.com/769871/172572201-e871fb27-e7e8-4f09-b02f-b720ecb96db0.png">
	<td> <img width="354" alt="Screen Shot 2022-06-08 at 09 35 54" src="https://user-images.githubusercontent.com/769871/172572137-a9e1a99a-ff98-488f-90f4-3a2fad9a571f.png">
</table>

I removed the top outline on the reply preview container as the composer is already in a box when used in that container and the border radius used there does not match the border radius of the outer container.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fixes right panel composer look and feel ([\#8783](https://github.com/matrix-org/matrix-react-sdk/pull/8783)). Fixes vector-im/element-web#22459.<!-- CHANGELOG_PREVIEW_END -->