### PR TITLE
Fix tile crash around tooltipify links

### DIFF
--- a/src/utils/tooltipify.tsx
+++ b/src/utils/tooltipify.tsx
@@ -47,12 +47,17 @@ export function tooltipifyLinks(rootNodes: ArrayLike<Element>, ignoredNodes: Ele
         if (node.tagName === "A" && node.getAttribute("href")
             && node.getAttribute("href") !== node.textContent.trim()
         ) {
-            const href = node.getAttribute("href");
+            let href = node.getAttribute("href");
+            try {
+                href = new URL(href, window.location.href).toString();
+            } catch (e) {
+                // Not all hrefs will be valid URLs
+            }
 
             // The node's innerHTML was already sanitized before being rendered in the first place, here we are just
             // wrapping the link with the LinkWithTooltip component, keeping the same children. Ideally we'd do this
             // without the superfluous span but this is not something React trivially supports at this time.
-            const tooltip = <LinkWithTooltip tooltip={new URL(href, window.location.href).toString()}>
+            const tooltip = <LinkWithTooltip tooltip={href}>
                 <span dangerouslySetInnerHTML={{ __html: node.innerHTML }} />
             </LinkWithTooltip>;
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23253

Skipping tests as this code will soon be replaced

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix tile crash around tooltipify links ([\#9270](https://github.com/matrix-org/matrix-react-sdk/pull/9270)). Fixes vector-im/element-web#23253.<!-- CHANGELOG_PREVIEW_END -->