### PR TITLE
 Use "frequently used emojis" for autocompletion in composer

### DIFF
--- a/src/autocomplete/EmojiProvider.tsx
+++ b/src/autocomplete/EmojiProvider.tsx
@@ -105,9 +105,11 @@ export default class EmojiProvider extends AutocompleteProvider {
 
         let completions = [];
         const { command, range } = this.getCurrentCommand(query, selection);
+        
         if (command && command[0].length > 2) {
             const matchedString = command[0];
             completions = this.matcher.match(matchedString, limit);
+
             // Do second match with shouldMatchWordsOnly in order to match against 'name'
             completions = completions.concat(this.nameMatcher.match(matchedString));
 
@@ -134,7 +136,7 @@ export default class EmojiProvider extends AutocompleteProvider {
 
             completions = completions.slice(0, LIMIT);
 
-            //do a second sort to place emoji matching with frequently used one on top
+            // Do a second sort to place emoji matching with frequently used one on top
             sorters.length = 0;
             this.recentlyUsed.forEach(emoji => {
                 sorters.push(c => score(emoji.shortcodes[0], c.emoji.shortcodes[0]));

--- a/src/autocomplete/EmojiProvider.tsx
+++ b/src/autocomplete/EmojiProvider.tsx
@@ -105,7 +105,7 @@ export default class EmojiProvider extends AutocompleteProvider {
 
         let completions = [];
         const { command, range } = this.getCurrentCommand(query, selection);
-        
+
         if (command && command[0].length > 2) {
             const matchedString = command[0];
             completions = this.matcher.match(matchedString, limit);

--- a/src/autocomplete/EmojiProvider.tsx
+++ b/src/autocomplete/EmojiProvider.tsx
@@ -31,7 +31,6 @@ import { ICompletion, ISelectionRange } from './Autocompleter';
 import SettingsStore from "../settings/SettingsStore";
 import { EMOJI, IEmoji, getEmojiFromUnicode } from '../emoji';
 import { TimelineRenderingType } from '../contexts/RoomContext';
-
 import * as recent from '../emojipicker/recent';
 
 const LIMIT = 20;

--- a/src/autocomplete/EmojiProvider.tsx
+++ b/src/autocomplete/EmojiProvider.tsx
@@ -113,7 +113,7 @@ export default class EmojiProvider extends AutocompleteProvider {
             // Do second match with shouldMatchWordsOnly in order to match against 'name'
             completions = completions.concat(this.nameMatcher.match(matchedString));
 
-            const sorters = [];
+            let sorters = [];
             // make sure that emoticons come first
             sorters.push(c => score(matchedString, c.emoji.emoticon || ""));
 
@@ -137,7 +137,7 @@ export default class EmojiProvider extends AutocompleteProvider {
             completions = completions.slice(0, LIMIT);
 
             // Do a second sort to place emoji matching with frequently used one on top
-            sorters.length = 0;
+            sorters = [];
             this.recentlyUsed.forEach(emoji => {
                 sorters.push(c => score(emoji.shortcodes[0], c.emoji.shortcodes[0]));
             });

--- a/test/autocomplete/EmojiProvider-test.ts
+++ b/test/autocomplete/EmojiProvider-test.ts
@@ -47,7 +47,7 @@ describe('EmojiProvider', function() {
     const testRoom = mkStubRoom(undefined, undefined, undefined);
     stubClient();
     MatrixClientPeg.get();
-    
+
     it.each(EMOJI_SHORTCODES)('Returns consistent results after final colon %s', async function(emojiShortcode) {
         const ep = new EmojiProvider(testRoom);
         const range = { "beginning": true, "start": 0, "end": 3 };
@@ -76,15 +76,14 @@ describe('EmojiProvider', function() {
         add("😚"); //kissing_closed_eyes
         const emojiProvider = new EmojiProvider(null);
 
-        let completionsList = await emojiProvider.getCompletions(":kis", {beginning: true, end: 3, start: 3});
+        let completionsList = await emojiProvider.getCompletions(":kis", { beginning: true, end: 3, start: 3 });
         expect(completionsList[0].component.props.title).toEqual(":kissing_heart:");
         expect(completionsList[1].component.props.title).toEqual(":kissing_closed_eyes:");
-    
-        completionsList = await emojiProvider.getCompletions(":kissing_c", {beginning: true, end: 3, start: 3});
+
+        completionsList = await emojiProvider.getCompletions(":kissing_c", { beginning: true, end: 3, start: 3 });
         expect(completionsList[0].component.props.title).toEqual(":kissing_closed_eyes:");
-    
-        completionsList = await emojiProvider.getCompletions(":so", {beginning: true, end: 2, start: 2});
+
+        completionsList = await emojiProvider.getCompletions(":so", { beginning: true, end: 2, start: 2 });
         expect(completionsList[0].component.props.title).toEqual(":sob:");
     });
-
 });

--- a/test/autocomplete/EmojiProvider-test.ts
+++ b/test/autocomplete/EmojiProvider-test.ts
@@ -77,12 +77,10 @@ describe('EmojiProvider', function() {
         const emojiProvider = new EmojiProvider(null);
 
         let completionsList = await emojiProvider.getCompletions(":kis", {beginning: true, end: 3, start: 3});
-        console.debug(completionsList.map(emoji => emoji.completion));
         expect(completionsList[0].component.props.title).toEqual(":kissing_heart:");
         expect(completionsList[1].component.props.title).toEqual(":kissing_closed_eyes:");
     
         completionsList = await emojiProvider.getCompletions(":kissing_c", {beginning: true, end: 3, start: 3});
-        console.debug(completionsList.map(emoji => emoji.completion));
         expect(completionsList[0].component.props.title).toEqual(":kissing_closed_eyes:");
     
         completionsList = await emojiProvider.getCompletions(":so", {beginning: true, end: 2, start: 2});

--- a/test/autocomplete/EmojiProvider-test.ts
+++ b/test/autocomplete/EmojiProvider-test.ts
@@ -16,6 +16,9 @@ limitations under the License.
 
 import EmojiProvider from '../../src/autocomplete/EmojiProvider';
 import { mkStubRoom } from '../test-utils/test-utils';
+import { add } from "../../src/emojipicker/recent";
+import { stubClient } from "../test-utils";
+import { MatrixClientPeg } from '../../src/MatrixClientPeg';
 
 const EMOJI_SHORTCODES = [
     ":+1",
@@ -42,7 +45,9 @@ const TOO_SHORT_EMOJI_SHORTCODE = [
 
 describe('EmojiProvider', function() {
     const testRoom = mkStubRoom(undefined, undefined, undefined);
-
+    stubClient();
+    MatrixClientPeg.get();
+    
     it.each(EMOJI_SHORTCODES)('Returns consistent results after final colon %s', async function(emojiShortcode) {
         const ep = new EmojiProvider(testRoom);
         const range = { "beginning": true, "start": 0, "end": 3 };
@@ -64,4 +69,24 @@ describe('EmojiProvider', function() {
 
         expect(completions[0].completion).toEqual(expectedEmoji);
     });
+
+    it('Returns correct autocompletion based on recently used emoji', async function() {
+        add("😘"); //kissing_heart
+        add("😘");
+        add("😚"); //kissing_closed_eyes
+        const emojiProvider = new EmojiProvider(null);
+
+        let completionsList = await emojiProvider.getCompletions(":kis", {beginning: true, end: 3, start: 3});
+        console.debug(completionsList.map(emoji => emoji.completion));
+        expect(completionsList[0].component.props.title).toEqual(":kissing_heart:");
+        expect(completionsList[1].component.props.title).toEqual(":kissing_closed_eyes:");
+    
+        completionsList = await emojiProvider.getCompletions(":kissing_c", {beginning: true, end: 3, start: 3});
+        console.debug(completionsList.map(emoji => emoji.completion));
+        expect(completionsList[0].component.props.title).toEqual(":kissing_closed_eyes:");
+    
+        completionsList = await emojiProvider.getCompletions(":so", {beginning: true, end: 2, start: 2});
+        expect(completionsList[0].component.props.title).toEqual(":sob:");
+    });
+
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18978

Place "frequently used emojis" on top position in the composer autocomplete panel.

Signed-off-by: <grimhilt@users.noreply.github.com>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 *  Use "frequently used emojis" for autocompletion in composer ([\#8998](https://github.com/matrix-org/matrix-react-sdk/pull/8998)). Fixes vector-im/element-web#18978. Contributed by @grimhilt.<!-- CHANGELOG_PREVIEW_END -->