### PR TITLE
Hide overflow of public room description on spotlight dialog result

### DIFF
--- a/res/css/views/dialogs/_SpotlightDialog.scss
+++ b/res/css/views/dialogs/_SpotlightDialog.scss
@@ -283,14 +283,15 @@ limitations under the License.
                         }
                     }
                     .mx_SpotlightDialog_result_publicRoomDescription {
-                        display: -webkit-box;
                         color: $secondary-content;
                         font-size: $font-12px;
                         white-space: normal;
                         word-wrap: break-word;
                         line-height: $font-20px;
+                        display: -webkit-box;
                         -webkit-box-orient: vertical;
                         -webkit-line-clamp: 3;
+                        overflow: hidden;
                     }
                 }
 


### PR DESCRIPTION
|Before|After|
|---------|-------|
|![before](https://user-images.githubusercontent.com/3362943/174472908-02e7c70d-1a7a-4f69-a371-c98c586ae699.png)|![after](https://user-images.githubusercontent.com/3362943/174472905-dd49cff7-7708-4275-b6e0-ec83c55a2df1.png)|

Please look for `-webkit-line-clamp` for other cases.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Hide overflow of public room description on spotlight dialog result ([\#8870](https://github.com/matrix-org/matrix-react-sdk/pull/8870)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->