### PR TITLE
Include mx_EventTile_bubbleContainer in mx_EventTile

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -28,6 +28,28 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         color: $alert;
     }
 
+    &.mx_EventTile_bubbleContainer {
+        display: grid;
+        grid-template-columns: 1fr 100px;
+
+        .mx_EventTile_line {
+            margin-right: 0;
+            grid-column: 1 / 3;
+            padding: 0 !important; // override default padding of mx_EventTile_line so that we can be centered
+        }
+
+        .mx_EventTile_msgOption {
+            grid-column: 2;
+        }
+
+        &:hover {
+            .mx_EventTile_line {
+                // To avoid bubble events being highlighted
+                background-color: inherit !important;
+            }
+        }
+    }
+
     .mx_EventTile_avatar {
         cursor: pointer;
         user-select: none;
@@ -461,29 +483,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
     }
 
     // on ELS we need the margin to allow interaction with the expand/collapse button which is normally in the RR gutter
-}
-
-.mx_EventTile_bubbleContainer {
-    display: grid;
-    grid-template-columns: 1fr 100px;
-
-    .mx_EventTile_line {
-        margin-right: 0;
-        grid-column: 1 / 3;
-        // override default padding of mx_EventTile_line so that we can be centered
-        padding: 0 !important;
-    }
-
-    .mx_EventTile_msgOption {
-        grid-column: 2;
-    }
-
-    &:hover {
-        .mx_EventTile_line {
-            // To avoid bubble events being highlighted
-            background-color: inherit !important;
-        }
-    }
 }
 
 .mx_EventTile_bigEmoji {


### PR DESCRIPTION
This PR moves `mx_EventTile_bubbleContainer` style rules to `mx_EventTile` to make it possible to move `mx_EventTile_msgOption` out of `mx_EventTile:not([data-layout=bubble])` safely.

The combination with `mx_EventTile_bubbleContainer` and `mx_EventTile` is specified [here](https://github.com/luixxiul/matrix-react-sdk/blob/663c99a08ae1e3cf00ed7181e352d274a3bfefa0/src/components/views/rooms/EventTile.tsx#L988-L990) and has already been available on [_EventBubbleTile.scss](https://github.com/luixxiul/matrix-react-sdk/blob/663c99a08ae1e3cf00ed7181e352d274a3bfefa0/res/css/views/rooms/_EventBubbleTile.scss#L592).

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/176838336-f9f87a94-cfa9-47e2-a916-6021e11bbb01.png)|![after](https://user-images.githubusercontent.com/3362943/176838295-801e7b5d-1bd8-493e-b002-fabb0c221348.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->