### PR TITLE
Improve _FilePanel.scss

### DIFF
--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -98,7 +98,11 @@ limitations under the License.
 
                 .mx_DisambiguatedProfile {
                     line-height: initial;
-                    color: $event-timestamp-color;
+
+                    .mx_DisambiguatedProfile_displayName,
+                    .mx_DisambiguatedProfile_mxid {
+                        color: $event-timestamp-color;
+                    }
                 }
 
                 .mx_MessageTimestamp {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -97,12 +97,7 @@ limitations under the License.
                 margin-top: -2px;
 
                 .mx_DisambiguatedProfile {
-                    color: $event-timestamp-color; // for ellipsis
-
-                    .mx_DisambiguatedProfile_displayName,
-                    .mx_DisambiguatedProfile_mxid {
-                        color: $event-timestamp-color;
-                    }
+                    color: $event-timestamp-color; // for ellipsis. Color of displayName and mxid is inherited
                 }
 
                 .mx_MessageTimestamp {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -71,20 +71,20 @@ limitations under the License.
         .mx_MFileBody_download {
             padding-top: $spacing-8;
             display: flex;
+            justify-content: space-between;
             font-size: $font-14px;
             color: $event-timestamp-color;
+
+            .mx_MImageBody_size {
+                font-size: $font-14px;
+                text-align: right;
+                white-space: nowrap;
+            }
         }
 
         .mx_MFileBody_downloadLink {
             flex: 1 1 auto;
             color: $light-fg-color;
-        }
-
-        .mx_MImageBody_size {
-            flex: 1 0 0;
-            font-size: $font-14px;
-            text-align: right;
-            white-space: nowrap;
         }
 
         .mx_EventTile_senderDetails {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -89,17 +89,16 @@ limitations under the License.
 
         .mx_EventTile_senderDetails {
             display: flex;
+            justify-content: space-between;
             margin-top: -2px;
 
             .mx_DisambiguatedProfile {
-                flex: 1 1 auto;
                 line-height: initial;
                 opacity: 1.0;
                 color: $event-timestamp-color;
             }
 
             .mx_MessageTimestamp {
-                flex: 1 0 0;
                 text-align: right;
                 visibility: visible;
                 position: initial;

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -87,28 +87,26 @@ limitations under the License.
             white-space: nowrap;
         }
 
-        .mx_DisambiguatedProfile {
-            flex: 1 1 auto;
-            line-height: initial;
-            opacity: 1.0;
-            color: $event-timestamp-color;
+        .mx_EventTile_senderDetails {
+            display: flex;
+            margin-top: -2px;
+
+            .mx_DisambiguatedProfile {
+                flex: 1 1 auto;
+                line-height: initial;
+                opacity: 1.0;
+                color: $event-timestamp-color;
+            }
+
+            .mx_MessageTimestamp {
+                flex: 1 0 0;
+                text-align: right;
+                visibility: visible;
+                position: initial;
+                font-size: $font-14px;
+                opacity: 1.0;
+            }
         }
-
-        .mx_MessageTimestamp {
-            flex: 1 0 0;
-            text-align: right;
-            visibility: visible;
-            position: initial;
-            font-size: $font-14px;
-            opacity: 1.0;
-        }
-    }
-
-    /* Overides for the sender details line */
-
-    .mx_EventTile_senderDetails {
-        display: flex;
-        margin-top: -2px;
     }
 
     .mx_EventTile_senderDetailsLink {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -94,16 +94,12 @@ limitations under the License.
 
             .mx_DisambiguatedProfile {
                 line-height: initial;
-                opacity: 1.0;
                 color: $event-timestamp-color;
             }
 
             .mx_MessageTimestamp {
                 text-align: right;
-                visibility: visible;
-                position: initial;
                 font-size: $font-14px;
-                opacity: 1.0;
             }
         }
     }

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -96,9 +96,13 @@ limitations under the License.
                 justify-content: space-between;
                 margin-top: -2px;
 
-                .mx_DisambiguatedProfile_displayName,
-                .mx_DisambiguatedProfile_mxid {
-                    color: $event-timestamp-color;
+                .mx_DisambiguatedProfile {
+                    color: $event-timestamp-color; // for ellipsis
+
+                    .mx_DisambiguatedProfile_displayName,
+                    .mx_DisambiguatedProfile_mxid {
+                        color: $event-timestamp-color;
+                    }
                 }
 
                 .mx_MessageTimestamp {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -96,13 +96,9 @@ limitations under the License.
                 justify-content: space-between;
                 margin-top: -2px;
 
-                .mx_DisambiguatedProfile {
-                    line-height: initial;
-
-                    .mx_DisambiguatedProfile_displayName,
-                    .mx_DisambiguatedProfile_mxid {
-                        color: $event-timestamp-color;
-                    }
+                .mx_DisambiguatedProfile_displayName,
+                .mx_DisambiguatedProfile_mxid {
+                    color: $event-timestamp-color;
                 }
 
                 .mx_MessageTimestamp {

--- a/res/css/structures/_FilePanel.scss
+++ b/res/css/structures/_FilePanel.scss
@@ -87,28 +87,27 @@ limitations under the License.
             color: $light-fg-color;
         }
 
-        .mx_EventTile_senderDetails {
-            display: flex;
-            justify-content: space-between;
-            margin-top: -2px;
+        // anchor link as wrapper
+        .mx_EventTile_senderDetailsLink {
+            text-decoration: none;
 
-            .mx_DisambiguatedProfile {
-                line-height: initial;
-                color: $event-timestamp-color;
-            }
+            .mx_EventTile_senderDetails {
+                display: flex;
+                justify-content: space-between;
+                margin-top: -2px;
 
-            .mx_MessageTimestamp {
-                text-align: right;
-                font-size: $font-14px;
+                .mx_DisambiguatedProfile {
+                    line-height: initial;
+                    color: $event-timestamp-color;
+                }
+
+                .mx_MessageTimestamp {
+                    text-align: right;
+                    font-size: $font-14px;
+                }
             }
         }
     }
-
-    .mx_EventTile_senderDetailsLink {
-        text-decoration: none;
-    }
-
-    /* Overrides for the wrappers around the body tile */
 
     .mx_EventTile_line {
         margin-inline-end: 0;


### PR DESCRIPTION
This PR intends to improve `_FilePanel.scss`.

- Create space between elements with `space-between`, instead of using `flex: 1` with `text-align`
- Remove obsolete declarations which are not used

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/178098747-6bfdc819-b40d-4434-8156-4c51227589fc.png)|![after](https://user-images.githubusercontent.com/3362943/178641404-54792504-82ac-4629-bbe1-1849d1caaf93.png)|

type: enhancement


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve _FilePanel.scss ([\#9031](https://github.com/matrix-org/matrix-react-sdk/pull/9031)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->