### PR TITLE
Move mx_EventTile_highlight out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -81,8 +81,6 @@ limitations under the License.
         &::before {
             background-color: $event-highlight-bg-color;
         }
-
-        color: $alert;
     }
 
     /* For replies */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -23,6 +23,11 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     flex-shrink: 0;
 
+    &.mx_EventTile_highlight,
+    &.mx_EventTile_highlight .markdown-body {
+        color: $alert;
+    }
+
     .mx_EventTile_avatar {
         cursor: pointer;
         user-select: none;
@@ -91,8 +96,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     &[data-layout=group] {
         &.mx_EventTile_highlight,
         &.mx_EventTile_highlight .markdown-body {
-            color: $alert;
-
             .mx_EventTile_line {
                 background-color: $event-highlight-bg-color;
             }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -89,6 +89,15 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &[data-layout=irc],
     &[data-layout=group] {
+        &.mx_EventTile_highlight,
+        &.mx_EventTile_highlight .markdown-body {
+            color: $alert;
+
+            .mx_EventTile_line {
+                background-color: $event-highlight-bg-color;
+            }
+        }
+
         .mx_EventTile_e2eIcon {
             position: absolute;
         }
@@ -225,15 +234,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     &.mx_EventTile_selected > .mx_EventTile_line {
         box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $accent;
         background-color: $event-selected-color;
-    }
-
-    &.mx_EventTile_highlight,
-    &.mx_EventTile_highlight .markdown-body {
-        color: $alert;
-
-        .mx_EventTile_line {
-            background-color: $event-highlight-bg-color;
-        }
     }
 
     &.mx_EventTile_selected.mx_EventTile_info .mx_EventTile_line {


### PR DESCRIPTION
||Before|After|
|-|---------|------|
|IRC layout|![after3](https://user-images.githubusercontent.com/3362943/176591334-fc541c17-89a7-458c-bebc-8d0a3405f18b.png)|(unchanged)|
|Modern layout|![after1](https://user-images.githubusercontent.com/3362943/176591317-37e78f3f-cad1-47b1-9263-3745aad95801.png)|(unchanged)|
|Bubble layout|![after2](https://user-images.githubusercontent.com/3362943/176591328-7d522836-5c97-46a3-9cf6-723f0a877ff0.png)|(unchanged)|

This PR moves `mx_EventTile_highlight` out of `mx_EventTile:not([data-layout=bubble])`, specifying the color declaration used on all of the layouts on `_EventTile.scss`.

Please ignore the text direction inside the pill (the display name was manually edited from one in RTL language with the browser devtool temporarily).

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->