### PR TITLE
Hopefully improve Cypress test reliability by increasing the default timeout

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,6 @@
         "runMode": 2,
         "openMode": 0
     },
+    "defaultCommandTimeout": 10000,
     "chromeWebSecurity": false
 }


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->