### PR TITLE
Fix clickable area of general event list summary toggle

### DIFF
--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -112,11 +112,6 @@ limitations under the License.
     cursor: pointer;
 }
 
-.mx_GenericEventListSummary_toggle {
-    color: $accent;
-    cursor: pointer;
-}
-
 .mx_GenericEventListSummary_line {
     border-bottom: 1px solid $primary-hairline-color;
     margin-left: 63px;

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -76,7 +76,6 @@ limitations under the License.
             }
 
             &[aria-expanded=true] {
-                text-align: right;
                 margin-inline-start: auto; // reduce clickable area
             }
         }

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -67,10 +67,12 @@ limitations under the License.
         }
 
         .mx_GenericEventListSummary_toggle {
-            margin: 0 55px 0 5px;
+            margin-block: 0;
+            margin-inline-end: 55px;
 
             &[aria-expanded=false] {
                 order: 9;
+                margin-inline-start: 5px;
             }
 
             &[aria-expanded=true] {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -75,6 +75,7 @@ limitations under the License.
 
             &[aria-expanded=true] {
                 text-align: right;
+                margin-inline-start: auto; // reduce clickable area
             }
         }
 

--- a/src/components/views/elements/GenericEventListSummary.tsx
+++ b/src/components/views/elements/GenericEventListSummary.tsx
@@ -119,7 +119,12 @@ const GenericEventListSummary: React.FC<IProps> = ({
             data-layout={layout}
             data-testid={testId}
         >
-            <AccessibleButton className="mx_GenericEventListSummary_toggle" onClick={toggleExpanded} aria-expanded={expanded}>
+            <AccessibleButton
+                kind="link_inline"
+                className="mx_GenericEventListSummary_toggle"
+                onClick={toggleExpanded}
+                aria-expanded={expanded}
+            >
                 { expanded ? _t('collapse') : _t('expand') }
             </AccessibleButton>
             { body }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22722

This PR reduces the clickable area of the general event list summary toggle link button (`collapse`) on bubble layout.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177039782-cc97afa5-b815-4e45-9a62-ce3363400d2b.png)|![after](https://user-images.githubusercontent.com/3362943/177039780-f4d70d98-5370-4c16-b4b3-3e619a791c8b.png)|

Blue: clickable area
Yellow: margin

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix clickable area of general event list summary toggle ([\#8979](https://github.com/matrix-org/matrix-react-sdk/pull/8979)). Fixes vector-im/element-web#22722. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->