### PR TITLE
Unbreak in-app permalink tooltips

### DIFF
--- a/src/utils/tooltipify.tsx
+++ b/src/utils/tooltipify.tsx
@@ -53,11 +53,11 @@ export function tooltipifyLinks(rootNodes: ArrayLike<Element>, ignoredNodes: Ele
             const href = node.getAttribute("href");
 
             const tooltip = <LinkWithTooltip tooltip={new URL(href, window.location.href).toString()}>
-                <span dangerouslySetInnerHTML={{ __html: node.outerHTML }} />
+                {node.innerHTML}
             </LinkWithTooltip>;
 
             ReactDOM.render(tooltip, container);
-            node.parentNode.replaceChild(container, node);
+            node.replaceChildren(container);
             containers.push(container);
             tooltipified = true;
         }

--- a/src/utils/tooltipify.tsx
+++ b/src/utils/tooltipify.tsx
@@ -53,7 +53,7 @@ export function tooltipifyLinks(rootNodes: ArrayLike<Element>, ignoredNodes: Ele
             const href = node.getAttribute("href");
 
             const tooltip = <LinkWithTooltip tooltip={new URL(href, window.location.href).toString()}>
-                {node.innerHTML}
+                { node.innerHTML }
             </LinkWithTooltip>;
 
             ReactDOM.render(tooltip, container);

--- a/test/utils/tooltipify-test.tsx
+++ b/test/utils/tooltipify-test.tsx
@@ -41,9 +41,10 @@ describe('tooltipify', () => {
         const containers: Element[] = [];
         tooltipifyLinks([root], [], containers);
         expect(containers).toHaveLength(1);
-        const anchor = root.querySelector(".mx_TextWithTooltip_target a");
+        const anchor = root.querySelector("a");
         expect(anchor?.getAttribute("href")).toEqual("/foo");
-        expect(anchor?.innerHTML).toEqual("click");
+        const tooltip = anchor.querySelector(".mx_TextWithTooltip_target");
+        expect(tooltip).toBeDefined();
     });
 
     it('ignores node', () => {


### PR DESCRIPTION
Fixes vector-im/element-web#22874

For explanation, the in-app links work via a click event handler. That handler got lost because the original anchor was copied into the tooltip container via its HTML only. To fix this, I swapped the hierarchy so that the tooltip container is rendered inside the original anchor without changing it.

This seems to work in my testing. Given that this is the second regression caused by https://github.com/matrix-org/matrix-react-sdk/pull/8394, I'd appreciate some more testing though.

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Unbreak in-app permalink tooltips ([\#9087](https://github.com/matrix-org/matrix-react-sdk/pull/9087)). Fixes vector-im/element-web#22874.<!-- CHANGELOG_PREVIEW_END -->