### PR TITLE
cypress: up the rate limit values for the synapse container

### DIFF
--- a/cypress/plugins/synapsedocker/templates/default/homeserver.yaml
+++ b/cypress/plugins/synapsedocker/templates/default/homeserver.yaml
@@ -22,8 +22,29 @@ log_config: "/data/log.config"
 rc_messages_per_second: 10000
 rc_message_burst_count: 10000
 rc_registration:
- per_second: 10000
- burst_count: 10000
+  per_second: 10000
+  burst_count: 10000
+rc_joins:
+  local:
+    per_second: 9999
+    burst_count: 9999
+  remote:
+    per_second: 9999
+    burst_count: 9999
+rc_joins_per_room:
+  per_second: 9999
+  burst_count: 9999
+rc_3pid_validation:
+  per_second: 1000
+  burst_count: 1000
+
+rc_invites:
+  per_room:
+    per_second: 1000
+    burst_count: 1000
+  per_user:
+    per_second: 1000
+    burst_count: 1000
 
 rc_login:
   address:


### PR DESCRIPTION
Otherwise things like `/createRoom` will quickly hit the rate limit.