### PR TITLE
Use mx_SettingsTab_subsectionText for the text under the top header of appearance user settings tab

### DIFF
--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -20,8 +20,7 @@ limitations under the License.
 
 .mx_AppearanceUserSettingsTab {
     .mx_SettingsTab_subsectionText {
-        margin-bottom: 32px;
-        margin-top: 12px;
+        margin-block: $spacing-12 $spacing-32;
         color: $primary-content; // Same as mx_SettingsTab
     }
 }

--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -19,7 +19,7 @@ limitations under the License.
 }
 
 .mx_AppearanceUserSettingsTab {
-    > .mx_SettingsTab_SubHeading {
+    .mx_SettingsTab_subsectionText {
         margin-bottom: 32px;
         margin-top: 12px;
     }

--- a/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_AppearanceUserSettingsTab.scss
@@ -22,6 +22,7 @@ limitations under the License.
     .mx_SettingsTab_subsectionText {
         margin-bottom: 32px;
         margin-top: 12px;
+        color: $primary-content; // Same as mx_SettingsTab
     }
 }
 

--- a/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
@@ -143,7 +143,7 @@ export default class AppearanceUserSettingsTab extends React.Component<IProps, I
         return (
             <div className="mx_SettingsTab mx_AppearanceUserSettingsTab">
                 <div className="mx_SettingsTab_heading">{ _t("Customise your appearance") }</div>
-                <div className="mx_SettingsTab_SubHeading">
+                <div className="mx_SettingsTab_subheading mx_SettingsTab_SubHeading">
                     { _t("Appearance Settings only affect this %(brand)s session.", { brand }) }
                 </div>
                 <ThemeChoicePanel />

--- a/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
@@ -143,7 +143,7 @@ export default class AppearanceUserSettingsTab extends React.Component<IProps, I
         return (
             <div className="mx_SettingsTab mx_AppearanceUserSettingsTab">
                 <div className="mx_SettingsTab_heading">{ _t("Customise your appearance") }</div>
-                <div className="mx_SettingsTab_subheading mx_SettingsTab_SubHeading">
+                <div className="mx_SettingsTab_subsectionText">
                     { _t("Appearance Settings only affect this %(brand)s session.", { brand }) }
                 </div>
                 <ThemeChoicePanel />


### PR DESCRIPTION
|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/173232286-971e5d93-52c5-46d1-8469-af0b0ee53e55.png)|![after](https://user-images.githubusercontent.com/3362943/173232275-cbc76687-c048-477d-9e49-e02f9ec23e29.png)|
|![before1](https://user-images.githubusercontent.com/3362943/173232288-d4d4c8da-6b85-4739-8793-16b96d397778.png)|![after1](https://user-images.githubusercontent.com/3362943/173232283-05a83e6d-560f-406f-9618-765b9caf6f9f.png)|

- `mx_SettingsTab_subheading` is more widely used instead of `mx_SettingsTab_SubHeading` (case sensitive).
- Also it rather should be `mx_SettingsTab_subsectionText`, following cases on other tabs such as labs.
- The current text color is used instead of the default one.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->