### PR TITLE
Re-add margin to tiles based on EventTileBubble

### DIFF
--- a/res/css/views/messages/_CreateEvent.scss
+++ b/res/css/views/messages/_CreateEvent.scss
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_CreateEvent {
+.mx_EventTileBubble.mx_CreateEvent {
+    margin: var(--EventTileBubble_margin-block) auto;
+
     &::before {
         background-color: $header-panel-text-primary-color;
         mask-image: url('$(res)/img/element-icons/chat-bubbles.svg');

--- a/res/css/views/messages/_EventTileBubble.scss
+++ b/res/css/views/messages/_EventTileBubble.scss
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 .mx_EventTileBubble {
+    --EventTileBubble_margin-block: 10px; // TODO: Use a spacing variable
+
     background-color: $dark-panel-bg-color;
     padding: 10px; // TODO: Use a spacing variable
     border-radius: 8px;

--- a/res/css/views/messages/_MJitsiWidgetEvent.scss
+++ b/res/css/views/messages/_MJitsiWidgetEvent.scss
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_MJitsiWidgetEvent {
+.mx_EventTileBubble.mx_MJitsiWidgetEvent {
+    margin: var(--EventTileBubble_margin-block) auto;
+
     &::before {
         background-color: $header-panel-text-primary-color; // XXX: Variable abuse
         mask-image: url('$(res)/img/element-icons/call/video-call.svg');

--- a/res/css/views/messages/_MJitsiWidgetEvent.scss
+++ b/res/css/views/messages/_MJitsiWidgetEvent.scss
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 .mx_EventTileBubble.mx_MJitsiWidgetEvent {
-    margin: var(--EventTileBubble_margin-block) auto;
-
     &::before {
         background-color: $header-panel-text-primary-color; // XXX: Variable abuse
         mask-image: url('$(res)/img/element-icons/call/video-call.svg');

--- a/res/css/views/messages/_common_CryptoEvent.scss
+++ b/res/css/views/messages/_common_CryptoEvent.scss
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_cryptoEvent {
+.mx_EventTileBubble.mx_cryptoEvent {
+    margin: var(--EventTileBubble_margin-block) auto;
+
     // white infill for the transparency
     &.mx_cryptoEvent_icon::before {
         background-color: #ffffff;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -74,7 +74,7 @@ $left-gutter: 64px;
     }
 
     .mx_EventTileBubble {
-        margin-block: 10px; // TODO: Use a spacing variable
+        margin-block: var(--EventTileBubble_margin-block);
     }
 
     .mx_MImageBody {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -238,6 +238,10 @@ $left-gutter: 64px;
         .mx_EventTileBubble {
             position: relative;
             left: var(--EventTile_irc_line_info-inset-inline-start);
+
+            &.mx_cryptoEvent {
+                left: unset;
+            }
         }
 
         .mx_ReplyTile .mx_EventTileBubble {

--- a/res/css/views/rooms/_HistoryTile.scss
+++ b/res/css/views/rooms/_HistoryTile.scss
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_HistoryTile::before {
-    background-color: $header-panel-text-primary-color;
-    mask-image: url('$(res)/img/element-icons/hide.svg');
+.mx_EventTileBubble.mx_HistoryTile {
+    margin: var(--EventTileBubble_margin-block) auto;
+
+    &::before {
+        background-color: $header-panel-text-primary-color;
+        mask-image: url('$(res)/img/element-icons/hide.svg');
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22772

This PR re-adds margin around tiles based on `EventTileBubble`, such as `HistoryTile`.

| |Before|After|
|-|---------|------|
|HistoryTile|![before1](https://user-images.githubusercontent.com/3362943/177810464-498a90da-a941-4532-9e8c-40e119b52a9c.png)|![after1](https://user-images.githubusercontent.com/3362943/177810437-4882af7a-4065-454f-ae48-dd8b5218775b.png)|
|HistoryTile (IRC layout)|![before](https://user-images.githubusercontent.com/3362943/177825776-fb4815f0-bc8f-4d85-966c-52a4a333b851.png)|![after](https://user-images.githubusercontent.com/3362943/177823985-b090e201-5a70-44ba-9df0-ce202372bbd6.png)|
|CryptoEvent|![before1](https://user-images.githubusercontent.com/3362943/177821116-3c44b00d-127f-4c51-9014-600013d08dcc.png)|![after1](https://user-images.githubusercontent.com/3362943/177821091-9f761d7e-949a-43c9-b91e-620a10dac27f.png)|
|CryptoEvent|![before](https://user-images.githubusercontent.com/3362943/177825352-44ef37e6-2faa-48c7-a1ce-fe99e391576d.png)|![after](https://user-images.githubusercontent.com/3362943/177824985-ca0e09b7-fbf5-49fd-8458-ac3473ca408f.png)|
|MJitsiWidgetEvent|(unchanged)|![after](https://user-images.githubusercontent.com/3362943/177824240-420f6cb2-0e84-464a-b8b5-8581a878fce9.png)↑ default margin is not required because it appears inside EventTile|

type: defect
element-web notes: none

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
![after2](https://user-images.githubusercontent.com/3362943/177822751-66db571a-dcbd-4fd2-898f-534d6f0edebb.png)

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Re-add margin to tiles based on EventTileBubble ([\#9015](https://github.com/matrix-org/matrix-react-sdk/pull/9015)). Fixes vector-im/element-web#22772. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->