### PR TITLE
Reduce bottom margin of ReplyChain on compact modern layout

### DIFF
--- a/res/css/views/elements/_ReplyChain.pcss
+++ b/res/css/views/elements/_ReplyChain.pcss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .mx_ReplyChain {
-    margin: 0 0 $spacing-8 0;
+    margin: 0; // Reset default blockquote margin
     padding-left: 10px; // TODO: Use a spacing variable
     border-left: 2px solid var(--username-color); // TODO: Use a spacing variable
     border-radius: 2px; // TODO: Use a spacing variable

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -113,8 +113,6 @@ $left-gutter: 64px;
     }
 
     .mx_ReplyChain {
-        margin-bottom: $spacing-8;
-
         &.mx_ReplyChain--expanded {
             .mx_EventTile_body {
                 display: block;
@@ -271,6 +269,10 @@ $left-gutter: 64px;
         .mx_EventTileBubble {
             margin-inline: auto;
         }
+
+        .mx_ReplyChain {
+            margin-bottom: $spacing-8;
+        }
     }
 
     &[data-layout="irc"] {
@@ -293,6 +295,10 @@ $left-gutter: 64px;
             &.mx_cryptoEvent {
                 left: unset;
             }
+        }
+
+        .mx_ReplyChain {
+            margin: 0;
         }
 
         .mx_ReplyTile .mx_EventTileBubble {

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -114,12 +114,12 @@ $left-gutter: 64px;
 
     .mx_ReplyChain {
         margin-bottom: $spacing-8;
-    }
 
-    .mx_ReplyChain--expanded {
-        .mx_EventTile_body {
-            display: block;
-            overflow-y: scroll;
+        &.mx_ReplyChain--expanded {
+            .mx_EventTile_body {
+                display: block;
+                overflow-y: scroll;
+            }
         }
 
         .mx_EventTile_collapsedCodeBlock {

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -112,12 +112,10 @@ $left-gutter: 64px;
         gap: $spacing-4;
     }
 
-    .mx_ReplyChain {
-        &.mx_ReplyChain--expanded {
-            .mx_EventTile_body {
-                display: block;
-                overflow-y: scroll;
-            }
+    .mx_ReplyChain--expanded {
+        .mx_EventTile_body {
+            display: block;
+            overflow-y: scroll;
         }
 
         .mx_EventTile_collapsedCodeBlock {

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -112,6 +112,10 @@ $left-gutter: 64px;
         gap: $spacing-4;
     }
 
+    .mx_ReplyChain {
+        margin-bottom: $spacing-8;
+    }
+
     .mx_ReplyChain--expanded {
         .mx_EventTile_body {
             display: block;
@@ -1246,6 +1250,10 @@ $left-gutter: 64px;
             .mx_EventTile_line,
             .mx_EventTile_reply {
                 padding-block: var(--MatrixChat_useCompactLayout_line-spacing-block);
+            }
+
+            .mx_ReplyChain {
+                margin-bottom: $spacing-4;
             }
 
             &.mx_EventTile_info {

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -177,7 +177,6 @@ $irc-line-height: $font-18px;
     }
 
     .mx_ReplyChain {
-        margin: 0;
         .mx_DisambiguatedProfile {
             order: unset;
             width: unset;


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22748

This PR reduces bottom margin of ReplyChain on compact modern layout from `8px` to `4px`, specifying the common margin value for both bubble and modern/group layouts on `_EventTile.pcss`.

Input on design/UI would be appreciated.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177003819-74d8e9b9-d53b-4479-ac93-d9c232fa46ee.png)|![after](https://user-images.githubusercontent.com/3362943/177003816-6bc1d3f7-4771-4bba-ac32-0b8881a28732.png)|
|![before](https://user-images.githubusercontent.com/3362943/177004073-d01f8dc0-9ea3-4edf-a65c-6cc1e864e17a.png)|![after](https://user-images.githubusercontent.com/3362943/177004077-983014a3-e0d5-496d-8e74-aca3249151c7.png)|


type: enhancement

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Reduce bottom margin of ReplyChain on compact modern layout ([\#8972](https://github.com/matrix-org/matrix-react-sdk/pull/8972)). Fixes vector-im/element-web#22748. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->