### PR TITLE
Add "Connect to tor server" checkbox

### DIFF
--- a/res/css/views/elements/_ServerPicker.pcss
+++ b/res/css/views/elements/_ServerPicker.pcss
@@ -79,6 +79,12 @@ limitations under the License.
         grid-column: 1 / 2;
         grid-row: 3;
     }
+
+    .mx_ServerPicker_tor {
+        grid-column: 1;
+        grid-row: 4;
+        margin-top: 10px;
+    }
 }
 
 .mx_ServerPicker_helpDialog {

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -24,6 +24,7 @@ import SdkConfig from "../../../SdkConfig";
 import Modal from "../../../Modal";
 import ServerPickerDialog from "../dialogs/ServerPickerDialog";
 import InfoDialog from "../dialogs/InfoDialog";
+import StyledCheckbox from './StyledCheckbox';
 
 interface IProps {
     title?: string;
@@ -97,6 +98,13 @@ const ServerPicker = ({ title, dialogTitle, serverConfig, onServerConfigChange }
         </span>
         { editBtn }
         { desc }
+        <StyledCheckbox
+            className="mx_ServerPicker_tor"
+            checked={serverConfig.isTorConnect}
+            onChange={(e) => onServerConfigChange({ ...serverConfig, isTorConnect: e.target.checked })}
+        >
+            { _t('Connect to tor server') }
+        </StyledCheckbox>
     </div>;
 };
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3500,5 +3500,6 @@
     "Activate selected button": "Activate selected button",
     "New line": "New line",
     "Force complete": "Force complete",
-    "Search (must be enabled)": "Search (must be enabled)"
+    "Search (must be enabled)": "Search (must be enabled)",
+    "Connect to tor server": "Connect to tor server"
 }

--- a/src/utils/AutoDiscoveryUtils.tsx
+++ b/src/utils/AutoDiscoveryUtils.tsx
@@ -252,6 +252,7 @@ export default class AutoDiscoveryUtils {
             isDefault: false,
             warning: hsResult.error,
             isNameResolvable: !isSynthetic,
+            isTorConnect: false,
         });
     }
 }

--- a/src/utils/ValidatedServerConfig.ts
+++ b/src/utils/ValidatedServerConfig.ts
@@ -24,6 +24,7 @@ export class ValidatedServerConfig {
     isDefault: boolean;
     // when the server config is based on static URLs the hsName is not resolvable and things may wish to use hsUrl
     isNameResolvable: boolean;
+    isTorConnect: boolean;
 
     warning: string;
 }


### PR DESCRIPTION
At the login (registration) the checkbox "Connect to the tor server" is added. When the checkbox is active, a flag is added to the serverConfig.


Before:
![Снимок экрана 2022-08-13 в 17 42 37](https://user-images.githubusercontent.com/60852700/184499162-65e1affe-2852-4fda-8d66-2cb89297f145.png)

After:
![Снимок экрана 2022-08-13 в 17 41 46](https://user-images.githubusercontent.com/60852700/184499161-967f6324-5678-4206-9551-7756c50fb454.png)



<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->