### PR TITLE
cypress: log stdout/stderr when docker exec fails

### DIFF
--- a/cypress/plugins/docker/index.ts
+++ b/cypress/plugins/docker/index.ts
@@ -61,9 +61,14 @@ export function dockerExec(args: {
         childProcess.execFile("docker", [
             "exec", args.containerId,
             ...args.params,
-        ], { encoding: 'utf8' }, err => {
-            if (err) reject(err);
-            else resolve();
+        ], { encoding: 'utf8' }, (err, stdout, stderr) => {
+            if (err) {
+                console.log(stdout);
+                console.log(stderr);
+                reject(err);
+                return;
+            }
+            resolve();
         });
     });
 }


### PR DESCRIPTION
Otherwise you cannot debug anything with errors like:
```
> Command failed: docker exec 134c9a0afd7dadd0b82ce69b4d72d3d6d8ca1b211540d4390a88357b68fa03b9 pg_isready -U postgres
```
Now we include the stdout/err prior to logging this.

element-web notes: none


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->