### PR TITLE
Extract RoomStatusBarUnsentMessages

### DIFF
--- a/res/css/structures/_RoomStatusBar.pcss
+++ b/res/css/structures/_RoomStatusBar.pcss
@@ -138,7 +138,7 @@ limitations under the License.
                 mask-image: url('$(res)/img/element-icons/trashcan.svg');
             }
 
-            &.mx_RoomStatusBar_unsentResendAllBtn {
+            &.mx_RoomStatusBar_unsentRetry {
                 padding-left: 34px; // 28px from above, but +6px to account for the wider icon
 
                 &::before {

--- a/src/components/structures/RoomStatusBar.tsx
+++ b/src/components/structures/RoomStatusBar.tsx
@@ -24,11 +24,11 @@ import Resend from '../../Resend';
 import dis from '../../dispatcher/dispatcher';
 import { messageForResourceLimitError } from '../../utils/ErrorUtils';
 import { Action } from "../../dispatcher/actions";
-import NotificationBadge from "../views/rooms/NotificationBadge";
 import { StaticNotificationState } from "../../stores/notifications/StaticNotificationState";
 import AccessibleButton from "../views/elements/AccessibleButton";
 import InlineSpinner from "../views/elements/InlineSpinner";
 import MatrixClientContext from "../../contexts/MatrixClientContext";
+import { RoomStatusBarUnsentMessages } from './RoomStatusBarUnsentMessages';
 
 const STATUS_BAR_HIDDEN = 0;
 const STATUS_BAR_EXPANDED = 1;
@@ -240,7 +240,7 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
             <AccessibleButton onClick={this.onCancelAllClick} className="mx_RoomStatusBar_unsentCancelAllBtn">
                 { _t("Delete all") }
             </AccessibleButton>
-            <AccessibleButton onClick={this.onResendAllClick} className="mx_RoomStatusBar_unsentResendAllBtn">
+            <AccessibleButton onClick={this.onResendAllClick} className="mx_RoomStatusBar_unsentRetry">
                 { _t("Retry all") }
             </AccessibleButton>
         </>;
@@ -252,28 +252,12 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
             </>;
         }
 
-        return <>
-            <div className="mx_RoomStatusBar mx_RoomStatusBar_unsentMessages">
-                <div role="alert">
-                    <div className="mx_RoomStatusBar_unsentBadge">
-                        <NotificationBadge
-                            notification={StaticNotificationState.RED_EXCLAMATION}
-                        />
-                    </div>
-                    <div>
-                        <div className="mx_RoomStatusBar_unsentTitle">
-                            { title }
-                        </div>
-                        <div className="mx_RoomStatusBar_unsentDescription">
-                            { _t("You can select all or individual messages to retry or delete") }
-                        </div>
-                    </div>
-                    <div className="mx_RoomStatusBar_unsentButtonBar">
-                        { buttonRow }
-                    </div>
-                </div>
-            </div>
-        </>;
+        return <RoomStatusBarUnsentMessages
+            title={title}
+            description={_t("You can select all or individual messages to retry or delete")}
+            notificationState={StaticNotificationState.RED_EXCLAMATION}
+            buttons={buttonRow}
+        />;
     }
 
     public render(): JSX.Element {

--- a/src/components/structures/RoomStatusBarUnsentMessages.tsx
+++ b/src/components/structures/RoomStatusBarUnsentMessages.tsx
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { ReactElement } from "react";
+
+import { StaticNotificationState } from "../../stores/notifications/StaticNotificationState";
+import NotificationBadge from "../views/rooms/NotificationBadge";
+
+interface RoomStatusBarUnsentMessagesProps {
+    title: string;
+    description?: string;
+    notificationState: StaticNotificationState;
+    buttons: ReactElement;
+}
+
+export const RoomStatusBarUnsentMessages = (props: RoomStatusBarUnsentMessagesProps): ReactElement => {
+    return (
+        <div className="mx_RoomStatusBar mx_RoomStatusBar_unsentMessages">
+            <div role="alert">
+                <div className="mx_RoomStatusBar_unsentBadge">
+                    <NotificationBadge
+                        notification={props.notificationState}
+                    />
+                </div>
+                <div>
+                    <div className="mx_RoomStatusBar_unsentTitle">
+                        { props.title }
+                    </div>
+                    {
+                        props.description &&
+                        <div className="mx_RoomStatusBar_unsentDescription">
+                            { props.description }
+                        </div>
+                    }
+                </div>
+                <div className="mx_RoomStatusBar_unsentButtonBar">
+                    { props.buttons }
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/test/components/structures/RoomStatusBarUnsentMessages-test.tsx
+++ b/test/components/structures/RoomStatusBarUnsentMessages-test.tsx
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RoomStatusBarUnsentMessages } from "../../../src/components/structures/RoomStatusBarUnsentMessages";
+import { StaticNotificationState } from "../../../src/stores/notifications/StaticNotificationState";
+
+describe("RoomStatusBarUnsentMessages", () => {
+    const title = "test title";
+    const description = "test description";
+    const buttonsText = "test buttons";
+    const buttons = <div>{ buttonsText }</div>;
+
+    beforeEach(() => {
+        render(
+            <RoomStatusBarUnsentMessages
+                title={title}
+                description={description}
+                buttons={buttons}
+                notificationState={StaticNotificationState.RED_EXCLAMATION}
+            />,
+        );
+    });
+
+    it("should render the values passed as props", () => {
+        screen.getByText(title);
+        screen.getByText(description);
+        screen.getByText(buttonsText);
+        // notification state
+        screen.getByText("!");
+    });
+});


### PR DESCRIPTION
`RoomStatusBarUnsentMessages` will be re-used for local rooms.

Towards: https://github.com/matrix-org/matrix-react-sdk/pull/8612

element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->