### PR TITLE
Stop using absolute property to place beta pill on RoomPreviewCard

### DIFF
--- a/res/css/views/rooms/_RoomPreviewCard.scss
+++ b/res/css/views/rooms/_RoomPreviewCard.scss
@@ -71,6 +71,11 @@ limitations under the License.
                 color: $secondary-content;
             }
         }
+
+        // XXX Remove this when video rooms leave beta
+        .mx_BetaCard_betaPill {
+            align-self: start;
+        }
     }
 
     .mx_RoomPreviewCard_avatar {
@@ -104,13 +109,6 @@ limitations under the License.
                 mask-repeat: no-repeat;
                 mask-image: url('$(res)/img/element-icons/call/video-call.svg');
             }
-        }
-
-        // XXX Remove this when video rooms leave beta
-        .mx_BetaCard_betaPill {
-            position: absolute;
-            right: $spacing-24;
-            top: $spacing-32;
         }
     }
 

--- a/src/components/views/rooms/RoomPreviewCard.tsx
+++ b/src/components/views/rooms/RoomPreviewCard.tsx
@@ -102,6 +102,7 @@ const RoomPreviewCard: FC<IProps> = ({ room, onJoinButtonClicked, onRejectButton
                         { inviteSender }
                     </div> : null }
                 </div>
+                <BetaPill onClick={viewLabs} tooltipTitle={_t("Video rooms are a beta feature")} />
             </div>;
         }
 
@@ -152,7 +153,6 @@ const RoomPreviewCard: FC<IProps> = ({ room, onJoinButtonClicked, onRejectButton
         avatarRow = <>
             <RoomAvatar room={room} height={50} width={50} viewAvatarOnClick />
             <div className="mx_RoomPreviewCard_video" />
-            <BetaPill onClick={viewLabs} tooltipTitle={_t("Video rooms are a beta feature")} />
         </>;
     } else if (room.isSpaceRoom()) {
         avatarRow = <RoomAvatar room={room} height={80} width={80} viewAvatarOnClick />;


### PR DESCRIPTION
Because the beta pill needs space for itself.

https://developer.mozilla.org/en-US/docs/Web/CSS/position#values

> `absolute`
> The element is removed from the normal document flow, and no space is created for the element in the page layout. 

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/174480623-ae0be6b2-33b8-446c-b69b-12081ba001a1.png)|![after](https://user-images.githubusercontent.com/3362943/174480617-4e7fa800-2b2e-4327-904b-805c8027c1cb.png)|

Fixes https://github.com/vector-im/element-web/issues/22617

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Stop using absolute property to place beta pill on RoomPreviewCard ([\#8872](https://github.com/matrix-org/matrix-react-sdk/pull/8872)). Fixes vector-im/element-web#22617. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->