### PR TITLE
Add try-catch around blurhash loading

### DIFF
--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -136,7 +136,11 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
             this.forceUpdate(); // we don't really have a reliable thing to update, so just update the whole thing
         });
 
-        this.loadBlurhash();
+        try {
+            this.loadBlurhash();
+        } catch (e) {
+            logger.error("Failed to load blurhash", e);
+        }
 
         if (this.props.mediaEventHelper.media.isEncrypted && this.state.decryptedUrl === null) {
             try {


### PR DESCRIPTION
Related https://github.com/vector-im/element-web/issues/21809

Without this, decrypting the video if needed would get hosed by any blurhash exceptions

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add try-catch around blurhash loading ([\#8830](https://github.com/matrix-org/matrix-react-sdk/pull/8830)).<!-- CHANGELOG_PREVIEW_END -->