### PR TITLE
Remove references to mx_GroupLayout from scss files

### DIFF
--- a/res/css/views/elements/_EventTilePreview.scss
+++ b/res/css/views/elements/_EventTilePreview.scss
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_EventTilePreview_loader {
-    &.mx_IRCLayout,
-    &.mx_GroupLayout {
-        padding: 9px 0;
-    }
+.mx_FontScalingPanel_fontSlider_preview.mx_EventTilePreview_loader {
+    padding: 9px 0;
 }

--- a/res/css/views/rooms/_ReadReceiptGroup.scss
+++ b/res/css/views/rooms/_ReadReceiptGroup.scss
@@ -21,7 +21,7 @@ limitations under the License.
     display: inline-block;
     // This aligns the avatar with the last line of the
     // message. We want to move it one line up
-    // See .mx_GroupLayout .mx_EventTile .mx_EventTile_line in _GroupLayout.scss
+    // See .mx_EventTile[data-layout=group] .mx_EventTile_line in _EventTile.scss
     top: calc(-$font-22px - 3px);
     user-select: none;
     z-index: 1;

--- a/src/components/views/elements/EventTilePreview.tsx
+++ b/src/components/views/elements/EventTilePreview.tsx
@@ -117,7 +117,6 @@ export default class EventTilePreview extends React.Component<IProps, IState> {
     public render() {
         const className = classnames(this.props.className, {
             "mx_IRCLayout": this.props.layout == Layout.IRC,
-            "mx_GroupLayout": this.props.layout == Layout.Group,
             "mx_EventTilePreview_loader": !this.props.userId,
         });
 

--- a/test/components/views/settings/__snapshots__/FontScalingPanel-test.tsx.snap
+++ b/test/components/views/settings/__snapshots__/FontScalingPanel-test.tsx.snap
@@ -19,7 +19,7 @@ exports[`FontScalingPanel renders the font scaling UI 1`] = `
       userId={null}
     >
       <div
-        className="mx_FontScalingPanel_fontSlider_preview mx_GroupLayout mx_EventTilePreview_loader"
+        className="mx_FontScalingPanel_fontSlider_preview mx_EventTilePreview_loader"
       >
         <Spinner
           h={32}


### PR DESCRIPTION
And enable padding inside the font scaling slider preview to all message layouts, including message bubble.

The images should be identical except the first row.

Closes https://github.com/vector-im/element-web/issues/22626

Notes: Add padding to font scaling loader for message bubble layout

|Before|After|
|---------|------|
|![before5](https://user-images.githubusercontent.com/3362943/174629443-c7189b3f-d85c-41de-a83b-657c62834357.png)|![after5](https://user-images.githubusercontent.com/3362943/174629408-319f80fe-0279-4ae4-a4a7-c35dfc23ef5c.png)|
|![before1](https://user-images.githubusercontent.com/3362943/174628650-91bb37e3-ffc5-4f55-a3a3-d32aef42423b.png)|![after1](https://user-images.githubusercontent.com/3362943/174627702-b0b0a95c-61b0-4cc3-9daa-d9308b4c71f7.png)|
|![before2](https://user-images.githubusercontent.com/3362943/174627809-15d3eba2-f868-452c-bb10-a2b003687445.png)|![after2](https://user-images.githubusercontent.com/3362943/174627745-0a8749d3-6cdd-4810-a93f-627281e731ee.png)|
|![before3](https://user-images.githubusercontent.com/3362943/174627848-ca91b6fe-4fcc-4273-83e3-83b30068aaf9.png)|![after3](https://user-images.githubusercontent.com/3362943/174627771-907f204c-122d-47ae-9313-6d93e8584076.png)|
|![before4](https://user-images.githubusercontent.com/3362943/174628017-ba56b0ca-4e42-4b06-99bf-f13b8a31cb1a.png)|![after4](https://user-images.githubusercontent.com/3362943/174627780-a7972ac9-d508-4688-9676-33b0f675f948.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add padding to font scaling loader for message bubble layout ([\#8875](https://github.com/matrix-org/matrix-react-sdk/pull/8875)). Fixes vector-im/element-web#22626. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->