### PR TITLE
Hide sticker picker for local rooms (backport)

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -51,6 +51,7 @@ import { SettingUpdatedPayload } from "../../../dispatcher/payloads/SettingUpdat
 import MessageComposerButtons from './MessageComposerButtons';
 import { ButtonEvent } from '../elements/AccessibleButton';
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
+import { isLocalRoom } from '../../../utils/localRoom/isLocalRoom';
 
 let instanceCount = 0;
 
@@ -350,6 +351,10 @@ export default class MessageComposer extends React.Component<IProps, IState> {
         });
     };
 
+    private get showStickersButton(): boolean {
+        return this.state.showStickersButton && !isLocalRoom(this.props.room);
+    }
+
     public render() {
         const controls = [
             this.props.e2eStatus ?
@@ -475,7 +480,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                             setStickerPickerOpen={this.setStickerPickerOpen}
                             showLocationButton={!window.electron}
                             showPollsButton={this.state.showPollsButton}
-                            showStickersButton={this.state.showStickersButton}
+                            showStickersButton={this.showStickersButton}
                             toggleButtonMenu={this.toggleButtonMenu}
                         /> }
                         { showSendButton && (

--- a/test/components/views/rooms/MessageComposer-test.tsx
+++ b/test/components/views/rooms/MessageComposer-test.tsx
@@ -28,48 +28,66 @@ import RoomContext from "../../../../src/contexts/RoomContext";
 import { IRoomState } from "../../../../src/components/structures/RoomView";
 import ResizeNotifier from "../../../../src/utils/ResizeNotifier";
 import { RoomPermalinkCreator } from "../../../../src/utils/permalinks/Permalinks";
+import { LocalRoom } from "../../../../src/models/LocalRoom";
+import MessageComposerButtons from "../../../../src/components/views/rooms/MessageComposerButtons";
 
 describe("MessageComposer", () => {
     stubClient();
     const cli = createTestClient();
-    const room = mkStubRoom("!roomId:server", "Room 1", cli);
 
-    it("Renders a SendMessageComposer and MessageComposerButtons by default", () => {
-        const wrapper = wrapAndRender({ room });
+    describe("for a Room", () => {
+        const room = mkStubRoom("!roomId:server", "Room 1", cli);
 
-        expect(wrapper.find("SendMessageComposer")).toHaveLength(1);
-        expect(wrapper.find("MessageComposerButtons")).toHaveLength(1);
+        it("Renders a SendMessageComposer and MessageComposerButtons by default", () => {
+            const wrapper = wrapAndRender({ room });
+
+            expect(wrapper.find("SendMessageComposer")).toHaveLength(1);
+            expect(wrapper.find("MessageComposerButtons")).toHaveLength(1);
+        });
+
+        it("Does not render a SendMessageComposer or MessageComposerButtons when user has no permission", () => {
+            const wrapper = wrapAndRender({ room }, false);
+
+            expect(wrapper.find("SendMessageComposer")).toHaveLength(0);
+            expect(wrapper.find("MessageComposerButtons")).toHaveLength(0);
+            expect(wrapper.find(".mx_MessageComposer_noperm_error")).toHaveLength(1);
+        });
+
+        it("Does not render a SendMessageComposer or MessageComposerButtons when room is tombstoned", () => {
+            const wrapper = wrapAndRender({ room }, true, mkEvent({
+                event: true,
+                type: "m.room.tombstone",
+                room: room.roomId,
+                user: "@user1:server",
+                skey: "",
+                content: {},
+                ts: Date.now(),
+            }));
+
+            expect(wrapper.find("SendMessageComposer")).toHaveLength(0);
+            expect(wrapper.find("MessageComposerButtons")).toHaveLength(0);
+            expect(wrapper.find(".mx_MessageComposer_roomReplaced_header")).toHaveLength(1);
+        });
     });
 
-    it("Does not render a SendMessageComposer or MessageComposerButtons when user has no permission", () => {
-        const wrapper = wrapAndRender({ room }, false);
+    describe("for a LocalRoom", () => {
+        const localRoom = new LocalRoom("!room:example.com", cli, cli.getUserId());
 
-        expect(wrapper.find("SendMessageComposer")).toHaveLength(0);
-        expect(wrapper.find("MessageComposerButtons")).toHaveLength(0);
-        expect(wrapper.find(".mx_MessageComposer_noperm_error")).toHaveLength(1);
-    });
-
-    it("Does not render a SendMessageComposer or MessageComposerButtons when room is tombstoned", () => {
-        const wrapper = wrapAndRender({ room }, true, mkEvent({
-            event: true,
-            type: "m.room.tombstone",
-            room: room.roomId,
-            user: "@user1:server",
-            skey: "",
-            content: {},
-            ts: Date.now(),
-        }));
-
-        expect(wrapper.find("SendMessageComposer")).toHaveLength(0);
-        expect(wrapper.find("MessageComposerButtons")).toHaveLength(0);
-        expect(wrapper.find(".mx_MessageComposer_roomReplaced_header")).toHaveLength(1);
+        it("should pass the sticker picker disabled prop", () => {
+            const wrapper = wrapAndRender({ room: localRoom });
+            expect(wrapper.find(MessageComposerButtons).props().showStickersButton).toBe(false);
+        });
     });
 });
 
-function wrapAndRender(props = {}, canSendMessages = true, tombstone?: MatrixEvent): ReactWrapper {
+function wrapAndRender(
+    props: Partial<React.ComponentProps<typeof MessageComposer>> = {},
+    canSendMessages = true,
+    tombstone?: MatrixEvent,
+): ReactWrapper {
     const mockClient = MatrixClientPeg.get();
     const roomId = "myroomid";
-    const room: any = {
+    const room: any = props.room || {
         currentState: undefined,
         roomId,
         client: mockClient,


### PR DESCRIPTION
## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: The first message in a DM can no longer be a sticker. This has been changed to avoid issues with the integration manager.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * The first message in a DM can no longer be a sticker. This has been changed to avoid issues with the integration manager. ([\#9180](https://github.com/matrix-org/matrix-react-sdk/pull/9180)).<!-- CHANGELOG_PREVIEW_END -->