### PR TITLE
Add even more stability to view source test case

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -238,7 +238,7 @@ describe("Timeline", () => {
             cy.contains(".mx_RoomView_body .mx_EventTile[data-scroll-tokens]", "MessageEdit").should("exist");
 
             // Click top left of the event toggle, which should not be covered by MessageActionBar's safe area
-            cy.get(".mx_EventTile .mx_ViewSourceEvent").realHover().within(() => {
+            cy.get(".mx_EventTile .mx_ViewSourceEvent").should("exist").realHover().within(() => {
                 cy.get(".mx_ViewSourceEvent_toggle").click('topLeft', { force: false });
             });
 


### PR DESCRIPTION
Follow-on from https://github.com/matrix-org/matrix-react-sdk/pull/9156 after seeing more failures from the test case.

Fixes https://github.com/vector-im/element-web/issues/23053

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->