### PR TITLE
Skip escaping edits if the input wasn't markdown to begin with

### DIFF
--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -24,11 +24,14 @@ import { Part, PartCreator, Type } from "./parts";
 import SdkConfig from "../SdkConfig";
 import { textToHtmlRainbow } from "../utils/colour";
 import { stripPlainReply } from "../utils/Reply";
+import Markdown from "../Markdown";
 
 const LIST_TYPES = ["UL", "OL", "LI"];
 
 // Escapes all markup in the given text
 function escape(text: string): string {
+    const parser = new Markdown(text);
+    if (parser.isPlainText()) return text;
     return text.replace(/[\\*_[\]`<]|^>/g, match => `\\${match}`);
 }
 

--- a/test/editor/deserialize-test.ts
+++ b/test/editor/deserialize-test.ts
@@ -97,6 +97,12 @@ describe('editor/deserialize', function() {
             expect(parts.length).toBe(1);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/me says DON'T SHOUT!" });
         });
+        it("should not escape where redundant", () => {
+            const text = "matrix-react-sdk/res/themes/light/css/_light.scss";
+            const parts = normalize(parseEvent(textMessage(text, "m.text"), createPartCreator()));
+            expect(parts).toHaveLength(1);
+            expect(parts[0]).toStrictEqual({ type: "plain", text });
+        });
     });
     describe('html messages', function() {
         it('inline styling', function() {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22456

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Skip escaping edits if the input wasn't markdown to begin with ([\#9288](https://github.com/matrix-org/matrix-react-sdk/pull/9288)). Fixes vector-im/element-web#22456.<!-- CHANGELOG_PREVIEW_END -->