### PR TITLE
Remove 100% min-width hack from mx_GenericEventListSummary[data-layout=bubble][data-expanded=false]

### DIFF
--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -43,8 +43,8 @@ limitations under the License.
         &[data-expanded=false] {
             display: flex;
             align-items: center;
-            justify-content: flex-start;
-            padding: 0 49px; // Align with left edge of bubble tiles
+            justify-content: space-between;
+            padding-inline-start: 49px; // Align with left edge of bubble tiles
         }
 
         // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
@@ -68,7 +68,6 @@ limitations under the License.
 
         .mx_GenericEventListSummary_toggle {
             margin-block: 0;
-            margin-inline-end: 55px;
 
             &[aria-expanded=false] {
                 order: 9;
@@ -77,6 +76,7 @@ limitations under the License.
 
             &[aria-expanded=true] {
                 margin-inline-start: auto; // reduce clickable area
+                margin-inline-end: 55px;
             }
         }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -44,7 +44,6 @@ limitations under the License.
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding-inline-start: 49px; // Align with left edge of bubble tiles
             column-gap: 5px;
         }
 
@@ -76,7 +75,7 @@ limitations under the License.
 
             &[aria-expanded=true] {
                 margin-inline-start: auto; // reduce clickable area
-                margin-inline-end: var(--EventBubbleTile-margin-inline-end);
+                margin-inline-end: var(--EventTile_bubble-margin-inline-end);
             }
         }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -45,6 +45,7 @@ limitations under the License.
             align-items: center;
             justify-content: space-between;
             padding-inline-start: 49px; // Align with left edge of bubble tiles
+            column-gap: 5px;
         }
 
         // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
@@ -71,7 +72,6 @@ limitations under the License.
 
             &[aria-expanded=false] {
                 order: 9;
-                margin-inline-start: 5px;
             }
 
             &[aria-expanded=true] {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -76,7 +76,7 @@ limitations under the License.
 
             &[aria-expanded=true] {
                 margin-inline-start: auto; // reduce clickable area
-                margin-inline-end: 55px;
+                margin-inline-end: var(--EventBubbleTile-margin-inline-end);
             }
         }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -75,7 +75,7 @@ limitations under the License.
 
             &[aria-expanded=true] {
                 margin-inline-start: auto; // reduce clickable area
-                margin-inline-end: var(--EventTile_bubble-margin-inline-end);
+                margin-inline-end: var(--EventTile_bubble-margin-inline-end); // as the parent has zero margin
             }
         }
 

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -28,8 +28,13 @@ limitations under the License.
     --gutterSize: 11px;
     --cornerRadius: 12px;
     --maxWidth: 70%;
-    --EventBubbleTile-margin-inline-end: 60px;
-    margin-right: var(--EventBubbleTile-margin-inline-end);
+
+    // For both event tile and event list summary
+    --EventTile_bubble-margin-inline-start: 49px;
+    --EventTile_bubble-margin-inline-end: 60px;
+
+    margin-inline-start: var(--EventTile_bubble-margin-inline-start);
+    margin-inline-end: var(--EventTile_bubble-margin-inline-end);
 }
 
 .mx_RoomView_searchResultsPanel {
@@ -49,8 +54,6 @@ limitations under the License.
 }
 
 .mx_EventTile[data-layout=bubble] {
-    --EventTile_bubble-margin-inline-start: 49px;
-    --EventTile_bubble-margin-inline-end: 60px;
     --EventTile_bubble_line-margin-inline-start: -9px;
     --EventTile_bubble_line-margin-inline-end: -12px;
     --EventTile_bubble_gap-inline: 5px;

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -28,7 +28,8 @@ limitations under the License.
     --gutterSize: 11px;
     --cornerRadius: 12px;
     --maxWidth: 70%;
-    margin-right: 60px;
+    --EventBubbleTile-margin-inline-end: 60px;
+    margin-right: var(--EventBubbleTile-margin-inline-end);
 }
 
 .mx_RoomView_searchResultsPanel {

--- a/res/css/views/rooms/_EventBubbleTile.scss
+++ b/res/css/views/rooms/_EventBubbleTile.scss
@@ -595,6 +595,13 @@ limitations under the License.
     display: flex;
     align-items: center;
     justify-content: flex-start;
+
+    .mx_EventTile_line,
+    .mx_EventTile_info {
+        min-width: 100%;
+        // Preserve alignment with left edge of text in bubbles
+        margin: 0;
+    }
 }
 
 .mx_EventTile.mx_EventTile_bubbleContainer[data-layout=bubble],
@@ -608,13 +615,6 @@ limitations under the License.
         position: static;
         order: -1;
         margin-inline-end: var(--EventTile_bubble_gap-inline); // Same spacing between E2E icon and a hidden event
-    }
-
-    .mx_EventTile_line,
-    .mx_EventTile_info {
-        min-width: 100%;
-        // Preserve alignment with left edge of text in bubbles
-        margin: 0;
     }
 
     .mx_EventTile_e2eIcon {


### PR DESCRIPTION
This PR:

- Removes `min-width: 100%` hack from `mx_GenericEventListSummary[data-layout=bubble][data-expanded=false]`. It is not ideal to force 100% width with `min-width: 100%`, suppressing values for spacing specified by other declarations.
- Align the right edge of `expand` / `collapse` link buttons with a variable (--EventBubbleTile-margin-inline-end).
- Prevent link buttons text from overflowing. Fixes https://github.com/vector-im/element-web/issues/22743

Before:

![before1](https://user-images.githubusercontent.com/3362943/177478592-512093c5-3e8d-4ce5-a630-26ab7b086ca5.png)
![before2](https://user-images.githubusercontent.com/3362943/177478596-ab2ffcf2-9ddd-4e39-a562-c19c7fc0da4d.png)
![before](https://user-images.githubusercontent.com/3362943/177480123-59eb3cd2-a488-4eb5-aa79-1197fd9b747e.png)

After:

![after1](https://user-images.githubusercontent.com/3362943/177478566-7822dcf4-0e5a-4dcd-9adb-7fe130df1073.png)
![after2](https://user-images.githubusercontent.com/3362943/177478585-b971657d-ecad-4d12-a6fd-bd776c42f0a6.png)
![after](https://user-images.githubusercontent.com/3362943/177480116-c899fa15-a6eb-45b4-a563-08dce7ac82a4.png)

type: defect
Notes: Align the right edge of expand / collapse link buttons of generic event list summary in bubble layout with a variable 


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Align the right edge of expand / collapse link buttons of generic event list summary in bubble layout with a variable ([\#8992](https://github.com/matrix-org/matrix-react-sdk/pull/8992)). Fixes vector-im/element-web#22743. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->