### PR TITLE
Fix grid blowout on pinned event tiles

### DIFF
--- a/res/css/views/rooms/_PinnedEventTile.scss
+++ b/res/css/views/rooms/_PinnedEventTile.scss
@@ -34,6 +34,14 @@ limitations under the License.
         border-top: 1px solid $menu-border-color;
     }
 
+    .mx_PinnedEventTile_senderAvatar,
+    .mx_PinnedEventTile_sender,
+    .mx_PinnedEventTile_unpinButton,
+    .mx_PinnedEventTile_message,
+    .mx_PinnedEventTile_footer {
+        min-width: 0; // Prevent a grid blowout
+    }
+
     .mx_PinnedEventTile_senderAvatar {
         grid-area: avatar;
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22543

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/173197098-4ad631e0-f882-4354-90a5-f0cb081b2c55.png)|![after](https://user-images.githubusercontent.com/3362943/173197096-c481164c-8de4-4bf9-8e9d-873516e0cc22.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix grid blowout on pinned event tiles ([\#8816](https://github.com/matrix-org/matrix-react-sdk/pull/8816)). Fixes vector-im/element-web#22543. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->