### PR TITLE
Ensure timestamp on generic event list summary is not hidden from TimelineCard

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.scss
+++ b/res/css/views/right_panel/_TimelineCard.scss
@@ -155,7 +155,7 @@ limitations under the License.
             .mx_EventTile_line,
             .mx_GenericEventListSummary_unstyledList > .mx_EventTile_info .mx_EventTile_avatar ~ .mx_EventTile_line {
                 padding-inline-start: var(--BaseCard_EventTile-spacing-inline);
-                padding-inline-end: var(--BaseCard_EventTile-spacing-inline);
+                padding-inline-end: $MessageTimestamp_width; // ensure timestamp is not hidden
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22755

This PR applies the timestamp width as padding to event lines of generic event list summary on TimelineCard, to ensure that timestamp is not hidden.

This same solution has been applied outside of the event list summaries already here: https://github.com/luixxiul/matrix-react-sdk/blob/30519b52ee4b697f4fff7348c1b971d85c47100b/res/css/views/right_panel/_TimelineCard.scss#L58

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177610982-d92c5936-9a45-4cff-904b-c66e0af291d6.png)|![after](https://user-images.githubusercontent.com/3362943/177610965-7fbd42d0-4038-457c-a1aa-fd70c9cea09b.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ensure timestamp on generic event list summary is not hidden from TimelineCard ([\#9000](https://github.com/matrix-org/matrix-react-sdk/pull/9000)). Fixes vector-im/element-web#22755. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->