### PR TITLE
Add a bit of safety around timestamp handling for threads

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1121,9 +1121,13 @@ export class UnwrappedEventTile extends React.Component<IProps, IState> {
             || Boolean(this.state.contextMenu));
 
         // Thread panel shows the timestamp of the last reply in that thread
-        const ts = this.context.timelineRenderingType !== TimelineRenderingType.ThreadsList
+        let ts = this.context.timelineRenderingType !== TimelineRenderingType.ThreadsList
             ? this.props.mxEvent.getTs()
-            : this.state.thread?.replyToEvent.getTs();
+            : this.state.thread?.replyToEvent?.getTs();
+        if (typeof ts !== "number") {
+            // Fall back to something we can use
+            ts = this.props.mxEvent.getTs();
+        }
 
         const messageTimestamp = <MessageTimestamp
             showRelative={this.context.timelineRenderingType === TimelineRenderingType.ThreadsList}


### PR DESCRIPTION
Addresses cause of https://github.com/vector-im/element-web/issues/22141#issuecomment-1155649785 and the comment which follows.

To be closed:
* https://github.com/matrix-org/element-web-rageshakes/issues/13612
* https://github.com/matrix-org/element-web-rageshakes/issues/13611

(can't reasonably use auto-close features of github)

Unrelated cause to https://github.com/vector-im/element-web/issues/22141

element-web notes: Fix a class of crash related to threads.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add a bit of safety around timestamp handling for threads ([\#8845](https://github.com/matrix-org/matrix-react-sdk/pull/8845)).<!-- CHANGELOG_PREVIEW_END -->