### PR TITLE
Improve mx_MatrixChat_useCompactLayout on _EventTile.scss

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1094,6 +1094,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
             padding-top: var(--MatrixChat_useCompactLayout_group-padding-top);
 
+            .mx_EventTile_line,
+            .mx_EventTile_reply {
+                padding-top: 0;
+                padding-bottom: 0;
+            }
+
             &.mx_EventTile_info {
                 padding-top: 0; // same as the padding for non-compact .mx_EventTile.mx_EventTile_info
                 font-size: $font-13px;
@@ -1111,37 +1117,30 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             &.mx_EventTile_emote {
                 padding-top: $spacing-8; // add a bit more space for emotes so that avatars don't collide
 
-                &.mx_EventTile_continuation {
-                    .mx_EventTile_line,
-                    .mx_EventTile_reply {
-                        padding-top: 0;
-                        padding-bottom: 0;
-                    }
-                }
-
                 .mx_EventTile_avatar {
                     top: 2px;
                 }
 
                 .mx_EventTile_line,
                 .mx_EventTile_reply {
-                    padding-top: 0;
                     padding-bottom: 1px;
+                }
+
+                &.mx_EventTile_continuation {
+                    .mx_EventTile_line,
+                    .mx_EventTile_reply {
+                        padding-bottom: 0;
+                    }
                 }
             }
 
+            // Cascading - apply zero padding to every element including mx_EventTile_emote
             &.mx_EventTile_continuation {
                 padding-top: 0;
             }
 
             .mx_EventTile_avatar {
                 top: 2px;
-            }
-
-            .mx_EventTile_line,
-            .mx_EventTile_reply {
-                padding-top: 0;
-                padding-bottom: 0;
             }
 
             .mx_EventTile_e2eIcon {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1091,13 +1091,15 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         // Override :not([data-layout="bubble"])
         &[data-layout=group] {
             --MatrixChat_useCompactLayout_group-padding-top: $spacing-4;
+            --MatrixChat_useCompactLayout-top-avatar: 2px;
+            --MatrixChat_useCompactLayout-top-e2eIcon: 3px;
+            --MatrixChat_useCompactLayout_line-spacing-block: 0px;
 
             padding-top: var(--MatrixChat_useCompactLayout_group-padding-top);
 
             .mx_EventTile_line,
             .mx_EventTile_reply {
-                padding-top: 0;
-                padding-bottom: 0;
+                padding-block: var(--MatrixChat_useCompactLayout_line-spacing-block);
             }
 
             &.mx_EventTile_info {
@@ -1107,7 +1109,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 .mx_EventTile_e2eIcon,
                 .mx_EventTile_avatar {
                     top: 0;
-                    margin-block: 0;
+                    margin-block: var(--MatrixChat_useCompactLayout_line-spacing-block);
                 }
 
                 .mx_EventTile_line,
@@ -1120,7 +1122,7 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 padding-top: $spacing-8; // add a bit more space for emotes so that avatars don't collide
 
                 .mx_EventTile_avatar {
-                    top: 2px;
+                    top: var(--MatrixChat_useCompactLayout-top-avatar);
                 }
 
                 .mx_EventTile_line,
@@ -1131,22 +1133,22 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 &.mx_EventTile_continuation {
                     .mx_EventTile_line,
                     .mx_EventTile_reply {
-                        padding-bottom: 0;
+                        padding-bottom: var(--MatrixChat_useCompactLayout_line-spacing-block);
                     }
                 }
             }
 
             // Cascading - apply zero padding to every element including mx_EventTile_emote
             &.mx_EventTile_continuation {
-                padding-top: 0;
+                padding-top: var(--MatrixChat_useCompactLayout_line-spacing-block);
             }
 
             .mx_EventTile_avatar {
-                top: 2px;
+                top: var(--MatrixChat_useCompactLayout-top-avatar);
             }
 
             .mx_EventTile_e2eIcon {
-                top: 3px;
+                top: var(--MatrixChat_useCompactLayout-top-e2eIcon);
             }
 
             .mx_DisambiguatedProfile {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1132,6 +1132,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 }
             }
 
+            &.mx_EventTile_continuation {
+                padding-top: 0;
+            }
+
             .mx_EventTile_avatar {
                 top: 2px;
             }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1104,8 +1104,10 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 padding-top: 0; // same as the padding for non-compact .mx_EventTile.mx_EventTile_info
                 font-size: $font-13px;
 
+                .mx_EventTile_e2eIcon,
                 .mx_EventTile_avatar {
-                    top: $spacing-4;
+                    top: 0;
+                    margin-block: 0;
                 }
 
                 .mx_EventTile_line,

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1112,8 +1112,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
                 padding-top: $spacing-8; // add a bit more space for emotes so that avatars don't collide
 
                 &.mx_EventTile_continuation {
-                    padding-top: 0;
-
                     .mx_EventTile_line,
                     .mx_EventTile_reply {
                         padding-top: 0;


### PR DESCRIPTION
This PR:
- Ensure zero padding-top for `mx_EventTile_continuation` in `mx_MatrixChat_useCompactLayout`. Currently the zero padding is applied with the same style block with `!important` flag on `_EventTile.scss`. This PR ensures that the zero padding on compact modern/group layout continues to be applied even after removing the flag, along with `:not()` pseudo class.
- Align E2E icon and avatar of info tile in compact modern layout. Fixes https://github.com/vector-im/element-web/issues/22652.

|Normal|Compact|
|----------|------------|
|![before2](https://user-images.githubusercontent.com/3362943/176984755-14c58760-9d9e-4ba7-b080-79a9aeb08f21.png)|![after2](https://user-images.githubusercontent.com/3362943/176984753-550f0eda-c1e5-4c55-a912-00c467c58b88.png)|

| |Before|After|
|-|---------|------|
|Align avatar|![before](https://user-images.githubusercontent.com/3362943/176176384-ead7f5b4-605b-4f10-ba18-b84e69c66007.png)|![after](https://user-images.githubusercontent.com/3362943/176176272-b285be29-ba3e-4f6c-a626-ad36740f4936.png)|
|||![after](https://user-images.githubusercontent.com/3362943/176985193-9fa834ef-8b46-47f2-ae43-9555294a60e5.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
Notes: Align E2E icon and avatar of info tile in compact modern layout

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Align E2E icon and avatar of info tile in compact modern layout ([\#8965](https://github.com/matrix-org/matrix-react-sdk/pull/8965)). Fixes vector-im/element-web#22652. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->