### PR TITLE
Attempt to set the language when setting up Cypress tests

### DIFF
--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -82,6 +82,9 @@ Cypress.Commands.add("initTestUser", (synapse: SynapseInstance, displayName: str
             win.localStorage.setItem("mx_is_guest", "false");
             win.localStorage.setItem("mx_has_pickle_key", "false");
             win.localStorage.setItem("mx_has_access_token", "true");
+
+            // Ensure the language is set to a consistent value
+            win.localStorage.setItem("mx_local_settings", '{"language":"en"}');
         });
 
         return cy.visit("/").then(() => {


### PR DESCRIPTION
I don't know whether it will work, but this is intended to prevent i18n-related flakiness in Cypress tests by setting the language when the user logs in.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->