### PR TITLE
Reload map on reconnect

### DIFF
--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -17,11 +17,10 @@ limitations under the License.
 
 import React, { ComponentProps, createRef } from 'react';
 import { Blurhash } from "react-blurhash";
-import { SyncState } from 'matrix-js-sdk/src/sync';
 import classNames from 'classnames';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
 import { logger } from "matrix-js-sdk/src/logger";
-import { ClientEvent } from "matrix-js-sdk/src/client";
+import { ClientEvent, ClientEventHandlerMap } from "matrix-js-sdk/src/client";
 
 import MFileBody from './MFileBody';
 import Modal from '../../../Modal';
@@ -38,6 +37,7 @@ import { MatrixClientPeg } from '../../../MatrixClientPeg';
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
 import { blobIsAnimated, mayBeAnimated } from '../../../utils/Image';
 import { presentableTextForFile } from "../../../utils/FileUtils";
+import { createReconnectedListener } from '../../../utils/connection';
 
 enum Placeholder {
     NoImage,
@@ -68,9 +68,12 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
     private image = createRef<HTMLImageElement>();
     private timeout?: number;
     private sizeWatcher: string;
+    private reconnectedListener: ClientEventHandlerMap[ClientEvent.Sync];
 
     constructor(props: IBodyProps) {
         super(props);
+
+        this.reconnectedListener = createReconnectedListener(this.clearError);
 
         this.state = {
             imgError: false,
@@ -80,20 +83,6 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
             placeholder: Placeholder.NoImage,
         };
     }
-
-    // FIXME: factor this out and apply it to MVideoBody and MAudioBody too!
-    private onClientSync = (syncState: SyncState, prevState: SyncState): void => {
-        if (this.unmounted) return;
-        // Consider the client reconnected if there is no error with syncing.
-        // This means the state could be RECONNECTING, SYNCING, PREPARED or CATCHUP.
-        const reconnected = syncState !== SyncState.Error && prevState !== syncState;
-        if (reconnected && this.state.imgError) {
-            // Load the image again
-            this.setState({
-                imgError: false,
-            });
-        }
-    };
 
     protected showImage(): void {
         localStorage.setItem("mx_ShowImage_" + this.props.mxEvent.getId(), "true");
@@ -159,11 +148,17 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         imgElement.src = this.state.thumbUrl ?? this.state.contentUrl;
     };
 
+    private clearError = () => {
+        MatrixClientPeg.get().off(ClientEvent.Sync, this.reconnectedListener);
+        this.setState({ imgError: false });
+    };
+
     private onImageError = (): void => {
         this.clearBlurhashTimeout();
         this.setState({
             imgError: true,
         });
+        MatrixClientPeg.get().on(ClientEvent.Sync, this.reconnectedListener);
     };
 
     private onImageLoad = (): void => {
@@ -317,7 +312,6 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
 
     componentDidMount() {
         this.unmounted = false;
-        MatrixClientPeg.get().on(ClientEvent.Sync, this.onClientSync);
 
         const showImage = this.state.showImage ||
             localStorage.getItem("mx_ShowImage_" + this.props.mxEvent.getId()) === "true";
@@ -347,7 +341,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
 
     componentWillUnmount() {
         this.unmounted = true;
-        MatrixClientPeg.get().removeListener(ClientEvent.Sync, this.onClientSync);
+        MatrixClientPeg.get().off(ClientEvent.Sync, this.reconnectedListener);
         this.clearBlurhashTimeout();
         SettingsStore.unwatchSetting(this.sizeWatcher);
         if (this.state.isAnimated && this.state.thumbUrl) {

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ClientEvent, ClientEventHandlerMap } from "matrix-js-sdk/src/matrix";
+import { SyncState } from "matrix-js-sdk/src/sync";
+
+/**
+ * Creates a MatrixClient event listener function that can be used to get notified about reconnects.
+ * @param callback The callback to be called on reconnect
+ */
+export const createReconnectedListener = (callback: () => void): ClientEventHandlerMap[ClientEvent.Sync] => {
+    return (syncState: SyncState, prevState: SyncState) => {
+        if (syncState !== SyncState.Error && prevState !== syncState) {
+            // Consider the client reconnected if there is no error with syncing.
+            // This means the state could be RECONNECTING, SYNCING, PREPARED or CATCHUP.
+            callback();
+        }
+    };
+};

--- a/test/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
+++ b/test/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
@@ -120,6 +120,10 @@ exports[`MLocationBody <MLocationBody> without error renders map correctly 1`] =
                       "error": Array [
                         [Function],
                         [Function],
+                        [Function],
+                        [Function],
+                        [Function],
+                        [Function],
                       ],
                     },
                     "_eventsCount": 1,
@@ -130,8 +134,16 @@ exports[`MLocationBody <MLocationBody> without error renders map correctly 1`] =
                           mockConstructor {},
                           "top-right",
                         ],
+                        Array [
+                          mockConstructor {},
+                          "top-right",
+                        ],
                       ],
                       "results": Array [
+                        Object {
+                          "type": "return",
+                          "value": undefined,
+                        },
                         Object {
                           "type": "return",
                           "value": undefined,
@@ -148,8 +160,18 @@ exports[`MLocationBody <MLocationBody> without error renders map correctly 1`] =
                             "lon": -0.1276,
                           },
                         ],
+                        Array [
+                          Object {
+                            "lat": 51.5076,
+                            "lon": -0.1276,
+                          },
+                        ],
                       ],
                       "results": Array [
+                        Object {
+                          "type": "return",
+                          "value": undefined,
+                        },
                         Object {
                           "type": "return",
                           "value": undefined,

--- a/test/utils/connection-test.ts
+++ b/test/utils/connection-test.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ClientEvent, ClientEventHandlerMap } from "matrix-js-sdk/src/matrix";
+import { SyncState } from "matrix-js-sdk/src/sync";
+
+import { createReconnectedListener } from "../../src/utils/connection";
+
+describe("createReconnectedListener", () => {
+    let reconnectedListener: ClientEventHandlerMap[ClientEvent.Sync];
+    let onReconnect: jest.Mock;
+
+    beforeEach(() => {
+        onReconnect = jest.fn();
+        reconnectedListener = createReconnectedListener(onReconnect);
+    });
+
+    [
+        [SyncState.Prepared, SyncState.Syncing],
+        [SyncState.Syncing, SyncState.Reconnecting],
+        [SyncState.Reconnecting, SyncState.Syncing],
+    ].forEach(([from, to]) => {
+        it(`should invoke the callback on a transition from ${from} to ${to}`, () => {
+            reconnectedListener(to, from);
+            expect(onReconnect).toBeCalled();
+        });
+    });
+
+    [
+        [SyncState.Syncing, SyncState.Syncing],
+        [SyncState.Catchup, SyncState.Error],
+        [SyncState.Reconnecting, SyncState.Error],
+    ].forEach(([from, to]) => {
+        it(`should not invoke the callback on a transition from ${from} to ${to}`, () => {
+            reconnectedListener(to, from);
+            expect(onReconnect).not.toBeCalled();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #20993

Notes: Location sharing maps are now loaded after reconnection

PSD-282

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Location sharing maps are now loaded after reconnection ([\#8848](https://github.com/matrix-org/matrix-react-sdk/pull/8848)). Fixes undefined/matrix-react-sdk#20993. Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->