### PR TITLE
Move style declarations out of :not([data-layout=bubble]) in ThreadView

### DIFF
--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1137,7 +1137,7 @@ $left-gutter: 64px;
     .mx_GenericEventListSummary {
         &[data-layout=irc],
         &[data-layout=group] {
-             > .mx_EventTile_line {
+            > .mx_EventTile_line {
                 padding-inline-start: var(--ThreadView_group_spacing-start); // align summary text with message text
                 padding-inline-end: var(--ThreadView_group_spacing-end); // align summary text with message text
             }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -322,7 +322,7 @@ $left-gutter: 64px;
             &.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
             &.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
             &.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
-                padding-left: calc($left-gutter + 18px + $selected-message-border-width);
+                padding-inline-start: calc($left-gutter + 18px + $selected-message-border-width);
             }
         }
     }
@@ -1018,14 +1018,6 @@ $left-gutter: 64px;
             }
         }
 
-        &:not([data-layout=bubble]) {
-            &:hover.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
-            &:hover.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
-            &:hover.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
-                padding-inline-start: 0; // Override
-            }
-        }
-
         &[data-layout=bubble] {
             margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
             margin-inline-end: var(--BaseCard_EventTile-spacing-inline);
@@ -1133,6 +1125,14 @@ $left-gutter: 64px;
             .mx_MessageTimestamp {
                 position: absolute; // for IRC layout
                 top: 2px; // Align with mx_EventTile_content
+            }
+
+            &:hover {
+                &.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
+                &.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
+                &.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
+                    padding-inline-start: 0;
+                }
             }
         }
     }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1059,8 +1059,6 @@ $left-gutter: 64px;
             padding-block-start: $spacing-16;
 
             .mx_EventTile_line {
-                padding-block: var(--BaseCard_EventTile_line-padding-block);
-
                 .mx_EventTile_content {
                     &.mx_EditMessageComposer {
                         padding-inline-start: 0; // align start of first letter with that of the event body

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1020,23 +1020,10 @@ $left-gutter: 64px;
         }
 
         &:not([data-layout=bubble]) {
-            padding-top: $spacing-16;
-
             &:hover.mx_EventTile_verified.mx_EventTile_info .mx_EventTile_line,
             &:hover.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
             &:hover.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
                 padding-inline-start: 0; // Override
-            }
-
-            .mx_EventTile_line {
-                padding-top: var(--BaseCard_EventTile_line-padding-block);
-                padding-bottom: var(--BaseCard_EventTile_line-padding-block);
-
-                .mx_EventTile_content {
-                    &.mx_EditMessageComposer {
-                        padding-inline-start: 0; // align start of first letter with that of the event body
-                    }
-                }
             }
         }
 
@@ -1064,6 +1051,22 @@ $left-gutter: 64px;
 
                 .mx_EventTile_line.mx_EventTile_mediaLine {
                     margin: 0 var(--EventTile_bubble_line-margin-inline-end) 0 0; // align with normal messages
+                }
+            }
+        }
+
+        &[data-layout=irc],
+        &[data-layout=group] {
+            padding-block-start: $spacing-16;
+
+            .mx_EventTile_line {
+                padding-top: var(--BaseCard_EventTile_line-padding-block);
+                padding-bottom: var(--BaseCard_EventTile_line-padding-block);
+
+                .mx_EventTile_content {
+                    &.mx_EditMessageComposer {
+                        padding-inline-start: 0; // align start of first letter with that of the event body
+                    }
                 }
             }
         }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -999,15 +999,13 @@ $left-gutter: 64px;
             &[data-layout=group] {
                 padding-top: 0;
 
-                .mx_MessageTimestamp {
-                    top: 2px; // Align with avatar
-                }
-            }
-
-            &:not([data-layout=bubble]) {
                 .mx_EventTile_avatar {
                     left: calc($MessageTimestamp_width + 14px - 4px); // 14px: avatar width, 4px: align with text
                     z-index: 9; // position above the hover styling
+                }
+
+                .mx_MessageTimestamp {
+                    top: 2px; // Align with avatar
                 }
             }
 

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -953,8 +953,7 @@ $left-gutter: 64px;
         }
 
         .mx_EventTile_line {
-            padding-top: var(--BaseCard_EventTile_line-padding-block);
-            padding-bottom: var(--BaseCard_EventTile_line-padding-block);
+            padding-block: var(--BaseCard_EventTile_line-padding-block);
         }
 
         .mx_EventTile_line,
