### PR TITLE
Allow AppTiles to shrink as much as necessary

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.scss
+++ b/res/css/views/rooms/_AppsDrawer.scss
@@ -16,6 +16,8 @@ limitations under the License.
 */
 
 $MiniAppTileHeight: 200px;
+// TODO this should be 300px but that's too large
+$MinWidth: 240px;
 
 .mx_AppsDrawer {
     margin: $container-gap-width;
@@ -88,6 +90,30 @@ $MiniAppTileHeight: 200px;
             opacity: 0.8;
         }
     }
+
+    .mx_AppTile {
+        width: 50%;
+        min-width: $MinWidth;
+    }
+
+    &.mx_AppsDrawer_2apps .mx_AppTile {
+        width: 50%;
+
+        &:nth-child(3) {
+            flex-grow: 1;
+            width: 0 !important;
+            min-width: $MinWidth !important;
+        }
+    }
+    &.mx_AppsDrawer_3apps .mx_AppTile {
+        width: 33%;
+
+        &:nth-child(3) {
+            flex-grow: 1;
+            width: 0 !important;
+            min-width: $MinWidth !important;
+        }
+    }
 }
 
 .mx_AppsContainer_resizer {
@@ -122,31 +148,7 @@ $MiniAppTileHeight: 200px;
     }
 }
 
-// TODO this should be 300px but that's too large
-$MinWidth: 240px;
-
-.mx_AppsDrawer_2apps .mx_AppTile {
-    width: 50%;
-
-    &:nth-child(3) {
-        flex-grow: 1;
-        width: 0 !important;
-        min-width: $MinWidth !important;
-    }
-}
-.mx_AppsDrawer_3apps .mx_AppTile {
-    width: 33%;
-
-    &:nth-child(3) {
-        flex-grow: 1;
-        width: 0 !important;
-        min-width: $MinWidth !important;
-    }
-}
-
 .mx_AppTile {
-    width: 50%;
-    min-width: $MinWidth;
     border: $container-border-width solid $widget-menu-bar-bg-color;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
I've done a cursory test to make sure that this isn't impacting the layout of AppTiles other than video rooms.

A better solution would perhaps be to automatically close the right panel at a certain breakpoint, however the user could still open the right panel again in that case, so I don't think that would fully resolve https://github.com/vector-im/element-web/issues/22499. This is intended as more of a hotfix anyways to be able to get video rooms out the door.

Before|After
-|-
![Screenshot 2022-06-09 at 09-50-50 Element 3 Robin's video room 2](https://user-images.githubusercontent.com/48614497/172863746-ab1347f5-544d-4eb3-b28b-e9ded628cf9c.png)|![Screenshot 2022-06-09 at 09-50-38 Element 3 Robin's video room 2](https://user-images.githubusercontent.com/48614497/172863745-d4332245-467d-4da1-b940-903054f89f5b.png)

Closes https://github.com/vector-im/element-web/issues/22499

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Allow AppTiles to shrink as much as necessary ([\#8805](https://github.com/matrix-org/matrix-react-sdk/pull/8805)). Fixes vector-im/element-web#22499.<!-- CHANGELOG_PREVIEW_END -->