### PR TITLE
Add space for the stroke on message editor on IRC layout

### DIFF
--- a/res/css/views/rooms/_EditMessageComposer.scss
+++ b/res/css/views/rooms/_EditMessageComposer.scss
@@ -16,12 +16,14 @@ limitations under the License.
 */
 
 .mx_EditMessageComposer {
+    --EditMessageComposer-padding-inline: 3px;
+
     display: flex;
     flex-direction: column;
     max-width: 100%; // disable overflow
     width: auto;
     gap: 5px;
-    padding: 3px;
+    padding: 3px var(--EditMessageComposer-padding-inline);
 
     .mx_BasicMessageComposer_input {
         border-radius: 4px;

--- a/res/css/views/rooms/_EventTile.scss
+++ b/res/css/views/rooms/_EventTile.scss
@@ -247,6 +247,13 @@ $left-gutter: 64px;
         .mx_ReplyTile .mx_EventTileBubble {
             left: unset; // Cancel the value specified above for the tile inside ReplyTile
         }
+
+        &.mx_EventTile_isEditing > .mx_EventTile_line {
+            .mx_EditMessageComposer {
+                // add space for the stroke on box-shadow
+                padding-inline-start: calc($selected-message-border-width + var(--EditMessageComposer-padding-inline));
+            }
+        }
     }
 
     &[data-layout=group] {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22785

This PR adds space (`$selected-message-border-width`) to the area for the stroke created with box-shadow on `mx_EditMessageComposer` on IRC layout.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/178095983-24958520-8b9e-46ed-9361-23d250b148dd.png)|![after](https://user-images.githubusercontent.com/3362943/178095974-339de6dd-32ca-49cb-9dcf-8b442d3e9114.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add space for the stroke on message editor on IRC layout ([\#9030](https://github.com/matrix-org/matrix-react-sdk/pull/9030)). Fixes vector-im/element-web#22785. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->