### PR TITLE
Remove support for unstable private read receipts

### DIFF
--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -127,8 +127,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
     public async componentDidMount(): Promise<void> {
         this.setState({
             disablingReadReceiptsSupported: (
-                await MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc2285.stable") ||
-                await MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc2285")
+                await MatrixClientPeg.get().doesServerSupportUnstableFeature("org.matrix.msc2285.stable")
             ),
         });
     }


### PR DESCRIPTION
<hr>

We want there to be a reasonable transition time to switch to stable private read receipts, so this is blocked until that time passes