### PR TITLE
Improve help user settings tab styling

### DIFF
--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -15,11 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_HelpUserSettingsTab_debugButton {
-    margin-bottom: 5px;
-    margin-top: 5px;
-}
-
 .mx_HelpUserSettingsTab span.mx_AccessibleButton {
     word-break: break-word;
 }

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -22,10 +22,10 @@ limitations under the License.
     }
 
     details {
-        margin: $spacing-12 auto;
+        margin: $spacing-16 auto;
 
         summary {
-            margin-bottom: $spacing-12;
+            margin-bottom: $spacing-16;
         }
     }
 }

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -15,10 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_HelpUserSettingsTab span.mx_AccessibleButton {
-    word-break: break-word;
-}
-
 .mx_HelpUserSettingsTab code {
     word-break: break-all;
     user-select: all;

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -15,7 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_HelpUserSettingsTab code {
-    word-break: break-all;
-    user-select: all;
+.mx_HelpUserSettingsTab {
+    code {
+        word-break: break-all;
+        user-select: all;
+    }
+
+    details {
+        margin: $spacing-12 auto;
+    }
 }

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.scss
@@ -23,5 +23,9 @@ limitations under the License.
 
     details {
         margin: $spacing-12 auto;
+
+        summary {
+            margin-bottom: $spacing-12;
+        }
     }
 }

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -125,7 +125,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
         return (
             <div className='mx_SettingsTab_section'>
                 <span className='mx_SettingsTab_subheading'>{ _t("Credits") }</span>
-                <ul>
+                <ul className='mx_SettingsTab_subsectionText'>
                     <li>
                         The <a href="themes/element/img/backgrounds/lake.jpg" rel="noreferrer noopener" target="_blank">
                             default cover photo

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -298,7 +298,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                         { _t("Homeserver is") } <code>{ MatrixClientPeg.get().getHomeserverUrl() }</code><br />
                         { _t("Identity server is") } <code>{ MatrixClientPeg.get().getIdentityServerUrl() }</code><br />
                         <details>
-                            <summary>{ _t("Access Token") }</summary><br />
+                            <summary>{ _t("Access Token") }</summary>
                             <b>{ _t("Your access token gives full access to your account."
                                + " Do not share it with anyone.") }</b>
                             <CopyableText getTextToCopy={() => MatrixClientPeg.get().getAccessToken()}>

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -110,7 +110,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
         }
 
         return (
-            <div className='mx_SettingsTab_section mx_HelpUserSettingsTab_versions'>
+            <div className='mx_SettingsTab_section'>
                 <span className='mx_SettingsTab_subheading'>{ _t("Legal") }</span>
                 <div className='mx_SettingsTab_subsectionText'>
                     { legalLinks }
@@ -280,7 +280,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                         { _t("Keyboard Shortcuts") }
                     </AccessibleButton>
                 </div>
-                <div className='mx_SettingsTab_section mx_HelpUserSettingsTab_versions'>
+                <div className='mx_SettingsTab_section'>
                     <span className='mx_SettingsTab_subheading'>{ _t("Versions") }</span>
                     <div className='mx_SettingsTab_subsectionText'>
                         <CopyableText getTextToCopy={this.getVersionTextToCopy}>
@@ -292,7 +292,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                 </div>
                 { this.renderLegal() }
                 { this.renderCredits() }
-                <div className='mx_SettingsTab_section mx_HelpUserSettingsTab_versions'>
+                <div className='mx_SettingsTab_section'>
                     <span className='mx_SettingsTab_subheading'>{ _t("Advanced") }</span>
                     <div className='mx_SettingsTab_subsectionText'>
                         { _t("Homeserver is") } <code>{ MatrixClientPeg.get().getHomeserverUrl() }</code><br />

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -245,11 +245,11 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                             "last interacted with, and the usernames of other users. " +
                             "They do not contain messages.",
                         ) }
-                        <div className='mx_HelpUserSettingsTab_debugButton'>
-                            <AccessibleButton onClick={this.onBugReport} kind='primary'>
-                                { _t("Submit debug logs") }
-                            </AccessibleButton>
-                        </div>
+                    </div>
+                    <AccessibleButton onClick={this.onBugReport} kind='primary'>
+                        { _t("Submit debug logs") }
+                    </AccessibleButton>
+                    <div className='mx_SettingsTab_subsectionText'>
                         { _t(
                             "To report a Matrix-related security issue, please read the Matrix.org " +
                             "<a>Security Disclosure Policy</a>.", {},

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -295,8 +295,8 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                 <div className='mx_SettingsTab_section'>
                     <span className='mx_SettingsTab_subheading'>{ _t("Advanced") }</span>
                     <div className='mx_SettingsTab_subsectionText'>
-                        { _t("Homeserver is") } <code>{ MatrixClientPeg.get().getHomeserverUrl() }</code><br />
-                        { _t("Identity server is") } <code>{ MatrixClientPeg.get().getIdentityServerUrl() }</code><br />
+                        <div>{ _t("Homeserver is") } <code>{ MatrixClientPeg.get().getHomeserverUrl() }</code></div>
+                        <div>{ _t("Identity server is") } <code>{ MatrixClientPeg.get().getIdentityServerUrl() }</code></div>
                         <details>
                             <summary>{ _t("Access Token") }</summary>
                             <b>{ _t("Your access token gives full access to your account."

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -306,11 +306,9 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                                 { MatrixClientPeg.get().getAccessToken() }
                             </CopyableText>
                         </details><br />
-                        <div className='mx_HelpUserSettingsTab_debugButton'>
-                            <AccessibleButton onClick={this.onClearCacheAndReload} kind='danger'>
-                                { _t("Clear cache and reload") }
-                            </AccessibleButton>
-                        </div>
+                        <AccessibleButton onClick={this.onClearCacheAndReload} kind='danger'>
+                            { _t("Clear cache and reload") }
+                        </AccessibleButton>
                     </div>
                 </div>
             </div>

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -297,7 +297,6 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                     <div className='mx_SettingsTab_subsectionText'>
                         { _t("Homeserver is") } <code>{ MatrixClientPeg.get().getHomeserverUrl() }</code><br />
                         { _t("Identity server is") } <code>{ MatrixClientPeg.get().getIdentityServerUrl() }</code><br />
-                        <br />
                         <details>
                             <summary>{ _t("Access Token") }</summary><br />
                             <b>{ _t("Your access token gives full access to your account."
@@ -305,7 +304,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                             <CopyableText getTextToCopy={() => MatrixClientPeg.get().getAccessToken()}>
                                 { MatrixClientPeg.get().getAccessToken() }
                             </CopyableText>
-                        </details><br />
+                        </details>
                         <AccessibleButton onClick={this.onClearCacheAndReload} kind='danger'>
                             { _t("Clear cache and reload") }
                         </AccessibleButton>


### PR DESCRIPTION
- Remove the special margin around the buttons
- Remove the obsolete class name `mx_HelpUserSettingsTab_versions`
- Remove `<br>`s used for setting margin
- Apply `mx_SettingsTab_subsectionText` to the credits list 

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/173408285-46bd050d-2a56-49a9-baf4-04d22f80ce23.png)|![after](https://user-images.githubusercontent.com/3362943/173408248-9f7462c9-1f12-4839-a16e-0ec4e378483a.png)|
|![before1](https://user-images.githubusercontent.com/3362943/173408297-a462ddc7-5964-4518-a1d7-abb21fcc32a8.png)|![after1](https://user-images.githubusercontent.com/3362943/173408279-9740e23f-bf5c-4669-94db-1b22d74bcf27.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
