### PR TITLE
Improve _GenericEventListSummary.scss

### DIFF
--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -23,16 +23,12 @@ limitations under the License.
 
     &[data-layout=irc],
     &[data-layout=group] {
+        margin-top: $spacing-8;
+
         .mx_GenericEventListSummary_toggle {
             float: right;
             margin-block: 0;
             margin-inline: 0 10px;
-        }
-    }
-
-    &[data-layout=group] {
-        .mx_GenericEventListSummary_avatars {
-            padding-top: $spacing-8;
         }
     }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -16,6 +16,7 @@ limitations under the License.
 
 .mx_GenericEventListSummary {
     position: relative;
+    margin-top: $spacing-8;
 
     .mx_GenericEventListSummary_avatars {
         margin-right: $spacing-8;
@@ -23,8 +24,6 @@ limitations under the License.
 
     &[data-layout=irc],
     &[data-layout=group] {
-        margin-top: $spacing-8;
-
         .mx_GenericEventListSummary_toggle {
             float: right;
             margin-block: 0;

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -84,6 +84,26 @@ limitations under the License.
             }
         }
     }
+
+    .mx_MatrixChat_useCompactLayout & {
+        font-size: $font-13px;
+
+        .mx_EventTile_line {
+            line-height: $font-20px;
+        }
+
+        .mx_GenericEventListSummary_line {
+            line-height: $font-22px;
+        }
+
+        .mx_GenericEventListSummary_toggle {
+            margin-top: 3px;
+        }
+
+        .mx_TextualEvent.mx_GenericEventListSummary_summary {
+            font-size: $font-13px;
+        }
+    }
 }
 
 .mx_GenericEventListSummary_unstyledList {
@@ -110,26 +130,4 @@ limitations under the License.
     border-bottom: 1px solid $primary-hairline-color;
     margin-left: 63px;
     line-height: $font-30px;
-}
-
-.mx_MatrixChat_useCompactLayout {
-    .mx_GenericEventListSummary {
-        font-size: $font-13px;
-
-        .mx_EventTile_line {
-            line-height: $font-20px;
-        }
-
-        .mx_GenericEventListSummary_line {
-            line-height: $font-22px;
-        }
-
-        .mx_GenericEventListSummary_toggle {
-            margin-top: 3px;
-        }
-    }
-
-    .mx_TextualEvent.mx_GenericEventListSummary_summary {
-        font-size: $font-13px;
-    }
 }

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -103,11 +103,11 @@ limitations under the License.
     display: inline-block;
     margin-right: 8px;
     line-height: $font-12px;
-}
 
-.mx_GenericEventListSummary_avatars .mx_BaseAvatar {
+.mx_BaseAvatar {
     margin-right: -4px;
     cursor: pointer;
+}
 }
 
 .mx_GenericEventListSummary_line {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -41,7 +41,7 @@ limitations under the License.
             margin-block: 0;
 
             &[aria-expanded=false] {
-                order: 9;
+                order: 9; // TODO: Remove
             }
 
             &[aria-expanded=true] {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -17,17 +17,15 @@ limitations under the License.
 .mx_GenericEventListSummary {
     position: relative;
 
+    .mx_GenericEventListSummary_avatars {
+        margin-right: $spacing-8;
+    }
+
     &[data-layout=irc],
     &[data-layout=group] {
         .mx_GenericEventListSummary_toggle {
             float: right;
             margin: 8px 10px 0 0;
-        }
-    }
-
-    &[data-layout=irc] {
-        .mx_GenericEventListSummary_avatars {
-            margin: 0 9px 0 0;
         }
     }
 
@@ -98,7 +96,6 @@ limitations under the License.
 
 .mx_GenericEventListSummary_avatars {
     display: inline-block;
-    margin-right: 8px;
     line-height: $font-12px;
 
     .mx_BaseAvatar {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -104,10 +104,10 @@ limitations under the License.
     margin-right: 8px;
     line-height: $font-12px;
 
-.mx_BaseAvatar {
-    margin-right: -4px;
-    cursor: pointer;
-}
+    .mx_BaseAvatar {
+        margin-right: -4px;
+        cursor: pointer;
+    }
 }
 
 .mx_GenericEventListSummary_line {
@@ -124,13 +124,13 @@ limitations under the License.
             line-height: $font-20px;
         }
 
-    .mx_GenericEventListSummary_line {
-        line-height: $font-22px;
-    }
+        .mx_GenericEventListSummary_line {
+            line-height: $font-22px;
+        }
 
-    .mx_GenericEventListSummary_toggle {
-        margin-top: 3px;
-    }
+        .mx_GenericEventListSummary_toggle {
+            margin-top: 3px;
+        }
     }
 
     .mx_TextualEvent.mx_GenericEventListSummary_summary {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -22,11 +22,14 @@ limitations under the License.
         margin-right: $spacing-8;
     }
 
+    .mx_GenericEventListSummary_toggle {
+        margin-block: 0;
+    }
+
     &[data-layout=irc],
     &[data-layout=group] {
         .mx_GenericEventListSummary_toggle {
             float: right;
-            margin-block: 0;
             margin-inline: 0 10px;
         }
     }

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -27,7 +27,6 @@ limitations under the License.
 
     &[data-layout=irc] {
         .mx_GenericEventListSummary_avatars {
-            padding: 0;
             margin: 0 9px 0 0;
         }
     }
@@ -83,10 +82,6 @@ limitations under the License.
 
         .mx_GenericEventListSummary_line {
             display: none;
-        }
-
-        .mx_GenericEventListSummary_avatars {
-            padding-top: 0;
         }
     }
 }

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -23,16 +23,18 @@ limitations under the License.
             float: right;
             margin: 8px 10px 0 0;
         }
