### PR TITLE
Use default styling on nested numbered lists due to MD being sensitive

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -609,6 +609,11 @@ $left-gutter: 64px;
             display: inline-block;
         }
         */
+
+        /* Override nested lists being lower-roman */
+        ol ol, ul ol {
+            list-style-type: revert;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22935

![image](https://user-images.githubusercontent.com/2403652/181241662-368c6587-0f86-4152-9a92-4d1839c551cb.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use default styling on nested numbered lists due to MD being sensitive ([\#9110](https://github.com/matrix-org/matrix-react-sdk/pull/9110)). Fixes vector-im/element-web#22935.<!-- CHANGELOG_PREVIEW_END -->