### PR TITLE
Stop using :not() pseudo class for mx_MImageBody to decrease the specificity of the rule for images on file panel

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -55,10 +55,6 @@ limitations under the License.
     }
 }
 
-.mx_FilePanel .mx_EventTile .mx_MImageBody {
-    margin-right: 0px;
-}
-
 .mx_FilePanel .mx_EventTile .mx_MFileBody {
     line-height: 2.4rem;
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -72,6 +72,13 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         gap: $spacing-4;
     }
 
+    &[data-layout=irc],
+    &[data-layout=group] {
+        .mx_MImageBody {
+            margin-right: 34px;
+        }
+    }
+
     &[data-layout=group] {
         > .mx_DisambiguatedProfile {
             line-height: $font-20px;
@@ -275,8 +282,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 
     .mx_MImageBody {
-        margin-right: 34px;
-
         .mx_MImageBody_thumbnail_container {
             justify-content: flex-start;
             min-height: $font-44px;


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22640

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/175460824-e6efe9d3-62d4-48aa-894d-ab4b4cb788af.png)|![after](https://user-images.githubusercontent.com/3362943/175460794-a77808ee-8406-407b-b108-dc28c4a56703.png)|

Wrapping `mx_EventTile` with `mx_FilePanel` does not work here as "[[t]his pseudo-class can increase the specificity of a rule](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#description)". The rule does not seem to have worked, and can be removed.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
Notes: Remove inline end margin from images on file panel

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove inline end margin from images on file panel ([\#8886](https://github.com/matrix-org/matrix-react-sdk/pull/8886)). Fixes vector-im/element-web#22640. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->