### PR TITLE
Live location sharing - render message deleted tile for redacted beacons (PSF-1150)

### DIFF
--- a/src/utils/beacon/timeline.ts
+++ b/src/utils/beacon/timeline.ts
@@ -23,5 +23,9 @@ import { M_BEACON_INFO } from "matrix-js-sdk/src/@types/beacon";
  */
 export const shouldDisplayAsBeaconTile = (event: MatrixEvent): boolean => (
     M_BEACON_INFO.matches(event.getType()) &&
-    !!event.getContent()?.live
+    (
+        event.getContent()?.live ||
+        // redacted beacons should show 'message deleted' tile
+        event.isRedacted()
+    )
 );

--- a/test/utils/beacon/timeline-test.ts
+++ b/test/utils/beacon/timeline-test.ts
@@ -25,9 +25,15 @@ describe('shouldDisplayAsBeaconTile', () => {
     const liveBeacon = makeBeaconInfoEvent(userId, roomId, { isLive: true });
     const notLiveBeacon = makeBeaconInfoEvent(userId, roomId, { isLive: false });
     const memberEvent = new MatrixEvent({ type: EventType.RoomMember });
+    const redactedBeacon = makeBeaconInfoEvent(userId, roomId, { isLive: false });
+    redactedBeacon.makeRedacted(redactedBeacon);
 
     it('returns true for a beacon with live property set to true', () => {
         expect(shouldDisplayAsBeaconTile(liveBeacon)).toBe(true);
+    });
+
+    it('returns true for a redacted beacon', () => {
+        expect(shouldDisplayAsBeaconTile(redactedBeacon)).toBe(true);
     });
 
     it('returns false for a beacon with live property set to false', () => {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location sharing - render message deleted tile for redacted beacons

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location sharing - render message deleted tile for redacted beacons ([\#8905](https://github.com/matrix-org/matrix-react-sdk/pull/8905)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->