### PR TITLE
Override the disambiguated profile colour in percy tests

### DIFF
--- a/res/css/views/messages/_DisambiguatedProfile.pcss
+++ b/res/css/views/messages/_DisambiguatedProfile.pcss
@@ -34,3 +34,10 @@ limitations under the License.
         color: $primary-content;
     }
 }
+
+@media only percy {
+    .mx_DisambiguatedProfile_displayName {
+        /* Override the colour in percy tests for screenshot consistency */
+        color: $username-variant1-color !important;
+    }
+}


### PR DESCRIPTION
For https://percy.io/dfde73bd/matrix-react-sdk/builds/20418184/changed/1144243017?browser=edge&browser_ids=18%2C22%2C23%2C25&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=1024%2C1920

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->