### PR TITLE
Move style rules of EventTile on hover out of mx_EventTile:not([data-layout=bubble])

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -295,6 +295,14 @@ $left-gutter: 64px;
         &.mx_EventTile_info .mx_EventTile_line {
             padding-left: calc($left-gutter + 20px); // override padding-left $left-gutter
         }
+
+        &:hover {
+            &.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
+            &.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
+            &.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
+                padding-left: calc($left-gutter + 18px + $selected-message-border-width);
+            }
+        }
     }
 
     &[data-layout=bubble] {
@@ -368,12 +376,6 @@ $left-gutter: 64px;
             background-color: $accent;
             color: $accent-fg-color;
         }
-    }
-
-    &:hover.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
-    &:hover.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
-    &:hover.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
-        padding-left: calc($left-gutter + 18px + $selected-message-border-width);
     }
 
     /* End to end encryption stuff */

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -193,6 +193,20 @@ $left-gutter: 64px;
         &.mx_EventTile_continuation .mx_EventTile_line {
             clear: both;
         }
+
+        &:hover {
+            &.mx_EventTile_verified .mx_EventTile_line {
+                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-verified-color;
+            }
+
+            &.mx_EventTile_unverified .mx_EventTile_line {
+                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unverified-color;
+            }
+
+            &.mx_EventTile_unknown .mx_EventTile_line {
+                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unknown-color;
+            }
+        }
     }
 
     &[data-layout=irc] {
@@ -347,18 +361,6 @@ $left-gutter: 64px;
             background-color: $accent;
             color: $accent-fg-color;
         }
-    }
-
-    &:hover.mx_EventTile_verified .mx_EventTile_line {
-        box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-verified-color;
-    }
-
-    &:hover.mx_EventTile_unverified .mx_EventTile_line {
-        box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unverified-color;
-    }
-
-    &:hover.mx_EventTile_unknown .mx_EventTile_line {
-        box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unknown-color;
     }
 
     &:hover.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -199,6 +199,10 @@ $left-gutter: 64px;
             --EventTile_hover_box-shadow-offset-x: calc(50px + $selected-message-border-width);
             --EventTile_hover_box-shadow-spread-radius: -50px;
 
+            .mx_EventTile_line {
+                background-color: $event-selected-color;
+            }
+
             &.mx_EventTile_verified .mx_EventTile_line {
                 box-shadow: inset var(--EventTile_hover_box-shadow-offset-x) 0 0 var(--EventTile_hover_box-shadow-spread-radius) $e2e-verified-color;
             }
@@ -347,7 +351,6 @@ $left-gutter: 64px;
         padding-left: calc($left-gutter + 18px);
     }
 
-    &.mx_EventTile:hover .mx_EventTile_line,
     &.mx_EventTile.mx_EventTile_actionBarFocused .mx_EventTile_line,
     &.mx_EventTile.focus-visible:focus-within .mx_EventTile_line {
         background-color: $event-selected-color;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -195,16 +195,20 @@ $left-gutter: 64px;
         }
 
         &:hover {
+            // TODO: Adjust the values for IRC layout
+            --EventTile_hover_box-shadow-offset-x: calc(50px + $selected-message-border-width);
+            --EventTile_hover_box-shadow-spread-radius: -50px;
+
             &.mx_EventTile_verified .mx_EventTile_line {
-                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-verified-color;
+                box-shadow: inset var(--EventTile_hover_box-shadow-offset-x) 0 0 var(--EventTile_hover_box-shadow-spread-radius) $e2e-verified-color;
             }
 
             &.mx_EventTile_unverified .mx_EventTile_line {
-                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unverified-color;
+                box-shadow: inset var(--EventTile_hover_box-shadow-offset-x) 0 0 var(--EventTile_hover_box-shadow-spread-radius) $e2e-unverified-color;
             }
 
             &.mx_EventTile_unknown .mx_EventTile_line {
-                box-shadow: inset calc(50px + $selected-message-border-width) 0 0 -50px $e2e-unknown-color;
+                box-shadow: inset var(--EventTile_hover_box-shadow-offset-x) 0 0 var(--EventTile_hover_box-shadow-spread-radius) $e2e-unknown-color;
             }
         }
     }

--- a/res/css/views/rooms/_IRCLayout.scss
+++ b/res/css/views/rooms/_IRCLayout.scss
@@ -181,7 +181,6 @@ $irc-line-height: $font-18px;
     .mx_EventTile:hover.mx_EventTile_verified .mx_EventTile_line,
     .mx_EventTile:hover.mx_EventTile_unverified .mx_EventTile_line,
     .mx_EventTile:hover.mx_EventTile_unknown .mx_EventTile_line {
-        padding-left: 0;
         border-left: 0;
     }
 


### PR DESCRIPTION
This PR moves style rules of EventTile on hover out of `mx_EventTile:not([data-layout=bubble])`. The values for box-shadow have been specified for modern layout and they needs configuring for IRC layout, though it is not scope of this PR.

|Before|After|
|---------|------|
|![before1](https://user-images.githubusercontent.com/3362943/177685353-a8fdcda6-baba-4c06-b012-061da93a9d2e.png)|![after1](https://user-images.githubusercontent.com/3362943/177685340-36ccdae5-cd5b-462c-8ee2-c4b5774671ef.png)|



Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->