### PR TITLE
Move mx_EventTile_continuation out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -73,10 +73,6 @@ limitations under the License.
         margin-right: 0;
     }
 
-    &.mx_EventTile_continuation {
-        margin-top: 2px;
-    }
-
     &.mx_EventTile_highlight {
         &::before {
             background-color: $event-highlight-bg-color;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -247,6 +247,12 @@ $left-gutter: 64px;
             padding-top: 0px !important;
         }
     }
+
+    &[data-layout=bubble] {
+        &.mx_EventTile_continuation {
+            margin-top: 2px;
+        }
+    }
 }
 
 .mx_EventTile:not([data-layout=bubble]) {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -191,6 +191,10 @@ $left-gutter: 64px;
                 background-color: $event-highlight-bg-color;
             }
         }
+
+        &.mx_EventTile_continuation .mx_EventTile_line {
+            clear: both;
+        }
     }
 
     &[data-layout=group] {
@@ -238,6 +242,10 @@ $left-gutter: 64px;
             position: absolute;
             z-index: 9;
         }
+
+        &.mx_EventTile_continuation {
+            padding-top: 0px !important;
+        }
     }
 }
 
@@ -275,17 +283,9 @@ $left-gutter: 64px;
         }
     }
 
-    &.mx_EventTile_continuation {
-        padding-top: 0px !important;
-    }
-
     .mx_MessageTimestamp {
         left: 0px;
         text-align: center;
-    }
-
-    &.mx_EventTile_continuation .mx_EventTile_line {
-        clear: both;
     }
 
     /* this is used for the tile for the event which is selected via the URL.


### PR DESCRIPTION
| |Before|After|After (image)|
|-|---------|------|-|
|IRC layout|![before1](https://user-images.githubusercontent.com/3362943/176602053-7e2ddeda-e6a1-4ca2-9a54-a9d66400fb10.png)|![after1](https://user-images.githubusercontent.com/3362943/176602033-51e7d592-9a1d-44a8-b1ac-d9d92a008228.png)|![after1](https://user-images.githubusercontent.com/3362943/176603490-2d95969e-2b1a-4676-9f1f-13f430a43ee3.png)|
|Modern layout|![before2](https://user-images.githubusercontent.com/3362943/176602047-6d8537d1-51c0-4a75-801d-824ec3acb5f1.png)|![after2](https://user-images.githubusercontent.com/3362943/176602041-fcd59e96-4754-43a1-b337-9cba32b7b306.png)|![after2](https://user-images.githubusercontent.com/3362943/176603495-c7f3157b-f3ea-49c7-9622-c1da0e472772.png)|
|Bubble layout|(unchanged)|![after](https://user-images.githubusercontent.com/3362943/176602023-1b3cd58b-e269-4b5a-a9eb-1f74d5c66ed8.png)|![after](https://user-images.githubusercontent.com/3362943/176603484-8efdf70f-3412-41c2-93e7-5b1d40e100b9.png)|




This PR moves `mx_EventTile_continuation` out of `mx_EventTile:not([data-layout=bubble])`.

The declaration with zero padding value is expected to be applied to modern/group layout only, as EventTile on IRC layout is specified with zero padding on [_IRCLayout.scss](https://github.com/matrix-org/matrix-react-sdk/blob/d439871ea11b532b05f3de15d4f2be395faa9461/res/css/views/rooms/_IRCLayout.scss#L36) generally, whether it has the class `mx_EventTile_continuation` or not.

Please note that `!important` flag cannot be removed yet due to [`padding-top: 18px`](https://github.com/matrix-org/matrix-react-sdk/blob/d439871ea11b532b05f3de15d4f2be395faa9461/res/css/views/rooms/_EventTile.scss#L182) inside `.mx_EventTile:not([data-layout=bubble])`.

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->