### PR TITLE
Fix URL previews causing messages to become unrenderable

### DIFF
--- a/src/components/views/rooms/LinkPreviewWidget.tsx
+++ b/src/components/views/rooms/LinkPreviewWidget.tsx
@@ -120,8 +120,9 @@ export default class LinkPreviewWidget extends React.Component<IProps> {
         // opaque string. This does not allow any HTML to be injected into the DOM.
         const description = AllHtmlEntities.decode(p["og:description"] || "");
 
-        const anchor = <a href={this.props.link} target="_blank" rel="noreferrer noopener">{ p["og:title"] }</a>;
-        const needsTooltip = PlatformPeg.get()?.needsUrlTooltips() && this.props.link !== p["og:title"].trim();
+        const title = p["og:title"]?.trim() ?? "";
+        const anchor = <a href={this.props.link} target="_blank" rel="noreferrer noopener">{ title }</a>;
+        const needsTooltip = PlatformPeg.get()?.needsUrlTooltips() && this.props.link !== title;
 
         return (
             <div className="mx_LinkPreviewWidget">


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22766

Empty titles aren't really our problem in this code.

**Note**: regression tests are difficult because it involves testing URL previews. We might be able to hope for a test which drives the component directly, but that's not super reliable compared to a real world integration test.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix URL previews causing messages to become unrenderable ([\#9028](https://github.com/matrix-org/matrix-react-sdk/pull/9028)). Fixes vector-im/element-web#22766.<!-- CHANGELOG_PREVIEW_END -->