### PR TITLE
Keep draft in composer when a slash command syntax errors

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -332,13 +332,14 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
                 const [cmd, args, commandText] = getSlashCommand(this.model);
                 if (cmd) {
                     const threadId = editedEvent?.getThread()?.id || null;
+                    const [content, commandSuccessful] = await runSlashCommand(cmd, args, roomId, threadId);
+                    if (!commandSuccessful) {
+                        return; // errored
+                    }
+
                     if (cmd.category === CommandCategories.messages) {
-                        editContent["m.new_content"] = await runSlashCommand(cmd, args, roomId, threadId);
-                        if (!editContent["m.new_content"]) {
-                            return; // errored
-                        }
+                        editContent["m.new_content"] = content;
                     } else {
-                        runSlashCommand(cmd, args, roomId, threadId);
                         shouldSend = false;
                     }
                 } else if (!await shouldSendAnyway(commandText)) {

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -351,12 +351,13 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                     ? this.props.relation?.event_id
                     : null;
 
-                if (cmd.category === CommandCategories.messages) {
-                    content = await runSlashCommand(cmd, args, this.props.room.roomId, threadId);
-                    if (!content) {
-                        return; // errored
-                    }
+                let commandSuccessful: boolean;
+                [content, commandSuccessful] = await runSlashCommand(cmd, args, this.props.room.roomId, threadId);
+                if (!commandSuccessful) {
+                    return; // errored
+                }
 
+                if (cmd.category === CommandCategories.messages) {
                     attachRelation(content, this.props.relation);
                     if (replyToEvent) {
                         addReplyToMessageContent(content, replyToEvent, {
@@ -365,7 +366,6 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                         });
                     }
                 } else {
-                    runSlashCommand(cmd, args, this.props.room.roomId, threadId);
                     shouldSend = false;
                 }
             } else if (!await shouldSendAnyway(commandText)) {

--- a/src/editor/commands.tsx
+++ b/src/editor/commands.tsx
@@ -59,7 +59,7 @@ export async function runSlashCommand(
     args: string,
     roomId: string,
     threadId: string | null,
-): Promise<IContent | null> {
+): Promise<[content: IContent | null, success: boolean]> {
     const result = cmd.run(roomId, threadId, args);
     let messageContent: IContent | null = null;
     let error = result.error;
@@ -96,9 +96,10 @@ export async function runSlashCommand(
             title: _t(title),
             description: errText,
         });
+        return [null, false];
     } else {
         logger.log("Command success.");
-        if (messageContent) return messageContent;
+        return [messageContent, true];
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22384

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Keep draft in composer when a slash command syntax errors ([\#8811](https://github.com/matrix-org/matrix-react-sdk/pull/8811)). Fixes vector-im/element-web#22384.<!-- CHANGELOG_PREVIEW_END -->