### PR TITLE
Prefer using the canonical alias in spotlight search

### DIFF
--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -603,7 +603,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
             if (isPublicRoomResult(result)) {
                 const clientRoom = cli.getRoom(result.publicRoom.room_id);
                 const listener = (ev) => {
-                    viewRoom(result.publicRoom.room_id, true, ev.type !== "click");
+                    viewRoom(result.publicRoom.canonical_alias ?? result.publicRoom.room_id, true, ev.type !== "click");
                 };
                 return (
                     <Option

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -91,6 +91,7 @@ import { PublicRoomResultDetails } from "./PublicRoomResultDetails";
 import { RoomResultContextMenus } from "./RoomResultContextMenus";
 import { RoomContextDetails } from "../../rooms/RoomContextDetails";
 import { TooltipOption } from "./TooltipOption";
+import { getDisplayAliasForAliasSet } from "../../../../Rooms";
 
 const MAX_RECENT_SEARCHES = 10;
 const SECTION_LIMIT = 50; // only show 50 results per section for performance reasons
@@ -480,12 +481,15 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
         // eslint-disable-next-line
     }, [results, filter]);
 
-    const viewRoom = (roomId: string, persist = false, viaKeyboard = false) => {
+    const viewRoom = (room: {room_id: string}|{room_alias: string}, persist = false, viaKeyboard = false) => {
         if (persist) {
+            if ('room_alias' in room) {
+                throw Error('Cannot persist room if room_alias is given');
+            }
             const recents = new Set(SettingsStore.getValue("SpotlightSearch.recentSearches", null).reverse());
             // remove & add the room to put it at the end
-            recents.delete(roomId);
-            recents.add(roomId);
+            recents.delete(room.room_id);
+            recents.add(room.room_id);
 
             SettingsStore.setValue(
                 "SpotlightSearch.recentSearches",
@@ -497,9 +501,9 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
 
         defaultDispatcher.dispatch<ViewRoomPayload>({
             action: Action.ViewRoom,
-            room_id: roomId,
             metricsTrigger: "WebUnifiedSearch",
             metricsViaKeyboard: viaKeyboard,
+            ...room,
         });
         onFinished();
     };
@@ -555,7 +559,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                         id={`mx_SpotlightDialog_button_result_${result.room.roomId}`}
                         key={`${Section[result.section]}-${result.room.roomId}`}
                         onClick={(ev) => {
-                            viewRoom(result.room.roomId, true, ev?.type !== "click");
+                            viewRoom({room_id: result.room.roomId}, true, ev?.type !== "click");
                         }}
                         endAdornment={<RoomResultContextMenus room={result.room} />}
                         {...ariaProperties}
@@ -603,7 +607,9 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
             if (isPublicRoomResult(result)) {
                 const clientRoom = cli.getRoom(result.publicRoom.room_id);
                 const listener = (ev) => {
-                    viewRoom(result.publicRoom.canonical_alias ?? result.publicRoom.room_id, true, ev.type !== "click");
+                    const { publicRoom } = result;
+                    const alias = getDisplayAliasForAliasSet(publicRoom.canonical_alias, publicRoom.aliases);
+                    viewRoom(alias ? { room_alias: alias } : { room_id: publicRoom.room_id }, true, ev.type !== "click");
                 };
                 return (
                     <Option
@@ -782,7 +788,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                 id={`mx_SpotlightDialog_button_result_${room.room_id}`}
                                 key={room.room_id}
                                 onClick={(ev) => {
-                                    viewRoom(room.room_id, true, ev?.type !== "click");
+                                    viewRoom({room_id: room.room_id}, true, ev?.type !== "click");
                                 }}
                             >
                                 <BaseAvatar
@@ -974,7 +980,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                     id={`mx_SpotlightDialog_button_recentSearch_${room.roomId}`}
                                     key={room.roomId}
                                     onClick={(ev) => {
-                                        viewRoom(room.roomId, true, ev?.type !== "click");
+                                        viewRoom({room_id: room.roomId}, true, ev?.type !== "click");
                                     }}
                                     endAdornment={<RoomResultContextMenus room={room} />}
                                     {...ariaProperties}
@@ -1016,7 +1022,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                 title={room.name}
                                 key={room.roomId}
                                 onClick={(ev) => {
-                                    viewRoom(room.roomId, false, ev.type !== "click");
+                                    viewRoom({room_id: room.roomId}, false, ev.type !== "click");
                                 }}
                             >
                                 <DecoratedRoomAvatar room={room} avatarSize={32} tooltipProps={{ tabIndex: -1 }} />

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -608,7 +608,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                     viewRoom({
                         roomAlias: publicRoom.canonical_alias || publicRoom.aliases?.[0],
                         roomId: publicRoom.room_id,
-                    }, false, ev.type !== "click");
+                    }, true, ev.type !== "click");
                 };
                 return (
                     <Option

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -559,7 +559,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                         id={`mx_SpotlightDialog_button_result_${result.room.roomId}`}
                         key={`${Section[result.section]}-${result.room.roomId}`}
                         onClick={(ev) => {
-                            viewRoom({room_id: result.room.roomId}, true, ev?.type !== "click");
+                            viewRoom({ room_id: result.room.roomId }, true, ev?.type !== "click");
                         }}
                         endAdornment={<RoomResultContextMenus room={result.room} />}
                         {...ariaProperties}
@@ -609,7 +609,11 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                 const listener = (ev) => {
                     const { publicRoom } = result;
                     const alias = getDisplayAliasForAliasSet(publicRoom.canonical_alias, publicRoom.aliases);
-                    viewRoom(alias ? { room_alias: alias } : { room_id: publicRoom.room_id }, true, ev.type !== "click");
+                    viewRoom(alias ? {
+                        room_alias: alias
+                    } : {
+                        room_id: publicRoom.room_id
+                    }, true, ev.type !== "click");
                 };
                 return (
                     <Option
@@ -788,7 +792,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                 id={`mx_SpotlightDialog_button_result_${room.room_id}`}
                                 key={room.room_id}
                                 onClick={(ev) => {
-                                    viewRoom({room_id: room.room_id}, true, ev?.type !== "click");
+                                    viewRoom({ room_id: room.room_id }, true, ev?.type !== "click");
                                 }}
                             >
                                 <BaseAvatar
@@ -980,7 +984,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                     id={`mx_SpotlightDialog_button_recentSearch_${room.roomId}`}
                                     key={room.roomId}
                                     onClick={(ev) => {
-                                        viewRoom({room_id: room.roomId}, true, ev?.type !== "click");
+                                        viewRoom({ room_id: room.roomId }, true, ev?.type !== "click");
                                     }}
                                     endAdornment={<RoomResultContextMenus room={room} />}
                                     {...ariaProperties}
@@ -1022,7 +1026,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                                 title={room.name}
                                 key={room.roomId}
                                 onClick={(ev) => {
-                                    viewRoom({room_id: room.roomId}, false, ev.type !== "click");
+                                    viewRoom({ room_id: room.roomId }, false, ev.type !== "click");
                                 }}
                             >
                                 <DecoratedRoomAvatar room={room} avatarSize={32} tooltipProps={{ tabIndex: -1 }} />

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -499,7 +499,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
             action: Action.ViewRoom,
             metricsTrigger: "WebUnifiedSearch",
             metricsViaKeyboard: viaKeyboard,
-            room_id: room.roomAlias ? undefined : room.roomId,
+            room_id: room.roomId,
             room_alias: room.roomAlias,
         });
         onFinished();

--- a/src/dispatcher/payloads/ViewRoomPayload.ts
+++ b/src/dispatcher/payloads/ViewRoomPayload.ts
@@ -26,7 +26,9 @@ import { IOpts } from "../../createRoom";
 export interface ViewRoomPayload extends Pick<ActionPayload, "action"> {
     action: Action.ViewRoom;
 
-    // either of room_id or room_alias must be specified
+    // either or both of room_id or room_alias must be specified
+    // where possible, a room_id should be provided with a room_alias as it reduces
+    // the number of API calls required.
     room_id?: string;
     room_alias?: string;
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22845

Public rooms on other homeservers are not joinable via the roomId if they haven't been joined by other users on your homeserver.

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [N/A] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Joining federated rooms via the spotlight search should no longer cause a "No known servers" error.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Joining federated rooms via the spotlight search should no longer cause a "No known servers" error. ([\#9055](https://github.com/matrix-org/matrix-react-sdk/pull/9055)). Fixes vector-im/element-web#22845. Contributed by @Half-Shot.<!-- CHANGELOG_PREVIEW_END -->