### PR TITLE
MessageComposerButtons: code cleanup, move buttons out of dropdown

### DIFF
--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -103,11 +103,15 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
 
     return <UploadButtonContextProvider roomId={roomId} relation={props.relation}>
         { mainButtons }
-        { moreButtons.length > 0 && <AccessibleTooltipButton
-            className={moreOptionsClasses}
-            onClick={props.toggleButtonMenu}
-            title={_t("More options")}
-        /> }
+        { moreButtons.length > 0 &&
+            (narrow ?
+                <AccessibleTooltipButton
+                    className={moreOptionsClasses}
+                    onClick={props.toggleButtonMenu}
+                    title={_t("More options")}
+                /> : moreButtons
+            )
+        }
         { props.isMenuOpen && (
             <IconizedContextMenu
                 onFinished={props.toggleButtonMenu}

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -74,10 +74,10 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
         ];
         moreButtons = [
             uploadButton(), // props passed via UploadButtonContext
-            showStickersButton(props),
+            stickersButton(props),
             voiceRecordingButton(props, narrow),
             props.showPollsButton && pollButton(room, props.relation),
-            showLocationButton(props, room, roomId, matrixClient),
+            props.showLocationButton && locationButton(props, room, roomId, matrixClient),
         ];
     } else {
         mainButtons = [
@@ -85,10 +85,10 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             uploadButton(), // props passed via UploadButtonContext
         ];
         moreButtons = [
-            showStickersButton(props),
+            stickersButton(props),
             voiceRecordingButton(props, narrow),
             props.showPollsButton && pollButton(room, props.relation),
-            showLocationButton(props, room, roomId, matrixClient),
+            locationButton(props, room, roomId, matrixClient),
         ];
     }
 
@@ -265,7 +265,7 @@ const UploadButton = () => {
     />;
 };
 
