### PR TITLE
Move mx_EventTile_msgOption out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -163,6 +163,22 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             margin-right: 10px;
         }
 
+        .mx_EventTile_msgOption {
+            float: right;
+            text-align: right;
+            position: relative;
+            width: 90px;
+
+            /* Hack to stop the height of this pushing the messages apart.
+               Replaces margin-top: -6px. This interacts better with a read
+               marker being in between. Content overflows. */
+            height: 1px;
+
+            a {
+                text-decoration: none;
+            }
+        }
+
         &.mx_EventTile_highlight,
         &.mx_EventTile_highlight .markdown-body {
             .mx_EventTile_line {
@@ -301,22 +317,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
 
     &.mx_EventTile_contextual {
         opacity: 0.4;
-    }
-
-    .mx_EventTile_msgOption {
-        float: right;
-        text-align: right;
-        position: relative;
-        width: 90px;
-
-        /* Hack to stop the height of this pushing the messages apart.
-           Replaces margin-top: -6px. This interacts better with a read
-           marker being in between. Content overflows. */
-        height: 1px;
-
-        a {
-            text-decoration: none;
-        }
     }
 
     &:hover.mx_EventTile_verified .mx_EventTile_line {

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -39,7 +39,7 @@ $irc-line-height: $font-18px;
             margin-right: $right-padding;
         }
 
-        > .mx_EventTile_msgOption {
+        .mx_EventTile_msgOption {
             order: 5;
             flex-shrink: 0;
 


### PR DESCRIPTION
This PR moves `mx_EventTile_msgOption` out of `mx_EventTile:not([data-layout=bubble])`. This change should not affect something outside of the chat panel, as the element is hidden with `display:none` there (FontScalingPanel, LayoutSwitcher, etc).

| |Before|After|
|-|---------|------|
|IRC layout|![before1](https://user-images.githubusercontent.com/3362943/177006579-8e664a21-f69f-4897-adf1-6f086f41aa03.png)|![after1](https://user-images.githubusercontent.com/3362943/177006572-79eeaeb9-cb11-4590-b7d5-091a413b0659.png)|
|Modern layout|![before2](https://user-images.githubusercontent.com/3362943/177006582-245f7099-5b0b-4e45-ae53-bf726a0a7543.png)|![after2](https://user-images.githubusercontent.com/3362943/177006586-78b5a047-d792-46a0-a3f7-4010fd28291d.png)|


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->