### PR TITLE
Move mx_DisambiguatedProfile out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -92,8 +92,6 @@ limitations under the License.
 .mx_FilePanel .mx_EventTile .mx_DisambiguatedProfile {
     flex: 1 1 auto;
     line-height: initial;
-    padding: 0px;
-    font-size: $font-14px;
     opacity: 1.0;
     color: $event-timestamp-color;
 }

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -39,6 +39,14 @@ limitations under the License.
                 top: 12px;
                 left: -3px;
             }
+
+            .mx_DisambiguatedProfile {
+                margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
+            }
+
+            .mx_ReplyTile .mx_DisambiguatedProfile {
+                margin-inline-start: 0;
+            }
         }
 
         &[data-layout=bubble] {
@@ -66,14 +74,9 @@ limitations under the License.
                 }
             }
 
-            .mx_DisambiguatedProfile,
             .mx_ReactionsRow,
             .mx_ThreadSummary {
                 margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
-            }
-
-            .mx_ReplyTile .mx_DisambiguatedProfile {
-                margin-inline-start: 0;
             }
 
             .mx_ReactionsRow {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -70,6 +70,14 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
+    .mx_DisambiguatedProfile {
+        color: $primary-content;
+        font-size: $font-14px;
+        display: inline-block;
+        padding-bottom: 0px;
+        padding-top: 0px;
+    }
+
     .mx_ReactionsRow {
         display: flex;
         flex-flow: wrap;
@@ -167,14 +175,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &.mx_EventTile_continuation {
         padding-top: 0px !important;
-    }
-
-    .mx_DisambiguatedProfile {
-        color: $primary-content;
-        font-size: $font-14px;
-        display: inline-block;
-        padding-bottom: 0px;
-        padding-top: 0px;
     }
 
     &.mx_EventTile_isEditing .mx_MessageTimestamp {

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -157,11 +157,9 @@ $irc-line-height: $font-18px;
     .mx_DisambiguatedProfile {
         width: var(--name-width);
         margin-inline-end: 0; // override mx_EventTile > *
-        display: flex;
+        display: inline-block;
         order: 2;
         flex-shrink: 0;
-        justify-content: flex-start;
-        align-items: center;
 
         > .mx_DisambiguatedProfile_displayName {
             width: 100%;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -157,7 +157,6 @@ $irc-line-height: $font-18px;
     .mx_DisambiguatedProfile {
         width: var(--name-width);
         margin-inline-end: 0; // override mx_EventTile > *
-        display: inline-block;
         order: 2;
         flex-shrink: 0;
 

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -95,24 +95,24 @@ $irc-line-height: $font-18px;
                 padding: 0 5px;
             }
 
-        &:hover {
-            overflow: visible;
-            z-index: 10;
-
-            > .mx_DisambiguatedProfile_displayName {
+            &:hover {
                 overflow: visible;
-                display: inline;
-                background-color: $event-selected-color;
-                border-radius: 8px 0 0 8px;
-                padding-right: 8px;
-            }
+                z-index: 10;
 
-            > .mx_DisambiguatedProfile_mxid {
-                visibility: visible;
-                opacity: 1;
-                background-color: $event-selected-color;
+                > .mx_DisambiguatedProfile_displayName {
+                    overflow: visible;
+                    display: inline;
+                    background-color: $event-selected-color;
+                    border-radius: 8px 0 0 8px;
+                    padding-right: 8px;
+                }
+
+                > .mx_DisambiguatedProfile_mxid {
+                    visibility: visible;
+                    opacity: 1;
+                    background-color: $event-selected-color;
+                }
             }
-        }
         }
 
         .mx_MessageTimestamp {

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -75,6 +75,46 @@ $irc-line-height: $font-18px;
             }
         }
 
+        .mx_DisambiguatedProfile {
+            width: var(--name-width);
+            margin-inline-end: 0; // override mx_EventTile > *
+            order: 2;
+            flex-shrink: 0;
+
+            > .mx_DisambiguatedProfile_displayName {
+                width: 100%;
+                text-align: end;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+
+            > .mx_DisambiguatedProfile_mxid {
+                visibility: collapse;
+                // Override the inherited margin.
+                margin-left: 0;
+                padding: 0 5px;
+            }
+        }
+
+        .mx_DisambiguatedProfile:hover {
+            overflow: visible;
+            z-index: 10;
+
+            > .mx_DisambiguatedProfile_displayName {
+                overflow: visible;
+                display: inline;
+                background-color: $event-selected-color;
+                border-radius: 8px 0 0 8px;
+                padding-right: 8px;
+            }
+
+            > .mx_DisambiguatedProfile_mxid {
+                visibility: visible;
+                opacity: 1;
+                background-color: $event-selected-color;
+            }
+        }
+
         .mx_MessageTimestamp {
             font-size: $font-10px;
             text-align: right;
@@ -152,46 +192,6 @@ $irc-line-height: $font-18px;
     .mx_EventTile:hover.mx_EventTile_unknown .mx_EventTile_line {
         padding-left: 0;
         border-left: 0;
-    }
-
-    .mx_DisambiguatedProfile {
-        width: var(--name-width);
-        margin-inline-end: 0; // override mx_EventTile > *
-        order: 2;
-        flex-shrink: 0;
-
-        > .mx_DisambiguatedProfile_displayName {
-            width: 100%;
-            text-align: end;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        > .mx_DisambiguatedProfile_mxid {
-            visibility: collapse;
-            // Override the inherited margin.
-            margin-left: 0;
-            padding: 0 5px;
-        }
-    }
-
-    .mx_DisambiguatedProfile:hover {
-        overflow: visible;
-        z-index: 10;
-
-        > .mx_DisambiguatedProfile_displayName {
-            overflow: visible;
-            display: inline;
-            background-color: $event-selected-color;
-            border-radius: 8px 0 0 8px;
-            padding-right: 8px;
-        }
-
-        > .mx_DisambiguatedProfile_mxid {
-            visibility: visible;
-            opacity: 1;
-            background-color: $event-selected-color;
-        }
     }
 
     .mx_ReplyChain {

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -94,9 +94,8 @@ $irc-line-height: $font-18px;
                 margin-left: 0;
                 padding: 0 5px;
             }
-        }
 
-        .mx_DisambiguatedProfile:hover {
+        &:hover {
             overflow: visible;
             z-index: 10;
 
@@ -113,6 +112,7 @@ $irc-line-height: $font-18px;
                 opacity: 1;
                 background-color: $event-selected-color;
             }
+        }
         }
 
         .mx_MessageTimestamp {

--- a/res/css/views/rooms/_ReplyTile.scss
+++ b/res/css/views/rooms/_ReplyTile.scss
@@ -105,11 +105,6 @@ limitations under the License.
     }
 
     .mx_DisambiguatedProfile {
-        font-size: $font-14px;
         line-height: $font-17px;
-
-        display: inline-block; // anti-zalgo, with overflow hidden
-        padding: 0;
-        margin: 0;
     }
 }


### PR DESCRIPTION
This PR moves `mx_DisambiguatedProfile` style declarations out of `mx_EventTile:not([data-layout=bubble])`, removing inherited declarations.

The profile on IRC layout was provided with flexbox style rules, which have not worked due to `:not()` pseudo class.

| |Before|After|
|-|---------|------|
|Modern layout|![before1](https://user-images.githubusercontent.com/3362943/175800337-08e805e6-1736-42ef-a8d7-b1396b5c3dc3.png)|![after1](https://user-images.githubusercontent.com/3362943/175800326-315da9cb-4136-40d1-9c31-ef897bf930cf.png)|
|IRC layout|![before2](https://user-images.githubusercontent.com/3362943/175800341-74257213-675d-45ff-9c2f-2b9b24db7eef.png)|![after2](https://user-images.githubusercontent.com/3362943/175800333-32293367-5491-40d8-bfb6-e5d0e0fda3e6.png)|
|TimelineCard|![before3](https://user-images.githubusercontent.com/3362943/175800686-088969e4-e3dc-45b2-90d1-1423c9594067.png)|![after3](https://user-images.githubusercontent.com/3362943/175800681-65bff1a7-d0d0-4683-9d97-4de6f6c5c6d2.png)|







Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->