### PR TITLE
Pin back Synapse used in Cypress to alleviate test failures

### DIFF
--- a/cypress/plugins/synapsedocker/index.ts
+++ b/cypress/plugins/synapsedocker/index.ts
@@ -100,7 +100,9 @@ async function synapseStart(template: string): Promise<SynapseInstance> {
     console.log(`Starting synapse with config dir ${synCfg.configDir}...`);
 
     const synapseId = await dockerRun({
-        image: "matrixdotorg/synapse:develop",
+        // XXX: switch back to `develop` tag once the threads receipts issue is fixed
+        // https://github.com/vector-im/element-web/issues/23451
+        image: "matrixdotorg/synapse:latest",
         containerName: `react-sdk-cypress-synapse`,
         params: [
             "--rm",


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->