### PR TITLE
Set Synapse log level to `DEBUG` for cypress tests temporarily

### DIFF
--- a/cypress/plugins/synapsedocker/templates/consent/log.config
+++ b/cypress/plugins/synapsedocker/templates/consent/log.config
@@ -26,7 +26,7 @@ loggers:
     synapse.storage.SQL:
         # beware: increasing this to DEBUG will make synapse log sensitive
         # information such as access tokens.
-        level: INFO
+        level: DEBUG
 
     twisted:
         # We send the twisted logging directly to the file handler,
@@ -36,7 +36,7 @@ loggers:
         propagate: false
 
 root:
-    level: INFO
+    level: DEBUG
 
     # Write logs to the `buffer` handler, which will buffer them together in memory,
     # then write them to a file.

--- a/cypress/plugins/synapsedocker/templates/default/log.config
+++ b/cypress/plugins/synapsedocker/templates/default/log.config
@@ -26,7 +26,7 @@ loggers:
     synapse.storage.SQL:
         # beware: increasing this to DEBUG will make synapse log sensitive
         # information such as access tokens.
-        level: INFO
+        level: DEBUG
 
     twisted:
         # We send the twisted logging directly to the file handler,
@@ -36,7 +36,7 @@ loggers:
         propagate: false
 
 root:
-    level: INFO
+    level: DEBUG
 
     # Write logs to the `buffer` handler, which will buffer them together in memory,
     # then write them to a file.


### PR DESCRIPTION
Until we narrow down the remaining flake cases this will give us a chance at identifying real-world flake issues.

`DEBUG` is the noisiest level.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->