### PR TITLE
Fix read receipts group position on TimelineCard in compact modern/group layout

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -50,6 +50,8 @@ limitations under the License.
 
         &[data-layout=irc],
         &[data-layout=group] {
+            --TimelineCard_ReadReceiptGroup-inset-block-start: -6px;
+
             &.mx_EventTile_info .mx_EventTile_line,
             .mx_EventTile_line {
                 padding: var(--BaseCard_EventTile_line-padding-block) var(--BaseCard_EventTile-spacing-inline);
@@ -97,6 +99,10 @@ limitations under the License.
                 margin-inline-end: $spacing-8; // See: var(--ThreadView_group_spacing-end) for ReactionsRow on _EventTile.scss
             }
 
+            .mx_ReadReceiptGroup {
+                top: var(--TimelineCard_ReadReceiptGroup-inset-block-start);
+            }
+
             .mx_ThreadSummary {
                 margin-inline-end: 0;
                 max-width: min(calc(100% - 36px), 600px);
@@ -107,6 +113,14 @@ limitations under the License.
             .mx_EventTile_avatar,
             .mx_MessageTimestamp {
                 position: absolute;
+            }
+        }
+
+        &[data-layout=group] {
+            // Read receipt group on compact modern layout
+            // mx_TimelineCard is wrapped by mx_MatrixChat_useCompactLayout
+            .mx_MatrixChat_useCompactLayout & .mx_ReadReceiptGroup {
+                top: var(--TimelineCard_ReadReceiptGroup-inset-block-start);
             }
         }
 
@@ -139,10 +153,6 @@ limitations under the License.
             padding-inline-start: var(--BaseCard_EventTile-spacing-inline);
             padding-inline-end: var(--BaseCard_EventTile-spacing-inline);
         }
-    }
-
-    .mx_ReadReceiptGroup {
-        top: -6px;
     }
 
     .mx_WhoIsTypingTile {

--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -118,7 +118,8 @@ limitations under the License.
 
         &[data-layout=group] {
             // Read receipt group on compact modern layout
-            // mx_TimelineCard is wrapped by mx_MatrixChat_useCompactLayout
+            // This is required because mx_TimelineCard is a child element wrapped by mx_MatrixChat_useCompactLayout,
+            // which specifies the default position of mx_ReadReceiptGroup on compact modern layout.
             .mx_MatrixChat_useCompactLayout & .mx_ReadReceiptGroup {
                 top: var(--TimelineCard_ReadReceiptGroup-inset-block-start);
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22715

This PR fixes the read receipts group position on TimelineCard in compact modern/group layout. The position on bubble layout has been specified with `_EventBubbleTile.scss`.

| |Before|After|
|-|---------|------|
|Normal layout|(unchanged)|![before2](https://user-images.githubusercontent.com/3362943/176998860-d5d8e532-7ec5-4ffa-8cf7-558721365ef9.png)|
|Compact layout|![before1](https://user-images.githubusercontent.com/3362943/176998858-6c822811-6c42-47d6-9ffb-08214a7950fe.png)|![after1](https://user-images.githubusercontent.com/3362943/176998853-afa80c18-acfe-4fc9-ba5f-2e9ce5e921b3.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix read receipts group position on TimelineCard in compact modern/group layout ([\#8971](https://github.com/matrix-org/matrix-react-sdk/pull/8971)). Fixes vector-im/element-web#22715. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->