### PR TITLE
Fix flakiness of kick.spec.ts due to `cy.get(...).contains(...).should(...);` anti-pattern

### DIFF
--- a/cypress/e2e/integration-manager/kick.spec.ts
+++ b/cypress/e2e/integration-manager/kick.spec.ts
@@ -84,11 +84,7 @@ function sendActionFromIntegrationManager(integrationManagerUrl: string, targetR
 
 function expectKickedMessage(shouldExist: boolean) {
     // Expand any event summaries
-    cy.get(".mx_RoomView_MessageList").within(roomView => {
-        if (roomView.find(".mx_GenericEventListSummary_toggle[aria-expanded=false]").length > 0) {
-            cy.get(".mx_GenericEventListSummary_toggle[aria-expanded=false]").click({ multiple: true });
-        }
-    });
+    cy.get(".mx_GenericEventListSummary_toggle[aria-expanded=false]").click({ multiple: true });
 
     // Check for the event message (or lack thereof)
     cy.contains(".mx_EventTile_line", `${USER_DISPLAY_NAME} removed ${BOT_DISPLAY_NAME}: ${KICK_REASON}`)

--- a/cypress/e2e/integration-manager/kick.spec.ts
+++ b/cypress/e2e/integration-manager/kick.spec.ts
@@ -91,8 +91,7 @@ function expectKickedMessage(shouldExist: boolean) {
     });
 
     // Check for the event message (or lack thereof)
-    cy.get(".mx_EventTile_line")
-        .contains(`${USER_DISPLAY_NAME} removed ${BOT_DISPLAY_NAME}: ${KICK_REASON}`)
+    cy.contains(".mx_EventTile_line", `${USER_DISPLAY_NAME} removed ${BOT_DISPLAY_NAME}: ${KICK_REASON}`)
         .should(shouldExist ? "exist" : "not.exist");
 }
 


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->