### PR TITLE
Live location share - disallow message pinning (PSF-1084)

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
-Copyright 2015 - 2021 The Matrix.org Foundation C.I.C.
+Copyright 2015 - 2022 The Matrix.org Foundation C.I.C.
 Copyright 2021 - 2022 Šimon Brandner <simon.bra.ag@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,13 @@ import Modal from '../../../Modal';
 import Resend from '../../../Resend';
 import SettingsStore from '../../../settings/SettingsStore';
 import { isUrlPermitted } from '../../../HtmlUtils';
-import { canEditContent, editEvent, isContentActionable, isLocationEvent } from '../../../utils/EventUtils';
+import {
+    canEditContent,
+    canPinEvent,
+    editEvent,
+    isContentActionable,
+    isLocationEvent,
+} from '../../../utils/EventUtils';
 import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOptionList } from './IconizedContextMenu';
 import { ReadPinsEventId } from "../right_panel/types";
 import { Action } from "../../../dispatcher/actions";
@@ -121,7 +127,9 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
         const canRedact = room.currentState.maySendRedactionForEvent(this.props.mxEvent, cli.credentials.userId)
             && this.props.mxEvent.getType() !== EventType.RoomServerAcl
             && this.props.mxEvent.getType() !== EventType.RoomEncryption;
-        let canPin = room.currentState.mayClientSendStateEvent(EventType.RoomPinnedEvents, cli);
+
+        let canPin = room.currentState.mayClientSendStateEvent(EventType.RoomPinnedEvents, cli) &&
+            canPinEvent(this.props.mxEvent);
 
         // HACK: Intentionally say we can't pin if the user doesn't want to use the functionality
         if (!SettingsStore.getValue("feature_pinning")) canPin = false;
@@ -204,6 +212,7 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
         const eventId = this.props.mxEvent.getId();
 
         const pinnedIds = room?.currentState?.getStateEvents(EventType.RoomPinnedEvents, "")?.getContent().pinned || [];
