### PR TITLE
Reuse empty string & space string logic for event types in devtools

### DIFF
--- a/src/components/views/dialogs/devtools/RoomState.tsx
+++ b/src/components/views/dialogs/devtools/RoomState.tsx
@@ -67,12 +67,12 @@ interface IEventTypeProps extends Pick<IDevtoolsProps, "onBack"> {
 const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
     const context = useContext(DevtoolsContext);
     const [query, setQuery] = useState("");
-    const [event, setEvent] = useState<MatrixEvent>(null);
+    const [event, setEvent] = useState<MatrixEvent | null>(null);
 
     const events = context.room.currentState.events.get(eventType);
 
     useEffect(() => {
-        if (events.size === 1 && events.has("")) {
+        if (events?.size === 1 && events.has("")) {
             setEvent(events.get(""));
         } else {
             setEvent(null);
@@ -81,7 +81,7 @@ const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
 
     if (event) {
         const _onBack = () => {
-            if (events.size === 1 && events.has("")) {
+            if (events?.size === 1 && events.has("")) {
                 onBack();
             } else {
                 setEvent(null);
@@ -104,7 +104,7 @@ const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
 export const RoomStateExplorer = ({ onBack, setTool }: IDevtoolsProps) => {
     const context = useContext(DevtoolsContext);
     const [query, setQuery] = useState("");
-    const [eventType, setEventType] = useState<string>(null);
+    const [eventType, setEventType] = useState<string | null>(null);
 
     const events = context.room.currentState.events;
 

--- a/src/components/views/dialogs/devtools/RoomState.tsx
+++ b/src/components/views/dialogs/devtools/RoomState.tsx
@@ -80,10 +80,14 @@ const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
     }, [events]);
 
     if (event) {
-        const onBack = () => {
-            setEvent(null);
+        const _onBack = () => {
+            if (events.size === 1 && events.has("")) {
+                onBack();
+            } else {
+                setEvent(null);
+            }
         };
-        return <EventViewer mxEvent={event} onBack={onBack} Editor={StateEventEditor} />;
+        return <EventViewer mxEvent={event} onBack={_onBack} Editor={StateEventEditor} />;
     }
 
     return <BaseTool onBack={onBack}>
@@ -104,7 +108,7 @@ export const RoomStateExplorer = ({ onBack, setTool }: IDevtoolsProps) => {
 
     const events = context.room.currentState.events;
 
-    if (eventType) {
+    if (eventType !== null) {
         const onBack = () => {
             setEventType(null);
         };

--- a/src/components/views/dialogs/devtools/RoomState.tsx
+++ b/src/components/views/dialogs/devtools/RoomState.tsx
@@ -41,6 +41,25 @@ export const StateEventEditor = ({ mxEvent, onBack }: IEditorProps) => {
     return <EventEditor fieldDefs={fields} defaultContent={defaultContent} onSend={onSend} onBack={onBack} />;
 };
 
+interface StateEventButtonProps {
+    label: string;
+    onClick(): void;
+}
+
+const StateEventButton = ({ label, onClick }: StateEventButtonProps) => {
+    const trimmed = label.trim();
+
+    return <button
+        className={classNames("mx_DevTools_button", {
+            mx_DevTools_RoomStateExplorer_button_hasSpaces: trimmed.length !== label.length,
+            mx_DevTools_RoomStateExplorer_button_emptyString: !trimmed,
+        })}
+        onClick={onClick}
+    >
+        { trimmed ? label : _t("<%(count)s spaces>", { count: label.length }) }
+    </button>;
+};
+
 interface IEventTypeProps extends Pick<IDevtoolsProps, "onBack"> {
     eventType: string;
 }
@@ -70,23 +89,9 @@ const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
     return <BaseTool onBack={onBack}>
         <FilteredList query={query} onChange={setQuery}>
             {
-                Array.from(events.entries()).map(([stateKey, ev]) => {
-                    const trimmed = stateKey.trim();
-                    const onClick = () => {
-                        setEvent(ev);
-                    };
-
-                    return <button
-                        className={classNames("mx_DevTools_button", {
-                            mx_DevTools_RoomStateExplorer_button_hasSpaces: trimmed.length !== stateKey.length,
-                            mx_DevTools_RoomStateExplorer_button_emptyString: !trimmed,
-                        })}
-                        key={stateKey}
-                        onClick={onClick}
-                    >
-                        { trimmed ? stateKey : _t("<%(count)s spaces>", { count: stateKey.length }) }
-                    </button>;
-                })
+                Array.from(events.entries()).map(([stateKey, ev]) => (
+                    <StateEventButton key={stateKey} label={stateKey} onClick={() => setEvent(ev)} />
+                ))
             }
         </FilteredList>
     </BaseTool>;
@@ -113,19 +118,9 @@ export const RoomStateExplorer = ({ onBack, setTool }: IDevtoolsProps) => {
     return <BaseTool onBack={onBack} actionLabel={_t("Send custom state event")} onAction={onAction}>
         <FilteredList query={query} onChange={setQuery}>
             {
-                Array.from(events.keys()).map((eventType) => {
-                    const onClick = () => {
-                        setEventType(eventType);
-                    };
-
-                    return <button
-                        className="mx_DevTools_button"
-                        key={eventType}
-                        onClick={onClick}
-                    >
-                        { eventType }
-                    </button>;
-                })
+                Array.from(events.keys()).map((eventType) => (
+                    <StateEventButton key={eventType} label={eventType} onClick={() => setEventType(eventType)} />
+                ))
             }
         </FilteredList>
     </BaseTool>;

--- a/src/components/views/dialogs/devtools/RoomState.tsx
+++ b/src/components/views/dialogs/devtools/RoomState.tsx
@@ -69,11 +69,11 @@ const RoomStateExplorerEventType = ({ eventType, onBack }: IEventTypeProps) => {
     const [query, setQuery] = useState("");
     const [event, setEvent] = useState<MatrixEvent | null>(null);
 
-    const events = context.room.currentState.events.get(eventType);
+    const events = context.room.currentState.events.get(eventType)!;
 
     useEffect(() => {
-        if (events?.size === 1 && events.has("")) {
-            setEvent(events.get(""));
+        if (events.size === 1 && events.has("")) {
+            setEvent(events.get("")!);
         } else {
             setEvent(null);
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23115

![image](https://user-images.githubusercontent.com/2403652/186400747-dbd5c6fd-8686-43f2-8d5a-eb085b70cf37.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Reuse empty string & space string logic for event types in devtools ([\#9218](https://github.com/matrix-org/matrix-react-sdk/pull/9218)). Fixes vector-im/element-web#23115.<!-- CHANGELOG_PREVIEW_END -->