### PR TITLE
Improve timing safety of useLatestResult test

### DIFF
--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -47,20 +47,20 @@ describe("useLatestResult", () => {
         await act(async () => {
             await sleep(25);
         });
-        expect(wrapper.text()).toContain("0");
+        expect(wrapper.text()).toEqual("0");
         wrapper.setProps({ doRequest, query: 1 });
         await act(async () => {
-            await sleep(15);
+            await sleep(10);
         });
         wrapper.setProps({ doRequest, query: 2 });
         await act(async () => {
-            await sleep(15);
+            await sleep(10);
         });
-        expect(wrapper.text()).toContain("0");
+        expect(wrapper.text()).toEqual("0");
         await act(async () => {
             await sleep(15);
         });
-        expect(wrapper.text()).toContain("2");
+        expect(wrapper.text()).toEqual("2");
     });
 
     it("should prevent out-of-order results", async () => {
@@ -73,7 +73,7 @@ describe("useLatestResult", () => {
         await act(async () => {
             await sleep(5);
         });
-        expect(wrapper.text()).toContain("0");
+        expect(wrapper.text()).toEqual("0");
         wrapper.setProps({ doRequest, query: 50 });
         await act(async () => {
             await sleep(5);
@@ -82,10 +82,10 @@ describe("useLatestResult", () => {
         await act(async () => {
             await sleep(5);
         });
-        expect(wrapper.text()).toContain("1");
+        expect(wrapper.text()).toEqual("1");
         await act(async () => {
             await sleep(50);
         });
-        expect(wrapper.text()).toContain("1");
+        expect(wrapper.text()).toEqual("1");
     });
 });


### PR DESCRIPTION
and fix contains to be equals instead, as it's *possible* we can accidentally punch in 20 or something and still have the test pass.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->