### PR TITLE
Remove Riot-era media query declarations of event tile on mobile UI

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1046,7 +1046,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 }
 
 // Media query for mobile UI
-// See: https://github.com/matrix-org/matrix-react-sdk/pull/4656
 @media only screen and (max-width: 480px) {
     .mx_EventTile_content {
         margin-right: 0;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -273,21 +273,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         margin: 0;
         padding: 4px 64px;
     }
-
-    // Media query to improve UI on mobile
-    // See: https://github.com/matrix-org/matrix-react-sdk/pull/4656
-    @media only screen and (max-width: 480px) {
-        .mx_EventTile_line,
-        .mx_EventTile_reply {
-            padding-left: 0;
-            margin-right: 0;
-        }
-
-        .mx_EventTile_content {
-            margin-top: 10px;
-            margin-right: 0;
-        }
-    }
 }
 
 .mx_GenericEventListSummary:not([data-layout=bubble]) {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -273,6 +273,21 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         margin: 0;
         padding: 4px 64px;
     }
+
+    // Media query to improve UI on mobile
+    // See: https://github.com/matrix-org/matrix-react-sdk/pull/4656
+    @media only screen and (max-width: 480px) {
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
+            padding-left: 0;
+            margin-right: 0;
+        }
+
+        .mx_EventTile_content {
+            margin-top: 10px;
+            margin-right: 0;
+        }
+    }
 }
 
 .mx_GenericEventListSummary:not([data-layout=bubble]) {
@@ -678,20 +693,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile:not(:hover):not(.mx_EventTile_actionBarFocused):not([data-whatinput='keyboard'] :focus-within):not(.focus-visible:focus-within) {
     .mx_MessageActionBar .mx_Indicator {
         animation: none;
-    }
-}
-
-@media only screen and (max-width: 480px) {
-
-    .mx_EventTile_line,
-    .mx_EventTile_reply {
-        padding-left: 0;
-        margin-right: 0;
-    }
-
-    .mx_EventTile_content {
-        margin-top: 10px;
-        margin-right: 0;
     }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1044,3 +1044,11 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 }
+
+// Media query for mobile UI
+// See: https://github.com/matrix-org/matrix-react-sdk/pull/4656
+@media only screen and (max-width: 480px) {
+    .mx_EventTile_content {
+        margin-right: 0;
+    }
+}


### PR DESCRIPTION
This PR removes the margin declarations in order to remove the obsolete start block margin from event tiles on a narrow (0 - 480px) viewport.

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/173182459-869aa45a-0d84-4124-9978-c86d519b8b3e.png)|![after](https://user-images.githubusercontent.com/3362943/173184899-2224a944-b3f1-4e55-978b-d1d3fae85295.png)|

### Riot-era

[This PR](
https://github.com/matrix-org/matrix-react-sdk/pull/4656) at Riot-era added media query for mobile UI, which should display the timeline [this way (picture)](https://github.com/matrix-org/matrix-react-sdk/pull/4656#discussion_r434156348), removing inline margin and adding 10px start block margin.

The style declarations have been obsolete from some point, and currently they apply redundant margin as below to both bubble layout and non-bubble layouts.

![before](https://user-images.githubusercontent.com/3362943/173182458-4527eef2-4099-400e-b742-e0c45d5e772f.png)
![before1](https://user-images.githubusercontent.com/3362943/173182459-869aa45a-0d84-4124-9978-c86d519b8b3e.png)

If those style declarations were used for the current event tile, it would be displayed as below. This might look better with some tweaks, but it would break the current layout anyway.

![before2](https://user-images.githubusercontent.com/3362943/173182461-e090ffff-36a2-4b05-9afe-03e80ba2d03f.png)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

Notes: Remove top margin from event tile on a narrow viewport

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove top margin from event tile on a narrow viewport ([\#8814](https://github.com/matrix-org/matrix-react-sdk/pull/8814)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->