### PR TITLE
Improve _IRCLayout.scss to remove space between the avatar and info text

### DIFF
--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -107,10 +107,7 @@ $irc-line-height: $font-18px;
         }
 
         .mx_EventTile_e2eIcon {
-            padding: 0;
-
             flex-grow: 0;
-
             background-position: center;
         }
 

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -47,7 +47,8 @@ $irc-line-height: $font-18px;
             align-items: center;
 
             // Need to use important to override the js provided height and width values.
-            > .mx_BaseAvatar, > .mx_BaseAvatar > * {
+            > .mx_BaseAvatar,
+            > .mx_BaseAvatar > * {
                 height: $font-14px !important;
                 width: $font-14px !important;
                 font-size: $font-10px !important;

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -40,21 +40,6 @@ $irc-line-height: $font-18px;
             margin-right: var(--right-padding);
         }
 
-        .mx_EventTile_msgOption {
-            order: 5;
-            flex-shrink: 0;
-        }
-
-        .mx_EventTile_line,
-        .mx_EventTile_reply {
-            display: flex;
-            flex-direction: column;
-            order: 3;
-            flex-grow: 1;
-            flex-shrink: 1;
-            min-width: 0;
-        }
-
         .mx_EventTile_avatar {
             order: 1;
             position: relative;
@@ -140,8 +125,23 @@ $irc-line-height: $font-18px;
             }
         }
 
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
+            order: 3;
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+            flex-shrink: 1;
+            min-width: 0;
+        }
+
         .mx_EventTile_reply {
             order: 4;
+        }
+
+        .mx_EventTile_msgOption {
+            order: 5;
+            flex-shrink: 0;
         }
 
         .mx_EditMessageComposer_buttons {

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -38,11 +38,22 @@ $irc-line-height: $font-18px;
             margin-right: var(--right-padding);
         }
 
+        .mx_EventTile_avatar,
+        .mx_EventTile_e2eIcon {
+            height: $irc-line-height;
+        }
+
+        .mx_EventTile_avatar,
+        .mx_DisambiguatedProfile,
+        .mx_EventTile_e2eIcon,
+        .mx_EventTile_msgOption {
+            flex-shrink: 0;
+        }
+
         .mx_EventTile_avatar {
             order: 1;
             position: relative;
-            flex-shrink: 0;
-            height: $irc-line-height;
+
             display: flex;
             align-items: center;
 
@@ -60,7 +71,6 @@ $irc-line-height: $font-18px;
             width: var(--name-width);
             margin-inline-end: 0; // override mx_EventTile > *
             order: 2;
-            flex-shrink: 0;
 
             > .mx_DisambiguatedProfile_displayName {
                 width: 100%;
@@ -99,10 +109,7 @@ $irc-line-height: $font-18px;
         .mx_EventTile_e2eIcon {
             padding: 0;
 
-            flex-shrink: 0;
             flex-grow: 0;
-
-            height: $font-18px;
 
             background-position: center;
         }
@@ -140,7 +147,6 @@ $irc-line-height: $font-18px;
 
         .mx_EventTile_msgOption {
             order: 5;
-            flex-shrink: 0;
         }
 
         .mx_EditMessageComposer_buttons {

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -154,6 +154,15 @@ $irc-line-height: $font-18px;
                 line-height: $irc-line-height;
             }
         }
+
+        // Suppress highlight thing from the normal Layout.
+        &:hover.mx_EventTile_verified,
+        &:hover.mx_EventTile_unverified,
+        &:hover.mx_EventTile_unknown {
+            .mx_EventTile_line {
+                border-left: 0;
+            }
+        }
     }
 
     .mx_EventTile_emote {
@@ -164,13 +173,6 @@ $irc-line-height: $font-18px;
 
     blockquote {
         margin: 0;
-    }
-
-    // Suppress highlight thing from the normal Layout.
-    .mx_EventTile:hover.mx_EventTile_verified .mx_EventTile_line,
-    .mx_EventTile:hover.mx_EventTile_unverified .mx_EventTile_line,
-    .mx_EventTile:hover.mx_EventTile_unknown .mx_EventTile_line {
-        border-left: 0;
     }
 
     .mx_ReplyChain {

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -26,16 +26,15 @@ $irc-line-height: $font-18px;
     .mx_EventTile[data-layout="irc"] {
         --EventTile_irc_line-padding-block: 1px;
 
+        display: flex;
+        align-items: flex-start;
+        padding-top: 0;
+
         // timestamps are links which shouldn't be underlined
         > a {
             text-decoration: none;
             min-width: $MessageTimestamp_width;
         }
-
-        display: flex;
-        flex-direction: row;
-        align-items: flex-start;
-        padding-top: 0;
 
         > * {
             margin-right: var(--right-padding);

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -19,7 +19,7 @@ $irc-line-height: $font-18px;
 .mx_IRCLayout {
     --name-width: 70px;
     --icon-width: 14px;
-    --right-padding: 5px;
+    --right-padding: 5px;  // TODO: Use a spacing variable
 
     line-height: $irc-line-height !important;
 
@@ -89,7 +89,7 @@ $irc-line-height: $font-18px;
                 visibility: collapse;
                 // Override the inherited margin.
                 margin-left: 0;
-                padding: 0 5px;
+                padding: 0 5px; // TODO: Use a spacing variable
             }
 
             &:hover {
@@ -101,7 +101,7 @@ $irc-line-height: $font-18px;
                     display: inline;
                     background-color: $event-selected-color;
                     border-radius: 8px 0 0 8px;
-                    padding-right: 8px;
+                    padding-right: $spacing-8;
                 }
 
                 > .mx_DisambiguatedProfile_mxid {

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -23,7 +23,7 @@ $irc-line-height: $font-18px;
 
     line-height: $irc-line-height !important;
 
-    .mx_EventTile {
+    .mx_EventTile[data-layout="irc"] {
         --EventTile_irc_line-padding-block: 1px;
 
         // timestamps are links which shouldn't be underlined

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -148,6 +148,13 @@ $irc-line-height: $font-18px;
         .mx_EditMessageComposer_buttons {
             position: relative;
         }
+
+        &.mx_EventTile_info {
+            .mx_ViewSourceEvent, // For hidden events
+            .mx_TextualEvent {
+                line-height: $irc-line-height;
+            }
+        }
     }
 
     .mx_EventTile_emote {
@@ -158,13 +165,6 @@ $irc-line-height: $font-18px;
 
     blockquote {
         margin: 0;
-    }
-
-    .mx_EventTile.mx_EventTile_info {
-        .mx_ViewSourceEvent, // For hidden events
-        .mx_TextualEvent {
-            line-height: $irc-line-height;
-        }
     }
 
     // Suppress highlight thing from the normal Layout.

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -30,10 +30,8 @@ $irc-line-height: $font-18px;
         align-items: flex-start;
         padding-top: 0;
 
-        // timestamps are links which shouldn't be underlined
         > a {
-            text-decoration: none;
-            min-width: $MessageTimestamp_width;
+            min-width: $MessageTimestamp_width; // ensure space for EventTile without timestamp
         }
 
         > * {


### PR DESCRIPTION
This PR organizes style rules on `_IRCLayout.scss` to clarify the structure.

|Before|After|
|---------|------|
|||

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve _IRCLayout.scss to remove space between the avatar and info text ([\#8858](https://github.com/matrix-org/matrix-react-sdk/pull/8858)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->