### PR TITLE
Reduce video rooms log spam

### DIFF
--- a/src/stores/VideoChannelStore.ts
+++ b/src/stores/VideoChannelStore.ts
@@ -201,6 +201,7 @@ export default class VideoChannelStore extends AsyncStoreWithClient<null> {
             messaging,
             `action:${ElementWidgetActions.JoinCall}`,
             (ev: CustomEvent<IWidgetApiRequest>) => {
+                ev.preventDefault();
                 this.ack(ev);
                 return true;
             },
@@ -281,42 +282,49 @@ export default class VideoChannelStore extends AsyncStoreWithClient<null> {
         await removeOurDevice(room);
     };
 
-    private ack = (ev: CustomEvent<IWidgetApiRequest>) => {
+    private ack = (ev: CustomEvent<IWidgetApiRequest>, messaging = this.activeChannel) => {
         // Even if we don't have a reply to a given widget action, we still need
         // to give the widget API something to acknowledge receipt
-        this.activeChannel.transport.reply(ev.detail, {});
+        messaging.transport.reply(ev.detail, {});
     };
 
     private onHangup = async (ev: CustomEvent<IWidgetApiRequest>) => {
-        this.ack(ev);
+        ev.preventDefault();
+        const messaging = this.activeChannel;
         // In case this hangup is caused by Jitsi Meet crashing at startup,
         // wait for the connection event in order to avoid racing
         if (!this.connected) await waitForEvent(this, VideoChannelEvent.Connect);
         await this.setDisconnected();
+        this.ack(ev, messaging);
     };
 
     private onParticipants = (ev: CustomEvent<IWidgetApiRequest>) => {
+        ev.preventDefault();
         this.participants = ev.detail.data.participants as IJitsiParticipant[];
         this.emit(VideoChannelEvent.Participants, this.roomId, ev.detail.data.participants);
         this.ack(ev);
     };
 
     private onMuteAudio = (ev: CustomEvent<IWidgetApiRequest>) => {
+        ev.preventDefault();
         this.audioMuted = true;
         this.ack(ev);
     };
 
     private onUnmuteAudio = (ev: CustomEvent<IWidgetApiRequest>) => {
+        ev.preventDefault();
         this.audioMuted = false;
         this.ack(ev);
     };
 
     private onMuteVideo = (ev: CustomEvent<IWidgetApiRequest>) => {
+        ev.preventDefault();
         this.videoMuted = true;
         this.ack(ev);
     };
 
     private onUnmuteVideo = (ev: CustomEvent<IWidgetApiRequest>) => {
+        ev.preventDefault();
         this.videoMuted = false;
         this.ack(ev);
     };

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -374,6 +374,7 @@ export class StopGapWidget extends EventEmitter {
         if (WidgetType.JITSI.matches(this.mockWidget.type)) {
             this.messaging.on(`action:${ElementWidgetActions.HangupCall}`,
                 (ev: CustomEvent<IHangupCallApiRequest>) => {
+                    ev.preventDefault();
                     if (ev.detail.data?.errorMessage) {
                         Modal.createDialog(ErrorDialog, {
                             title: _t("Connection lost"),
@@ -382,6 +383,7 @@ export class StopGapWidget extends EventEmitter {
                             }),
                         });
                     }
+                    this.messaging.transport.reply(ev.detail, <IWidgetApiRequestEmptyData>{});
                 },
             );
         }

--- a/test/stores/VideoChannelStore-test.ts
+++ b/test/stores/VideoChannelStore-test.ts
@@ -96,7 +96,7 @@ describe("VideoChannelStore", () => {
         const waitForConnect = new Promise<void>(resolve =>
             store.once(VideoChannelEvent.Connect, resolve),
         );
-        join({ detail: {} } as unknown as CustomEvent<IWidgetApiRequest>);
+        join(new CustomEvent("widgetapirequest", { detail: {} }) as CustomEvent<IWidgetApiRequest>);
         await waitForConnect;
     };
 
@@ -109,7 +109,7 @@ describe("VideoChannelStore", () => {
         const waitForHangup = new Promise<void>(resolve =>
             store.once(VideoChannelEvent.Disconnect, resolve),
         );
-        hangup({ detail: {} } as unknown as CustomEvent<IWidgetApiRequest>);
+        hangup(new CustomEvent("widgetapirequest", { detail: {} }) as CustomEvent<IWidgetApiRequest>);
         await waitForHangup;
     };
 


### PR DESCRIPTION
If you forget to call `preventDefault` in widget action handlers, matrix-widget-api logs a bunch of errors complaining that the action is unsupported/unhandled, even if it isn't.

element-web notes: none
(to avoid duplicate notes with https://github.com/vector-im/element-web/pull/22665)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Reduce video rooms log spam ([\#8913](https://github.com/matrix-org/matrix-react-sdk/pull/8913)).<!-- CHANGELOG_PREVIEW_END -->