### PR TITLE
Add default use case selection based on `io.element.default_use_case` .well-known key

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -137,6 +137,7 @@ import { TimelineRenderingType } from "../../contexts/RoomContext";
 import { UseCaseSelection } from '../views/elements/UseCaseSelection';
 import { ValidatedServerConfig } from '../../utils/ValidatedServerConfig';
 import { isLocalRoom } from '../../utils/localRoom/isLocalRoom';
+import { getDefaultUseCase } from '../../utils/WellKnownUtils';
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1261,7 +1262,13 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             MatrixClientPeg.currentUserIsJustRegistered() &&
             SettingsStore.getValue("FTUE.useCaseSelection") === null
         ) {
-            this.setStateForNewView({ view: Views.USE_CASE_SELECTION });
+            const defaultUseCase = getDefaultUseCase();
+            if (defaultUseCase) {
+                // Skip presenting selection
+                this.onShowPostLoginScreen(defaultUseCase);
+            } else {
+                this.setStateForNewView({ view: Views.USE_CASE_SELECTION });
+            }
 
             // Listen to changes in settings and hide the use case screen if appropriate - this is necessary because
             // account settings can still be changing at this point in app init (due to the initial sync being cached,

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -16,10 +16,13 @@ limitations under the License.
 
 import { IClientWellKnown } from 'matrix-js-sdk/src/client';
 import { UnstableValue } from 'matrix-js-sdk/src/NamespacedValue';
+import { logger } from 'matrix-js-sdk/src/logger';
 
 import { MatrixClientPeg } from '../MatrixClientPeg';
+import { UseCase } from '../settings/enums/UseCase';
 
 const CALL_BEHAVIOUR_WK_KEY = "io.element.call_behaviour";
+const DEFAULT_USE_CASE = "io.element.default_use_case";
 const E2EE_WK_KEY = "io.element.e2ee";
 const E2EE_WK_KEY_DEPRECATED = "im.vector.riot.e2ee";
 export const TILE_SERVER_WK_KEY = new UnstableValue(
@@ -112,4 +115,19 @@ export function getSecureBackupSetupMethods(): SecureBackupSetupMethod[] {
         ];
     }
     return wellKnown["secure_backup_setup_methods"];
+}
+
+export function getDefaultUseCase(): UseCase | undefined {
+    return defaultUseCaseFromWellKnown(MatrixClientPeg.get().getClientWellKnown());
+}
+
+export function defaultUseCaseFromWellKnown(
+    clientWellKnown?: IClientWellKnown | undefined,
+): UseCase {
+    const useCase = clientWellKnown?.[DEFAULT_USE_CASE]
+    if (useCase !== undefined && !Object.values(UseCase).includes(useCase)) {
+        logger.warn(`.well-known use case '${useCase} isn't a valid use case.'`);
+        return undefined;
+    }
+    return useCase;
 }


### PR DESCRIPTION
Implementation of https://github.com/vector-im/element-meta/issues/525

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->