### PR TITLE
Fix warning about 'start' value usage

### DIFF
--- a/res/css/views/dialogs/_SpotlightDialog.scss
+++ b/res/css/views/dialogs/_SpotlightDialog.scss
@@ -243,7 +243,7 @@ limitations under the License.
                     display: inline-flex;
                     flex-direction: row;
                     margin-left: auto;
-                    align-items: start;
+                    align-items: flex-start;
                 }
 
                 &.mx_SpotlightDialog_result_multiline {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22823

This PR fixes warning about 'start' value usage on `_SpotlightDialog.scss`

````
2022-07-12 22:54:46.662 [element-js] WARNING in ../matrix-react-sdk/res/themes/light/css/light.scss (./node_modules/css-loader/dist/cjs.js??ref--8-1!./node_modules/postcss-loader/src??postcss!../matrix-react-sdk/res/themes/light/css/light.scss)
2022-07-12 22:54:46.662 [element-js] Module Warning (from ./node_modules/postcss-loader/src/index.js):
2022-07-12 22:54:46.662 [element-js] Warning
2022-07-12 22:54:46.662 [element-js] 
2022-07-12 22:54:46.662 [element-js] (246:21) start value has mixed support, consider using flex-start instead
````

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: task

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->