### PR TITLE
Improve view source dialog style

### DIFF
--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -20,13 +20,13 @@ limitations under the License.
             word-break: break-all;
         }
     }
-}
 
 .mx_ViewSource_separator {
     clear: both;
     border-bottom: 1px solid #e5e5e5;
     padding-top: 0.7em;
     padding-bottom: 0.7em;
+}
 }
 
 .mx_ViewSource_heading {

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -26,8 +26,8 @@ limitations under the License.
 
     .mx_ViewSource_header {
         border-bottom: 1px solid $quinary-content;
-        padding-bottom: 0.7em;
-        margin-bottom: 0.7em;
+        padding-bottom: $spacing-12;
+        margin-bottom: $spacing-12;
 
         .mx_CopyableText {
             word-break: break-all;
@@ -38,11 +38,11 @@ limitations under the License.
         font-size: $font-17px;
         font-weight: 400;
         color: $primary-content;
-        margin-top: 0.7em;
+        margin-top: $spacing-12;
     }
 
     .mx_ViewSource_details {
-        margin-top: 0.8em;
+        margin-top: $spacing-12;
     }
 
     .mx_ViewSource_container {

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -25,16 +25,13 @@ limitations under the License.
     }
 
     .mx_ViewSource_header {
+        border-bottom: 1px solid #e5e5e5;
+        padding-bottom: 0.7em;
+        margin-bottom: 0.7em;
+
         .mx_CopyableText {
             word-break: break-all;
         }
-    }
-
-    .mx_ViewSource_separator {
-        clear: both;
-        border-bottom: 1px solid #e5e5e5;
-        padding-top: 0.7em;
-        padding-bottom: 0.7em;
     }
 
     .mx_ViewSource_heading {

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -18,7 +18,7 @@ limitations under the License.
     pre {
         text-align: left;
         font-size: $font-12px;
-        padding: 0.5em 1em 0.5em 1em;
+        padding: 0.5em 1em;
         word-wrap: break-word;
         white-space: pre-wrap;
         overflow-wrap: anywhere;

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -15,6 +15,15 @@ limitations under the License.
 */
 
 .mx_ViewSource {
+pre {
+    text-align: left;
+    font-size: $font-12px;
+    padding: 0.5em 1em 0.5em 1em;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
     .mx_ViewSource_header {
         .mx_CopyableText {
             word-break: break-all;
@@ -34,15 +43,6 @@ limitations under the License.
     font-weight: 400;
     color: $primary-content;
     margin-top: 0.7em;
-}
-
-.mx_ViewSource pre {
-    text-align: left;
-    font-size: $font-12px;
-    padding: 0.5em 1em 0.5em 1em;
-    word-wrap: break-word;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
 }
 
 .mx_ViewSource_details {

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -36,7 +36,6 @@ pre {
     padding-top: 0.7em;
     padding-bottom: 0.7em;
 }
-}
 
 .mx_ViewSource_heading {
     font-size: $font-17px;
@@ -54,5 +53,6 @@ pre {
 
 .mx_CopyableText_border {
     width: 100%;
+}
 }
 }

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -44,11 +44,8 @@ limitations under the License.
         margin-top: $spacing-12;
     }
 
-    .mx_ViewSource_container {
-        max-width: calc(100% - 24px);
-
-        .mx_CopyableText_border {
-            width: 100%;
-        }
+    .mx_CopyableText_border {
+        box-sizing: border-box;
+        width: 100%;
     }
 }

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -51,8 +51,8 @@ pre {
 
 .mx_ViewSource_container {
     max-width: calc(100% - 24px);
-}
 
-.mx_ViewSource_container .mx_CopyableText_border {
+.mx_CopyableText_border {
     width: 100%;
+}
 }

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -16,7 +16,6 @@ limitations under the License.
 
 .mx_ViewSource {
     pre {
-        text-align: left;
         font-size: $font-12px;
         padding: 0.5em 1em;
         word-wrap: break-word;

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 .mx_ViewSource {
-pre {
-    text-align: left;
-    font-size: $font-12px;
-    padding: 0.5em 1em 0.5em 1em;
-    word-wrap: break-word;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-}
+    pre {
+        text-align: left;
+        font-size: $font-12px;
+        padding: 0.5em 1em 0.5em 1em;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
 
     .mx_ViewSource_header {
         .mx_CopyableText {
@@ -30,29 +30,29 @@ pre {
         }
     }
 
-.mx_ViewSource_separator {
-    clear: both;
-    border-bottom: 1px solid #e5e5e5;
-    padding-top: 0.7em;
-    padding-bottom: 0.7em;
-}
+    .mx_ViewSource_separator {
+        clear: both;
+        border-bottom: 1px solid #e5e5e5;
+        padding-top: 0.7em;
+        padding-bottom: 0.7em;
+    }
 
-.mx_ViewSource_heading {
-    font-size: $font-17px;
-    font-weight: 400;
-    color: $primary-content;
-    margin-top: 0.7em;
-}
+    .mx_ViewSource_heading {
+        font-size: $font-17px;
+        font-weight: 400;
+        color: $primary-content;
+        margin-top: 0.7em;
+    }
 
-.mx_ViewSource_details {
-    margin-top: 0.8em;
-}
+    .mx_ViewSource_details {
+        margin-top: 0.8em;
+    }
 
-.mx_ViewSource_container {
-    max-width: calc(100% - 24px);
+    .mx_ViewSource_container {
+        max-width: calc(100% - 24px);
 
-.mx_CopyableText_border {
-    width: 100%;
-}
-}
+        .mx_CopyableText_border {
+            width: 100%;
+        }
+    }
 }

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_ViewSource {
+    .mx_ViewSource_header {
+        .mx_CopyableText {
+            word-break: break-all;
+        }
+    }
+}
+
 .mx_ViewSource_separator {
     clear: both;
     border-bottom: 1px solid #e5e5e5;

--- a/res/css/structures/_ViewSource.scss
+++ b/res/css/structures/_ViewSource.scss
@@ -25,7 +25,7 @@ limitations under the License.
     }
 
     .mx_ViewSource_header {
-        border-bottom: 1px solid #e5e5e5;
+        border-bottom: 1px solid $quinary-content;
         padding-bottom: 0.7em;
         margin-bottom: 0.7em;
 

--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -167,12 +167,10 @@ export default class ViewSource extends React.Component<IProps, IState> {
         return (
             <BaseDialog className="mx_ViewSource" onFinished={this.props.onFinished} title={_t("View Source")}>
                 <div>
-                    <div>
+                    <div className="mx_ViewSource_header">
                         <CopyableText getTextToCopy={() => roomId} border={false}>
                             { _t("Room ID: %(roomId)s", { roomId }) }
                         </CopyableText>
-                    </div>
-                    <div>
                         <CopyableText getTextToCopy={() => eventId} border={false}>
                             { _t("Event ID: %(eventId)s", { eventId }) }
                         </CopyableText>

--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -79,13 +79,11 @@ export default class ViewSource extends React.Component<IProps, IState> {
                                 { _t("Decrypted event source") }
                             </span>
                         </summary>
-                        <div className="mx_ViewSource_container">
-                            <CopyableText getTextToCopy={copyDecryptedFunc}>
-                                <SyntaxHighlight language="json">
-                                    { stringify(decryptedEventSource) }
-                                </SyntaxHighlight>
-                            </CopyableText>
-                        </div>
+                        <CopyableText getTextToCopy={copyDecryptedFunc}>
+                            <SyntaxHighlight language="json">
+                                { stringify(decryptedEventSource) }
+                            </SyntaxHighlight>
+                        </CopyableText>
                     </details>
                     <details className="mx_ViewSource_details">
                         <summary>
@@ -93,13 +91,11 @@ export default class ViewSource extends React.Component<IProps, IState> {
                                 { _t("Original event source") }
                             </span>
                         </summary>
-                        <div className="mx_ViewSource_container">
-                            <CopyableText getTextToCopy={copyOriginalFunc}>
-                                <SyntaxHighlight language="json">
-                                    { stringify(originalEventSource) }
-                                </SyntaxHighlight>
-                            </CopyableText>
-                        </div>
+                        <CopyableText getTextToCopy={copyOriginalFunc}>
+                            <SyntaxHighlight language="json">
+                                { stringify(originalEventSource) }
+                            </SyntaxHighlight>
+                        </CopyableText>
                     </details>
                 </>
             );
@@ -109,13 +105,11 @@ export default class ViewSource extends React.Component<IProps, IState> {
                     <div className="mx_ViewSource_heading">
                         { _t("Original event source") }
                     </div>
-                    <div className="mx_ViewSource_container">
-                        <CopyableText getTextToCopy={copyOriginalFunc}>
-                            <SyntaxHighlight language="json">
-                                { stringify(originalEventSource) }
-                            </SyntaxHighlight>
-                        </CopyableText>
-                    </div>
+                    <CopyableText getTextToCopy={copyOriginalFunc}>
+                        <SyntaxHighlight language="json">
+                            { stringify(originalEventSource) }
+                        </SyntaxHighlight>
+                    </CopyableText>
                 </>
             );
         }

--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -166,18 +166,16 @@ export default class ViewSource extends React.Component<IProps, IState> {
         const canEdit = mxEvent.isState() ? this.canSendStateEvent(mxEvent) : canEditContent(this.props.mxEvent);
         return (
             <BaseDialog className="mx_ViewSource" onFinished={this.props.onFinished} title={_t("View Source")}>
-                <div>
-                    <div className="mx_ViewSource_header">
-                        <CopyableText getTextToCopy={() => roomId} border={false}>
-                            { _t("Room ID: %(roomId)s", { roomId }) }
-                        </CopyableText>
-                        <CopyableText getTextToCopy={() => eventId} border={false}>
-                            { _t("Event ID: %(eventId)s", { eventId }) }
-                        </CopyableText>
-                    </div>
-                    <div className="mx_ViewSource_separator" />
-                    { isEditing ? this.editSourceContent() : this.viewSourceContent() }
+                <div className="mx_ViewSource_header">
+                    <CopyableText getTextToCopy={() => roomId} border={false}>
+                        { _t("Room ID: %(roomId)s", { roomId }) }
+                    </CopyableText>
+                    <CopyableText getTextToCopy={() => eventId} border={false}>
+                        { _t("Event ID: %(eventId)s", { eventId }) }
+                    </CopyableText>
                 </div>
+                <div className="mx_ViewSource_separator" />
+                { isEditing ? this.editSourceContent() : this.viewSourceContent() }
                 { !isEditing && canEdit && (
                     <div className="mx_Dialog_buttons">
                         <button onClick={() => this.onEdit()}>{ _t("Edit") }</button>

--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -174,7 +174,6 @@ export default class ViewSource extends React.Component<IProps, IState> {
                         { _t("Event ID: %(eventId)s", { eventId }) }
                     </CopyableText>
                 </div>
-                <div className="mx_ViewSource_separator" />
                 { isEditing ? this.editSourceContent() : this.viewSourceContent() }
                 { !isEditing && canEdit && (
                     <div className="mx_Dialog_buttons">


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22636

|Before|After|
|---------|------|
|![before (copy 1)](https://user-images.githubusercontent.com/3362943/175240070-6c5989e3-4f39-4470-8e20-8be43ace7eb1.png)|![after (copy 1)](https://user-images.githubusercontent.com/3362943/175240039-458d30e9-7a53-4e38-a7ea-343901daad11.png)|

- Let room ID and event ID wrapped with `break-all` value
- Remove redundant `div`s including `mx_ViewSource_separator`
- Use a variable for header border color 
- Apply spacing variables
- Apply `border-box` to remove `mx_ViewSource_container`

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve view source dialog style ([\#8883](https://github.com/matrix-org/matrix-react-sdk/pull/8883)). Fixes vector-im/element-web#22636. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->