### PR TITLE
Unit tests: make beacon events more specific

### DIFF
--- a/test/components/views/beacon/BeaconStatus-test.tsx
+++ b/test/components/views/beacon/BeaconStatus-test.tsx
@@ -51,13 +51,13 @@ describe('<BeaconStatus />', () => {
         it('renders without children', () => {
             // mock for stable snapshot
             jest.spyOn(Date, 'now').mockReturnValue(123456789);
-            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', {}, '$1'));
+            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', { isLive: false }, '$1'));
             const component = getComponent({ beacon, displayStatus: BeaconDisplayStatus.Active });
             expect(component).toMatchSnapshot();
         });
 
         it('renders with children', () => {
-            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:sever'));
+            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:sever', { isLive: false }));
             const component = getComponent({
                 beacon,
                 children: <span data-test-id='test'>test</span>,
@@ -69,7 +69,7 @@ describe('<BeaconStatus />', () => {
         it('renders static remaining time when displayLiveTimeRemaining is falsy', () => {
             // mock for stable snapshot
             jest.spyOn(Date, 'now').mockReturnValue(123456789);
-            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', {}, '$1'));
+            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', { isLive: false }, '$1'));
             const component = getComponent({ beacon, displayStatus: BeaconDisplayStatus.Active });
             expect(component.text().includes('Live until 11:17')).toBeTruthy();
         });
@@ -77,7 +77,7 @@ describe('<BeaconStatus />', () => {
         it('renders live time remaining when displayLiveTimeRemaining is truthy', () => {
             // mock for stable snapshot
             jest.spyOn(Date, 'now').mockReturnValue(123456789);
-            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', {}, '$1'));
+            const beacon = new Beacon(makeBeaconInfoEvent('@user:server', '!room:server', { isLive: false }, '$1'));
             const component = getComponent({
                 beacon, displayStatus: BeaconDisplayStatus.Active,
                 displayLiveTimeRemaining: true,

--- a/test/components/views/beacon/__snapshots__/BeaconStatus-test.tsx.snap
+++ b/test/components/views/beacon/__snapshots__/BeaconStatus-test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<BeaconStatus /> active state renders without children 1`] = `
       "_beaconInfo": Object {
         "assetType": "m.self",
         "description": undefined,
-        "live": undefined,
+        "live": false,
         "timeout": 3600000,
         "timestamp": 123456789,
       },
       "_events": Object {},
       "_eventsCount": 0,
-      "_isLive": undefined,
+      "_isLive": false,
       "_latestLocationEvent": undefined,
       "_maxListeners": undefined,
       "clearLatestLocation": [Function],
@@ -24,7 +24,7 @@ exports[`<BeaconStatus /> active state renders without children 1`] = `
       "rootEvent": Object {
         "content": Object {
           "description": undefined,
-          "live": undefined,
+          "live": false,
           "org.matrix.msc3488.asset": Object {
             "type": "m.self",
           },
@@ -71,13 +71,13 @@ exports[`<BeaconStatus /> active state renders without children 1`] = `
             "_beaconInfo": Object {
               "assetType": "m.self",
               "description": undefined,
-              "live": undefined,
+              "live": false,
               "timeout": 3600000,
               "timestamp": 123456789,
             },
             "_events": Object {},
             "_eventsCount": 0,
-            "_isLive": undefined,
+            "_isLive": false,
             "_latestLocationEvent": undefined,
             "_maxListeners": undefined,
             "clearLatestLocation": [Function],
@@ -86,7 +86,7 @@ exports[`<BeaconStatus /> active state renders without children 1`] = `
             "rootEvent": Object {
               "content": Object {
                 "description": undefined,
-                "live": undefined,
+                "live": false,
                 "org.matrix.msc3488.asset": Object {
                   "type": "m.self",
                 },


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

https://github.com/matrix-org/matrix-js-sdk/pull/2591 bug fix changes how beacon model evaluates an undefined live property, now always returning a boolean.
Update the beacon events used here to have an explicit live property to avoid broken snapshots when 2591 is merged

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->