### PR TITLE
Fix tile soft crash in ReplyInThreadButton

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -73,7 +73,7 @@ const ReplyInThreadButton = ({ mxEvent, closeMenu }: IReplyInThreadButton) => {
     const relationType = mxEvent?.getRelation()?.rel_type;
 
     // Can't create a thread from an event with an existing relation
-    if (Boolean(relationType) && relationType !== RelationType.Thread) return;
+    if (Boolean(relationType) && relationType !== RelationType.Thread) return null;
 
     const onClick = (): void => {
         if (!localStorage.getItem("mx_seen_feature_thread")) {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/element-web-rageshakes/issues/15493

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix tile soft crash in ReplyInThreadButton ([\#9300](https://github.com/matrix-org/matrix-react-sdk/pull/9300)). Fixes matrix-org/element-web-rageshakes#15493.<!-- CHANGELOG_PREVIEW_END -->