### PR TITLE
Fix lost padding of event tile info line

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -338,7 +338,7 @@ $left-gutter: 64px;
         }
 
         .mx_EventTile_line {
-            padding: 3px 0 2px; // Align with mx_EventTile_avatar and mx_EventTile_e2eIcon
+            padding-block: 3px 2px; // Align with mx_EventTile_avatar and mx_EventTile_e2eIcon
 
             .mx_MessageTimestamp {
                 top: 0;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22754
Fixes https://github.com/vector-im/element-web/issues/22759

cf. https://github.com/matrix-org/matrix-react-sdk/pull/8994

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
element-web notes: none

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix lost padding of event tile info line ([\#9009](https://github.com/matrix-org/matrix-react-sdk/pull/9009)). Fixes vector-im/element-web#22754 and vector-im/element-web#22759. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->