### PR TITLE
Fix check for whether a pickle is stored

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -699,7 +699,7 @@ async function persistCredentials(credentials: IMatrixClientCreds): Promise<void
         } catch (e) {
             localStorage.setItem("mx_access_token", credentials.accessToken);
         }
-        if (localStorage.getItem("mx_has_pickle_key")) {
+        if (localStorage.getItem("mx_has_pickle_key") === "true") {
             logger.error("Expected a pickle key, but none provided.  Encryption may not work.");
         }
     }


### PR DESCRIPTION
We store a boolean as a string, so when we set the localstorage to `"false"`, the console gets slightly more red with anger.

This doesn't appear to have any consequences beyond devx and a noisy console.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->