### PR TITLE
Consider cascading order of style rules on _EventTile.scss

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -27,37 +27,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     flex-shrink: 0;
 
-    &.mx_EventTile_highlight,
-    &.mx_EventTile_highlight .markdown-body {
-        color: $alert;
-    }
-
-    &.mx_EventTile_bubbleContainer {
-        display: grid;
-        grid-template-columns: 1fr 100px;
-
-        .mx_EventTile_line {
-            margin-right: 0;
-            grid-column: 1 / 3;
-            padding: 0 !important; // override default padding of mx_EventTile_line so that we can be centered
-        }
-
-        .mx_EventTile_msgOption {
-            grid-column: 2;
-        }
-
-        &:hover {
-            .mx_EventTile_line {
-                // To avoid bubble events being highlighted
-                background-color: inherit !important;
-            }
-        }
-    }
-
-    &.mx_EventTile_isEditing .mx_MessageTimestamp {
-        visibility: hidden;
-    }
-
     .mx_EventTile_avatar {
         cursor: pointer;
         user-select: none;
@@ -137,15 +106,39 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
-    &[data-layout=irc],
-    &[data-layout=group] {
-        &.mx_EventTile_highlight,
-        &.mx_EventTile_highlight .markdown-body {
-            .mx_EventTile_line {
-                background-color: $event-highlight-bg-color;
-            }
+    &.mx_EventTile_highlight,
+    &.mx_EventTile_highlight .markdown-body {
+        color: $alert;
+    }
+
+    &.mx_EventTile_bubbleContainer {
+        display: grid;
+        grid-template-columns: 1fr 100px;
+
+        .mx_EventTile_line {
+            margin-right: 0;
+            grid-column: 1 / 3;
+            padding: 0 !important; // override default padding of mx_EventTile_line so that we can be centered
         }
 
+        .mx_EventTile_msgOption {
+            grid-column: 2;
+        }
+
+        &:hover {
+            .mx_EventTile_line {
+                // To avoid bubble events being highlighted
+                background-color: inherit !important;
+            }
+        }
+    }
+
+    &.mx_EventTile_isEditing .mx_MessageTimestamp {
+        visibility: hidden;
+    }
+
+    &[data-layout=irc],
+    &[data-layout=group] {
         .mx_EventTile_e2eIcon {
             position: absolute;
         }
@@ -169,20 +162,16 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         .mx_EventTile_reply {
             margin-right: 10px;
         }
+
+        &.mx_EventTile_highlight,
+        &.mx_EventTile_highlight .markdown-body {
+            .mx_EventTile_line {
+                background-color: $event-highlight-bg-color;
+            }
+        }
     }
 
     &[data-layout=group] {
-        > .mx_DisambiguatedProfile {
-            line-height: $font-20px;
-            margin-left: $left-gutter;
-            max-width: calc(100% - $left-gutter);
-        }
-
-        > .mx_EventTile_avatar {
-            position: absolute;
-            z-index: 9;
-        }
-
         .mx_EventTile_avatar {
             top: 14px;
             left: $spacing-8;
@@ -215,6 +204,17 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
         .mx_ReactionsRow {
             margin: $spacing-4 64px;
+        }
+
+        > .mx_DisambiguatedProfile {
+            line-height: $font-20px;
+            margin-left: $left-gutter;
+            max-width: calc(100% - $left-gutter);
+        }
+
+        > .mx_EventTile_avatar {
+            position: absolute;
+            z-index: 9;
         }
     }
 }


### PR DESCRIPTION
CSS rules cascade from the top to the bottom, therefore rules which generally define how elements are styled should be declared before specific rules, such as ones with `&.mx_EventTile_highlight` or `> .mx_DisambiguatedProfile`. This way it becomes possible to avoid adding redundant declarations, which are used to cancel the inherited values.

There is a lot of other rules inside `:not([data-layout=bubble])` which need sorting, but this PR does not touch them as the block will be removed anyway.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->