### PR TITLE
Tidy up _FilePanel.scss

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -29,9 +29,9 @@ limitations under the License.
     .mx_RoomView_MessageList {
         width: 100%;
 
-    h2 {
-        display: none;
-    }
+        h2 {
+            display: none;
+        }
     }
 
     /* FIXME: rather than having EventTile's default CSS be for MessagePanel,
@@ -54,44 +54,45 @@ limitations under the License.
         }
     }
 
-    .mx_MFileBody {
-        line-height: 2.4rem;
-    }
+    .mx_EventTile {
+        .mx_MFileBody {
+            line-height: 2.4rem;
+        }
 
-    .mx_MFileBody_download {
-        padding-top: 8px;
-        display: flex;
-        font-size: $font-14px;
-        color: $event-timestamp-color;
-    }
+        .mx_MFileBody_download {
+            padding-top: 8px;
+            display: flex;
+            font-size: $font-14px;
+            color: $event-timestamp-color;
+        }
 
-    .mx_MFileBody_downloadLink {
-        flex: 1 1 auto;
-        color: $light-fg-color;
-    }
+        .mx_MFileBody_downloadLink {
+            flex: 1 1 auto;
+            color: $light-fg-color;
+        }
 
-    .mx_MImageBody_size {
-        flex: 1 0 0;
-        font-size: $font-14px;
-        text-align: right;
-        white-space: nowrap;
-    }
+        .mx_MImageBody_size {
+            flex: 1 0 0;
+            font-size: $font-14px;
+            text-align: right;
+            white-space: nowrap;
+        }
 
-    .mx_DisambiguatedProfile {
-        flex: 1 1 auto;
-        line-height: initial;
-        opacity: 1.0;
-        color: $event-timestamp-color;
-    }
+        .mx_DisambiguatedProfile {
+            flex: 1 1 auto;
+            line-height: initial;
+            opacity: 1.0;
+            color: $event-timestamp-color;
+        }
 
-    .mx_MessageTimestamp {
-        flex: 1 0 0;
-        text-align: right;
-        visibility: visible;
-        position: initial;
-        font-size: $font-14px;
-        opacity: 1.0;
-    }
+        .mx_MessageTimestamp {
+            flex: 1 0 0;
+            text-align: right;
+            visibility: visible;
+            position: initial;
+            font-size: $font-14px;
+            opacity: 1.0;
+        }
     }
 
     /* Overides for the sender details line */

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -19,101 +19,101 @@ limitations under the License.
     flex: 1 1 0;
     overflow-y: auto;
     display: flex;
-}
 
-.mx_FilePanel .mx_RoomView_messageListWrapper {
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-}
+    .mx_RoomView_messageListWrapper {
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+    }
 
-.mx_FilePanel .mx_RoomView_MessageList {
-    width: 100%;
-}
+    .mx_RoomView_MessageList {
+        width: 100%;
+    }
 
-.mx_FilePanel .mx_RoomView_MessageList h2 {
-    display: none;
-}
+    .mx_RoomView_MessageList h2 {
+        display: none;
+    }
 
-/* FIXME: rather than having EventTile's default CSS be for MessagePanel,
+    /* FIXME: rather than having EventTile's default CSS be for MessagePanel,
    we should make EventTile a base CSS class and customise it specifically
    for usage in {Message,File,Notification}Panel. */
 
-.mx_FilePanel .mx_EventTile_avatar {
-    display: none;
-}
+    .mx_EventTile_avatar {
+        display: none;
+    }
 
-/* Overrides for the attachment body tiles */
+    /* Overrides for the attachment body tiles */
 
