### PR TITLE
Remove padding from event info line for hidden events on ThreadView

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -968,8 +968,6 @@ $left-gutter: 64px;
 
         // handling for hidden events (e.g reactions) in the thread view
         &.mx_EventTile_info {
-            padding-top: 0;
-
             .mx_EventTile_avatar {
                 position: absolute;
                 top: 1.5px; // Align with hidden event content
@@ -1000,6 +998,8 @@ $left-gutter: 64px;
 
             &[data-layout=irc],
             &[data-layout=group] {
+                padding-top: 0;
+
                 .mx_MessageTimestamp {
                     top: 2px; // Align with avatar
                 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22777

This PR removes top padding from event info line for hidden events on ThreadView.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/177922073-578094a9-b229-4997-9fb1-63d7a9994591.png)|![after](https://user-images.githubusercontent.com/3362943/177922066-60e9bef7-e887-411b-a7a3-149b520a22d0.png)|
|![before1](https://user-images.githubusercontent.com/3362943/177922078-1dda9d22-c318-4581-9b22-69b969e4bedd.png)↑`:not()` pseudo class|![after1](https://user-images.githubusercontent.com/3362943/177922071-c2f89a6c-eebf-4ec5-8a19-7c6211552c6d.png)|

type: defect
Notes: Fix avatar position on event info line for hidden events on a thread

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the 
changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix avatar position on event info line for hidden events on a thread ([\#9019](https://github.com/matrix-org/matrix-react-sdk/pull/9019)). Fixes vector-im/element-web#22777. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->