### PR TITLE
Fix all megolm error reported as unknown

### DIFF
--- a/src/DecryptionFailureTracker.ts
+++ b/src/DecryptionFailureTracker.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixError } from "matrix-js-sdk/src/http-api";
+import { DecryptionError } from "matrix-js-sdk/src/crypto/algorithms";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Error as ErrorEvent } from "@matrix-org/analytics-events/types/typescript/Error";
 
@@ -129,9 +129,13 @@ export class DecryptionFailureTracker {
     //     localStorage.setItem('mx-decryption-failure-event-ids', JSON.stringify([...this.trackedEvents]));
     // }
 
-    public eventDecrypted(e: MatrixEvent, err: MatrixError): void {
+    public eventDecrypted(e: MatrixEvent, err: DecryptionError): void {
+        // for now we only track megolm decrytion failures
+        if (e.event.content?.algorithm != "m.megolm.v1.aes-sha2") {
+            return
+        }
         if (err) {
-            this.addDecryptionFailure(new DecryptionFailure(e.getId(), err.errcode));
+            this.addDecryptionFailure(new DecryptionFailure(e.getId(), err.code));
         } else {
             // Could be an event in the failures, remove it
             this.removeDecryptionFailuresForEvent(e);

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -130,6 +130,7 @@ import { SnakedObject } from "../../utils/SnakedObject";
 import { leaveRoomBehaviour } from "../../utils/leave-behaviour";
 import VideoChannelStore from "../../stores/VideoChannelStore";
 import { IRoomStateEventsActionPayload } from "../../actions/MatrixActionCreators";
+import { DecryptionError } from 'matrix-js-sdk/src/crypto/algorithms';
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1493,7 +1494,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
         // When logging out, stop tracking failures and destroy state
         cli.on(HttpApiEvent.SessionLoggedOut, () => dft.stop());
-        cli.on(MatrixEventEvent.Decrypted, (e, err) => dft.eventDecrypted(e, err as MatrixError));
+        cli.on(MatrixEventEvent.Decrypted, (e, err) => dft.eventDecrypted(e, err as DecryptionError));
 
         cli.on(ClientEvent.Room, (room) => {
             if (MatrixClientPeg.get().isCryptoEnabled()) {

--- a/test/DecryptionFailureTracker-test.js
+++ b/test/DecryptionFailureTracker-test.js
@@ -22,13 +22,16 @@ class MockDecryptionError extends Error {
     constructor(code) {
         super();
 
-        this.errcode = code || 'MOCK_DECRYPTION_ERROR';
+        this.code = code || 'MOCK_DECRYPTION_ERROR';
     }
 }
 
 function createFailedDecryptionEvent() {
     const event = new MatrixEvent({
         event_id: "event-id-" + Math.random().toString(16).slice(2),
+        content: {
+            algorithm : "m.megolm.v1.aes-sha2"
+        }
     });
     event.setClearData(event.badEncryptedMessage(":("));
     return event;


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

All decryption reported by the failure tracker were mapped to the UnknownError name.
This is because the DecryptionError was improperly mapped to a MatrixError, and the code was trying to get `errCode`instead of `code` hence the UnknwonError.

Also the tracker as it is now was catching room decryptions and to_device decrytions (olm). A new analytics error has been created for to_device decryption, so for now we only report megolm decryption errors

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
