### PR TITLE
Fix font size of MessageTimestamp on TimelineCard

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -75,6 +75,7 @@ limitations under the License.
 
             .mx_MessageTimestamp {
                 inset-inline: auto 0;
+                font-size: $font-12px;
             }
 
             .mx_ReactionsRow {


### PR DESCRIPTION
[This line](https://github.com/matrix-org/matrix-react-sdk/commit/78a98415ebfc46ebc5c7d37eb1537eb1756f4f52#diff-f6d1464858812e6ea15c65a49935a089650e5e7adc0a380eeabfce5da896aa67L124) removed with https://github.com/matrix-org/matrix-react-sdk/pull/8818 on `_ThreadPanel.scss` has in fact specified the font size of MessageTimestamp on *TimelineCard* as well.

This PR re-adds the font size declaration for MessageTimestamp on TimelineCard.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/176677293-87a6b8c3-40c0-425e-a82c-e6e5091aa1b8.png)|![after](https://user-images.githubusercontent.com/3362943/176677310-e6eb33c3-2691-4239-bae4-55e0f0b9617f.png)|

The font size on bubble layout is expected to be `$font-10px`, therefore it is not necessary to apply the declaration to bubble layout.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix font size of MessageTimestamp on TimelineCard ([\#8950](https://github.com/matrix-org/matrix-react-sdk/pull/8950)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->