### PR TITLE
Fix space settings not opening for script-created spaces

### DIFF
--- a/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
+++ b/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
@@ -48,7 +48,7 @@ const SpaceSettingsGeneralTab = ({ matrixClient: cli, space, onFinished }: IProp
     const canSetName = space.currentState.maySendStateEvent(EventType.RoomName, userId);
     const nameChanged = name !== space.name;
 
-    const currentTopic = getTopic(space).text;
+    const currentTopic = getTopic(space)?.text;
     const [topic, setTopic] = useState<string>(currentTopic);
     const canSetTopic = space.currentState.maySendStateEvent(EventType.RoomTopic, userId);
     const topicChanged = topic !== currentTopic;

--- a/src/hooks/room/useTopic.ts
+++ b/src/hooks/room/useTopic.ts
@@ -21,10 +21,11 @@ import { Room } from "matrix-js-sdk/src/models/room";
 import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
 import { parseTopicContent, TopicState } from "matrix-js-sdk/src/content-helpers";
 import { MRoomTopicEventContent } from "matrix-js-sdk/src/@types/topic";
+import { Optional } from "matrix-events-sdk";
 
 import { useTypedEventEmitter } from "../useEventEmitter";
 
-export const getTopic = (room: Room) => {
+export const getTopic = (room: Room): Optional<TopicState> => {
     const content: MRoomTopicEventContent = room?.currentState?.getStateEvents(EventType.RoomTopic, "")?.getContent();
     return !!content ? parseTopicContent(content) : null;
 };


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22703

The only place we use this hook is the SpaceSettingsGeneralTab - no other components appear affected.

Per https://github.com/vector-im/element-web/issues/22703#issuecomment-1171582727 the path to invoke this requires scripts, so I don't believe a regression test is required. 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix space settings not opening for script-created spaces ([\#8957](https://github.com/matrix-org/matrix-react-sdk/pull/8957)). Fixes vector-im/element-web#22703.<!-- CHANGELOG_PREVIEW_END -->