### PR TITLE
Make invite dialogue fixed height

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.scss
+++ b/res/css/views/dialogs/_InviteDialog.scss
@@ -189,7 +189,7 @@ limitations under the License.
     // Prevent the dialog from jumping around randomly when elements change.
     display: flex;
     flex-direction: column;
-    max-height: 600px;
+    height: 600px;
     overflow: hidden;
 
     .mx_InviteDialog_addressBar {
@@ -197,6 +197,7 @@ limitations under the License.
     }
 
     .mx_InviteDialog_userSections {
+        flex-grow: 1;
         padding-inline-end: 0;
 
         .mx_InviteDialog_section {
@@ -209,7 +210,7 @@ limitations under the License.
 .mx_InviteDialog_content {
     display: flex;
     flex-direction: column;
-    flex-shrink: 1;
+    flex-grow: 1;
     overflow: hidden;
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![invite_before](https://user-images.githubusercontent.com/6216686/176451946-01153d4e-9909-49fd-bf8f-120598621c97.gif)  | ![invite_after](https://user-images.githubusercontent.com/6216686/176451962-75e01d27-db4a-4c9d-a59e-3d53e4e9db2d.gif) |

Fixes vector-im/element-web#22659