### PR TITLE
Remove uneven top and bottom padding from info event tile line on IRC layout

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -89,6 +89,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 
     &[data-layout=group] {
+        &.mx_EventTile_info {
+            .mx_EventTile_line {
+                padding: 3px 0 2px; // Align with mx_EventTile_avatar and mx_EventTile_e2eIcon on modern layout
+            }
+        }
+
         > .mx_DisambiguatedProfile {
             line-height: $font-20px;
             margin-left: $left-gutter;
@@ -161,8 +167,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
 
         .mx_EventTile_line {
-            padding: 3px 0 2px; // Align with mx_EventTile_avatar and mx_EventTile_e2eIcon
-
             .mx_MessageTimestamp {
                 top: 0;
             }


### PR DESCRIPTION
|Before (with `:not()` pseudo class)|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/176241677-ddfcace5-ebc1-4217-9436-521ffd4475b1.png)|![after](https://user-images.githubusercontent.com/3362943/176241661-e392f583-c667-4b3c-9159-0c4c9896c871.png)|
|↑ `mx_IRCLayout` is weaker than `:not()`|↑ zero padding is applied|
|![before](https://user-images.githubusercontent.com/3362943/176342036-edbd3bba-c659-44c9-9c3f-ed5e1b7f7a04.png)|![after](https://user-images.githubusercontent.com/3362943/176342021-8ce8907c-f3b0-475a-80a3-9c98882fd3f5.png)|

1px spacing has been applied to `mx_TextualEvent` on `_IRCLayout.scss` as below.

![after](https://user-images.githubusercontent.com/3362943/176242730-2ebf336c-7227-4f47-9ac1-245efd75259e.png)

Please note the inline start (left) padding added to the info event tile line on IRC layout is out of scope of this PR.

Notes: Remove uneven top and bottom padding from info event tile line on IRC layout

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove uneven top and bottom padding from info event tile line on IRC layout ([\#8929](https://github.com/matrix-org/matrix-react-sdk/pull/8929)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->