### PR TITLE
Fix clickable area of advanced toggle on appearance user settings tab

### DIFF
--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -32,11 +32,6 @@ limitations under the License.
         margin-bottom: 16px;
     }
 
-    .mx_AppearanceUserSettingsTab_AdvancedToggle {
-        color: $accent;
-        cursor: pointer;
-    }
-
     .mx_AppearanceUserSettingsTab_systemFont {
         margin-left: calc($font-16px + 10px);
     }

--- a/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
@@ -23,6 +23,7 @@ import { MatrixClientPeg } from '../../../../../MatrixClientPeg';
 import SettingsStore from "../../../../../settings/SettingsStore";
 import SettingsFlag from '../../../elements/SettingsFlag';
 import Field from '../../../elements/Field';
+import AccessibleButton from "../../../elements/AccessibleButton";
 import { SettingLevel } from "../../../../../settings/SettingLevel";
 import { UIFeature } from "../../../../../settings/UIFeature";
 import { Layout } from "../../../../../settings/enums/Layout";
@@ -90,12 +91,12 @@ export default class AppearanceUserSettingsTab extends React.Component<IProps, I
         if (!SettingsStore.getValue(UIFeature.AdvancedSettings)) return null;
 
         const brand = SdkConfig.get().brand;
-        const toggle = <div
-            className="mx_AppearanceUserSettingsTab_AdvancedToggle"
+        const toggle = <AccessibleButton
+            kind="link"
             onClick={() => this.setState({ showAdvanced: !this.state.showAdvanced })}
         >
             { this.state.showAdvanced ? _t("Hide advanced") : _t("Show advanced") }
-        </div>;
+        </AccessibleButton>;
 
         let advanced: React.ReactNode;
 


### PR DESCRIPTION
Fix https://github.com/vector-im/element-web/issues/22546

|  |Before|After|
|--|--------|-------|
|`Show advanced`|![before](https://user-images.githubusercontent.com/3362943/173225447-3a15b3c8-2961-48bf-81d6-204f5a8dc1f3.png)|![after](https://user-images.githubusercontent.com/3362943/173225444-0cc5c118-b1f3-4b5d-b9be-fa73cac08471.png)|
|`Hide advanced`|![before1](https://user-images.githubusercontent.com/3362943/173225448-1a9706ba-205d-452d-a83c-f4b66ea2fceb.png)|![after1](https://user-images.githubusercontent.com/3362943/173225446-5b8d54ed-a0c5-42aa-b05b-b7dd68629b31.png)|

The blue areas are clickable.

This PR also fixes the issue that the toggle cannot be selected with <kbd>Tab</kbd> key. The color setting has hidden the fact that the toggle is not AccessibleButton.


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

Type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix clickable area of advanced toggle on appearance user settings tab ([\#8820](https://github.com/matrix-org/matrix-react-sdk/pull/8820)). Fixes vector-im/element-web#22546. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->