@@ -1060,8 +1059,7 @@ $left-gutter: 64px;
             padding-block-start: $spacing-16;
 
             .mx_EventTile_line {
-                padding-top: var(--BaseCard_EventTile_line-padding-block);
-                padding-bottom: var(--BaseCard_EventTile_line-padding-block);
+                padding-block: var(--BaseCard_EventTile_line-padding-block);
 
                 .mx_EventTile_content {
                     &.mx_EditMessageComposer {

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1136,9 +1136,12 @@ $left-gutter: 64px;
     }
 
     .mx_GenericEventListSummary {
-        &:not([data-layout=bubble]) > .mx_EventTile_line {
-            padding-inline-start: var(--ThreadView_group_spacing-start); // align summary text with message text
-            padding-inline-end: var(--ThreadView_group_spacing-end); // align summary text with message text
+        &[data-layout=irc],
+        &[data-layout=group] {
+             > .mx_EventTile_line {
+                padding-inline-start: var(--ThreadView_group_spacing-start); // align summary text with message text
+                padding-inline-end: var(--ThreadView_group_spacing-end); // align summary text with message text
+            }
         }
     }
 }

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1107,8 +1107,7 @@ $left-gutter: 64px;
         }
 
         &[data-layout=bubble] {
-            margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
-            margin-inline-end: var(--BaseCard_EventTile-spacing-inline);
+            margin-inline: var(--BaseCard_EventTile-spacing-inline);
 
             &::before {
                 inset-inline: calc(-1 * var(--BaseCard_EventTile-spacing-inline));

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -1018,34 +1018,6 @@ $left-gutter: 64px;
             }
         }
 
-        &[data-layout=bubble] {
-            margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
-            margin-inline-end: var(--BaseCard_EventTile-spacing-inline);
-
-            &::before {
-                inset-inline: calc(-1 * var(--BaseCard_EventTile-spacing-inline));
-                z-index: auto; // enable background color on hover
-            }
-
-            .mx_ReactionsRow {
-                position: relative; // display on hover
-            }
-
-            .mx_EventTile_line.mx_EventTile_mediaLine {
-                padding-block: 0;
-                padding-inline-start: 0;
-                max-width: var(--EventBubbleTile_line-max-width);
-            }
-
-            &[data-self=true] {
-                align-items: flex-end;
-
-                .mx_EventTile_line.mx_EventTile_mediaLine {
-                    margin: 0 var(--EventTile_bubble_line-margin-inline-end) 0 0; // align with normal messages
-                }
-            }
-        }
-
         &[data-layout=irc],
         &[data-layout=group] {
             padding-block-start: $spacing-16;
@@ -1132,6 +1104,34 @@ $left-gutter: 64px;
                 &.mx_EventTile_unverified.mx_EventTile_info .mx_EventTile_line,
                 &.mx_EventTile_unknown.mx_EventTile_info .mx_EventTile_line {
                     padding-inline-start: 0;
+                }
+            }
+        }
+
+        &[data-layout=bubble] {
+            margin-inline-start: var(--BaseCard_EventTile-spacing-inline);
+            margin-inline-end: var(--BaseCard_EventTile-spacing-inline);
+
+            &::before {
+                inset-inline: calc(-1 * var(--BaseCard_EventTile-spacing-inline));
+                z-index: auto; // enable background color on hover
+            }
+
+            .mx_ReactionsRow {
+                position: relative; // display on hover
+            }
+
+            .mx_EventTile_line.mx_EventTile_mediaLine {
+                padding-block: 0;
+                padding-inline-start: 0;
+                max-width: var(--EventBubbleTile_line-max-width);
+            }
+
+            &[data-self=true] {
+                align-items: flex-end;
+
+                .mx_EventTile_line.mx_EventTile_mediaLine {
+                    margin: 0 var(--EventTile_bubble_line-margin-inline-end) 0 0; // align with normal messages
                 }
             }
         }


### PR DESCRIPTION
This PR moves style declarations out of `:not([data-layout=bubble])` in `mx_ThreadView`.

Also:
- Move style for IRC and modern layouts above bubble layout
- Apply zero inline start padding for hovered info event line to modern/group layout only (it is not required for IRC layout)

||Before|After|
|-|---------|------|
|`mx_EventTile`|![before1](https://user-images.githubusercontent.com/3362943/177947441-7ce1cf95-7593-4e42-94cd-4a35f02fcd38.png)|![after1](https://user-images.githubusercontent.com/3362943/177947408-6cbea098-54a1-456e-a8bf-d62b69881f9b.png)|
|Verified `mx_EventTile_info` on hover (cancel inline start padding)|![before2](https://user-images.githubusercontent.com/3362943/177947452-cc04e7ed-e763-4f1d-bca9-99c97a8d783e.png)|![after2](https://user-images.githubusercontent.com/3362943/177947425-4fea4534-86fc-4b1b-9024-a6e601913258.png)|
|Verified `mx_EventTile_info` on hover||![after3](https://user-images.githubusercontent.com/3362943/177947429-928ac4d4-6c3c-45b5-8591-afe79d83dece.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->