### PR TITLE
Ensure the max width value of the tooltip is used only on settings tabs

### DIFF
--- a/res/css/_common.scss
+++ b/res/css/_common.scss
@@ -705,11 +705,6 @@ legend {
     margin-right: 100px;
 }
 
-@define-mixin mx_Settings_tooltip {
-    // So it fits in the space provided by the page
-    max-width: 120px;
-}
-
 @define-mixin ProgressBarColour $colour {
     color: $colour;
     &::-moz-progress-bar {

--- a/res/css/views/settings/_SetIdServer.scss
+++ b/res/css/views/settings/_SetIdServer.scss
@@ -19,5 +19,5 @@ limitations under the License.
 }
 
 .mx_SetIdServer_tooltip {
-    @mixin mx_Settings_tooltip;
+    max-width: var(--SettingsTab_tooltip-max-width);
 }

--- a/res/css/views/settings/tabs/_SettingsTab.scss
+++ b/res/css/views/settings/tabs/_SettingsTab.scss
@@ -16,6 +16,8 @@ limitations under the License.
 
 .mx_SettingsTab {
     --SettingsTab_section-margin-bottom-preferences-labs: 30px;
+    --SettingsTab_tooltip-max-width: 120px; // So it fits in the space provided by the page
+
     color: $primary-content;
 
     a {


### PR DESCRIPTION
The mixin was introduced with #3330 for two scss files, but the mixin is currently used on only one file. Though the mixin could be deleted, I guess saving it for possible use would be better than simply replacing it with a value.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->