### PR TITLE
remove the grey gradient on images in bubbles in the timeline

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/res/css/views/rooms/_EventBubbleTile.pcss
@@ -292,23 +292,9 @@ limitations under the License.
             }
 
             /* we put the timestamps for media (other than stickers) atop the media */
-            /* for images we also apply a linear gradient and change the timestamp colour to aid readability */
             &.mx_EventTile_image {
                 .mx_MessageTimestamp {
-                    color: #ffffff; /* regardless of theme, always visible on the below gradient */
-                }
-
-                /* linear gradient to make the timestamp more visible */
-                .mx_MImageBody::before {
-                    content: "";
-                    position: absolute;
-                    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
-                    z-index: 1;
-                    top: 0;
-                    bottom: 0;
-                    left: 0;
-                    right: 0;
-                    pointer-events: none;
+                    color: #ffffff; /* regardless of theme */
                 }
             }
         }

--- a/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/res/css/views/rooms/_EventBubbleTile.pcss
@@ -294,7 +294,11 @@ limitations under the License.
             /* we put the timestamps for media (other than stickers) atop the media */
             &.mx_EventTile_image {
                 .mx_MessageTimestamp {
-                    color: #ffffff; /* regardless of theme */
+                    border-radius: $timeline-image-border-radius;
+                    /* Hardcoded colours because it's the same on all themes */
+                    background-color: rgba(0, 0, 0, 0.6);
+                    color: #ffffff;
+                    padding: 0px 4px 0px 4px;
                 }
             }
         }


### PR DESCRIPTION
given we now show the filename/size banner and timestamps with a nice lozenge overlay,
so the gradient is unnecessary and just screws up the image.

before:
<img width="348" alt="Screenshot 2022-09-06 at 10 46 10" src="https://user-images.githubusercontent.com/1294269/188603874-9a0a9ae7-96a1-443e-bd7f-0564a3ae2df6.png">

after:
<img width="428" alt="Screenshot 2022-09-04 at 23 02 11" src="https://user-images.githubusercontent.com/1294269/188335143-46570405-f5fe-4503-ad71-59546c09af6f.png">


fixes https://github.com/vector-im/element-web/issues/21651

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * remove the grey gradient on images in bubbles in the timeline ([\#9241](https://github.com/matrix-org/matrix-react-sdk/pull/9241)). Fixes vector-im/element-web#21651.<!-- CHANGELOG_PREVIEW_END -->