### PR TITLE
Move mx_EventTile_line and mx_EventTile_reply out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -40,7 +40,7 @@ limitations under the License.
                 padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
 
                 .mx_EventTile_e2eIcon {
-                    inset-inline-start: 8px;
+                    inset-inline-start: $spacing-8;
                 }
             }
 

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -46,13 +46,13 @@ limitations under the License.
 
             &.mx_EventTile_info {
                 .mx_EventTile_avatar {
-                    left: 18px;
+                    inset-inline-start: 18px;
                 }
             }
 
             .mx_EventTile_avatar {
                 position: absolute; // for IRC layout
-                left: -3px;
+                inset-inline-start: -3px;
             }
 
             .mx_EventTile_msgOption {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -39,6 +39,15 @@ limitations under the License.
                 left: -3px;
             }
 
+            .mx_EventTile_line {
+                padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-inline);
+                padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
+
+                .mx_EventTile_e2eIcon {
+                    inset-inline-start: 8px;
+                }
+            }
+
             .mx_EventTile_msgOption {
                 margin-inline-end: 0;
             }
@@ -78,8 +87,7 @@ limitations under the License.
         }
 
         &:not([data-layout="bubble"]) {
-            &.mx_EventTile_info .mx_EventTile_line,
-            .mx_EventTile_line {
+            &.mx_EventTile_info .mx_EventTile_line {
                 padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-inline);
                 padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
 

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -34,11 +34,7 @@ limitations under the License.
     .mx_EventTile {
         &[data-layout=irc],
         &[data-layout=group] {
-            .mx_EventTile_avatar {
-                position: absolute; // for IRC layout
-                left: -3px;
-            }
-
+            &.mx_EventTile_info .mx_EventTile_line,
             .mx_EventTile_line {
                 padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-inline);
                 padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
@@ -46,6 +42,17 @@ limitations under the License.
                 .mx_EventTile_e2eIcon {
                     inset-inline-start: 8px;
                 }
+            }
+
+            &.mx_EventTile_info {
+                .mx_EventTile_avatar {
+                    left: 18px;
+                }
+            }
+
+            .mx_EventTile_avatar {
+                position: absolute; // for IRC layout
+                left: -3px;
             }
 
             .mx_EventTile_msgOption {
@@ -87,25 +94,10 @@ limitations under the License.
         }
 
         &:not([data-layout="bubble"]) {
-            &.mx_EventTile_info .mx_EventTile_line {
-                padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-inline);
-                padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
-
-                .mx_EventTile_e2eIcon {
-                    inset-inline-start: 8px;
-                }
-            }
-
             .mx_MessageTimestamp {
                 position: absolute; // for modern layout and IRC layout
                 inset-inline-start: auto;
                 inset-inline-end: 0;
-            }
-
-            &.mx_EventTile_info {
-                .mx_EventTile_avatar {
-                    left: 18px;
-                }
             }
         }
     }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -90,7 +90,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_EventTile_line,
         .mx_EventTile_reply {
             position: relative;
-            padding-left: $left-gutter;
             border-radius: 8px;
         }
 
@@ -124,6 +123,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_EventTile_reply {
             padding-top: 1px;
             padding-bottom: 3px;
+            padding-left: $left-gutter;
             line-height: $font-22px;
         }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -86,6 +86,17 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_MImageBody {
             margin-right: 34px;
         }
+
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
+            position: relative;
+            padding-left: $left-gutter;
+            border-radius: 8px;
+        }
+
+        .mx_EventTile_reply {
+            margin-right: 10px;
+        }
     }
 
     &[data-layout=group] {
@@ -195,17 +206,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &.mx_EventTile_continuation .mx_EventTile_line {
         clear: both;
-    }
-
-    .mx_EventTile_line,
-    .mx_EventTile_reply {
-        position: relative;
-        padding-left: $left-gutter;
-        border-radius: 8px;
-    }
-
-    .mx_EventTile_reply {
-        margin-right: 10px;
     }
 
     /* this is used for the tile for the event which is selected via the URL.

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -49,7 +49,6 @@ $irc-line-height: $font-18px;
         }
 
         .mx_EventTile_line, .mx_EventTile_reply {
-            padding: 0;
             display: flex;
             flex-direction: column;
             order: 3;

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -48,7 +48,8 @@ $irc-line-height: $font-18px;
             }
         }
 
-        .mx_EventTile_line, .mx_EventTile_reply {
+        .mx_EventTile_line,
+        .mx_EventTile_reply {
             display: flex;
             flex-direction: column;
             order: 3;


### PR DESCRIPTION
This PR moves `mx_EventTile_line` and `mx_EventTile_reply` out of `mx_EventTile:not([data-layout=bubble])`, removing a declaration from `_IRClayout.scss` for cancelling an inherited padding value.

This PR should make it possible to fix inline start (left) padding of info event tile line on IRC layout.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->