### PR TITLE
add spaces to TileErrorBoundary

### DIFF
--- a/src/components/views/messages/TileErrorBoundary.tsx
+++ b/src/components/views/messages/TileErrorBoundary.tsx
@@ -92,8 +92,9 @@ export default class TileErrorBoundary extends React.Component<IProps, IState> {
                 <div className="mx_EventTile_line">
                     <span>
                         { _t("Can't load this message") }
-                        { mxEvent && ` (${mxEvent.getType()})` }
+                        { mxEvent && ` (${mxEvent.getType()}) ` }
                         { submitLogsButton }
+                        { ` ` }
                         { viewSourceButton }
                     </span>
                 </div>


### PR DESCRIPTION
| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/2803622/177776040-3e12360b-8f04-40b4-908a-b76c6586aa27.png) | ![image](https://user-images.githubusercontent.com/2803622/177776188-72c5c5cc-05b5-412c-a543-3e4eb900fe2c.png) |

Signed-off-by: Kim Brose <kim.brose@rwth-aachen.de>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
