### PR TITLE
Remove unspecced `original_event` field from the `readEventRelations` response

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -434,7 +434,6 @@ export class StopGapWidgetDriver extends WidgetDriver {
         }
 
         const {
-            originalEvent,
             events,
             nextBatch,
             prevBatch,
@@ -451,7 +450,6 @@ export class StopGapWidgetDriver extends WidgetDriver {
             });
 
         return {
-            originalEvent: originalEvent?.getEffectiveEvent(),
             chunk: events.map(e => e.getEffectiveEvent()),
             nextBatch,
             prevBatch,

--- a/test/stores/widgets/StopGapWidgetDriver-test.ts
+++ b/test/stores/widgets/StopGapWidgetDriver-test.ts
@@ -209,31 +209,12 @@ describe("StopGapWidgetDriver", () => {
             });
 
             await expect(driver.readEventRelations('$event')).resolves.toEqual({
-                originalEvent: expect.objectContaining({ content: {} }),
                 chunk: [],
                 nextBatch: undefined,
                 prevBatch: undefined,
             });
 
             expect(client.relations).toBeCalledWith('!this-room-id', '$event', null, null, {});
-        });
-
-        it('reads related events if the original event is missing', async () => {
-            client.relations.mockResolvedValue({
-                // the relations function can return an undefined event, even
-                // though the typings don't permit an undefined value.
-                originalEvent: undefined as any,
-                events: [],
-            });
-
-            await expect(driver.readEventRelations('$event', '!room-id')).resolves.toEqual({
-                originalEvent: undefined,
-                chunk: [],
-                nextBatch: undefined,
-                prevBatch: undefined,
-            });
-
-            expect(client.relations).toBeCalledWith('!room-id', '$event', null, null, {});
         });
 
         it('reads related events from a selected room', async () => {
@@ -244,7 +225,6 @@ describe("StopGapWidgetDriver", () => {
             });
 
             await expect(driver.readEventRelations('$event', '!room-id')).resolves.toEqual({
-                originalEvent: expect.objectContaining({ content: {} }),
                 chunk: [
                     expect.objectContaining({ content: {} }),
                     expect.objectContaining({ content: {} }),
@@ -272,7 +252,6 @@ describe("StopGapWidgetDriver", () => {
                 25,
                 'f',
             )).resolves.toEqual({
-                originalEvent: expect.objectContaining({ content: {} }),
                 chunk: [],
                 nextBatch: undefined,
                 prevBatch: undefined,


### PR DESCRIPTION
Relates to https://github.com/matrix-org/synapse/issues/12930

This removes the unspecced `original_event` field from the WidgetApi analog to https://github.com/matrix-org/matrix-widget-api/pull/75. Since the field was optional before, we can already remove it even without a release of the `matrix-widget-api` package.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->