### PR TITLE
Fix wrong assertions that all media events have a mimetype

### DIFF
--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -380,7 +380,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         if (content.info?.w && content.info?.h) {
             infoWidth = content.info.w;
             infoHeight = content.info.h;
-            infoSvg = content.info.mimetype.startsWith("image/svg");
+            infoSvg = content.info.mimetype === "image/svg+xml";
         } else {
             // Whilst the image loads, display nothing. We also don't display a blurhash image
             // because we don't really know what size of image we'll end up with.

--- a/src/utils/Image.ts
+++ b/src/utils/Image.ts
@@ -16,7 +16,7 @@
 
 import { arrayHasDiff } from "./arrays";
 
-export function mayBeAnimated(mimeType: string): boolean {
+export function mayBeAnimated(mimeType?: string): boolean {
     // AVIF animation support at the time of writing is only available in Chrome hence not having `blobIsAnimated` check
     return ["image/gif", "image/webp", "image/png", "image/apng", "image/avif"].includes(mimeType);
 }
@@ -34,7 +34,7 @@ function arrayBufferReadStr(arr: ArrayBuffer, start: number, len: number): strin
     return String.fromCharCode.apply(null, arrayBufferRead(arr, start, len));
 }
 
-export async function blobIsAnimated(mimeType: string, blob: Blob): Promise<boolean> {
+export async function blobIsAnimated(mimeType: string | undefined, blob: Blob): Promise<boolean> {
     switch (mimeType) {
         case "image/webp": {
             // Only extended file format WEBP images support animation, so grab the expected data range and verify header.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/element-web-rageshakes/issues/13727

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrong assertions that all media events have a mimetype ([\#8946](https://github.com/matrix-org/matrix-react-sdk/pull/8946)). Fixes matrix-org/element-web-rageshakes#13727.<!-- CHANGELOG_PREVIEW_END -->