### PR TITLE
Device manager - label devices as inactive (PSG-638)

### DIFF
--- a/res/css/components/views/settings/devices/_DeviceTile.pcss
+++ b/res/css/components/views/settings/devices/_DeviceTile.pcss
@@ -32,6 +32,11 @@ limitations under the License.
     color: $secondary-content;
 }
 
+.mx_DeviceTile_inactiveIcon {
+    height: 12px;
+    margin-right: $spacing-4; 
+}
+
 .mx_DeviceTile_actions {
     display: grid;
     grid-gap: $spacing-8;
@@ -39,3 +44,5 @@ limitations under the License.
 
     margin-left: $spacing-8;
 }
+
+

--- a/res/css/components/views/settings/devices/_DeviceTile.pcss
+++ b/res/css/components/views/settings/devices/_DeviceTile.pcss
@@ -18,7 +18,6 @@ limitations under the License.
     display: flex;
     flex-direction: row;
     align-items: center;
-
     width: 100%;
 }
 
@@ -27,22 +26,21 @@ limitations under the License.
 }
 
 .mx_DeviceTile_metadata {
-    margin-top: 2px;
+    margin-top: $spacing-4;
     font-size: $font-12px;
     color: $secondary-content;
+    line-height: $font-14px;
 }
 
 .mx_DeviceTile_inactiveIcon {
-    height: 12px;
-    margin-right: $spacing-4; 
+    height: 14px;
+    margin-right: $spacing-8;
+    vertical-align: middle;
 }
 
 .mx_DeviceTile_actions {
     display: grid;
     grid-gap: $spacing-8;
     grid-auto-flow: column;
-
     margin-left: $spacing-8;
 }
-
-

--- a/src/components/views/settings/devices/DeviceSecurityCard.tsx
+++ b/src/components/views/settings/devices/DeviceSecurityCard.tsx
@@ -20,12 +20,7 @@ import React from 'react';
 import { Icon as VerifiedIcon } from '../../../../../res/img/e2e/verified.svg';
 import { Icon as UnverifiedIcon } from '../../../../../res/img/e2e/warning.svg';
 import { Icon as InactiveIcon } from '../../../../../res/img/element-icons/settings/inactive.svg';
