### PR TITLE
Improve clickability of view source event toggle button 

### DIFF
--- a/cypress/e2e/14-timeline/timeline.spec.ts
+++ b/cypress/e2e/14-timeline/timeline.spec.ts
@@ -151,6 +151,28 @@ describe("Timeline", () => {
             cy.percySnapshot("Configured room on IRC layout");
         });
 
+        it("should click top left of view source event toggle", () => {
+            sendEvent(roomId);
+            cy.visit("/#/room/" + roomId);
+            cy.setSettingValue("showHiddenEventsInTimeline", null, SettingLevel.DEVICE, true);
+            cy.contains(".mx_RoomView_body .mx_GenericEventListSummary " +
+                ".mx_GenericEventListSummary_summary", "created and configured the room.");
+
+            // Edit message
+            cy.get(".mx_RoomView_body .mx_EventTile").contains(".mx_EventTile_line", "Message").within(() => {
+                cy.get('[aria-label="Edit"]').click({ force: true }); // Cypress has no ability to hover
+                cy.get(".mx_BasicMessageComposer_input").type("Edit{enter}");
+            });
+            cy.get(".mx_RoomView_body .mx_EventTile").contains(".mx_EventTile[data-scroll-tokens]", "MessageEdit");
+
+            // Click top left of the event toggle, which should not be covered by MessageActionBar's safe area
+            cy.get(".mx_EventTile .mx_ViewSourceEvent").realHover()
+                .get(".mx_EventTile .mx_ViewSourceEvent .mx_ViewSourceEvent_toggle").click('topLeft', { force: false });
+
+            // Make sure the expand toggle worked
+            cy.get(".mx_EventTile .mx_ViewSourceEvent_expanded .mx_ViewSourceEvent_toggle").should("be.visible");
+        });
+
         it("should click 'collapse' link button on the first hovered info event line on bubble layout", () => {
             cy.visit("/#/room/" + roomId);
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);

--- a/res/css/views/messages/_MessageActionBar.pcss
+++ b/res/css/views/messages/_MessageActionBar.pcss
@@ -69,8 +69,10 @@ limitations under the License.
 
         .mx_EventTile_info .mx_ViewSourceEvent ~ & {
             // improve clickability of view source event toggle button by removing vertical safe area
+            width: 100%;
             height: 100%;
             top: 0;
+            left: 0;
         }
     }
 

--- a/res/css/views/messages/_MessageActionBar.pcss
+++ b/res/css/views/messages/_MessageActionBar.pcss
@@ -66,6 +66,12 @@ limitations under the License.
             top: 0;
             left: 0;
         }
+
+        .mx_EventTile_info .mx_ViewSourceEvent ~ & {
+            // improve clickability of view source event toggle button by removing vertical safe area
+            height: 100%;
+            top: 0;
+        }
     }
 
     >* {

--- a/res/css/views/messages/_ViewSourceEvent.pcss
+++ b/res/css/views/messages/_ViewSourceEvent.pcss
@@ -41,6 +41,7 @@ limitations under the License.
         mask-position: 0 center;
         mask-size: auto 12px;
         width: 12px;
+        min-width: 12px;
         background-color: $accent;
         mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
     }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/21856

This PR intends to improve clickability of view source event toggle button by removing safe area.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/179410556-401c0b84-0d0c-47a3-bc78-a023cdba1845.png)|![after](https://user-images.githubusercontent.com/3362943/179411477-4fee443b-9fac-4268-a00d-6686ac488890.png)|
|![before1](https://user-images.githubusercontent.com/3362943/179410564-732e53df-f811-4d44-9f57-760ce2ffb9b8.png)||
|↑ Test against `develop`||

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: enhancement

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:



Changes in this project also generate changelogs in Element Web. To disable this, use the following:



or specify alternative text:


-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve clickability of view source event toggle button  ([\#9068](https://github.com/matrix-org/matrix-react-sdk/pull/9068)). Fixes vector-im/element-web#21856. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->