### PR TITLE
Move the beta pill to the right side and display the pill on video room only

### DIFF
--- a/res/css/views/rooms/_RoomPreviewCard.scss
+++ b/res/css/views/rooms/_RoomPreviewCard.scss
@@ -74,6 +74,7 @@ limitations under the License.
 
         // XXX Remove this when video rooms leave beta
         .mx_BetaCard_betaPill {
+            margin-inline-start: auto;
             align-self: start;
         }
     }

--- a/src/components/views/rooms/RoomPreviewCard.tsx
+++ b/src/components/views/rooms/RoomPreviewCard.tsx
@@ -102,7 +102,10 @@ const RoomPreviewCard: FC<IProps> = ({ room, onJoinButtonClicked, onRejectButton
                         { inviteSender }
                     </div> : null }
                 </div>
-                <BetaPill onClick={viewLabs} tooltipTitle={_t("Video rooms are a beta feature")} />
+                { room.isElementVideoRoom()
+                    ? <BetaPill onClick={viewLabs} tooltipTitle={_t("Video rooms are a beta feature")} />
+                    : null
+                }
             </div>;
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22619
Fixes https://github.com/vector-im/element-web/issues/22620

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

![after](https://user-images.githubusercontent.com/3362943/174485932-706e8559-f52f-4a5e-8f4c-57b78b2d53af.png)
![after1](https://user-images.githubusercontent.com/3362943/174485940-53e9118e-c3d6-4ad9-ad0a-8eac1edac74a.png)
![after2](https://user-images.githubusercontent.com/3362943/174486418-bed97697-e225-422b-8d32-b803b06abb03.png)


type: defect
element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Move the beta pill to the right side and display the pill on video room only ([\#8873](https://github.com/matrix-org/matrix-react-sdk/pull/8873)). Fixes vector-im/element-web#22619 and vector-im/element-web#22620. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->