### PR TITLE
Prevent new composer from overflowing from non-breakable text

### DIFF
--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -37,6 +37,8 @@ limitations under the License.
     }
 
     .mx_MessageComposer_row {
+        /* This forces the composer to wrap its content, even if it has no word boundaries. Fixes #22507 */
+        overflow: hidden;
         grid-area: composer;
     }
 

--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -37,7 +37,6 @@ limitations under the License.
     }
 
     .mx_MessageComposer_row {
-        /* This forces the composer to wrap its content, even if it has no word boundaries. Fixes #22507 */
         overflow-x: clip;
         grid-area: composer;
     }

--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -38,7 +38,7 @@ limitations under the License.
 
     .mx_MessageComposer_row {
         /* This forces the composer to wrap its content, even if it has no word boundaries. Fixes #22507 */
-        overflow: hidden;
+        overflow-x: clip;
         grid-area: composer;
     }
 

--- a/res/css/views/rooms/_MessageComposer.scss
+++ b/res/css/views/rooms/_MessageComposer.scss
@@ -37,7 +37,7 @@ limitations under the License.
     }
 
     .mx_MessageComposer_row {
-        overflow-x: clip;
+        min-width: 0;
         grid-area: composer;
     }
 


### PR DESCRIPTION
Type: Defect
Fixes: https://github.com/vector-im/element-web/issues/22507

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent new composer from overflowing from non-breakable text ([\#8829](https://github.com/matrix-org/matrix-react-sdk/pull/8829)). Fixes vector-im/element-web#22507. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->