### PR TITLE
Fix keyboard shortcuts on settings tab being wrapped

### DIFF
--- a/res/css/views/settings/_KeyboardShortcut.scss
+++ b/res/css/views/settings/_KeyboardShortcut.scss
@@ -20,16 +20,11 @@ limitations under the License.
         padding: 5px;
         border-radius: 4px;
         background-color: $header-panel-bg-color;
-        margin-right: 5px;
         min-width: 20px;
         text-align: center;
         display: inline-block;
         border: 1px solid $kbd-border-color;
         box-shadow: 0 2px $kbd-border-color;
         text-transform: capitalize;
-
-        & + kbd {
-            margin-left: 5px;
-        }
     }
 }

--- a/res/css/views/settings/_KeyboardShortcut.scss
+++ b/res/css/views/settings/_KeyboardShortcut.scss
@@ -26,7 +26,6 @@ limitations under the License.
         display: inline-block;
         border: 1px solid $kbd-border-color;
         box-shadow: 0 2px $kbd-border-color;
-        margin-bottom: 4px;
         text-transform: capitalize;
 
         & + kbd {

--- a/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
@@ -16,9 +16,18 @@ limitations under the License.
 */
 
 .mx_KeyboardUserSettingsTab .mx_SettingsTab_section {
-    .mx_KeyboardShortcut_shortcutRow {
+    .mx_KeyboardShortcut_shortcutRow,
+    .mx_KeyboardShortcut {
         display: flex;
         justify-content: space-between;
         align-items: center;
+    }
+
+    .mx_KeyboardShortcut_shortcutRow {
+        column-gap: $spacing-8;
+
+        .mx_KeyboardShortcut {
+            flex-wrap: nowrap;
+        }
     }
 }

--- a/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
@@ -34,6 +34,7 @@ limitations under the License.
 
         .mx_KeyboardShortcut {
             flex-wrap: nowrap;
+            column-gap: 5px; // TODO: Use a spacing variable
         }
     }
 }

--- a/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_KeyboardUserSettingsTab.scss
@@ -25,6 +25,12 @@ limitations under the License.
 
     .mx_KeyboardShortcut_shortcutRow {
         column-gap: $spacing-8;
+        margin-bottom: $spacing-4;
+
+        // TODO: Use flexbox
+        &:last-of-type {
+            margin-bottom: 0;
+        }
 
         .mx_KeyboardShortcut {
             flex-wrap: nowrap;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22547

This PR fixes keyboard shortcuts wrapped on the keyboard user settings tab, moving the margin settings from keys themselves to keys inside shortcuts.

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/173240462-baa68dd2-61fa-4789-bb75-fbb3900d2f61.png)|![after1](https://user-images.githubusercontent.com/3362943/173240454-37442d16-dd1e-4bb1-b43d-c4396edb2378.png)|
|![before2](https://user-images.githubusercontent.com/3362943/173240465-8b67e04f-8a23-43d7-9757-4bb838e03aaf.png)|![after2](https://user-images.githubusercontent.com/3362943/173240457-3c5cdaab-9cad-44aa-921a-6b8da9c36511.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix keyboard shortcuts on settings tab being wrapped ([\#8825](https://github.com/matrix-org/matrix-react-sdk/pull/8825)). Fixes vector-im/element-web#22547. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->