-.mx_FilePanel .mx_EventTile:not([data-layout=bubble]) {
-    word-break: break-word;
-    margin-top: 10px;
-    padding-top: 0;
+    .mx_EventTile:not([data-layout=bubble]) {
+        word-break: break-word;
+        margin-top: 10px;
+        padding-top: 0;
+
+        .mx_EventTile_line {
+            padding-left: 0;
+        }
+    }
+
+    .mx_EventTile .mx_MFileBody {
+        line-height: 2.4rem;
+    }
+
+    .mx_EventTile .mx_MFileBody_download {
+        padding-top: 8px;
+        display: flex;
+        font-size: $font-14px;
+        color: $event-timestamp-color;
+    }
+
+    .mx_EventTile .mx_MFileBody_downloadLink {
+        flex: 1 1 auto;
+        color: $light-fg-color;
+    }
+
+    .mx_EventTile .mx_MImageBody_size {
+        flex: 1 0 0;
+        font-size: $font-14px;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    /* Overides for the sender details line */
+
+    .mx_EventTile_senderDetails {
+        display: flex;
+        margin-top: -2px;
+    }
+
+    .mx_EventTile_senderDetailsLink {
+        text-decoration: none;
+    }
+
+    .mx_EventTile .mx_DisambiguatedProfile {
+        flex: 1 1 auto;
+        line-height: initial;
+        opacity: 1.0;
+        color: $event-timestamp-color;
+    }
+
+    .mx_EventTile .mx_MessageTimestamp {
+        flex: 1 0 0;
+        text-align: right;
+        visibility: visible;
+        position: initial;
+        font-size: $font-14px;
+        opacity: 1.0;
+    }
+
+    /* Overrides for the wrappers around the body tile */
 
     .mx_EventTile_line {
-        padding-left: 0;
+        margin-right: 0px;
+        padding-left: 0px;
     }
-}
 
-.mx_FilePanel .mx_EventTile .mx_MFileBody {
-    line-height: 2.4rem;
-}
-
-.mx_FilePanel .mx_EventTile .mx_MFileBody_download {
-    padding-top: 8px;
-    display: flex;
-    font-size: $font-14px;
-    color: $event-timestamp-color;
-}
-
-.mx_FilePanel .mx_EventTile .mx_MFileBody_downloadLink {
-    flex: 1 1 auto;
-    color: $light-fg-color;
-}
-
-.mx_FilePanel .mx_EventTile .mx_MImageBody_size {
-    flex: 1 0 0;
-    font-size: $font-14px;
-    text-align: right;
-    white-space: nowrap;
-}
-
-/* Overides for the sender details line */
-
-.mx_FilePanel .mx_EventTile_senderDetails {
-    display: flex;
-    margin-top: -2px;
-}
-
-.mx_FilePanel .mx_EventTile_senderDetailsLink {
-    text-decoration: none;
-}
-
-.mx_FilePanel .mx_EventTile .mx_DisambiguatedProfile {
-    flex: 1 1 auto;
-    line-height: initial;
-    opacity: 1.0;
-    color: $event-timestamp-color;
-}
-
-.mx_FilePanel .mx_EventTile .mx_MessageTimestamp {
-    flex: 1 0 0;
-    text-align: right;
-    visibility: visible;
-    position: initial;
-    font-size: $font-14px;
-    opacity: 1.0;
-}
-
-/* Overrides for the wrappers around the body tile */
-
-.mx_FilePanel .mx_EventTile_line {
-    margin-right: 0px;
-    padding-left: 0px;
-}
-
-.mx_FilePanel .mx_EventTile_selected .mx_EventTile_line {
-    padding-left: 0px;
+    .mx_EventTile_selected .mx_EventTile_line {
+        padding-left: 0px;
+    }
 }
 
 .mx_FilePanel_empty::before {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -42,9 +42,9 @@ limitations under the License.
         display: none;
     }
 
+    .mx_EventTile {
     /* Overrides for the attachment body tiles */
-
-    .mx_EventTile:not([data-layout=bubble]) {
+    &:not([data-layout=bubble]) {
         word-break: break-word;
         margin-top: 10px;
         padding-top: 0;
@@ -54,7 +54,6 @@ limitations under the License.
         }
     }
 
-    .mx_EventTile {
         .mx_MFileBody {
             line-height: 2.4rem;
         }

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -50,7 +50,7 @@ limitations under the License.
             padding-top: 0;
 
             .mx_EventTile_line {
-                padding-left: 0;
+                padding-inline-start: 0;
             }
         }
 
@@ -59,7 +59,7 @@ limitations under the License.
         }
 
         .mx_MFileBody_download {
-            padding-top: 8px;
+            padding-top: $spacing-8;
             display: flex;
             font-size: $font-14px;
             color: $event-timestamp-color;
@@ -108,12 +108,12 @@ limitations under the License.
     /* Overrides for the wrappers around the body tile */
 
     .mx_EventTile_line {
-        margin-right: 0px;
-        padding-left: 0px;
-    }
+        margin-inline-end: 0;
+        padding-inline-start: 0;
 
-    .mx_EventTile_selected .mx_EventTile_line {
-        padding-left: 0px;
+        .mx_EventTile_selected & {
+            padding-inline-start: 0;
+        }
     }
 }
 

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -52,6 +52,16 @@ limitations under the License.
             .mx_EventTile_line {
                 padding-inline-start: 0;
             }
+
+            &:hover {
+                &.mx_EventTile_verified,
+                &.mx_EventTile_unverified,
+                &.mx_EventTile_unknown {
+                    .mx_EventTile_line {
+                        box-shadow: none;
+                    }
+                }
+            }
         }
 
         .mx_MFileBody {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -28,10 +28,10 @@ limitations under the License.
 
     .mx_RoomView_MessageList {
         width: 100%;
-    }
 
-    .mx_RoomView_MessageList h2 {
+    h2 {
         display: none;
+    }
     }
 
     /* FIXME: rather than having EventTile's default CSS be for MessagePanel,
@@ -54,27 +54,44 @@ limitations under the License.
         }
     }
 
-    .mx_EventTile .mx_MFileBody {
+    .mx_MFileBody {
         line-height: 2.4rem;
     }
 
-    .mx_EventTile .mx_MFileBody_download {
+    .mx_MFileBody_download {
         padding-top: 8px;
         display: flex;
         font-size: $font-14px;
         color: $event-timestamp-color;
     }
 
-    .mx_EventTile .mx_MFileBody_downloadLink {
+    .mx_MFileBody_downloadLink {
         flex: 1 1 auto;
         color: $light-fg-color;
     }
 
-    .mx_EventTile .mx_MImageBody_size {
+    .mx_MImageBody_size {
         flex: 1 0 0;
         font-size: $font-14px;
         text-align: right;
         white-space: nowrap;
+    }
+
+    .mx_DisambiguatedProfile {
+        flex: 1 1 auto;
+        line-height: initial;
+        opacity: 1.0;
+        color: $event-timestamp-color;
+    }
+
+    .mx_MessageTimestamp {
+        flex: 1 0 0;
+        text-align: right;
+        visibility: visible;
+        position: initial;
+        font-size: $font-14px;
+        opacity: 1.0;
+    }
     }
 
     /* Overides for the sender details line */
@@ -86,22 +103,6 @@ limitations under the License.
 
     .mx_EventTile_senderDetailsLink {
         text-decoration: none;
-    }
-
-    .mx_EventTile .mx_DisambiguatedProfile {
-        flex: 1 1 auto;
-        line-height: initial;
-        opacity: 1.0;
-        color: $event-timestamp-color;
-    }
-
-    .mx_EventTile .mx_MessageTimestamp {
-        flex: 1 0 0;
-        text-align: right;
-        visibility: visible;
-        position: initial;
-        font-size: $font-14px;
-        opacity: 1.0;
     }
 
     /* Overrides for the wrappers around the body tile */

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -43,16 +43,16 @@ limitations under the License.
     }
 
     .mx_EventTile {
-    /* Overrides for the attachment body tiles */
-    &:not([data-layout=bubble]) {
-        word-break: break-word;
-        margin-top: 10px;
-        padding-top: 0;
+        /* Overrides for the attachment body tiles */
+        &:not([data-layout=bubble]) {
+            word-break: break-word;
+            margin-top: 10px;
+            padding-top: 0;
 
-        .mx_EventTile_line {
-            padding-left: 0;
+            .mx_EventTile_line {
+                padding-left: 0;
+            }
         }
-    }
 
         .mx_MFileBody {
             line-height: 2.4rem;

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -96,7 +96,7 @@ limitations under the License.
 
         .mx_MessageTimestamp {
             flex: 1 0 0;
-            text-align: right;
+            text-align: right; // FIXME: .mx_EventTile:not([data-layout=bubble]) .mx_MessageTimestamp
             visibility: visible;
             position: initial;
             font-size: $font-14px;


### PR DESCRIPTION
This PR tidies up `_FilePanel.scss`, before removing `:not()` pseudo class and fixing the timestamp position by moving a class out of the pseudo class on `_EventTile.scss`.
 
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->