### PR TITLE
Fix long username overflow from reply preview on timeline of main panel and right panel

### DIFF
--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -63,6 +63,22 @@ limitations under the License.
     .mx_VoiceMessagePrimaryContainer {
         margin-right: $spacing-8;
     }
+
+    .mx_ReplyPreview_header {
+        overflow: hidden;
+
+        .mx_ReplyPreview_header_replyTo {
+            // 16px: cancel button
+            max-width: calc(100% - var(--ReplyPreview_padding-inline) - 16px - var(--ReplyPreview_gap-inline));
+
+            // "Reply to <User />"
+            > span {
+                display: flex;
+                white-space: nowrap;
+                column-gap: $spacing-4;
+            }
+        }
+    }
 }
 
 .mx_MessageComposer_autocomplete_wrapper {

--- a/res/css/views/rooms/_ReplyPreview.scss
+++ b/res/css/views/rooms/_ReplyPreview.scss
@@ -15,6 +15,9 @@ limitations under the License.
 */
 
 .mx_ReplyPreview {
+    --ReplyPreview_padding-inline: $spacing-16;
+    --ReplyPreview_gap-inline: $spacing-8;
+
     border: 1px solid $system;
 
     margin-left: calc(-1 * $spacing-16);
@@ -39,7 +42,7 @@ limitations under the License.
     > svg {
         width: 1em;
         vertical-align: middle;
-        margin-right: $spacing-8;
+        margin-right: var(--ReplyPreview_gap-inline);
     }
 
     .mx_CancelButton {

--- a/src/components/views/rooms/ReplyPreview.tsx
+++ b/src/components/views/rooms/ReplyPreview.tsx
@@ -48,10 +48,11 @@ export default class ReplyPreview extends React.Component<IProps> {
         return <div className="mx_ReplyPreview">
             <div className="mx_ReplyPreview_header">
                 <ReplyIcon />
-                { _t('Reply to <User />', {}, {
-                    'User': () => <SenderProfile mxEvent={this.props.replyToEvent} as="span" />,
-                }) } &nbsp;
-
+                <span className="mx_ReplyPreview_header_replyTo">
+                    { _t('Reply to <User />', {}, {
+                        'User': () => <SenderProfile mxEvent={this.props.replyToEvent} as="span" />,
+                    }) }
+                </span>
                 <CancelButton onClick={() => cancelQuoting(this.context.timelineRenderingType)} />
             </div>
             <ReplyTile


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22495

This PR sets the max-width so that the displayName would not overflow from the reply preview on timeline of the main panel and the right panel.

Before:
![before](https://user-images.githubusercontent.com/3362943/172781886-6926b49f-afc3-46fd-9227-b9f1846a0d83.png)

After:
![after](https://user-images.githubusercontent.com/3362943/172781835-acc40051-1425-454e-9744-c16818380081.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix long username overflow from reply preview on timeline of main panel and right panel ([\#8800](https://github.com/matrix-org/matrix-react-sdk/pull/8800)). Fixes vector-im/element-web#22495. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->