### PR TITLE
Add top padding to EventTilePreview loader

### DIFF
--- a/res/css/views/elements/_EventTilePreview.scss
+++ b/res/css/views/elements/_EventTilePreview.scss
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_FontScalingPanel_preview.mx_EventTilePreview_loader {
-    padding: 9px 0;
+.mx_FontScalingPanel {
+    .mx_FontScalingPanel_preview.mx_EventTilePreview_loader {
+        padding: var(--FontScalingPanel_preview-padding-block) 0;
+    }
 }

--- a/res/css/views/settings/_FontScalingPanel.scss
+++ b/res/css/views/settings/_FontScalingPanel.scss
@@ -23,9 +23,11 @@ limitations under the License.
     }
 
     .mx_FontScalingPanel_preview {
+        --FontScalingPanel_preview-padding-block: 9px;
+
         border: 1px solid $quinary-content;
         border-radius: 10px;
-        padding: 0 $spacing-16 9px $spacing-16;
+        padding: 0 $spacing-16 var(--FontScalingPanel_preview-padding-block) $spacing-16;
         pointer-events: none;
         display: flow-root;
 


### PR DESCRIPTION
This PR adds top padding to `EventTilePreview` loader with a variable.

Fixes https://github.com/vector-im/element-web/issues/22719

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177031010-ee5a57da-2294-43be-a791-57817b8bde84.png)|![after](https://user-images.githubusercontent.com/3362943/177031001-faf1960e-af4b-4553-af01-5c9daf86b4bf.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add top padding to EventTilePreview loader ([\#8977](https://github.com/matrix-org/matrix-react-sdk/pull/8977)). Fixes vector-im/element-web#22719. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->