### PR TITLE
Move mx_EventTile_contextual out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -44,11 +44,6 @@ limitations under the License.
                 display: none;
             }
         }
-
-        // Mirror rough designs for "greyed out" text
-        &.mx_EventTile_contextual .mx_EventTile_line {
-            opacity: 0.4;
-        }
     }
 }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -106,6 +106,12 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
     }
 
+    .mx_RoomView_searchResultsPanel & {
+        &.mx_EventTile_contextual {
+            opacity: 0.4;
+        }
+    }
+
     &.mx_EventTile_highlight,
     &.mx_EventTile_highlight .markdown-body {
         color: $alert;
@@ -297,10 +303,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
             background-color: $accent;
             color: $accent-fg-color;
         }
-    }
-
-    &.mx_EventTile_contextual {
-        opacity: 0.4;
     }
 
     .mx_EventTile_msgOption {


### PR DESCRIPTION
This PR moves `mx_EventTile_contextual` out of `mx_EventTile:not([data-layout=bubble])` to use the common style rule for search result panel on every layout.

| |Before|After|
|-|---------|------|
|IRC layout|(unchanged)|![after](https://user-images.githubusercontent.com/3362943/177010058-4a4dff30-1b2b-4315-8bdd-58d39718f99e.png)|
|Modern layout|(unchanged)|![after1](https://user-images.githubusercontent.com/3362943/177010062-6cab55fc-afa8-4216-81a5-c654d729f3eb.png)|
|Bubble layout|![before2](https://user-images.githubusercontent.com/3362943/177010066-baf0e293-6850-4d7d-9ff1-0873627eeada.png)|![after2](https://user-images.githubusercontent.com/3362943/177010063-7465c2ae-e567-4d7d-8af3-ee259b6db496.png)|

type: defect
Notes: Fix "greyed out" text style inconsistency on search result panel

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix "greyed out" text style inconsistency on search result panel ([\#8974](https://github.com/matrix-org/matrix-react-sdk/pull/8974)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->