### PR TITLE
Increase timout waiting for home screen after login in cypress test

### DIFF
--- a/cypress/e2e/login/login.spec.ts
+++ b/cypress/e2e/login/login.spec.ts
@@ -40,7 +40,7 @@ describe("Login", () => {
             cy.registerUser(synapse, username, password);
         });
 
-        it.only("logs in with an existing account and lands on the home screen", () => {
+        it("logs in with an existing account and lands on the home screen", () => {
             cy.injectAxe();
 
             cy.get("#mx_LoginForm_username", { timeout: 15000 }).should("be.visible");

--- a/cypress/e2e/login/login.spec.ts
+++ b/cypress/e2e/login/login.spec.ts
@@ -40,7 +40,7 @@ describe("Login", () => {
             cy.registerUser(synapse, username, password);
         });
 
-        it("logs in with an existing account and lands on the home screen", () => {
+        it.only("logs in with an existing account and lands on the home screen", () => {
             cy.injectAxe();
 
             cy.get("#mx_LoginForm_username", { timeout: 15000 }).should("be.visible");
@@ -58,7 +58,7 @@ describe("Login", () => {
             cy.startMeasuring("from-submit-to-home");
             cy.get(".mx_Login_submit").click();
 
-            cy.url().should('contain', '/#/home');
+            cy.url().should('contain', '/#/home', { timeout: 30000 });
             cy.stopMeasuring("from-submit-to-home");
         });
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23439

Sample failing run: https://dashboard.cypress.io/projects/ppvnzg/runs/4659/test-results/e0951d3c-6798-4267-8112-768dfbdda920

The screenshot there shows, that it is still setting up keys → increasing timeout

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->