### PR TITLE
Move mx_EventTile_e2eIcon style out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -102,6 +102,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             line-height: $font-22px;
         }
 
+        .mx_EventTile_e2eIcon {
+            position: absolute;
+            top: 6px;
+            left: 44px;
+            bottom: 0;
+            right: 0;
+        }
+
         .mx_ThreadSummary,
         .mx_ThreadSummaryIcon {
             margin-left: $left-gutter;
@@ -291,14 +299,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             min-height: $font-44px;
             min-width: $font-44px;
         }
-    }
-
-    .mx_EventTile_e2eIcon {
-        position: absolute;
-        top: 6px;
-        left: 44px;
-        bottom: 0;
-        right: 0;
     }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -74,6 +74,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &[data-layout=irc],
     &[data-layout=group] {
+        .mx_EventTile_e2eIcon {
+            position: absolute;
+        }
+
         .mx_MImageBody {
             margin-right: 34px;
         }
@@ -103,7 +107,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
 
         .mx_EventTile_e2eIcon {
-            position: absolute;
             inset: 6px 0 0 44px;
         }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -104,10 +104,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
         .mx_EventTile_e2eIcon {
             position: absolute;
-            top: 6px;
-            left: 44px;
-            bottom: 0;
-            right: 0;
+            inset: 6px 0 0 44px;
         }
 
         .mx_ThreadSummary,

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -84,10 +84,6 @@ $irc-line-height: $font-18px;
 
         > .mx_EventTile_e2eIcon {
             position: absolute;
-            right: unset;
-            left: unset;
-            top: 0;
-
             padding: 0;
 
             flex-shrink: 0;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -83,7 +83,6 @@ $irc-line-height: $font-18px;
         }
 
         .mx_EventTile_e2eIcon {
-            position: absolute;
             padding: 0;
 
             flex-shrink: 0;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -82,7 +82,7 @@ $irc-line-height: $font-18px;
             text-align: right;
         }
 
-        > .mx_EventTile_e2eIcon {
+        .mx_EventTile_e2eIcon {
             position: absolute;
             padding: 0;
 


### PR DESCRIPTION
This PR moves style rules of `mx_EventTile_e2eIcon` from `mx_EventTile:not([data-layout=bubble])` to `mx_EventTile[data-layout=irc]` and `mx_EventTile[data-layout=group]` in order to remove declarations which are used to cancel inherited values on IRC layout.

| |Before|After|
|-|---------|------|
|IRC layout|![before1](https://user-images.githubusercontent.com/3362943/175782417-56a790b0-49e0-4e94-937c-ea78f7497498.png)|![after1](https://user-images.githubusercontent.com/3362943/175782409-46759fd0-2bd5-4a38-b84a-509433ad4449.png)|
|Modern layout|![before2](https://user-images.githubusercontent.com/3362943/175782420-ba84ec9c-c5f5-42c0-999d-b67161136092.png)|![after2](https://user-images.githubusercontent.com/3362943/175782415-c3eebdc7-1e31-406a-9afe-5561ade89736.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->