### PR TITLE
Don't unnecessarily persist the host signup dialog

### DIFF
--- a/res/css/views/dialogs/_HostSignupDialog.scss
+++ b/res/css/views/dialogs/_HostSignupDialog.scss
@@ -105,17 +105,6 @@ limitations under the License.
     right: 25px;
 }
 
-.mx_HostSignup_persisted {
-    width: 90vw;
-    max-width: 580px;
-    height: 80vh;
-    max-height: 600px;
-    top: 0;
-    left: 0;
-    position: fixed;
-    display: none;
-}
-
 .mx_HostSignupDialog_minimized {
     position: fixed;
     bottom: 80px;

--- a/src/components/views/dialogs/HostSignupDialog.tsx
+++ b/src/components/views/dialogs/HostSignupDialog.tsx
@@ -20,7 +20,6 @@ import { logger } from "matrix-js-sdk/src/logger";
 
 import AccessibleButton from "../elements/AccessibleButton";
 import Modal from "../../../Modal";
-import PersistedElement from "../elements/PersistedElement";
 import QuestionDialog from './QuestionDialog';
 import SdkConfig from "../../../SdkConfig";
 import { _t } from "../../../languageHandler";
@@ -34,8 +33,6 @@ import {
 } from "./HostSignupDialogTypes";
 import { IConfigOptions } from "../../../IConfigOptions";
 import { SnakedObject } from "../../../utils/SnakedObject";
-
-const HOST_SIGNUP_KEY = "host_signup";
 
 interface IProps {}
 
@@ -111,8 +108,6 @@ export default class HostSignupDialog extends React.PureComponent<IProps, IState
 
     private closeDialog = async () => {
         window.removeEventListener("message", this.messageHandler);
-        // Ensure we destroy the host signup persisted element
-        PersistedElement.destroyElement("host_signup");
         // Finally clear the flag in
         return HostSignupStore.instance.setHostSignupActive(false);
     };
@@ -235,69 +230,65 @@ export default class HostSignupDialog extends React.PureComponent<IProps, IState
 
     public render(): React.ReactNode {
         return (
-            <div className="mx_HostSignup_persisted">
-                <PersistedElement key={HOST_SIGNUP_KEY} persistKey={HOST_SIGNUP_KEY}>
-                    <div className={classNames({ "mx_Dialog_wrapper": !this.state.minimized })}>
-                        <div
-                            className={classNames("mx_Dialog",
+            <div className={classNames({ "mx_Dialog_wrapper": !this.state.minimized })}>
+                <div
+                    className={classNames("mx_Dialog",
+                        {
+                            "mx_HostSignupDialog_minimized": this.state.minimized,
+                            "mx_HostSignupDialog": !this.state.minimized,
+                        },
+                    )}
+                >
+                    { this.state.minimized &&
+                        <div className="mx_Dialog_header mx_Dialog_headerWithButton">
+                            <div className="mx_Dialog_title">
+                                { _t("%(hostSignupBrand)s Setup", {
+                                    hostSignupBrand: this.config.get("brand"),
+                                }) }
+                            </div>
+                            <AccessibleButton
+                                className="mx_HostSignup_maximize_button"
+                                onClick={this.maximizeDialog}
+                                aria-label={_t("Maximise dialog")}
+                                title={_t("Maximise dialog")}
+                            />
+                        </div>
+                    }
+                    { !this.state.minimized &&
+                        <div className="mx_Dialog_header mx_Dialog_headerWithCancel">
+                            <AccessibleButton
+                                onClick={this.minimizeDialog}
+                                className="mx_HostSignup_minimize_button"
+                                aria-label={_t("Minimise dialog")}
+                                title={_t("Minimise dialog")}
+                            />
+                            <AccessibleButton
+                                onClick={this.onCloseClick}
+                                className="mx_Dialog_cancelButton"
+                                aria-label={_t("Close dialog")}
+                                title={_t("Close dialog")}
+                            />
+                        </div>
+                    }
+                    { this.state.error &&
+                        <div>
+                            { this.state.error }
+                        </div>
+                    }
+                    { !this.state.error &&
+                        <iframe
+                            title={_t(
+                                "Upgrade to %(hostSignupBrand)s",
                                 {
-                                    "mx_HostSignupDialog_minimized": this.state.minimized,
-                                    "mx_HostSignupDialog": !this.state.minimized,
+                                    hostSignupBrand: this.config.get("brand"),
                                 },
                             )}
-                        >
-                            { this.state.minimized &&
-                                <div className="mx_Dialog_header mx_Dialog_headerWithButton">
-                                    <div className="mx_Dialog_title">
-                                        { _t("%(hostSignupBrand)s Setup", {
-                                            hostSignupBrand: this.config.get("brand"),
-                                        }) }
-                                    </div>
-                                    <AccessibleButton
-                                        className="mx_HostSignup_maximize_button"
-                                        onClick={this.maximizeDialog}
-                                        aria-label={_t("Maximise dialog")}
-                                        title={_t("Maximise dialog")}
-                                    />
-                                </div>
-                            }
-                            { !this.state.minimized &&
-                                <div className="mx_Dialog_header mx_Dialog_headerWithCancel">
-                                    <AccessibleButton
-                                        onClick={this.minimizeDialog}
-                                        className="mx_HostSignup_minimize_button"
-                                        aria-label={_t("Minimise dialog")}
-                                        title={_t("Minimise dialog")}
-                                    />
-                                    <AccessibleButton
-                                        onClick={this.onCloseClick}
-                                        className="mx_Dialog_cancelButton"
-                                        aria-label={_t("Close dialog")}
-                                        title={_t("Close dialog")}
-                                    />
-                                </div>
-                            }
-                            { this.state.error &&
-                                <div>
-                                    { this.state.error }
-                                </div>
-                            }
-                            { !this.state.error &&
-                                <iframe
-                                    title={_t(
-                                        "Upgrade to %(hostSignupBrand)s",
-                                        {
-                                            hostSignupBrand: this.config.get("brand"),
-                                        },
-                                    )}
-                                    src={this.config.get("url")}
-                                    ref={this.iframeRef}
-                                    sandbox="allow-forms allow-scripts allow-same-origin allow-popups"
-                                />
-                            }
-                        </div>
-                    </div>
-                </PersistedElement>
+                            src={this.config.get("url")}
+                            ref={this.iframeRef}
+                            sandbox="allow-forms allow-scripts allow-same-origin allow-popups"
+                        />
+                    }
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/8747 made it more evident that the host signup dialog was relying on some quirks in how PersistedElement sizes and positions things that it probably shouldn't have been relying on. As far as I can tell, this dialog doesn't *need* to be a PersistedElement at all since it's mounted manually as part of LoggedInView, and so it doesn't look like there's any way for it to unexpectedly disappear on the user.

According to Travis this is supposed to be a bespoke widget in a proper dialog, but this is intended as a more short-term fix.

Closes https://github.com/vector-im/element-web/issues/22778

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't unnecessarily persist the host signup dialog ([\#9043](https://github.com/matrix-org/matrix-react-sdk/pull/9043)). Fixes vector-im/element-web#22778.<!-- CHANGELOG_PREVIEW_END -->