### PR TITLE
Remove obsolete style rules for "Show my Communities" which has been removed

### DIFF
--- a/res/css/views/settings/tabs/user/_PreferencesUserSettingsTab.scss
+++ b/res/css/views/settings/tabs/user/_PreferencesUserSettingsTab.scss
@@ -21,16 +21,5 @@ limitations under the License.
 
     .mx_SettingsTab_section {
         margin-bottom: var(--SettingsTab_section-margin-bottom-preferences-labs);
-
-        > details {
-            > summary {
-                cursor: pointer;
-                color: $primary-content;
-            }
-
-            & + .mx_SettingsFlag {
-                margin-top: 20px;
-            }
-        }
     }
 }


### PR DESCRIPTION
For the context, please see: https://github.com/matrix-org/matrix-react-sdk/pull/6594#event-5149977066.
`<details>` had been used for [`Show my Communities`](https://user-images.githubusercontent.com/2403652/129044857-54b4bc0a-31d0-4735-93a5-ab5b3e1096ed.png).

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->