### PR TITLE
Live location share - explicitly stop beacons replaced beacons (PSG-544)

### DIFF
--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -392,6 +392,12 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         roomId: Room['roomId'],
         beaconInfoContent: MBeaconInfoEventContent,
     ): Promise<void> => {
+        // explicitly stop any live beacons this user has
+        // to ensure they remain stopped
+        // if the new replacing beacon is redacted
+        const existingLiveBeaconIdsForRoom = this.getLiveBeaconIds(roomId);
+        await Promise.all(existingLiveBeaconIdsForRoom?.map(beaconId => this.stopBeacon(beaconId)));
+
         // eslint-disable-next-line camelcase
         const { event_id } = await this.matrixClient.unstable_createLiveBeacon(
             roomId,

--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -106,7 +106,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
      * ids of live beacons
      * ordered by creation time descending
      */
-    private liveBeaconIds = [];
+    private liveBeaconIds: BeaconIdentifier[] = [];
     private locationInterval: number;
     private geolocationError: GeolocationError | undefined;
     private clearPositionWatch: ClearWatchCallback | undefined;
@@ -396,7 +396,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         // to ensure they remain stopped
         // if the new replacing beacon is redacted
         const existingLiveBeaconIdsForRoom = this.getLiveBeaconIds(roomId);
-        await Promise.all(existingLiveBeaconIdsForRoom?.map(beaconId => this.stopBeacon(beaconId)));
+        await Promise.all(existingLiveBeaconIdsForRoom.map(beaconId => this.stopBeacon(beaconId)));
 
         // eslint-disable-next-line camelcase
         const { event_id } = await this.matrixClient.unstable_createLiveBeacon(

--- a/test/components/views/location/LocationShareMenu-test.tsx
+++ b/test/components/views/location/LocationShareMenu-test.tsx
@@ -78,6 +78,7 @@ describe('<LocationShareMenu />', () => {
         }),
         sendMessage: jest.fn(),
         unstable_createLiveBeacon: jest.fn().mockResolvedValue({ event_id: '1' }),
+        unstable_setLiveBeacon: jest.fn().mockResolvedValue({ event_id: '1' }),
         getVisibleRooms: jest.fn().mockReturnValue([]),
     });
 
@@ -386,7 +387,7 @@ describe('<LocationShareMenu />', () => {
             expect(getShareTypeOption(component, LocationShareType.Live).length).toBeFalsy();
         });
 
-        it('creates beacon info event on submission', () => {
+        it('creates beacon info event on submission', async () => {
             const onFinished = jest.fn();
             const component = getComponent({ onFinished });
 
@@ -398,6 +399,9 @@ describe('<LocationShareMenu />', () => {
                 getSubmitButton(component).at(0).simulate('click');
                 component.setProps({});
             });
+
+            // flush stopping existing beacons promises
+            await flushPromisesWithFakeTimers();
 
             expect(onFinished).toHaveBeenCalled();
             const [eventRoomId, eventContent] = mockClient.unstable_createLiveBeacon.mock.calls[0];
@@ -429,6 +433,7 @@ describe('<LocationShareMenu />', () => {
                 component.setProps({});
             });
 
+            await flushPromisesWithFakeTimers();
             await flushPromisesWithFakeTimers();
             await flushPromisesWithFakeTimers();
 

--- a/test/stores/OwnBeaconStore-test.ts
+++ b/test/stores/OwnBeaconStore-test.ts
@@ -1347,5 +1347,29 @@ describe('OwnBeaconStore', () => {
             // didn't throw, no error log
             expect(loggerErrorSpy).not.toHaveBeenCalled();
         });
+
+        it('stops existing live beacon for room before creates new beacon', async () => {
+            // room1 already has a live beacon for alice
+            makeRoomsWithStateEvents([
+                alicesRoom1BeaconInfo,
+                alicesRoom2BeaconInfo,
+            ]);
+            const store = await makeOwnBeaconStore();
+
+            const content = makeBeaconInfoContent(100);
+            await store.createLiveBeacon(room1Id, content);
+
+            // stop alicesRoom1BeaconInfo
+            expect(mockClient.unstable_setLiveBeacon).toHaveBeenCalledWith(
+                room1Id, expect.objectContaining({ live: false }),
+            );
+            // only called for beacons in room1, room2 beacon is not stopped
+            expect(mockClient.unstable_setLiveBeacon).toHaveBeenCalledTimes(1);
+
+            // new beacon created
+            expect(mockClient.unstable_createLiveBeacon).toHaveBeenCalledWith(
+                room1Id, content,
+            );
+        });
     });
 });


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Only one live beacon is allowed per-user per-room. When sharing live location, any previous live beacons in that room appear stopped and only the new beacon is live.
To make sure replaced beacons remain stopped if the new share is redacted, explicitly stop beacons before creating new beacons.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location share - explicitly stop beacons replaced beacons

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location share - explicitly stop beacons replaced beacons ([\#8933](https://github.com/matrix-org/matrix-react-sdk/pull/8933)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->