### PR TITLE
Remove unique settings from labs user settings tab

### DIFF
--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 .mx_SettingsTab {
+    --SettingsTab_section-margin-bottom-preferences-labs: 30px;
     color: $primary-content;
 }
 

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -21,9 +21,7 @@ limitations under the License.
 
     .mx_SettingsTab_section .mx_SettingsFlag {
         margin-right: 0; // remove right margin to align with beta cards
-        display: flex;
         align-items: center;
-        justify-content: space-between;
 
         .mx_ToggleSwitch {
             float: unset;

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -22,9 +22,5 @@ limitations under the License.
     .mx_SettingsTab_section .mx_SettingsFlag {
         margin-right: 0; // remove right margin to align with beta cards
         align-items: center;
-
-        .mx_ToggleSwitch {
-            float: unset;
-        }
     }
 }

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .mx_LabsUserSettingsTab {
-    .mx_SettingsTab_section .mx_SettingsFlag {
+    .mx_SettingsFlag {
         margin-right: 0; // remove right margin to align with beta cards
         align-items: center;
     }

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -15,10 +15,6 @@ limitations under the License.
 */
 
 .mx_LabsUserSettingsTab {
-    .mx_SettingsTab_subsectionText, .mx_SettingsTab_section {
-        margin-bottom: 30px;
-    }
-
     .mx_SettingsTab_section .mx_SettingsFlag {
         margin-right: 0; // remove right margin to align with beta cards
         align-items: center;

--- a/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_LabsUserSettingsTab.scss
@@ -15,6 +15,11 @@ limitations under the License.
 */
 
 .mx_LabsUserSettingsTab {
+    .mx_SettingsTab_subsectionText,
+    .mx_SettingsTab_section {
+        margin-bottom: var(--SettingsTab_section-margin-bottom-preferences-labs);
+    }
+
     .mx_SettingsFlag {
         margin-right: 0; // remove right margin to align with beta cards
         align-items: center;

--- a/res/css/views/settings/tabs/user/_PreferencesUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_PreferencesUserSettingsTab.scss
@@ -20,7 +20,7 @@ limitations under the License.
     }
 
     .mx_SettingsTab_section {
-        margin-bottom: 30px;
+        margin-bottom: var(--SettingsTab_section-margin-bottom-preferences-labs);
 
         > details {
             > summary {


### PR DESCRIPTION
This PR removes the unique settings from `_LabsUserSettingsTab.scss` in order to make the spacing same as the other tabs, other than the setting which specifies the toggle switch position.

|Before|After|
|--------|-------|
|![before](https://user-images.githubusercontent.com/3362943/173283894-5b15285c-dc39-4978-8cd9-72f0aa6fcc27.png)|![after](https://user-images.githubusercontent.com/3362943/173283877-d2b5ed5c-40d7-4f82-a79d-aaa843bb6189.png)|

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->