### PR TITLE
Remove inline margin from "From a thread" (ThreadSummaryIcon) on search result panel on IRC layout

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -97,7 +97,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
         .mx_ThreadSummary,
         .mx_ThreadSummaryIcon {
-            margin-left: 64px;
+            margin-left: $left-gutter;
         }
     }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -95,7 +95,8 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             line-height: $font-22px;
         }
 
-        .mx_ThreadSummary {
+        .mx_ThreadSummary,
+        .mx_ThreadSummaryIcon {
             margin-left: 64px;
         }
     }
@@ -107,10 +108,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     padding-top: 18px;
     font-size: $font-14px;
     position: relative;
-
-    .mx_ThreadSummaryIcon {
-        margin-left: 64px;
-    }
 
     .mx_EventTile_avatar {
         top: 14px;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -94,6 +94,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             padding-bottom: 3px;
             line-height: $font-22px;
         }
+
+        .mx_ThreadSummary {
+            margin-left: 64px;
+        }
     }
 }
 
@@ -104,7 +108,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     font-size: $font-14px;
     position: relative;
 
-    .mx_ThreadSummary,
     .mx_ThreadSummaryIcon {
         margin-left: 64px;
     }

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -39,11 +39,6 @@ $irc-line-height: $font-18px;
             margin-right: $right-padding;
         }
 
-        .mx_ThreadSummary {
-            margin-right: 0;
-            margin-left: 0;
-        }
-
         > .mx_EventTile_msgOption {
             order: 5;
             flex-shrink: 0;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22645

| |Before|After|
|-|--------|-------|
|`ThreadSummary` on IRC layout|![before1](https://user-images.githubusercontent.com/3362943/175757094-c021330b-8176-45aa-8ed9-9228d689fb99.png)| |
|`ThreadSummaryIcon` on IRC layout|![before](https://user-images.githubusercontent.com/3362943/175757090-a8210690-d7a5-4695-a167-ccd64a27c885.png)|![after](https://user-images.githubusercontent.com/3362943/175757084-ac6dfdc1-f440-4c84-ac44-1cec03b0dd44.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
Notes: Align "From a thread" on search result panel on IRC layout

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Align "From a thread" on search result panel on IRC layout ([\#8892](https://github.com/matrix-org/matrix-react-sdk/pull/8892)). Fixes vector-im/element-web#22645. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->