### PR TITLE
Simplify releases: move npm publishing to gha, consolidate scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Release Process
+on:
+  release:
+    types: [ published ]
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  npm:
+    name: Publish
+    uses: matrix-org/matrix-js-sdk/.github/workflows/release-npm.yml@develop
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/post-release.sh
+++ b/post-release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./node_modules/matrix-js-sdk/post-release.sh "$@"

--- a/release.sh
+++ b/release.sh
@@ -4,55 +4,9 @@
 
 set -e
 
-cd `dirname $0`
+cd "$(dirname "$0")"
 
 # This link seems to get eaten by the release process, so ensure it exists.
 yarn link matrix-js-sdk
 
-for i in matrix-js-sdk
-do
-    echo "Checking version of $i..."
-    depver=`cat package.json | jq -r .dependencies[\"$i\"]`
-    latestver=`yarn info -s $i dist-tags.next`
-    if [ "$depver" != "$latestver" ]
-    then
-        echo "The latest version of $i is $latestver but package.json depends on $depver."
-        echo -n "Type 'u' to auto-upgrade, 'c' to continue anyway, or 'a' to abort:"
-        read resp
-        if [ "$resp" != "u" ] && [ "$resp" != "c" ]
-        then
-            echo "Aborting."
-            exit 1
-        fi
-        if [ "$resp" == "u" ]
-        then
-            echo "Upgrading $i to $latestver..."
-            yarn add -E $i@$latestver
-            git add -u
-            git commit -m "Upgrade $i to $latestver"
-        fi
-    fi
-done
-
 ./node_modules/matrix-js-sdk/release.sh "$@"
-
-release="${1#v}"
-prerelease=0
-# We check if this build is a prerelease by looking to
-# see if the version has a hyphen in it. Crude,
-# but semver doesn't support postreleases so anything
-# with a hyphen is a prerelease.
-echo $release | grep -q '-' && prerelease=1
-
-if [ $prerelease -eq 0 ]
-then
-    # For a release, reset SDK deps back to the `develop` branch.
-    for i in matrix-js-sdk
-    do
-        echo "Resetting $i to develop branch..."
-        yarn add github:matrix-org/$i#develop
-        git add -u
-        git commit -m "Reset $i back to develop branch"
-    done
-    git push origin develop
-fi

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 #
 # Script to perform a release of matrix-react-sdk.
-#
-# Requires githib-changelog-generator; to install, do
-#   pip install git+https://github.com/matrix-org/github-changelog-generator.git
 
 set -e
 


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2616

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->