### PR TITLE
Re-add inline start padding to EventTile_line of GenericEventListSummary

### DIFF
--- a/cypress/e2e/14-timeline/timeline.spec.ts
+++ b/cypress/e2e/14-timeline/timeline.spec.ts
@@ -143,6 +143,14 @@ describe("Timeline", () => {
             });
         });
 
+        it("should create and configure a room on IRC layout", () => {
+            cy.visit("/#/room/" + roomId);
+            cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.IRC);
+            cy.contains(".mx_RoomView_body .mx_GenericEventListSummary[data-layout=irc] " +
+                ".mx_GenericEventListSummary_summary", "created and configured the room.");
+            cy.percySnapshot("Configured room on IRC layout");
+        });
+
         it("should click 'collapse' link button on the first hovered info event line on bubble layout", () => {
             cy.visit("/#/room/" + roomId);
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -487,9 +487,9 @@ $left-gutter: 64px;
 
         // Apply only collapsed events block
         > .mx_EventTile_line {
+            // 15 px of padding
             /* stylelint-disable-next-line declaration-colon-space-after */
             padding-left:
-                // 15 px of padding
                 calc(var(--name-width) + var(--icon-width) + $MessageTimestamp_width + 3 * var(--right-padding));
         }
     }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22869

|Before|After|
|--------|-------|
|![before](https://user-images.githubusercontent.com/3362943/179353714-f688059b-2585-44a0-a8c8-f8949d3b7bf8.png)|![after](https://user-images.githubusercontent.com/3362943/179353708-6c32a424-43d9-4bce-bdc8-97fe46a39716.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect
Notes: Re-add padding to generic event list summary on IRC layout

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:


Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Re-add padding to generic event list summary on IRC layout ([\#9063](https://github.com/matrix-org/matrix-react-sdk/pull/9063)). Fixes vector-im/element-web#22869. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->