### PR TITLE
Include device_id in voice broadcast info events

### DIFF
--- a/src/voice-broadcast/index.ts
+++ b/src/voice-broadcast/index.ts
@@ -40,6 +40,7 @@ export enum VoiceBroadcastInfoState {
 }
 
 export interface VoiceBroadcastInfoEventContent {
+    device_id: string;
     state: VoiceBroadcastInfoState;
     chunk_length?: number;
     ["m.relates_to"]?: {

--- a/src/voice-broadcast/models/VoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastRecording.ts
@@ -146,6 +146,7 @@ export class VoiceBroadcastRecording
             this.infoEvent.getRoomId(),
             VoiceBroadcastInfoEventType,
             {
+                device_id: this.client.getDeviceId(),
                 state: VoiceBroadcastInfoState.Stopped,
                 ["m.relates_to"]: {
                     rel_type: RelationType.Reference,

--- a/src/voice-broadcast/utils/startNewVoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/utils/startNewVoiceBroadcastRecording.ts
@@ -65,6 +65,7 @@ export const startNewVoiceBroadcastRecording = async (
         roomId,
         VoiceBroadcastInfoEventType,
         {
+            device_id: client.getDeviceId(),
             state: VoiceBroadcastInfoState.Started,
             chunk_length: 300,
         } as VoiceBroadcastInfoEventContent,

--- a/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
@@ -160,6 +160,7 @@ describe("VoiceBroadcastRecording", () => {
     describe("when created for a Voice Broadcast Info without relations", () => {
         beforeEach(() => {
             infoEvent = mkVoiceBroadcastInfoEvent({
+                device_id: client.getDeviceId(),
                 state: VoiceBroadcastInfoState.Started,
             });
             setUpVoiceBroadcastRecording();
@@ -179,6 +180,7 @@ describe("VoiceBroadcastRecording", () => {
                     roomId,
                     VoiceBroadcastInfoEventType,
                     {
+                        device_id: client.getDeviceId(),
                         state: VoiceBroadcastInfoState.Stopped,
                         ["m.relates_to"]: {
                             rel_type: RelationType.Reference,
@@ -344,6 +346,7 @@ describe("VoiceBroadcastRecording", () => {
     describe("when created for a Voice Broadcast Info with a Stopped relation", () => {
         beforeEach(() => {
             infoEvent = mkVoiceBroadcastInfoEvent({
+                device_id: client.getDeviceId(),
                 state: VoiceBroadcastInfoState.Started,
                 chunk_length: 300,
             });
@@ -353,6 +356,7 @@ describe("VoiceBroadcastRecording", () => {
             } as unknown as Relations;
             mocked(relationsContainer.getRelations).mockReturnValue([
                 mkVoiceBroadcastInfoEvent({
+                    device_id: client.getDeviceId(),
                     state: VoiceBroadcastInfoState.Stopped,
                     ["m.relates_to"]: {
                         rel_type: RelationType.Reference,

--- a/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
@@ -89,6 +89,7 @@ describe("startNewVoiceBroadcastRecording", () => {
             event: true,
             type: VoiceBroadcastInfoEventType,
             content: {
+                device_id: client.getDeviceId(),
                 state: VoiceBroadcastInfoState.Started,
             },
             user: client.getUserId(),


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

See https://github.com/vector-im/element-meta/discussions/632

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->