### PR TITLE
Don't overlap tile bubbles with timestamps in modern layout

### DIFF
--- a/res/css/views/messages/_EventTileBubble.scss
+++ b/res/css/views/messages/_EventTileBubble.scss
@@ -20,7 +20,7 @@ limitations under the License.
     border-radius: 8px;
     margin: 10px auto;
     // Reserve space for external timestamps, but also cap the width
-    max-width: min(calc(100% - 2 * 48px), 600px);
+    max-width: min(calc(100% - 2 * $MessageTimestamp_width), 600px);
     box-sizing: border-box;
     display: grid;
     grid-template-columns: 24px minmax(0, 1fr) min-content min-content;

--- a/res/css/views/messages/_EventTileBubble.scss
+++ b/res/css/views/messages/_EventTileBubble.scss
@@ -19,10 +19,16 @@ limitations under the License.
     padding: 10px;
     border-radius: 8px;
     margin: 10px auto;
-    max-width: min(90%, 600px);
+    // Reserve space for external timestamps, but also cap the width
+    max-width: min(calc(100% - 2 * 48px), 600px);
     box-sizing: border-box;
     display: grid;
     grid-template-columns: 24px minmax(0, 1fr) min-content min-content;
+
+    .mx_EventTile[data-layout=bubble] & {
+        // Timestamps are inside the tile, so the width can be less constrained
+        max-width: 600px;
+    }
 
     &::before, &::after {
         position: relative;


### PR DESCRIPTION
.|Modern layout|Bubble layout
-|-|-
Main timeline|![Screenshot 2022-06-27 at 11-19-33 Element 2 Test room](https://user-images.githubusercontent.com/48614497/175975932-44f48495-f0c5-405e-9a8a-98762c22bcbd.png)|![Screenshot 2022-06-27 at 11-19-58 Element 2 Test room](https://user-images.githubusercontent.com/48614497/175975933-dc5aacdc-3afa-4dd4-a666-f640ebf52c37.png)
Right panel|![Screenshot 2022-06-27 at 11-19-17 Element 2 Robin's video room 2](https://user-images.githubusercontent.com/48614497/175975931-578b6b00-cd91-4e34-a82f-a08cb9773f87.png)|![Screenshot 2022-06-27 at 11-18-53 Element 2 Robin's video room 2](https://user-images.githubusercontent.com/48614497/175975928-a9b8ffe1-a4d6-4eca-bed0-70bd2c62669f.png)

Closes https://github.com/vector-im/element-web/issues/22425

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't overlap tile bubbles with timestamps in modern layout ([\#8908](https://github.com/matrix-org/matrix-react-sdk/pull/8908)). Fixes vector-im/element-web#22425.<!-- CHANGELOG_PREVIEW_END -->