### PR TITLE
Use common subheading on sidebar user settings tab

### DIFF
--- a/res/css/views/settings/tabs/user/_SidebarUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SidebarUserSettingsTab.scss
@@ -15,10 +15,6 @@ limitations under the License.
 */
 
 .mx_SidebarUserSettingsTab {
-    .mx_SettingsTab_section {
-        margin-top: 12px;
-    }
-
     .mx_Checkbox {
         margin-top: 12px;
         font-size: $font-15px;

--- a/res/css/views/settings/tabs/user/_SidebarUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_SidebarUserSettingsTab.scss
@@ -19,13 +19,6 @@ limitations under the License.
         margin-top: 12px;
     }
 
-    .mx_SidebarUserSettingsTab_subheading {
-        font-size: $font-15px;
-        line-height: $font-24px;
-        color: $primary-content;
-        margin-bottom: 4px;
-    }
-
     .mx_Checkbox {
         margin-top: 12px;
         font-size: $font-15px;

--- a/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
@@ -55,9 +55,8 @@ const SidebarUserSettingsTab = () => {
     return (
         <div className="mx_SettingsTab mx_SidebarUserSettingsTab">
             <div className="mx_SettingsTab_heading">{ _t("Sidebar") }</div>
-
             <div className="mx_SettingsTab_section">
-                <div className="mx_SidebarUserSettingsTab_subheading">{ _t("Spaces to show") }</div>
+                <div className="mx_SettingsTab_subheading">{ _t("Spaces to show") }</div>
                 <div className="mx_SettingsTab_subsectionText">
                     { _t("Spaces are ways to group rooms and people. " +
                         "Alongside the spaces you're in, you can use some pre-built ones too.") }


### PR DESCRIPTION
This PR replaces the special sub heading `mx_SidebarUserSettingsTab_subheading` with the common one `mx_SettingsTab_subheading`.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/173233382-567828e2-2922-4cb3-995e-b85d7a08fb51.png)|![after](https://user-images.githubusercontent.com/3362943/173233372-51386dbe-bbfe-4160-9d88-e6994412f924.png)|
|![before1](https://user-images.githubusercontent.com/3362943/173233384-32f49326-a6ee-40d4-8537-4cccc06bbe63.png)|![after1](https://user-images.githubusercontent.com/3362943/173233380-000a5b08-bcd7-4ed2-910a-ede178647f4d.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use common subheading on sidebar user settings tab ([\#8823](https://github.com/matrix-org/matrix-react-sdk/pull/8823)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->