-
-export enum DeviceSecurityVariation {
-    Verified = 'Verified',
-    Unverified = 'Unverified',
-    Inactive = 'Inactive',
-}
+import { DeviceSecurityVariation } from './filter';
 interface Props {
     variation: DeviceSecurityVariation;
     heading: string;

--- a/src/components/views/settings/devices/DeviceTile.tsx
+++ b/src/components/views/settings/devices/DeviceTile.tsx
@@ -16,15 +16,14 @@ limitations under the License.
 
 import React, { Fragment } from "react";
 
-import { Icon as InactiveIcon } from "../../../../../res/img/external-link.svg";
+import { Icon as InactiveIcon } from '../../../../../res/img/element-icons/settings/inactive.svg';
 import { _t } from "../../../../languageHandler";
 import { formatDate, formatRelativeTime } from "../../../../DateUtils";
 import TooltipTarget from "../../elements/TooltipTarget";
 import { Alignment } from "../../elements/Tooltip";
 import Heading from "../../typography/Heading";
-import { DeviceWithVerification } from "./useOwnDevices";
 import { INACTIVE_DEVICE_AGE_MS, isDeviceInactive } from "./filter";
-
+import { DeviceWithVerification } from "./useOwnDevices";
 export interface DeviceTileProps {
     device: DeviceWithVerification;
     children?: React.ReactNode;

--- a/src/components/views/settings/devices/DeviceTile.tsx
+++ b/src/components/views/settings/devices/DeviceTile.tsx
@@ -16,12 +16,14 @@ limitations under the License.
 
 import React, { Fragment } from "react";
 
+import { Icon as InactiveIcon } from "../../../../../res/img/external-link.svg";
 import { _t } from "../../../../languageHandler";
 import { formatDate, formatRelativeTime } from "../../../../DateUtils";
 import TooltipTarget from "../../elements/TooltipTarget";
 import { Alignment } from "../../elements/Tooltip";
 import Heading from "../../typography/Heading";
 import { DeviceWithVerification } from "./useOwnDevices";
+import { INACTIVE_DEVICE_AGE_MS, isDeviceInactive } from "./filter";
 
 export interface DeviceTileProps {
     device: DeviceWithVerification;
@@ -45,7 +47,8 @@ const DeviceTileName: React.FC<{ device: DeviceWithVerification }> = ({ device }
     </Heading>;
 };
 
-const MS_6_DAYS = 6 * 24 * 60 * 60 * 1000;
+const MS_DAY = 24 * 60 * 60 * 1000;
+const MS_6_DAYS = 6 * MS_DAY;
 const formatLastActivity = (timestamp: number, now = new Date().getTime()): string => {
     // less than a week ago
     if (timestamp + MS_6_DAYS >= now) {
@@ -56,18 +59,40 @@ const formatLastActivity = (timestamp: number, now = new Date().getTime()): stri
     return formatRelativeTime(new Date(timestamp));
 };
 
-const DeviceMetadata: React.FC<{ value: string, id: string }> = ({ value, id }) => (
+const getInactiveMetadata = (device: DeviceWithVerification): { id: string, value: React.ReactNode } | undefined => {
+    const isInactive = isDeviceInactive(device);
+
+    if (!isInactive) {
+        return undefined;
+    }
+    const inactiveAgeDays = Math.round(INACTIVE_DEVICE_AGE_MS / MS_DAY);
+    return { id: 'inactive', value: (
+        <>
+            <InactiveIcon className="mx_DeviceTile_inactiveIcon" />
+            {
+                _t('Inactive for %(inactiveAgeDays)s+ days', { inactiveAgeDays }) +
+                ` (${formatLastActivity(device.last_seen_ts)})`
+            }
+        </>),
+    };
+};
+
+const DeviceMetadata: React.FC<{ value: string | React.ReactNode, id: string }> = ({ value, id }) => (
     value ? <span data-testid={`device-metadata-${id}`}>{ value }</span> : null
 );
 
 const DeviceTile: React.FC<DeviceTileProps> = ({ device, children, onClick }) => {
+    const inactive = getInactiveMetadata(device);
     const lastActivity = device.last_seen_ts && `${_t('Last activity')} ${formatLastActivity(device.last_seen_ts)}`;
     const verificationStatus = device.isVerified ? _t('Verified') : _t('Unverified');
-    const metadata = [
-        { id: 'isVerified', value: verificationStatus },
-        { id: 'lastActivity', value: lastActivity },
-        { id: 'lastSeenIp', value: device.last_seen_ip },
-    ];
+    // if device is inactive, don't display last activity or verificationStatus
+    const metadata = inactive
+        ? [inactive, { id: 'lastSeenIp', value: device.last_seen_ip }]
+        : [
+            { id: 'isVerified', value: verificationStatus },
+            { id: 'lastActivity', value: lastActivity },
+            { id: 'lastSeenIp', value: device.last_seen_ip },
+        ];
 
     return <div className="mx_DeviceTile" data-testid={`device-tile-${device.device_id}`}>
         <div className="mx_DeviceTile_info" onClick={onClick}>

--- a/src/components/views/settings/devices/FilteredDeviceList.tsx
+++ b/src/components/views/settings/devices/FilteredDeviceList.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React from 'react';
 
 import DeviceTile from './DeviceTile';
+import { filterDevicesBySecurityRecommendation } from './filter';
 import { DevicesDictionary, DeviceWithVerification } from './useOwnDevices';
 
 interface Props {
@@ -27,8 +28,9 @@ interface Props {
 const sortDevicesByLatestActivity = (left: DeviceWithVerification, right: DeviceWithVerification) =>
     (right.last_seen_ts || 0) - (left.last_seen_ts || 0);
 
-const getSortedDevices = (devices: DevicesDictionary) =>
-    Object.values(devices).sort(sortDevicesByLatestActivity);
+const getFilteredSortedDevices = (devices: DevicesDictionary) =>
+    filterDevicesBySecurityRecommendation(Object.values(devices), [])
+        .sort(sortDevicesByLatestActivity);
 
 /**
  * Filtered list of devices
@@ -36,7 +38,7 @@ const getSortedDevices = (devices: DevicesDictionary) =>
  * TODO(kerrya) Filtering to added as part of PSG-648
  */
 const FilteredDeviceList: React.FC<Props> = ({ devices }) => {
-    const sortedDevices = getSortedDevices(devices);
+    const sortedDevices = getFilteredSortedDevices(devices);
 
     return <ol className='mx_FilteredDeviceList'>
         { sortedDevices.map((device) =>

--- a/src/components/views/settings/devices/filter.ts
+++ b/src/components/views/settings/devices/filter.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { DeviceWithVerification } from "./useOwnDevices";
+
+// TODO put somewhere good when security card is merged
+export enum DeviceSecurityVariation {
+    Verified = 'Verified',
+    Unverified = 'Unverified',
+    Inactive = 'Inactive',
+}
+
+type DeviceFilterCondition = (device: DeviceWithVerification) => boolean;
+
+const INACTIVE_SESSION_AGE = 7.776e+9; // 90 days
+
+const filters: Record<DeviceSecurityVariation, DeviceFilterCondition> = {
+    [DeviceSecurityVariation.Verified]: device => !!device.isVerified,
+    [DeviceSecurityVariation.Unverified]: device => !device.isVerified,
+    [DeviceSecurityVariation.Inactive]: device => !!device.last_seen_ts &&
+        device.last_seen_ts < Date.now() - INACTIVE_SESSION_AGE,
+};
+
+export const filterDevicesBySecurityRecommendation = (
+    devices: DeviceWithVerification[],
+    securityVariations: DeviceSecurityVariation[],
+) => {
+    const activeFilters = securityVariations.map(variation => filters[variation]);
+    if (!activeFilters.length) {
+        return devices;
+    }
+    return devices.filter(device => activeFilters.every(filter => filter(device)));
+};

--- a/src/components/views/settings/devices/filter.ts
+++ b/src/components/views/settings/devices/filter.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { DeviceWithVerification } from "./useOwnDevices";
 
-// TODO put somewhere good when security card is merged
 export enum DeviceSecurityVariation {
     Verified = 'Verified',
     Unverified = 'Unverified',
@@ -27,8 +26,8 @@ type DeviceFilterCondition = (device: DeviceWithVerification) => boolean;
 
 export const INACTIVE_DEVICE_AGE_MS = 7.776e+9; // 90 days
 
-export const isDeviceInactive: DeviceFilterCondition = device => !!device.last_seen_ts &&
-device.last_seen_ts < Date.now() - INACTIVE_DEVICE_AGE_MS;
+export const isDeviceInactive: DeviceFilterCondition = device =>
+    !!device.last_seen_ts && device.last_seen_ts < Date.now() - INACTIVE_DEVICE_AGE_MS;
 
 const filters: Record<DeviceSecurityVariation, DeviceFilterCondition> = {
     [DeviceSecurityVariation.Verified]: device => !!device.isVerified,

--- a/src/components/views/settings/devices/filter.ts
+++ b/src/components/views/settings/devices/filter.ts
@@ -25,13 +25,15 @@ export enum DeviceSecurityVariation {
 
 type DeviceFilterCondition = (device: DeviceWithVerification) => boolean;
 
-const INACTIVE_SESSION_AGE = 7.776e+9; // 90 days
+export const INACTIVE_DEVICE_AGE_MS = 7.776e+9; // 90 days
+
+export const isDeviceInactive: DeviceFilterCondition = device => !!device.last_seen_ts &&
+device.last_seen_ts < Date.now() - INACTIVE_DEVICE_AGE_MS;
 
 const filters: Record<DeviceSecurityVariation, DeviceFilterCondition> = {
     [DeviceSecurityVariation.Verified]: device => !!device.isVerified,
     [DeviceSecurityVariation.Unverified]: device => !device.isVerified,
-    [DeviceSecurityVariation.Inactive]: device => !!device.last_seen_ts &&
-        device.last_seen_ts < Date.now() - INACTIVE_SESSION_AGE,
+    [DeviceSecurityVariation.Inactive]: isDeviceInactive,
 };
 
 export const filterDevicesBySecurityRecommendation = (

--- a/src/components/views/settings/tabs/user/SessionManagerTab.tsx
+++ b/src/components/views/settings/tabs/user/SessionManagerTab.tsx
@@ -20,10 +20,11 @@ import { _t } from "../../../../../languageHandler";
 import Spinner from '../../../elements/Spinner';
 import { useOwnDevices } from '../../devices/useOwnDevices';
 import DeviceTile from '../../devices/DeviceTile';
-import DeviceSecurityCard, { DeviceSecurityVariation } from '../../devices/DeviceSecurityCard';
+import DeviceSecurityCard from '../../devices/DeviceSecurityCard';
 import SettingsSubsection from '../../shared/SettingsSubsection';
-import SettingsTab from '../SettingsTab';
 import FilteredDeviceList from '../../devices/FilteredDeviceList';
+import { DeviceSecurityVariation } from '../../devices/filter';
+import SettingsTab from '../SettingsTab';
 
 const SessionManagerTab: React.FC = () => {
     const { devices, currentDeviceId, isLoading } = useOwnDevices();

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1703,6 +1703,7 @@
     "Device": "Device",
     "IP address": "IP address",
     "Session details": "Session details",
+    "Inactive for %(inactiveAgeDays)s+ days": "Inactive for %(inactiveAgeDays)s+ days",
     "Verified": "Verified",
     "Unverified": "Unverified",
     "Unable to remove contact information": "Unable to remove contact information",

--- a/test/components/views/settings/devices/DeviceSecurityCard-test.tsx
+++ b/test/components/views/settings/devices/DeviceSecurityCard-test.tsx
@@ -17,9 +17,8 @@ limitations under the License.
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import DeviceSecurityCard, {
-    DeviceSecurityVariation,
-} from '../../../../../src/components/views/settings/devices/DeviceSecurityCard';
+import DeviceSecurityCard from '../../../../../src/components/views/settings/devices/DeviceSecurityCard';
+import { DeviceSecurityVariation } from '../../../../../src/components/views/settings/devices/filter';
 
 describe('<DeviceSecurityCard />', () => {
     const defaultProps = {

--- a/test/components/views/settings/devices/DeviceTile-test.tsx
+++ b/test/components/views/settings/devices/DeviceTile-test.tsx
@@ -117,7 +117,7 @@ describe('<DeviceTile />', () => {
                 last_seen_ts: now - (MS_DAY * 100),
             };
             const { getByTestId, queryByTestId } = render(getComponent({ device }));
-            expect(getByTestId('device-metadata-inactive').textContent).toMatchSnapshot();
+            expect(getByTestId('device-metadata-inactive').textContent).toEqual('Inactive for 90+ days (Dec 4, 2021)');
             // last activity and verification not shown when inactive
             expect(queryByTestId('device-metadata-lastActivity')).toBeFalsy();
             expect(queryByTestId('device-metadata-verificationStatus')).toBeFalsy();

--- a/test/components/views/settings/devices/DeviceTile-test.tsx
+++ b/test/components/views/settings/devices/DeviceTile-test.tsx
@@ -109,5 +109,18 @@ describe('<DeviceTile />', () => {
             const { getByTestId } = render(getComponent({ device }));
             expect(getByTestId('device-metadata-lastActivity').textContent).toEqual('Last activity Dec 29, 2021');
         });
+
+        it('renders with inactive notice when last activity was more than 90 days ago', () => {
+            const device: IMyDevice = {
+                device_id: '123',
+                last_seen_ip: '1.2.3.4',
+                last_seen_ts: now - (MS_DAY * 100),
+            };
+            const { getByTestId, queryByTestId } = render(getComponent({ device }));
+            expect(getByTestId('device-metadata-inactive').textContent).toMatchSnapshot();
+            // last activity and verification not shown when inactive
+            expect(queryByTestId('device-metadata-lastActivity')).toBeFalsy();
+            expect(queryByTestId('device-metadata-verificationStatus')).toBeFalsy();
+        });
     });
 });

--- a/test/components/views/settings/devices/__snapshots__/DeviceTile-test.tsx.snap
+++ b/test/components/views/settings/devices/__snapshots__/DeviceTile-test.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<DeviceTile /> Last activity renders with inactive notice when last activity was more than 90 days ago 1`] = `"Inactive for 90+ days (Dec 4, 2021)"`;
-
 exports[`<DeviceTile /> renders a device with no metadata 1`] = `
 <div>
   <div

--- a/test/components/views/settings/devices/__snapshots__/DeviceTile-test.tsx.snap
+++ b/test/components/views/settings/devices/__snapshots__/DeviceTile-test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<DeviceTile /> Last activity renders with inactive notice when last activity was more than 90 days ago 1`] = `"Inactive for 90+ days (Dec 4, 2021)"`;
+
 exports[`<DeviceTile /> renders a device with no metadata 1`] = `
 <div>
   <div

--- a/test/components/views/settings/devices/filter-test.ts
+++ b/test/components/views/settings/devices/filter-test.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+    DeviceSecurityVariation,
+    filterDevicesBySecurityRecommendation,
+} from "../../../../../src/components/views/settings/devices/filter";
+
+const MS_DAY = 86400000;
+describe('filterDevicesBySecurityRecommendation()', () => {
+    const unverifiedNoMetadata = { device_id: 'unverified-no-metadata', isVerified: false };
+    const verifiedNoMetadata = { device_id: 'verified-no-metadata', isVerified: true };
+    const hundredDaysOld = { device_id: '100-days-old', isVerified: true, last_seen_ts: Date.now() - (MS_DAY * 100) };
+    const hundredDaysOldUnverified = {
+        device_id: 'unverified-100-days-old',
+        isVerified: false,
+        last_seen_ts: Date.now() - (MS_DAY * 100),
+    };
+    const fiftyDaysOld = { device_id: '50-days-old', isVerified: true, last_seen_ts: Date.now() - (MS_DAY * 50) };
+
+    const devices = [
+        unverifiedNoMetadata,
+        verifiedNoMetadata,
+        hundredDaysOld,
+        hundredDaysOldUnverified,
+        fiftyDaysOld,
+    ];
+
+    it('returns all devices when no securityRecommendations are passed', () => {
+        expect(filterDevicesBySecurityRecommendation(devices, [])).toBe(devices);
+    });
+
+    it('returns devices older than 90 days as inactive', () => {
+        expect(filterDevicesBySecurityRecommendation(devices, [DeviceSecurityVariation.Inactive])).toEqual([
+            // devices without ts metadata are not filtered as inactive
+            hundredDaysOld,
+            hundredDaysOldUnverified,
+        ]);
+    });
+
+    it('returns correct devices for verified filter', () => {
+        expect(filterDevicesBySecurityRecommendation(devices, [DeviceSecurityVariation.Verified])).toEqual([
+            verifiedNoMetadata,
+            hundredDaysOld,
+            fiftyDaysOld,
+        ]);
+    });
+
+    it('returns correct devices for unverified filter', () => {
+        expect(filterDevicesBySecurityRecommendation(devices, [DeviceSecurityVariation.Unverified])).toEqual([
+            unverifiedNoMetadata,
+            hundredDaysOldUnverified,
+        ]);
+    });
+
+    it('returns correct devices for combined verified and inactive filters', () => {
+        expect(filterDevicesBySecurityRecommendation(
+            devices,
+            [DeviceSecurityVariation.Unverified, DeviceSecurityVariation.Inactive],
+        )).toEqual([
+            hundredDaysOldUnverified,
+        ]);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

<img width="337" alt="Screenshot 2022-08-11 at 12 01 02" src="https://user-images.githubusercontent.com/3055605/184131403-fbcb26d1-1985-4b38-80e4-ee7ea5bf9cc6.png">


- Adds filtering util to be used in list views
- Adds inactive metadata to device tile

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Device manager - label devices as inactive


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Device manager - label devices as inactive ([\#9175](https://github.com/matrix-org/matrix-react-sdk/pull/9175)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->