### PR TITLE
Move mx_EventTile_body out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/elements/_ReplyChain.scss
+++ b/res/css/views/elements/_ReplyChain.scss
@@ -63,14 +63,3 @@ limitations under the License.
         border-left-color: $username-variant8-color;
     }
 }
-
-.mx_ReplyChain--expanded {
-    .mx_EventTile_body {
-        display: block;
-        overflow-y: scroll !important;
-    }
-    .mx_EventTile_collapsedCodeBlock {
-        // !important needed due to .mx_ReplyTile .mx_EventTile_content .mx_EventTile_pre_container > pre
-        display: block !important;
-    }
-}

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -96,6 +96,17 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         gap: $spacing-4;
     }
 
+    .mx_ReplyChain--expanded {
+        .mx_EventTile_body {
+            display: block;
+            overflow-y: scroll;
+        }
+
+        .mx_EventTile_collapsedCodeBlock {
+            display: block !important; // !important needed due to .mx_ReplyTile .mx_EventTile_content .mx_EventTile_pre_container > pre
+        }
+    }
+
     &[data-layout=irc],
     &[data-layout=group] {
         &.mx_EventTile_highlight,

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -33,6 +33,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         user-select: none;
     }
 
+    .mx_EventTile_body {
+        overflow-y: hidden;
+    }
+
     .mx_EventTile_receiptSent,
     .mx_EventTile_receiptSending {
         position: relative;
@@ -278,11 +282,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         a {
             text-decoration: none;
         }
-    }
-
-    /* De-zalgoing */
-    .mx_EventTile_body {
-        overflow-y: hidden;
     }
 
     &:hover.mx_EventTile_verified .mx_EventTile_line {


### PR DESCRIPTION
This PR moves `mx_EventTile_body` out of `mx_EventTile:not([data-layout=bubble])`, fixing the issue that the text (`mx_EventTile_body`) inside ReplyChain cannot be expanded on bubble layout. 

Fixes https://github.com/vector-im/element-web/issues/22709

After: 

https://user-images.githubusercontent.com/3362943/176826813-58931f11-f615-4ec1-a96a-da245cd323df.mp4


The issue can be reproduced on IRC layout as well, but it is out of scope of this PR as it requires to fix `_IRClayout.scss`, which is going to be addressed with https://github.com/matrix-org/matrix-react-sdk/pull/8959.

type: defect
Notes: Enable ReplyChain text to be expanded on bubble layout

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Enable ReplyChain text to be expanded on bubble layout ([\#8958](https://github.com/matrix-org/matrix-react-sdk/pull/8958)). Fixes vector-im/element-web#22709. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->