### PR TITLE
Fix the incorrect nesting of download button on MessageActionBar

### DIFF
--- a/res/css/views/messages/_MessageActionBar.scss
+++ b/res/css/views/messages/_MessageActionBar.scss
@@ -132,10 +132,10 @@ limitations under the License.
         &::after {
             mask-size: 14px;
             mask-image: url('$(res)/img/download.svg');
+        }
 
-            &.mx_MessageActionBar_downloadSpinnerButton::after {
-                background-color: transparent; // hide the download icon mask
-            }
+        &.mx_MessageActionBar_downloadSpinnerButton::after {
+            background-color: transparent; // hide the download icon mask
         }
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/8780/files#r892133986 (#8780)

The regression was introduced with https://github.com/matrix-org/matrix-react-sdk/pull/8780/commits/de9fc39015fddc3809939c24918dd29755fa5576

This PR fixes `.mx_MessageActionBar_downloadButton::after.mx_MessageActionBar_downloadSpinnerButton::after` into `.mx_MessageActionBar_downloadButton.mx_MessageActionBar_downloadSpinnerButton::after` by removing `::after` from `mx_MessageActionBar_downloadButton`.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the incorrect nesting of download button on MessageActionBar ([\#8785](https://github.com/matrix-org/matrix-react-sdk/pull/8785)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->