### PR TITLE
Fix applying programmatically set height for "top" room layout

### DIFF
--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -31,7 +31,6 @@ import Resizer from "../../../resizer/resizer";
 import PercentageDistributor from "../../../resizer/distributors/percentage";
 import { Container, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { clamp, percentageOf, percentageWithin } from "../../../utils/numbers";
-import { useStateCallback } from "../../../hooks/useStateCallback";
 import UIStore from "../../../stores/UIStore";
 import { IApp } from "../../../stores/WidgetStore";
 import { ActionPayload } from "../../../dispatcher/payloads";
@@ -330,13 +329,8 @@ const PersistentVResizer: React.FC<IPersistentResizerProps> = ({
         defaultHeight = 280;
     }
 
-    const [height, setHeight] = useStateCallback(defaultHeight, newHeight => {
-        newHeight = percentageOf(newHeight, minHeight, maxHeight) * 100;
-        WidgetLayoutStore.instance.setContainerHeight(room, Container.Top, newHeight);
-    });
-
     return <Resizable
-        size={{ height: Math.min(height, maxHeight), width: undefined }}
+        size={{ height: Math.min(defaultHeight, maxHeight), width: undefined }}
         minHeight={minHeight}
         maxHeight={maxHeight}
         onResizeStart={() => {
@@ -346,7 +340,15 @@ const PersistentVResizer: React.FC<IPersistentResizerProps> = ({
             resizeNotifier.notifyTimelineHeightChanged();
         }}
         onResizeStop={(e, dir, ref, d) => {
-            setHeight(height + d.height);
+            let newHeight = defaultHeight + d.height;
+            newHeight = percentageOf(newHeight, minHeight, maxHeight) * 100;
+
+            WidgetLayoutStore.instance.setContainerHeight(
+                room,
+                Container.Top,
+                newHeight,
+            );
+
             resizeNotifier.stopResizing();
         }}
         handleWrapperClass={handleWrapperClass}


### PR DESCRIPTION
When applying a room layout automatically (e.g. via `io.element.widgets.layout` state event), in cases the layout mode container it set to "top", the height was previously not correctly updated and stayed with the default value.

We have a widget that has a setup process that is enforcing a room layout via `io.element.widgets.layout`. If the widget does it while the room is already viewed in the client, the height currently defaults to a default height, instead of using the height specified in the state event.

This is caused by a local state that stores the height, that is not updated if the layout changes, but only by manual changes by the user. I removed the local state, as it was kept in sync synchronously with the state inside `WidgetLayoutStore` anyway.

**Before**
https://user-images.githubusercontent.com/648527/193409896-1d917274-758c-4011-a1ee-0ead65e6db5c.mov

**After**
https://user-images.githubusercontent.com/648527/193409899-3b1cd6f5-e1ad-4f83-8d95-d0d1de80eb6f.mov

I haven't created test yet, as far as I have seen there aren't any test for the particular area. But I'm up to writing some if you think it is worth it. But I need a hint where to place it. I think because of the user interactions and layouting, it will only work as a cypress tests. I can test both the programatic and mouse based modifications.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