+
         if (pinnedIds.includes(eventId)) {
             pinnedIds.splice(pinnedIds.indexOf(eventId), 1);
         } else {

--- a/src/events/forward/getForwardableBeacon.ts
+++ b/src/events/forward/getForwardableBeacon.ts
@@ -25,9 +25,9 @@ import { ForwardableEventTransformFunction } from "./types";
 export const getForwardableBeaconEvent: ForwardableEventTransformFunction = (event, cli) => {
     const room = cli.getRoom(event.getRoomId());
     const beacon = room.currentState.beacons?.get(getBeaconInfoIdentifier(event));
-    const latestLocationEvent = beacon.latestLocationEvent;
+    const latestLocationEvent = beacon?.latestLocationEvent;
 
-    if (beacon.isLive && latestLocationEvent) {
+    if (beacon?.isLive && latestLocationEvent) {
         return latestLocationEvent;
     }
     return null;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -284,3 +284,7 @@ export const isLocationEvent = (event: MatrixEvent): boolean => {
 export function hasThreadSummary(event: MatrixEvent): boolean {
     return event.isThreadRoot && event.getThread()?.length && !!event.getThread().replyToEvent;
 }
+
+export function canPinEvent(event: MatrixEvent): boolean {
+    return !M_BEACON_INFO.matches(event.getType());
+}

--- a/test/components/views/context_menus/MessageContextMenu-test.tsx
+++ b/test/components/views/context_menus/MessageContextMenu-test.tsx
@@ -44,9 +44,9 @@ jest.mock("../../../../src/utils/strings", () => ({
     getSelectedText: jest.fn(),
 }));
 jest.mock("../../../../src/utils/EventUtils", () => ({
+    // @ts-ignore don't mock everything
+    ...jest.requireActual("../../../../src/utils/EventUtils"),
     canEditContent: jest.fn(),
-    isContentActionable: jest.fn(),
-    isLocationEvent: jest.fn(),
 }));
 
 const roomId = 'roomid';
@@ -76,7 +76,6 @@ describe('MessageContextMenu', () => {
 
     describe('message forwarding', () => {
         it('allows forwarding a room message', () => {
-            mocked(isContentActionable).mockReturnValue(true);
 
             const eventContent = MessageEvent.from("hello");
             const menu = createMenuWithContent(eventContent);
@@ -92,7 +91,7 @@ describe('MessageContextMenu', () => {
         describe('forwarding beacons', () => {
             const aliceId = "@alice:server.org";
             beforeEach(() => {
-                mocked(isContentActionable).mockReturnValue(true);
+
             });
 
             it('does not allow forwarding a beacon that is not live', () => {
@@ -212,7 +211,6 @@ describe('MessageContextMenu', () => {
             const context = {
                 canSendMessages: true,
             };
-            mocked(isContentActionable).mockReturnValue(true);
 
             const menu = createRightClickMenuWithContent(eventContent, context);
             const replyButton = menu.find('div[aria-label="Reply"]');
@@ -224,9 +222,11 @@ describe('MessageContextMenu', () => {
             const context = {
                 canSendMessages: true,
             };
-            mocked(isContentActionable).mockReturnValue(false);
+            const unsentMessage = new MatrixEvent(eventContent.serialize());
+            // queued messages are not actionable
+            unsentMessage.setStatus(EventStatus.QUEUED)
 
-            const menu = createRightClickMenuWithContent(eventContent, context);
+            const menu = createMenu(unsentMessage, {}, context);
             const replyButton = menu.find('div[aria-label="Reply"]');
             expect(replyButton).toHaveLength(0);
         });
@@ -236,7 +236,6 @@ describe('MessageContextMenu', () => {
             const context = {
                 canReact: true,
             };
-            mocked(isContentActionable).mockReturnValue(true);
 
             const menu = createRightClickMenuWithContent(eventContent, context);
             const reactButton = menu.find('div[aria-label="React"]');

--- a/test/components/views/context_menus/MessageContextMenu-test.tsx
+++ b/test/components/views/context_menus/MessageContextMenu-test.tsx
@@ -98,6 +98,17 @@ describe('MessageContextMenu', () => {
             expect(menu.find('div[aria-label="Pin"]')).toHaveLength(0);
         });
 
+        it('does not show pin option for beacon_info event', () => {
+            const deadBeaconEvent = makeBeaconInfoEvent('@alice:server.org', roomId, { isLive: false });
+
+            const room = makeDefaultRoom();
+            jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
+
+            const menu = createMenu(deadBeaconEvent, {}, {}, undefined, room);
+
+            expect(menu.find('div[aria-label="Pin"]')).toHaveLength(0);
+        });
+
         it('does not show pin option when pinning feature is disabled', () => {
             const eventContent = MessageEvent.from("hello");
             const pinnableEvent = new MatrixEvent({ ...eventContent.serialize(), room_id: roomId });

--- a/test/components/views/context_menus/MessageContextMenu-test.tsx
+++ b/test/components/views/context_menus/MessageContextMenu-test.tsx
@@ -91,6 +91,7 @@ describe('MessageContextMenu', () => {
             const event = new MatrixEvent(eventContent.serialize());
 
             const room = makeDefaultRoom();
+            // mock permission to disallow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(false);
 
             const menu = createMenu(event, {}, {}, undefined, room);
@@ -102,6 +103,7 @@ describe('MessageContextMenu', () => {
             const deadBeaconEvent = makeBeaconInfoEvent('@alice:server.org', roomId, { isLive: false });
 
             const room = makeDefaultRoom();
+            // mock permission to allow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
 
             const menu = createMenu(deadBeaconEvent, {}, {}, undefined, room);
@@ -114,6 +116,7 @@ describe('MessageContextMenu', () => {
             const pinnableEvent = new MatrixEvent({ ...eventContent.serialize(), room_id: roomId });
 
             const room = makeDefaultRoom();
+            // mock permission to allow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
             // disable pinning feature
             jest.spyOn(SettingsStore, 'getValue').mockReturnValue(false);
@@ -128,6 +131,7 @@ describe('MessageContextMenu', () => {
             const pinnableEvent = new MatrixEvent({ ...eventContent.serialize(), room_id: roomId });
 
             const room = makeDefaultRoom();
+            // mock permission to allow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
 
             const menu = createMenu(pinnableEvent, {}, {}, undefined, room);
@@ -138,12 +142,16 @@ describe('MessageContextMenu', () => {
         it('pins event on pin option click', () => {
             const onFinished = jest.fn();
             const eventContent = MessageEvent.from("hello");
-            const pinsAccountData = new MatrixEvent({ content: { event_ids: ['!1', '!2'] } });
             const pinnableEvent = new MatrixEvent({ ...eventContent.serialize(), room_id: roomId });
             pinnableEvent.event.event_id = '!3';
             const client = MatrixClientPeg.get();
             const room = makeDefaultRoom();
+
+            // mock permission to allow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
+
+            // mock read pins account data
+            const pinsAccountData = new MatrixEvent({ content: { event_ids: ['!1', '!2'] } });
             jest.spyOn(room, 'getAccountData').mockReturnValue(pinsAccountData);
 
             const menu = createMenu(pinnableEvent, { onFinished }, {}, undefined, room);
@@ -173,12 +181,12 @@ describe('MessageContextMenu', () => {
 
         it('unpins event on pin option click when event is pinned', () => {
             const eventContent = MessageEvent.from("hello");
-            const pinsAccountData = new MatrixEvent({ content: { event_ids: ['!1', '!2'] } });
             const pinnableEvent = new MatrixEvent({ ...eventContent.serialize(), room_id: roomId });
             pinnableEvent.event.event_id = '!3';
             const client = MatrixClientPeg.get();
             const room = makeDefaultRoom();
 
+            // make the event already pinned in the room
             const pinEvent = new MatrixEvent({
                 type: EventType.RoomPinnedEvents,
                 room_id: roomId,
@@ -187,7 +195,11 @@ describe('MessageContextMenu', () => {
             });
             room.currentState.setStateEvents([pinEvent]);
 
+            // mock permission to allow adding pinned messages to room
             jest.spyOn(room.currentState, 'mayClientSendStateEvent').mockReturnValue(true);
+
+            // mock read pins account data
+            const pinsAccountData = new MatrixEvent({ content: { event_ids: ['!1', '!2'] } });
             jest.spyOn(room, 'getAccountData').mockReturnValue(pinsAccountData);
 
             const menu = createMenu(pinnableEvent, {}, {}, undefined, room);


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

- disable message pinning for live location tiles
- add tests to message pinning

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location share - disallow message pinning

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location share - disallow message pinning ([\#8928](https://github.com/matrix-org/matrix-react-sdk/pull/8928)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->