-
-        .mx_GenericEventListSummary_avatars {
-            padding-top: $spacing-8;
-        }
     }
 
     &[data-layout=irc] {
         .mx_GenericEventListSummary_avatars {
             padding: 0;
             margin: 0 9px 0 0;
+        }
+    }
+
+    &[data-layout=group] {
+        .mx_GenericEventListSummary_avatars {
+            padding-top: $spacing-8;
         }
     }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -16,7 +16,6 @@ limitations under the License.
 
 .mx_GenericEventListSummary {
     position: relative;
-    margin-top: $spacing-8;
 
     .mx_GenericEventListSummary_avatars {
         margin-right: $spacing-8;
@@ -32,6 +31,10 @@ limitations under the License.
             float: right;
             margin-inline: 0 10px;
         }
+    }
+
+    &[data-layout=group] {
+        margin-top: $spacing-8;
     }
 
     &[data-layout=bubble] {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -21,26 +21,18 @@ limitations under the License.
         margin-right: $spacing-8;
     }
 
-    &[data-layout=irc] {
-        margin-top: 0;
-    }
-
     &[data-layout=irc],
     &[data-layout=group] {
         .mx_GenericEventListSummary_toggle {
             float: right;
+            margin-block: 0;
             margin-inline: 0 10px;
-            margin-bottom: 0;
         }
     }
 
     &[data-layout=group] {
         .mx_GenericEventListSummary_avatars {
             padding-top: $spacing-8;
-        }
-
-        .mx_GenericEventListSummary_toggle {
-            margin-top: $spacing-8;
         }
     }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -21,10 +21,6 @@ limitations under the License.
         margin-right: $spacing-8;
     }
 
