### PR TITLE
Maximize width value of display name on TimelineCard with IRC/modern layout

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -55,6 +55,7 @@ limitations under the License.
 
             .mx_ReplyTile .mx_DisambiguatedProfile {
                 margin-inline-start: 0;
+                max-width: unset;
             }
 
             .mx_ReactionsRow {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -49,6 +49,10 @@ limitations under the License.
                 margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
             }
 
+            .mx_DisambiguatedProfile {
+                max-width: calc(100% - var(--BaseCard_EventTile-spacing-inline)); // instead of $left-gutter
+            }
+
             .mx_ReplyTile .mx_DisambiguatedProfile {
                 margin-inline-start: 0;
             }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22651

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/175866953-514f4fec-e95a-4912-9995-e0e4c9977bf4.png)|![after1](https://user-images.githubusercontent.com/3362943/175866934-37d9b646-c6d8-4531-8016-aedee691a1cd.png)|

`$left-gutter` is a variable for main timeline.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Maximize width value of display name on TimelineCard with IRC/modern layout ([\#8904](https://github.com/matrix-org/matrix-react-sdk/pull/8904)). Fixes vector-im/element-web#22651. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->