### PR TITLE
don't show rooms when they're ignored

### DIFF
--- a/src/stores/room-list/filters/VisibilityProvider.ts
+++ b/src/stores/room-list/filters/VisibilityProvider.ts
@@ -17,6 +17,7 @@
 import { Room } from "matrix-js-sdk/src/models/room";
 
 import CallHandler from "../../../CallHandler";
+import { MatrixClientPeg } from '../../../MatrixClientPeg';
 import { RoomListCustomisations } from "../../../customisations/RoomList";
 import VoipUserMapper from "../../../VoipUserMapper";
 
@@ -51,6 +52,11 @@ export class VisibilityProvider {
 
         // hide space rooms as they'll be shown in the SpacePanel
         if (room.isSpaceRoom()) {
+            return false;
+        }
+
+        const cli = MatrixClientPeg.get();
+        if (cli.getIgnoredInvites()?.ignored_rooms?.includes(room.roomId) ?? false) {
             return false;
         }
 


### PR DESCRIPTION
based on #8983. will want an additional UI change to warn users that they're looking at an ignored room (with an option to unignore) if they click on a room link for an ignored room

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->