-    .mx_GenericEventListSummary_toggle {
-        margin-block: 0;
-    }
-
     &[data-layout=irc],
     &[data-layout=group] {
         .mx_GenericEventListSummary_toggle {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -87,7 +87,7 @@ limitations under the License.
 
     .mx_MatrixChat_useCompactLayout & {
         font-size: $font-13px;
-        margin-top: 3px;
+        margin-top: $spacing-4;
 
         .mx_EventTile_line {
             line-height: $font-20px;

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -87,6 +87,7 @@ limitations under the License.
 
     .mx_MatrixChat_useCompactLayout & {
         font-size: $font-13px;
+        margin-top: 3px;
 
         .mx_EventTile_line {
             line-height: $font-20px;
@@ -94,10 +95,6 @@ limitations under the License.
 
         .mx_GenericEventListSummary_line {
             line-height: $font-22px;
-        }
-
-        .mx_GenericEventListSummary_toggle {
-            margin-top: 3px;
         }
 
         .mx_TextualEvent.mx_GenericEventListSummary_summary {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -35,6 +35,23 @@ limitations under the License.
         --maxWidth: 70%;
         margin-left: calc(var(--avatarSize) + var(--gutterSize));
 
+        .mx_GenericEventListSummary_toggle {
+            margin-block: 0;
+
+            &[aria-expanded=false] {
+                order: 9;
+            }
+
+            &[aria-expanded=true] {
+                margin-inline-start: auto; // reduce clickable area
+                margin-inline-end: var(--EventTile_bubble-margin-inline-end); // as the parent has zero margin
+            }
+        }
+
+        .mx_GenericEventListSummary_line {
+            display: none;
+        }
+
         &[data-expanded=false] {
             display: flex;
             align-items: center;
@@ -59,23 +76,6 @@ limitations under the License.
             &::before {
                 background: transparent;
             }
-        }
-
-        .mx_GenericEventListSummary_toggle {
-            margin-block: 0;
-
-            &[aria-expanded=false] {
-                order: 9;
-            }
-
-            &[aria-expanded=true] {
-                margin-inline-start: auto; // reduce clickable area
-                margin-inline-end: var(--EventTile_bubble-margin-inline-end); // as the parent has zero margin
-            }
-        }
-
-        .mx_GenericEventListSummary_line {
-            display: none;
         }
     }
 }

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -21,17 +21,26 @@ limitations under the License.
         margin-right: $spacing-8;
     }
 
+    &[data-layout=irc] {
+        margin-top: 0;
+    }
+
     &[data-layout=irc],
     &[data-layout=group] {
         .mx_GenericEventListSummary_toggle {
             float: right;
-            margin: 8px 10px 0 0;
+            margin-inline: 0 10px;
+            margin-bottom: 0;
         }
     }
 
     &[data-layout=group] {
         .mx_GenericEventListSummary_avatars {
             padding-top: $spacing-8;
+        }
+
+        .mx_GenericEventListSummary_toggle {
+            margin-top: $spacing-8;
         }
     }
 

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -119,10 +119,10 @@ limitations under the License.
 .mx_MatrixChat_useCompactLayout {
     .mx_GenericEventListSummary {
         font-size: $font-13px;
+
         .mx_EventTile_line {
             line-height: $font-20px;
         }
-    }
 
     .mx_GenericEventListSummary_line {
         line-height: $font-22px;
@@ -130,6 +130,7 @@ limitations under the License.
 
     .mx_GenericEventListSummary_toggle {
         margin-top: 3px;
+    }
     }
 
     .mx_TextualEvent.mx_GenericEventListSummary_summary {

--- a/res/css/views/elements/_GenericEventListSummary.scss
+++ b/res/css/views/elements/_GenericEventListSummary.scss
@@ -35,6 +35,7 @@ limitations under the License.
 
     &[data-layout=bubble] {
         --maxWidth: 70%;
+        display: flex;
         margin-left: calc(var(--avatarSize) + var(--gutterSize));
 
         .mx_GenericEventListSummary_toggle {
@@ -55,7 +56,6 @@ limitations under the License.
         }
 
         &[data-expanded=false] {
-            display: flex;
             align-items: center;
             justify-content: space-between;
             column-gap: 5px;
@@ -64,7 +64,6 @@ limitations under the License.
         // ideally we'd use display=contents here for the layout to all work regardless of the *ELS but
         // that breaks ScrollPanel's reliance upon offsetTop so we have to have a bit more finesse.
         &[data-expanded=true] {
-            display: flex;
             flex-direction: column;
             margin: 0;
         }


### PR DESCRIPTION
This PR improves `_GenericEventListSummary.scss`:

- Align avatars and `expand` on modern layout

| |Before|After| |
|-|---------|------|-|
|IRC layout|![before3](https://user-images.githubusercontent.com/3362943/177755218-6f910058-c805-40c9-9c09-4c970e29ed21.png)|![after3](https://user-images.githubusercontent.com/3362943/177755204-6a4982c6-dae1-432b-8a27-9ad14b6d3e34.png)|The top margin should be zero|
|Modern layout|![before2](https://user-images.githubusercontent.com/3362943/177755212-ef280e92-7691-466d-89bb-4e70aa6952e9.png)|![after2](https://user-images.githubusercontent.com/3362943/177755197-37cdaf39-aef4-4f99-b937-58996b901d0e.png)|Apply 8px margin to the parent|
|Bubble layout|(unchanged)|![after1](https://user-images.githubusercontent.com/3362943/177755182-7beb431f-ed81-4861-9cc0-1d398e16a30f.png)||







Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve _GenericEventListSummary.scss ([\#9005](https://github.com/matrix-org/matrix-react-sdk/pull/9005)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->