### PR TITLE
Fixes to ensure account data values do not go stale

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -428,8 +428,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         window.removeEventListener("resize", this.onWindowResized);
 
         if (this.accountPasswordTimer !== null) clearTimeout(this.accountPasswordTimer);
-
-        this.cli.off(ClientEvent.Sync, this.onInitialSync);
     }
 
     private onWindowResized = (): void => {

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -401,6 +401,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         }
     }
 
+    private get cli(): MatrixClient { return MatrixClientPeg.get(); }
+
     public componentDidMount(): void {
         window.addEventListener("resize", this.onWindowResized);
     }
@@ -426,6 +428,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         window.removeEventListener("resize", this.onWindowResized);
 
         if (this.accountPasswordTimer !== null) clearTimeout(this.accountPasswordTimer);
+
+        this.cli.off(ClientEvent.Sync, this.onInitialSync);
     }
 
     private onWindowResized = (): void => {
@@ -1258,8 +1262,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         this.themeWatcher.recheck();
         StorageManager.tryPersistStorage();
 
-        const cli = MatrixClientPeg.get();
-        createLocalNotificationSettingsIfNeeded(cli);
+        this.cli.on(ClientEvent.Sync, this.onInitialSync);
 
         if (
             MatrixClientPeg.currentUserIsJustRegistered() &&
@@ -1286,6 +1289,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             return this.onShowPostLoginScreen();
         }
     }
+
+    private onInitialSync = (): void => {
+        if (this.cli.isInitialSyncComplete()) {
+            this.cli.off(ClientEvent.Sync, this.onInitialSync);
+        }
+
+        createLocalNotificationSettingsIfNeeded(this.cli);
+    };
 
     private async onShowPostLoginScreen(useCase?: UseCase) {
         if (useCase) {

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -23,6 +23,7 @@ import { DeviceTrustLevel } from 'matrix-js-sdk/src/crypto/CrossSigning';
 import { VerificationRequest } from 'matrix-js-sdk/src/crypto/verification/request/VerificationRequest';
 import { sleep } from 'matrix-js-sdk/src/utils';
 import {
+    ClientEvent,
     IMyDevice,
     LOCAL_NOTIFICATION_SETTINGS_PREFIX,
     MatrixEvent,
@@ -744,5 +745,38 @@ describe('<SessionManagerTab />', () => {
             alicesDevice.device_id,
             { is_silenced: true },
         );
+    });
+
+    it("updates the UI when another session changes the local notifications", async () => {
+        const { getByTestId } = render(getComponent());
+
+        await act(async () => {
+            await flushPromisesWithFakeTimers();
+        });
+
+        toggleDeviceDetails(getByTestId, alicesDevice.device_id);
+
+        // device details are expanded
+        expect(getByTestId(`device-detail-${alicesDevice.device_id}`)).toBeTruthy();
+        expect(getByTestId('device-detail-push-notification')).toBeTruthy();
+
+        const checkbox = getByTestId('device-detail-push-notification-checkbox');
+
+        expect(checkbox).toBeTruthy();
+
+        expect(checkbox.getAttribute('aria-checked')).toEqual("true");
+
+        const evt = new MatrixEvent({
+            type: LOCAL_NOTIFICATION_SETTINGS_PREFIX.name + "." + alicesDevice.device_id,
+            content: {
+                is_silenced: false,
+            },
+        });
+
+        await act(async () => {
+            mockClient.emit(ClientEvent.AccountData, evt);
+        });
+
+        expect(checkbox.getAttribute('aria-checked')).toEqual("false");
     });
 });

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -769,7 +769,7 @@ describe('<SessionManagerTab />', () => {
         const evt = new MatrixEvent({
             type: LOCAL_NOTIFICATION_SETTINGS_PREFIX.name + "." + alicesDevice.device_id,
             content: {
-                is_silenced: false,
+                is_silenced: true,
             },
         });
 


### PR DESCRIPTION
Related to https://element-io.atlassian.net/browse/PSG-595

Account data events are only available after the initial sync. My code previously would incorrectly reset the push notification values.
Added an event to synchronise the local notification settings toggle when another session edits the value


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->