### PR TITLE
Move mx_MessageTimestamp out of mx_EventTile:not([data-layout=bubble]) on TimelineCard

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -51,7 +51,6 @@ limitations under the License.
             }
 
             .mx_EventTile_avatar {
-                position: absolute; // for IRC layout
                 inset-inline-start: -3px;
             }
 
@@ -75,7 +74,6 @@ limitations under the License.
             }
 
             .mx_MessageTimestamp {
-                position: absolute;
                 inset-inline: auto 0;
             }
 
@@ -86,6 +84,13 @@ limitations under the License.
             .mx_ThreadSummary {
                 margin-inline-end: 0;
                 max-width: min(calc(100% - 36px), 600px);
+            }
+        }
+
+        &[data-layout=irc] {
+            .mx_EventTile_avatar,
+            .mx_MessageTimestamp {
+                position: absolute;
             }
         }
 


### PR DESCRIPTION
This PR moves `mx_MessageTimestamp` style rules out of `mx_EventTile:not([data-layout=bubble])` on TimelineCard, to remove the style block with the pseudo class altogether.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->