### PR TITLE
Unbreak URL preview for formatted links with tooltips

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -236,7 +236,7 @@ export default abstract class BasePlatform {
      * @returns {boolean} whether the platform requires URL previews in tooltips
      */
     public needsUrlTooltips(): boolean {
-        return false;
+        return true;
     }
 
     /**

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -236,7 +236,7 @@ export default abstract class BasePlatform {
      * @returns {boolean} whether the platform requires URL previews in tooltips
      */
     public needsUrlTooltips(): boolean {
-        return true;
+        return false;
     }
 
     /**

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -93,8 +93,13 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
         // we should be pillify them here by doing the linkifying BEFORE the pillifying.
         pillifyLinks([this.contentRef.current], this.props.mxEvent, this.pills);
         HtmlUtils.linkifyElement(this.contentRef.current);
-        tooltipifyLinks([this.contentRef.current], this.pills, this.tooltips);
+
         this.calculateUrlPreview();
+
+        // tooltipifyLinks AFTER calculateUrlPreview because the DOM inside the tooltip
+        // container is empty before the internal component has mounted so calculateUrlPreview
+        // won't find any anchors
+        tooltipifyLinks([this.contentRef.current], this.pills, this.tooltips);
 
         if (this.props.mxEvent.getContent().format === "org.matrix.custom.html") {
             // Handle expansion and add buttons


### PR DESCRIPTION
Fixes: vector-im/element-web#22764
Signed-off-by: Johannes Marbach <johannesm@element.io>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Unbreak URL preview for formatted links with tooltips ([\#9022](https://github.com/matrix-org/matrix-react-sdk/pull/9022)). Fixes vector-im/element-web#22764. Contributed by @Johennes.<!-- CHANGELOG_PREVIEW_END -->