### PR TITLE
Fix text flow of thread summary content on threads list

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -850,6 +850,12 @@ $left-gutter: 64px;
                 line-height: var(--EventTile_ThreadSummary-line-height);
                 font-size: $font-12px; // Same font size as the counter on the main panel
             }
+
+            .mx_ThreadSummary_content {
+                text-overflow: ellipsis;
+                overflow: hidden;
+                white-space: nowrap;
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/matrix-org/matrix-react-sdk/pull/8868.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177469136-1f532193-4b30-4835-8446-1aadc5aa13ab.png)|![after](https://user-images.githubusercontent.com/3362943/177469118-1656d32c-c8ff-4601-ae22-3c442d8b08ea.png)|

type: defect
element-web notes: none

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
