### PR TITLE
fix: do not override default blockquote margin in IRC layout

### DIFF
--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -157,10 +157,6 @@ $irc-line-height: $font-18px;
         }
     }
 
-    blockquote {
-        margin: 0;
-    }
-
     .mx_EventTile.mx_EventTile_info {
         .mx_ViewSourceEvent, /* For hidden events */
         .mx_TextualEvent {


### PR DESCRIPTION
The removed piece of code was overriding the default margins.

Screenshot with:

![blockquote1](https://user-images.githubusercontent.com/476060/182840131-2ebf5514-a906-43b2-924c-9c8562b9d5bc.png)

Screenshot without:

![blockquote2](https://user-images.githubusercontent.com/476060/182840162-586c96f0-da23-4ba3-a220-4440d02bd4d5.png)
