### PR TITLE
End jitsi call when member is banned

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -210,7 +210,7 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private onMyMembership = (room: Room, membership: string): void => {
-        if (membership === "leave" && room.roomId === this.props.room?.roomId) {
+        if ((membership === "leave" || membership === "ban") && room.roomId === this.props.room?.roomId) {
             this.onUserLeftRoom();
         }
     };


### PR DESCRIPTION
Jitsi call needs to be ended when member is banned.

Currently if user A bans user B, then A don't see B in the call anymore, but B stays in the call (call window dialog is minimized) and B can hear/see what is going on in the call.

This PR invokes Jitsi call ending logic when user is banned.