### PR TITLE
Improve integration manager dialog style

### DIFF
--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -15,32 +15,32 @@ limitations under the License.
 */
 
 .mx_IntegrationManager {
-.mx_Dialog {
-    width: 60%;
-    height: 70%;
-    overflow: hidden;
-    padding: 0px;
-    max-width: initial;
-    max-height: initial;
-}
+    .mx_Dialog {
+        width: 60%;
+        height: 70%;
+        overflow: hidden;
+        padding: 0px;
+        max-width: initial;
+        max-height: initial;
+    }
 
-iframe {
-    background-color: #fff;
-    border: 0px;
-    width: 100%;
-    height: 100%;
-}
+    iframe {
+        background-color: #fff;
+        border: 0px;
+        width: 100%;
+        height: 100%;
+    }
 
-.mx_IntegrationManager_loading h3 {
-    text-align: center;
-}
+    .mx_IntegrationManager_loading h3 {
+        text-align: center;
+    }
 
-.mx_IntegrationManager_error {
-    text-align: center;
-    padding-top: 20px;
-}
+    .mx_IntegrationManager_error {
+        text-align: center;
+        padding-top: 20px;
+    }
 
-.mx_IntegrationManager_error h3 {
-    color: $alert;
-}
+    .mx_IntegrationManager_error h3 {
+        color: $alert;
+    }
 }

--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -19,14 +19,14 @@ limitations under the License.
         width: 60%;
         height: 70%;
         overflow: hidden;
-        padding: 0px;
+        padding: 0;
         max-width: initial;
         max-height: initial;
     }
 
     iframe {
         background-color: #fff;
-        border: 0px;
+        border: 0;
         width: 100%;
         height: 100%;
     }
@@ -37,10 +37,10 @@ limitations under the License.
     }
 
     .mx_IntegrationManager_error {
-        padding-top: 20px;
-    }
+        padding-top: $spacing-20;
 
-    .mx_IntegrationManager_error h3 {
-        color: $alert;
+        h3 {
+            color: $alert;
+        }
     }
 }

--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -31,12 +31,12 @@ limitations under the License.
         height: 100%;
     }
 
-    .mx_IntegrationManager_loading h3 {
+    .mx_IntegrationManager_loading,
+    .mx_IntegrationManager_error {
         text-align: center;
     }
 
     .mx_IntegrationManager_error {
-        text-align: center;
         padding-top: 20px;
     }
 

--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -31,6 +31,10 @@ limitations under the License.
         height: 100%;
     }
 
+    h3 {
+        margin-block: $spacing-20;
+    }
+
     .mx_IntegrationManager_loading,
     .mx_IntegrationManager_error {
         text-align: center;

--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_IntegrationManager .mx_Dialog {
+.mx_IntegrationManager {
+.mx_Dialog {
     width: 60%;
     height: 70%;
     overflow: hidden;
@@ -23,7 +24,7 @@ limitations under the License.
     max-height: initial;
 }
 
-.mx_IntegrationManager iframe {
+iframe {
     background-color: #fff;
     border: 0px;
     width: 100%;
@@ -41,4 +42,5 @@ limitations under the License.
 
 .mx_IntegrationManager_error h3 {
     color: $alert;
+}
 }

--- a/res/css/views/settings/_IntegrationManager.scss
+++ b/res/css/views/settings/_IntegrationManager.scss
@@ -16,10 +16,10 @@ limitations under the License.
 
 .mx_IntegrationManager {
     .mx_Dialog {
+        box-sizing: border-box;
         width: 60%;
         height: 70%;
         overflow: hidden;
-        padding: 0;
         max-width: initial;
         max-height: initial;
     }
@@ -36,11 +36,7 @@ limitations under the License.
         text-align: center;
     }
 
-    .mx_IntegrationManager_error {
-        padding-top: $spacing-20;
-
-        h3 {
-            color: $alert;
-        }
+    .mx_IntegrationManager_error h3 {
+        color: $alert;
     }
 }

--- a/src/components/views/settings/IntegrationManager.tsx
+++ b/src/components/views/settings/IntegrationManager.tsx
@@ -22,6 +22,7 @@ import { ActionPayload } from '../../../dispatcher/payloads';
 import Spinner from "../elements/Spinner";
 import { getKeyBindingsManager } from "../../../KeyBindingsManager";
 import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
+import Heading from '../typography/Heading';
 
 interface IProps {
     // false to display an error saying that we couldn't connect to the integration manager
@@ -88,7 +89,7 @@ export default class IntegrationManager extends React.Component<IProps, IState> 
         if (this.props.loading) {
             return (
                 <div className='mx_IntegrationManager_loading'>
-                    <h3>{ _t("Connecting to integration manager...") }</h3>
+                    <Heading size="h3">{ _t("Connecting to integration manager...") }</Heading>
                     <Spinner />
                 </div>
             );
@@ -97,7 +98,7 @@ export default class IntegrationManager extends React.Component<IProps, IState> 
         if (!this.props.connected || this.state.errored) {
             return (
                 <div className='mx_IntegrationManager_error'>
-                    <h3>{ _t("Cannot connect to integration manager") }</h3>
+                    <Heading size="h3">{ _t("Cannot connect to integration manager") }</Heading>
                     <p>{ _t("The integration manager is offline or it cannot reach your homeserver.") }</p>
                 </div>
             );


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22642

- Enable padding to the dialog, keeping its size with the `box-sizing` property
- Use `Heading` component
- Set the same block margin to the headings

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/175541120-bfde560b-9637-4f8a-aa16-992eb71e8051.png)|![after1](https://user-images.githubusercontent.com/3362943/175541018-34ea2baa-0668-4890-a5ed-27d0ba5ae7e5.png)|
|![before2](https://user-images.githubusercontent.com/3362943/175541146-f60d8263-195e-4e94-8e1f-f726b26c6e27.png)|![after2](https://user-images.githubusercontent.com/3362943/175541065-06a08438-d038-471a-8d0e-81d3393b0b7a.png)|
|![before3](https://user-images.githubusercontent.com/3362943/175541161-24e876b0-871b-4e5b-9e5b-3c6281aa5e94.png)|![after3](https://user-images.githubusercontent.com/3362943/175541097-dc354cd6-b69c-4de9-8eae-46098d0f90ef.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve integration manager dialog style ([\#8888](https://github.com/matrix-org/matrix-react-sdk/pull/8888)). Fixes vector-im/element-web#22642. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->