### PR TITLE
Fix flex blowout on image reply

### DIFF
--- a/res/css/views/messages/_MImageReplyBody.scss
+++ b/res/css/views/messages/_MImageReplyBody.scss
@@ -17,14 +17,17 @@ limitations under the License.
 .mx_MImageReplyBody {
     display: flex;
 
-    .mx_MImageBody_thumbnail_container {
+    .mx_MImageBody_thumbnail_container,
+    .mx_MImageReplyBody_info {
         flex: 1;
+        min-width: 0; // Prevent a blowout
+    }
+
+    .mx_MImageBody_thumbnail_container {
         margin-right: 4px;
     }
 
     .mx_MImageReplyBody_info {
-        flex: 1;
-
         .mx_MImageReplyBody_sender {
             grid-area: sender;
         }

--- a/res/css/views/messages/_MImageReplyBody.scss
+++ b/res/css/views/messages/_MImageReplyBody.scss
@@ -27,6 +27,10 @@ limitations under the License.
     .mx_MImageReplyBody_info {
         .mx_MImageReplyBody_sender {
             grid-area: sender;
+
+            .mx_DisambiguatedProfile {
+                max-width: 100%;
+            }
         }
 
         .mx_MImageReplyBody_filename {

--- a/res/css/views/messages/_MImageReplyBody.scss
+++ b/res/css/views/messages/_MImageReplyBody.scss
@@ -16,15 +16,12 @@ limitations under the License.
 
 .mx_MImageReplyBody {
     display: flex;
+    column-gap: $spacing-4;
 
     .mx_MImageBody_thumbnail_container,
     .mx_MImageReplyBody_info {
         flex: 1;
         min-width: 0; // Prevent a blowout
-    }
-
-    .mx_MImageBody_thumbnail_container {
-        margin-right: 4px;
     }
 
     .mx_MImageReplyBody_info {


### PR DESCRIPTION
|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/173003930-7995d271-478e-4b5f-b85e-3ba93e9e7e48.png)|![after1](https://user-images.githubusercontent.com/3362943/173003908-6f59ba33-ae38-42f3-8a4d-01c7f1e9994d.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