-function showStickersButton(props: IProps): ReactElement {
+function stickersButton(props: IProps): ReactElement {
     return (
         props.showStickersButton
             ? <CollapsibleButton
@@ -357,22 +357,20 @@ class PollButton extends React.PureComponent<IPollButtonProps> {
     }
 }
 
-function showLocationButton(
+function locationButton(
     props: IProps,
     room: Room,
     roomId: string,
     matrixClient: MatrixClient,
 ): ReactElement {
     return (
-        props.showLocationButton
-            ? <LocationButton
-                key="location"
-                roomId={roomId}
-                relation={props.relation}
-                sender={room.getMember(matrixClient.getUserId())}
-                menuPosition={props.menuPosition}
-            />
-            : null
+        <LocationButton
+            key="location"
+            roomId={roomId}
+            relation={props.relation}
+            sender={room.getMember(matrixClient.getUserId())}
+            menuPosition={props.menuPosition}
+        />
     );
 }
 

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -82,11 +82,11 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
     } else {
         mainButtons = [
             emojiButton(props),
+            stickersButton(props),
+            voiceRecordingButton(props, narrow),
             uploadButton(), // props passed via UploadButtonContext
         ];
         moreButtons = [
-            stickersButton(props),
-            voiceRecordingButton(props, narrow),
             props.showPollsButton && pollButton(room, props.relation),
             locationButton(props, room, roomId, matrixClient),
         ];

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -103,15 +103,11 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
 
     return <UploadButtonContextProvider roomId={roomId} relation={props.relation}>
         { mainButtons }
-        { moreButtons.length > 0 &&
-            (narrow ?
-                <AccessibleTooltipButton
-                    className={moreOptionsClasses}
-                    onClick={props.toggleButtonMenu}
-                    title={_t("More options")}
-                /> : moreButtons
-            )
-        }
+        { moreButtons.length > 0 && <AccessibleTooltipButton
+            className={moreOptionsClasses}
+            onClick={props.toggleButtonMenu}
+            title={_t("More options")}
+        /> }
         { props.isMenuOpen && (
             <IconizedContextMenu
                 onFinished={props.toggleButtonMenu}

--- a/test/components/views/rooms/MessageComposerButtons-test.tsx
+++ b/test/components/views/rooms/MessageComposerButtons-test.tsx
@@ -40,7 +40,7 @@ const mockProps: React.ComponentProps<typeof MessageComposerButtons> = {
 };
 
 describe("MessageComposerButtons", () => {
-    it("Renders emoji and upload buttons in wide mode", () => {
+    it("Renders all buttons in wide mode", () => {
         const buttons = wrapAndRender(
             <MessageComposerButtons
                 isMenuOpen={false}
@@ -55,32 +55,10 @@ describe("MessageComposerButtons", () => {
         expect(buttonLabels(buttons)).toEqual([
             "Emoji",
             "Attachment",
-            "More options",
-        ]);
-    });
-
-    it("Renders other buttons in menu in wide mode", () => {
-        const buttons = wrapAndRender(
-            <MessageComposerButtons
-                isMenuOpen={true}
-                showLocationButton={true}
-                showPollsButton={true}
-                showStickersButton={true}
-                {...mockProps}
-            />,
-            false,
-        );
-
-        expect(buttonLabels(buttons)).toEqual([
-            "Emoji",
-            "Attachment",
-            "More options",
-            [
-                "Sticker",
-                "Voice Message",
-                "Poll",
-                "Location",
-            ],
+            "Sticker",
+            "Voice Message",
+            "Poll",
+            "Location",
         ]);
     });
 

--- a/test/components/views/rooms/MessageComposerButtons-test.tsx
+++ b/test/components/views/rooms/MessageComposerButtons-test.tsx
@@ -40,7 +40,7 @@ const mockProps: React.ComponentProps<typeof MessageComposerButtons> = {
 };
 
 describe("MessageComposerButtons", () => {
-    it("Renders all buttons in wide mode", () => {
+    it("Renders emoji and upload buttons in wide mode", () => {
         const buttons = wrapAndRender(
             <MessageComposerButtons
                 isMenuOpen={false}
@@ -55,10 +55,32 @@ describe("MessageComposerButtons", () => {
         expect(buttonLabels(buttons)).toEqual([
             "Emoji",
             "Attachment",
-            "Sticker",
-            "Voice Message",
-            "Poll",
-            "Location",
+            "More options",
+        ]);
+    });
+
+    it("Renders other buttons in menu in wide mode", () => {
+        const buttons = wrapAndRender(
+            <MessageComposerButtons
+                isMenuOpen={true}
+                showLocationButton={true}
+                showPollsButton={true}
+                showStickersButton={true}
+                {...mockProps}
+            />,
+            false,
+        );
+
+        expect(buttonLabels(buttons)).toEqual([
+            "Emoji",
+            "Attachment",
+            "More options",
+            [
+                "Sticker",
+                "Voice Message",
+                "Poll",
+                "Location",
+            ],
         ]);
     });
 

--- a/test/components/views/rooms/MessageComposerButtons-test.tsx
+++ b/test/components/views/rooms/MessageComposerButtons-test.tsx
@@ -54,6 +54,8 @@ describe("MessageComposerButtons", () => {
 
         expect(buttonLabels(buttons)).toEqual([
             "Emoji",
+            "Sticker",
+            "Voice Message",
             "Attachment",
             "More options",
         ]);
@@ -73,11 +75,11 @@ describe("MessageComposerButtons", () => {
 
         expect(buttonLabels(buttons)).toEqual([
             "Emoji",
+            "Sticker",
+            "Voice Message",
             "Attachment",
             "More options",
             [
-                "Sticker",
-                "Voice Message",
                 "Poll",
                 "Location",
             ],


### PR DESCRIPTION
If we're in wide mode, we might away steal a bit more space from the text input to save a click for users.

There's 3 options in this PR:
1. First commit only (just a code refactor; same as before this PR)
![Screen Shot 2022-06-29 at 06 23 27](https://user-images.githubusercontent.com/25263210/176344457-296c8235-e40d-494c-bd29-41674a0480c7.png)
2. Second commit
![Screen Shot 2022-06-29 at 06 22 18](https://user-images.githubusercontent.com/25263210/176344349-f39d1c4d-74fe-4777-a9f2-25560e9fd275.png)
3. All commits
![Screen Shot 2022-06-29 at 06 22 29](https://user-images.githubusercontent.com/25263210/176344356-49ac7899-38e7-45a0-a948-9a29096ac937.png)

Opinions? I think <span>#</span>2 is too overloaded.

Notes: TBD
Type: enhancement 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * TBD ([\#8930](https://github.com/matrix-org/matrix-react-sdk/pull/8930)). Contributed by @ckiee.<!-- CHANGELOG_PREVIEW_END -->