### PR TITLE
Fix spaces feedback prompt wrongly showing when feedback is disabled

### DIFF
--- a/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -38,6 +38,7 @@ import SettingsStore from "../../../settings/SettingsStore";
 import { getKeyBindingsManager } from "../../../KeyBindingsManager";
 import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
+import { UIFeature } from "../../../settings/UIFeature";
 
 export const createSpace = async (
     name: string,
@@ -100,7 +101,7 @@ const nameToLocalpart = (name: string): string => {
 
 // XXX: Temporary for the Spaces release only
 export const SpaceFeedbackPrompt = ({ onClick }: { onClick?: () => void }) => {
-    if (!SdkConfig.get().bug_report_endpoint_url) return null;
+    if (!SdkConfig.get().bug_report_endpoint_url || !SettingsStore.getValue(UIFeature.Feedback)) return null;
 
     return <div className="mx_SpaceFeedbackPrompt">
         <span className="mx_SpaceFeedbackPrompt_text">{ _t("Spaces are a new feature.") }</span>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23314

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix spaces feedback prompt wrongly showing when feedback is disabled ([\#9302](https://github.com/matrix-org/matrix-react-sdk/pull/9302)). Fixes vector-im/element-web#23314.<!-- CHANGELOG_PREVIEW_END -->