### PR TITLE
Disable pointer events for replies to locations

### DIFF
--- a/res/css/components/views/messages/_MBeaconBody.scss
+++ b/res/css/components/views/messages/_MBeaconBody.scss
@@ -51,3 +51,8 @@ limitations under the License.
     max-width: 100%;
     width: 450px;
 }
+
+.mx_ReplyTile .mx_MBeaconBody {
+    // Prevent clicking a beacon within a reply
+    pointer-events: none;
+}

--- a/res/css/views/messages/_MLocationBody.scss
+++ b/res/css/views/messages/_MLocationBody.scss
@@ -42,3 +42,8 @@ limitations under the License.
 .mx_DisambiguatedProfile ~ .mx_MLocationBody {
     margin-top: 6px; // See: https://github.com/matrix-org/matrix-react-sdk/pull/8442
 }
+
+.mx_ReplyTile .mx_MLocationBody {
+    // Prevent clicking a location within a reply
+    pointer-events: none;
+}


### PR DESCRIPTION
Notes: Clicking location replies now redirects to the replied event instead of opening the map

Fixes vector-im/element-web#22667

PSD-283

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Clicking location replies now redirects to the replied event instead of opening the map ([\#8918](https://github.com/matrix-org/matrix-react-sdk/pull/8918)). Fixes vector-im/element-web#22667. Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->