### PR TITLE
Fix the size of the clickable area of images

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -150,8 +150,6 @@ $threadInfoLineHeight: calc(2 * $font-12px); // See: _commons.scss
         }
 
         .mx_MImageBody {
-            margin-right: var(--EventTile_content-margin-inline-end);
-
             .mx_MImageBody_thumbnail_container {
                 justify-content: flex-start;
                 min-height: $font-44px;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22282

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the size of the clickable area of images ([\#8987](https://github.com/matrix-org/matrix-react-sdk/pull/8987)). Fixes vector-im/element-web#22282.<!-- CHANGELOG_PREVIEW_END -->