### PR TITLE
Live location share - redact related locations on beacon redaction (PSF-1151)

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -52,6 +52,7 @@ import { OpenForwardDialogPayload } from "../../../dispatcher/payloads/OpenForwa
 import { OpenReportEventDialogPayload } from "../../../dispatcher/payloads/OpenReportEventDialogPayload";
 import { createMapSiteLinkFromEvent } from '../../../utils/location';
 import { getForwardableEvent } from '../../../events/forward/getForwardableEvent';
+import { M_BEACON } from 'matrix-js-sdk/src/@types/beacon';
 
 interface IProps extends IPosition {
     chevronFace: ChevronFace;
@@ -182,6 +183,9 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
 
     private onRedactClick = (): void => {
         const { mxEvent, onCloseDialog } = this.props;
+        const related = this.props.getRelationsForEvent(mxEvent.getId(), 'm.reference', M_BEACON.name);
+        const relatedAlt = this.props.getRelationsForEvent(mxEvent.getId(), 'm.reference', M_BEACON.altName);
+        console.log('hhh', { related, relatedAlt});
         createRedactEventDialog({
             mxEvent,
             onCloseDialog,

--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -52,7 +52,6 @@ import { OpenForwardDialogPayload } from "../../../dispatcher/payloads/OpenForwa
 import { OpenReportEventDialogPayload } from "../../../dispatcher/payloads/OpenReportEventDialogPayload";
 import { createMapSiteLinkFromEvent } from '../../../utils/location';
 import { getForwardableEvent } from '../../../events/forward/getForwardableEvent';
-import { M_BEACON } from 'matrix-js-sdk/src/@types/beacon';
 
 interface IProps extends IPosition {
     chevronFace: ChevronFace;
@@ -183,9 +182,6 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
 
     private onRedactClick = (): void => {
         const { mxEvent, onCloseDialog } = this.props;
-        const related = this.props.getRelationsForEvent(mxEvent.getId(), 'm.reference', M_BEACON.name);
-        const relatedAlt = this.props.getRelationsForEvent(mxEvent.getId(), 'm.reference', M_BEACON.altName);
-        console.log('hhh', { related, relatedAlt});
         createRedactEventDialog({
             mxEvent,
             onCloseDialog,

--- a/src/components/views/messages/MBeaconBody.tsx
+++ b/src/components/views/messages/MBeaconBody.tsx
@@ -25,6 +25,7 @@ import {
 } from 'matrix-js-sdk/src/matrix';
 import { BeaconLocationState } from 'matrix-js-sdk/src/content-helpers';
 import { randomString } from 'matrix-js-sdk/src/randomstring';
+import { M_BEACON } from 'matrix-js-sdk/src/@types/beacon';
 
 import MatrixClientContext from '../../../contexts/MatrixClientContext';
 import { useEventEmitterState } from '../../../hooks/useEventEmitter';
@@ -41,7 +42,6 @@ import OwnBeaconStatus from '../beacon/OwnBeaconStatus';
 import BeaconViewDialog from '../beacon/BeaconViewDialog';
 import { IBodyProps } from "./IBodyProps";
 import { GetRelationsForEvent } from '../rooms/EventTile';
-import { M_BEACON } from 'matrix-js-sdk/src/@types/beacon';
 
 const useBeaconState = (beaconInfoEvent: MatrixEvent): {
     beacon?: Beacon;
@@ -96,6 +96,7 @@ const useUniqueId = (eventId: string): string => {
     return id;
 };
 
+// remove related beacon locations on beacon redaction
 const useHandleBeaconRedaction = (
     event: MatrixEvent,
     getRelationsForEvent: GetRelationsForEvent,
@@ -105,8 +106,6 @@ const useHandleBeaconRedaction = (
         const relations = getRelationsForEvent ?
             getRelationsForEvent(event.getId(), RelationType.Reference, M_BEACON.name) :
             undefined;
-
-        console.log('hhh', { relations, event });
 
         relations?.getRelations()?.forEach(locationEvent => {
             cli.redactEvent(

--- a/src/components/views/messages/MBeaconBody.tsx
+++ b/src/components/views/messages/MBeaconBody.tsx
@@ -35,13 +35,13 @@ import { isBeaconWaitingToStart, useBeacon } from '../../../utils/beacon';
 import { isSelfLocation } from '../../../utils/location';
 import { BeaconDisplayStatus, getBeaconDisplayStatus } from '../beacon/displayStatus';
 import BeaconStatus from '../beacon/BeaconStatus';
+import OwnBeaconStatus from '../beacon/OwnBeaconStatus';
 import Map from '../location/Map';
 import MapFallback from '../location/MapFallback';
 import SmartMarker from '../location/SmartMarker';
-import OwnBeaconStatus from '../beacon/OwnBeaconStatus';
+import { GetRelationsForEvent } from '../rooms/EventTile';
 import BeaconViewDialog from '../beacon/BeaconViewDialog';
 import { IBodyProps } from "./IBodyProps";
-import { GetRelationsForEvent } from '../rooms/EventTile';
 
 const useBeaconState = (beaconInfoEvent: MatrixEvent): {
     beacon?: Beacon;

--- a/src/components/views/messages/MBeaconBody.tsx
+++ b/src/components/views/messages/MBeaconBody.tsx
@@ -14,8 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useContext, useEffect, useState } from 'react';
-import { Beacon, BeaconEvent, MatrixEvent } from 'matrix-js-sdk/src/matrix';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import {
+    Beacon,
+    BeaconEvent,
+    MatrixEvent,
+    MatrixEventEvent,
+    MatrixClient,
+    RelationType,
+} from 'matrix-js-sdk/src/matrix';
 import { BeaconLocationState } from 'matrix-js-sdk/src/content-helpers';
 import { randomString } from 'matrix-js-sdk/src/randomstring';
 
@@ -33,6 +40,8 @@ import SmartMarker from '../location/SmartMarker';
 import OwnBeaconStatus from '../beacon/OwnBeaconStatus';
 import BeaconViewDialog from '../beacon/BeaconViewDialog';
 import { IBodyProps } from "./IBodyProps";
+import { GetRelationsForEvent } from '../rooms/EventTile';
+import { M_BEACON } from 'matrix-js-sdk/src/@types/beacon';
 
 const useBeaconState = (beaconInfoEvent: MatrixEvent): {
     beacon?: Beacon;
@@ -87,7 +96,37 @@ const useUniqueId = (eventId: string): string => {
     return id;
 };
 
-const MBeaconBody: React.FC<IBodyProps> = React.forwardRef(({ mxEvent }, ref) => {
+const useHandleBeaconRedaction = (
+    event: MatrixEvent,
+    getRelationsForEvent: GetRelationsForEvent,
+    cli: MatrixClient,
+): void => {
+    const onBeforeBeaconInfoRedaction = useCallback((_event: MatrixEvent, redactionEvent: MatrixEvent) => {
+        const relations = getRelationsForEvent ?
+            getRelationsForEvent(event.getId(), RelationType.Reference, M_BEACON.name) :
+            undefined;
+
+        console.log('hhh', { relations, event });
+
+        relations?.getRelations()?.forEach(locationEvent => {
+            cli.redactEvent(
+                locationEvent.getRoomId(),
+                locationEvent.getId(),
+                undefined,
+                redactionEvent.getContent(),
+            );
+        });
+    }, [event, getRelationsForEvent, cli]);
+
+    useEffect(() => {
+        event.addListener(MatrixEventEvent.BeforeRedaction, onBeforeBeaconInfoRedaction);
+        return () => {
+            event.removeListener(MatrixEventEvent.BeforeRedaction, onBeforeBeaconInfoRedaction);
+        };
+    }, [event, onBeforeBeaconInfoRedaction]);
+};
+
+const MBeaconBody: React.FC<IBodyProps> = React.forwardRef(({ mxEvent, getRelationsForEvent }, ref) => {
     const {
         beacon,
         isLive,
@@ -101,6 +140,8 @@ const MBeaconBody: React.FC<IBodyProps> = React.forwardRef(({ mxEvent }, ref) =>
     const displayStatus = getBeaconDisplayStatus(isLive, latestLocationState, error, waitingToStart);
     const markerRoomMember = isSelfLocation(mxEvent.getContent()) ? mxEvent.sender : undefined;
     const isOwnBeacon = beacon?.beaconInfoOwner === matrixClient.getUserId();
+
+    useHandleBeaconRedaction(mxEvent, getRelationsForEvent, matrixClient);
 
     const onClick = () => {
         if (displayStatus !== BeaconDisplayStatus.Active) {

--- a/test/components/views/beacon/__snapshots__/BeaconMarker-test.tsx.snap
+++ b/test/components/views/beacon/__snapshots__/BeaconMarker-test.tsx.snap
@@ -38,6 +38,7 @@ exports[`<BeaconMarker /> renders marker when beacon has location 1`] = `
           },
           "org.matrix.msc3488.ts": 1647270879404,
         },
+        "room_id": undefined,
         "sender": "@alice:server",
         "type": "org.matrix.msc3672.beacon",
       },

--- a/test/test-utils/beacon.ts
+++ b/test/test-utils/beacon.ts
@@ -97,6 +97,7 @@ const DEFAULT_CONTENT_PROPS: ContentProps = {
 export const makeBeaconEvent = (
     sender: string,
     contentProps: Partial<ContentProps> = {},
+    roomId?: string,
 ): MatrixEvent => {
     const { geoUri, timestamp, beaconInfoId, description } = {
         ...DEFAULT_CONTENT_PROPS,
@@ -105,6 +106,7 @@ export const makeBeaconEvent = (
 
     return new MatrixEvent({
         type: M_BEACON.name,
+        room_id: roomId,
         sender,
         content: makeBeaconContent(geoUri, timestamp, beaconInfoId, description),
     });


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location share - redact related locations on beacon redaction

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
