### PR TITLE
Move mx_EventTile_avatar style rules out of ":not([data-layout=bubble])"

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -32,6 +32,15 @@ limitations under the License.
     }
 
     .mx_EventTile {
+        &[data-layout=irc],
+        &[data-layout=group] {
+            .mx_EventTile_avatar {
+                position: absolute; // for IRC layout
+                top: 12px;
+                left: -3px;
+            }
+        }
+
         &[data-layout=bubble] {
             &::before {
                 z-index: auto; // enable background color on hover
@@ -74,12 +83,6 @@ limitations under the License.
             .mx_ThreadSummary {
                 margin-right: 0;
                 max-width: min(calc(100% - 36px), 600px);
-            }
-
-            .mx_EventTile_avatar {
-                position: absolute; // for IRC layout
-                top: 12px;
-                left: -3px;
             }
 
             .mx_MessageTimestamp {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -21,6 +21,11 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 .mx_EventTile {
     flex-shrink: 0;
 
+    .mx_EventTile_avatar {
+        cursor: pointer;
+        user-select: none;
+    }
+
     .mx_EventTile_receiptSent,
     .mx_EventTile_receiptSending {
         position: relative;
@@ -91,6 +96,11 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             z-index: 9;
         }
 
+        .mx_EventTile_avatar {
+            top: 14px;
+            left: $spacing-8;
+        }
+
         .mx_MessageTimestamp {
             position: absolute; // for modern layout
         }
@@ -119,13 +129,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     padding-top: 18px;
     font-size: $font-14px;
     position: relative;
-
-    .mx_EventTile_avatar {
-        top: 14px;
-        left: 8px;
-        cursor: pointer;
-        user-select: none;
-    }
 
     &.mx_EventTile_info {
         padding-top: 0;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -61,8 +61,6 @@ $irc-line-height: $font-18px;
         > .mx_EventTile_avatar {
             order: 1;
             position: relative;
-            top: 0;
-            left: 0;
             flex-shrink: 0;
             height: $irc-line-height;
             display: flex;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -58,7 +58,7 @@ $irc-line-height: $font-18px;
             min-width: 0;
         }
 
-        > .mx_EventTile_avatar {
+        .mx_EventTile_avatar {
             order: 1;
             position: relative;
             flex-shrink: 0;
@@ -116,7 +116,7 @@ $irc-line-height: $font-18px;
     }
 
     .mx_EventTile_emote {
-        > .mx_EventTile_avatar {
+        .mx_EventTile_avatar {
             margin-left: calc(var(--name-width) + $icon-width + $right-padding);
         }
     }


### PR DESCRIPTION
This PR moves style rules for `mx_EventTile_avatar` out of `mx_EventTile:not([data-layout=bubble])` to reduce specificity increased by `:not()` pseudo class.

| |Before|After|
|-|---------|------|
|Modern layout|![before3](https://user-images.githubusercontent.com/3362943/175779515-4fc20bfa-84d4-4bb2-96f3-043a471e540a.png)|![after3](https://user-images.githubusercontent.com/3362943/175779487-a416ed04-8542-4600-acea-973d653fea92.png)|
|IRC layout|![before1](https://user-images.githubusercontent.com/3362943/175779506-fc1e10d8-878f-47dc-bef9-ea2a67b1cf73.png)|![after1](https://user-images.githubusercontent.com/3362943/175779482-109b8726-e335-4e4d-8767-eac0c99b966f.png)|
|IRC layout (emote)|![before2](https://user-images.githubusercontent.com/3362943/175779509-bf4fe91c-f36a-4a97-a197-d5ea3556b1da.png)|![after2](https://user-images.githubusercontent.com/3362943/175779472-3a27ab2e-6a8f-4ac6-a530-b1a004dead08.png)|


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->