### PR TITLE
Fix calls on homeservers without the unstable thirdparty endpoints

### DIFF
--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -273,7 +273,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
-            logger.log('Failed to lookup user from phone number', e);
+            logger.warn('Failed to lookup user from phone number', e);
             return Promise.resolve([]);
         }
     }
@@ -286,7 +286,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
-            logger.log('Failed to query SIP identity for user', e);
+            logger.warn('Failed to query SIP identity for user', e);
             return Promise.resolve([]);
         }
     }
@@ -299,7 +299,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
-            logger.log('Failed to query identity for SIP user', e);
+            logger.warn('Failed to query identity for SIP user', e);
             return Promise.resolve([]);
         }
     }

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -265,28 +265,40 @@ export default class CallHandler extends EventEmitter {
         return this.supportsSipNativeVirtual;
     }
 
-    public pstnLookup(phoneNumber: string): Promise<ThirdpartyLookupResponse[]> {
-        return MatrixClientPeg.get().getThirdpartyUser(
-            this.pstnSupportPrefixed ? PROTOCOL_PSTN_PREFIXED : PROTOCOL_PSTN, {
-                'm.id.phone': phoneNumber,
-            },
-        );
+    public async pstnLookup(phoneNumber: string): Promise<ThirdpartyLookupResponse[]> {
+        try {
+            return await MatrixClientPeg.get().getThirdpartyUser(
+                this.pstnSupportPrefixed ? PROTOCOL_PSTN_PREFIXED : PROTOCOL_PSTN, {
+                    'm.id.phone': phoneNumber,
+                },
+            );
+        } catch (e) {
+            return Promise.resolve([]);
+        }
     }
 
-    public sipVirtualLookup(nativeMxid: string): Promise<ThirdpartyLookupResponse[]> {
-        return MatrixClientPeg.get().getThirdpartyUser(
-            PROTOCOL_SIP_VIRTUAL, {
-                'native_mxid': nativeMxid,
-            },
-        );
+    public async sipVirtualLookup(nativeMxid: string): Promise<ThirdpartyLookupResponse[]> {
+        try {
+            return await MatrixClientPeg.get().getThirdpartyUser(
+                PROTOCOL_SIP_VIRTUAL, {
+                    'native_mxid': nativeMxid,
+                },
+            );
+        } catch (e) {
+            return Promise.resolve([]);
+        }
     }
 
-    public sipNativeLookup(virtualMxid: string): Promise<ThirdpartyLookupResponse[]> {
-        return MatrixClientPeg.get().getThirdpartyUser(
-            PROTOCOL_SIP_NATIVE, {
-                'virtual_mxid': virtualMxid,
-            },
-        );
+    public async sipNativeLookup(virtualMxid: string): Promise<ThirdpartyLookupResponse[]> {
+        try {
+            return await MatrixClientPeg.get().getThirdpartyUser(
+                PROTOCOL_SIP_NATIVE, {
+                    'virtual_mxid': virtualMxid,
+                },
+            );
+        } catch (e) {
+            return Promise.resolve([]);
+        }
     }
 
     private onCallIncoming = (call: MatrixCall): void => {

--- a/src/CallHandler.tsx
+++ b/src/CallHandler.tsx
@@ -273,6 +273,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
+            logger.log('Failed to lookup user from phone number', e);
             return Promise.resolve([]);
         }
     }
@@ -285,6 +286,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
+            logger.log('Failed to query SIP identity for user', e);
             return Promise.resolve([]);
         }
     }
@@ -297,6 +299,7 @@ export default class CallHandler extends EventEmitter {
                 },
             );
         } catch (e) {
+            logger.log('Failed to query identity for SIP user', e);
             return Promise.resolve([]);
         }
     }

--- a/test/CallHandler-test.ts
+++ b/test/CallHandler-test.ts
@@ -79,7 +79,7 @@ class FakeCall extends EventEmitter {
     roomId: string;
     callId = "fake call id";
 
-    constructor(roomId) {
+    constructor(roomId: string) {
         super();
 
         this.roomId = roomId;
@@ -104,7 +104,7 @@ function untilCallHandlerEvent(callHandler: CallHandler, event: CallHandlerEvent
 describe('CallHandler', () => {
     let dmRoomMap;
     let callHandler;
-    let audioElement;
+    let audioElement: HTMLAudioElement;
     let fakeCall;
 
     // what addresses the app has looked up via pstn and native lookup
@@ -151,7 +151,7 @@ describe('CallHandler', () => {
         };
 
         dmRoomMap = {
-            getUserIdForRoomId: roomId => {
+            getUserIdForRoomId: (roomId: string) => {
                 if (roomId === NATIVE_ROOM_ALICE) {
                     return NATIVE_ALICE;
                 } else if (roomId === NATIVE_ROOM_BOB) {
@@ -164,7 +164,7 @@ describe('CallHandler', () => {
                     return null;
                 }
             },
-            getDMRoomsForUserId: userId => {
+            getDMRoomsForUserId: (userId: string) => {
                 if (userId === NATIVE_ALICE) {
                     return [NATIVE_ROOM_ALICE];
                 } else if (userId === NATIVE_BOB) {
@@ -325,8 +325,8 @@ describe('CallHandler', () => {
 
 describe('CallHandler without third party protocols', () => {
     let dmRoomMap;
-    let callHandler;
-    let audioElement;
+    let callHandler: CallHandler;
+    let audioElement: HTMLAudioElement;
     let fakeCall;
 
     beforeEach(() => {
@@ -356,14 +356,14 @@ describe('CallHandler without third party protocols', () => {
         };
 
         dmRoomMap = {
-            getUserIdForRoomId: roomId => {
+            getUserIdForRoomId: (roomId: string) => {
                 if (roomId === NATIVE_ROOM_ALICE) {
                     return NATIVE_ALICE;
                 } else {
                     return null;
                 }
             },
-            getDMRoomsForUserId: userId => {
+            getDMRoomsForUserId: (userId: string) => {
                 if (userId === NATIVE_ALICE) {
                     return [NATIVE_ROOM_ALICE];
                 } else {
@@ -373,7 +373,7 @@ describe('CallHandler without third party protocols', () => {
         };
         DMRoomMap.setShared(dmRoomMap);
 
-        MatrixClientPeg.get().getThirdpartyUser = (proto, params) => {
+        MatrixClientPeg.get().getThirdpartyUser = (_proto, _params) => {
             throw new Error("Endpoint unsupported.");
         };
 


### PR DESCRIPTION
Calling that endpoint throws an error and aborts the entire call. We do
check if an empty list or null is returned by that endpoint everywhere,
so returning an empty list simulates the thirdparty stuff just not being
found.

Checking for "this.supportsSipNativeVirtual" doesn't necessarily work,
since that might not be set yet and as such breaks calls that rely on
this functionality working.

You can simulate that behaviour on synapse by just blackholing the /thirdparty endpoints (i.e. replacing them with a 404).

fixes https://github.com/vector-im/element-web/issues/21680

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Notes: Fix calls on homeservers without the unstable thirdparty endpoints.
Type: defect
<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix calls on homeservers without the unstable thirdparty endpoints. ([\#8931](https://github.com/matrix-org/matrix-react-sdk/pull/8931)). Fixes vector-im/element-web#21680. Contributed by @deepbluev7.<!-- CHANGELOG_PREVIEW_END -->