### PR TITLE
Hide screenshare button in video rooms on Desktop

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -288,6 +288,10 @@ export default abstract class BasePlatform {
         return false;
     }
 
+    public supportsJitsiScreensharing(): boolean {
+        return true;
+    }
+
     public overrideBrowserShortcuts(): boolean {
         return false;
     }

--- a/src/utils/WidgetUtils.ts
+++ b/src/utils/WidgetUtils.ts
@@ -26,6 +26,7 @@ import { CallType } from "matrix-js-sdk/src/webrtc/call";
 import { randomString, randomLowercaseString, randomUppercaseString } from "matrix-js-sdk/src/randomstring";
 
 import { MatrixClientPeg } from '../MatrixClientPeg';
+import PlatformPeg from '../PlatformPeg';
 import SdkConfig from "../SdkConfig";
 import dis from '../dispatcher/dispatcher';
 import WidgetEchoStore from '../stores/WidgetEchoStore';
@@ -510,6 +511,7 @@ export default class WidgetUtils {
             'roomId=$matrix_room_id',
             'theme=$theme',
             'roomName=$roomName',
+            `supportsScreensharing=${PlatformPeg.get().supportsJitsiScreensharing()}`,
         ];
         if (opts.auth) {
             queryStringParts.push(`auth=${opts.auth}`);

--- a/test/createRoom-test.ts
+++ b/test/createRoom-test.ts
@@ -19,7 +19,7 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
 import { IDevice } from "matrix-js-sdk/src/crypto/deviceinfo";
 import { RoomType } from "matrix-js-sdk/src/@types/event";
 
-import { stubClient, setupAsyncStoreWithClient } from "./test-utils";
+import { stubClient, setupAsyncStoreWithClient, mockPlatformPeg } from "./test-utils";
 import { MatrixClientPeg } from "../src/MatrixClientPeg";
 import WidgetStore from "../src/stores/WidgetStore";
 import WidgetUtils from "../src/utils/WidgetUtils";
@@ -27,11 +27,15 @@ import { VIDEO_CHANNEL_MEMBER } from "../src/utils/VideoChannelUtils";
 import createRoom, { canEncryptToAllUsers } from '../src/createRoom';
 
 describe("createRoom", () => {
+    mockPlatformPeg();
+
     let client: MatrixClient;
     beforeEach(() => {
         stubClient();
         client = MatrixClientPeg.get();
     });
+
+    afterEach(() => jest.clearAllMocks());
 
     it("sets up video rooms correctly", async () => {
         setupAsyncStoreWithClient(WidgetStore.instance, client);


### PR DESCRIPTION
As a stopgap solution for https://github.com/vector-im/element-web/issues/4880, we can hide the screensharing button in video rooms if the platform doesn't support it.

Depends on https://github.com/vector-im/element-web/pull/22810

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Hide screenshare button in video rooms on Desktop ([\#9045](https://github.com/matrix-org/matrix-react-sdk/pull/9045)).<!-- CHANGELOG_PREVIEW_END -->