### PR TITLE
Use span and style instead of font (W3C compliance)

### DIFF
--- a/src/utils/colour.ts
+++ b/src/utils/colour.ts
@@ -27,7 +27,7 @@ export function textToHtmlRainbow(str: string): string {
             const [a, b] = generateAB(i * frequency, 1);
             const [red, green, blue] = labToRGB(75, a, b);
             return (
-                '<span style="color:#' +
+                '<span data-mx-color="#' +
                 red.toString(16).padStart(2, "0") +
                 green.toString(16).padStart(2, "0") +
                 blue.toString(16).padStart(2, "0") +

--- a/src/utils/colour.ts
+++ b/src/utils/colour.ts
@@ -27,13 +27,13 @@ export function textToHtmlRainbow(str: string): string {
             const [a, b] = generateAB(i * frequency, 1);
             const [red, green, blue] = labToRGB(75, a, b);
             return (
-                '<font color="#' +
+                '<span style="color:#' +
                 red.toString(16).padStart(2, "0") +
                 green.toString(16).padStart(2, "0") +
                 blue.toString(16).padStart(2, "0") +
                 '">' +
                 c +
-                "</font>"
+                "</span>"
             );
         })
         .join("");

--- a/test/utils/colour-test.ts
+++ b/test/utils/colour-test.ts
@@ -18,7 +18,7 @@ import { textToHtmlRainbow } from "../../src/utils/colour";
 
 describe("textToHtmlRainbow", () => {
     it('correctly transform text to html without splitting the emoji in two', () => {
-        expect(textToHtmlRainbow('🐻')).toBe('<font color="#ff00be">🐻</font>');
-        expect(textToHtmlRainbow('🐕‍🦺')).toBe('<font color="#ff00be">🐕‍🦺</font>');
+        expect(textToHtmlRainbow('🐻')).toBe('<span style="color:#ff00be">🐻</span>');
+        expect(textToHtmlRainbow('🐕‍🦺')).toBe('<span style="color:#ff00be">🐕‍🦺</span>');
     });
 });

--- a/test/utils/colour-test.ts
+++ b/test/utils/colour-test.ts
@@ -18,7 +18,7 @@ import { textToHtmlRainbow } from "../../src/utils/colour";
 
 describe("textToHtmlRainbow", () => {
     it('correctly transform text to html without splitting the emoji in two', () => {
-        expect(textToHtmlRainbow('🐻')).toBe('<span style="color:#ff00be">🐻</span>');
-        expect(textToHtmlRainbow('🐕‍🦺')).toBe('<span style="color:#ff00be">🐕‍🦺</span>');
+        expect(textToHtmlRainbow('🐻')).toBe('<span data-mx-color="#ff00be">🐻</span>');
+        expect(textToHtmlRainbow('🐕‍🦺')).toBe('<span data-mx-color="#ff00be">🐕‍🦺</span>');
     });
 });


### PR DESCRIPTION
Currently, the rainbow command output a series of `<font>` elements. This HTML element has been depreciated in HTML4.01, and is obsolete in HTML5. This PR changes this to `<span style="color:the-colour">` instead.

I don't know if it's an enhancement (it's very small) or a fix (the current code still _works_, it's just W3C-invalid). Could someone help me on that? Thanks.

Signed-off-by: Lara Dufour <lara.dufour+github@ik.me>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->