### PR TITLE
Increase max length of voice messages to 15m (PSG-661)

### DIFF
--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -229,7 +229,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
         // go horribly over the limit. We also emit a warning state if needed.
         //
         // We use the recorder's perspective of time to make sure we don't cut off the last
-        // frame of audio, otherwise we end up with a 1:59 clip (119.68 seconds). This extra
+        // frame of audio, otherwise we end up with a 14:59 clip (899.68 seconds). This extra
         // safety can allow us to overshoot the target a bit, but at least when we say 2min
         // maximum we actually mean it.
         //

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -37,7 +37,7 @@ import mxRecorderWorkletPath from "./RecorderWorklet";
 const CHANNELS = 1; // stereo isn't important
 export const SAMPLE_RATE = 48000; // 48khz is what WebRTC uses. 12khz is where we lose quality.
 const BITRATE = 24000; // 24kbps is pretty high quality for our use case in opus.
-const TARGET_MAX_LENGTH = 120; // 2 minutes in seconds. Somewhat arbitrary, though longer == larger files.
+const TARGET_MAX_LENGTH = 900; // 15 minutes in seconds. Somewhat arbitrary, though longer == larger files.
 const TARGET_WARN_TIME_LEFT = 10; // 10 seconds, also somewhat arbitrary.
 
 export const RECORDING_PLAYBACK_SAMPLES = 44;

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -230,7 +230,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
         //
         // We use the recorder's perspective of time to make sure we don't cut off the last
         // frame of audio, otherwise we end up with a 14:59 clip (899.68 seconds). This extra
-        // safety can allow us to overshoot the target a bit, but at least when we say 2min
+        // safety can allow us to overshoot the target a bit, but at least when we say 15min
         // maximum we actually mean it.
         //
         // In testing, recorder time and worker time lag by about 400ms, which is roughly the


### PR DESCRIPTION
Closes: https://github.com/vector-im/element-web/issues/18620
Relates to: vector-im/element-ios#5415

Notes: Increase max length of voice messages to 15m

Signed-off-by: Johannes Marbach <johannesm@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Increase max length of voice messages to 15m ([\#9133](https://github.com/matrix-org/matrix-react-sdk/pull/9133)). Fixes vector-im/element-web#18620.<!-- CHANGELOG_PREVIEW_END -->