### PR TITLE
Hide screen-sharing button in Element Call on desktop

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -41,6 +41,7 @@ import { ElementWidgetActions } from "../stores/widgets/ElementWidgetActions";
 import WidgetStore from "../stores/WidgetStore";
 import { WidgetMessagingStore, WidgetMessagingStoreEvent } from "../stores/widgets/WidgetMessagingStore";
 import ActiveWidgetStore, { ActiveWidgetStoreEvent } from "../stores/ActiveWidgetStore";
+import PlatformPeg from "../PlatformPeg";
 
 const TIMEOUT_MS = 16000;
 
@@ -631,6 +632,8 @@ export class ElementCall extends Call {
             embed: "",
             preload: "",
             hideHeader: "",
+            // Currently, the screen-sharing support is the same is it is for Jitsi
+            hideScreensharing: PlatformPeg.get().supportsJitsiScreensharing() ? null : "",
             userId: client.getUserId()!,
             deviceId: client.getDeviceId(),
             roomId: groupCall.getRoomId()!,

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -632,12 +632,14 @@ export class ElementCall extends Call {
             embed: "",
             preload: "",
             hideHeader: "",
-            // Currently, the screen-sharing support is the same is it is for Jitsi
-            hideScreensharing: PlatformPeg.get().supportsJitsiScreensharing() ? null : "",
             userId: client.getUserId()!,
             deviceId: client.getDeviceId(),
             roomId: groupCall.getRoomId()!,
         });
+        // Currently, the screen-sharing support is the same is it is for Jitsi
+        if (!PlatformPeg.get().supportsJitsiScreensharing()) {
+            params.append("hideScreensharing", "");
+        }
         url.hash = `#?${params.toString()}`;
 
         // To use Element Call without touching room state, we create a virtual


### PR DESCRIPTION
Requires https://github.com/vector-im/element-call/pull/622

Currently, screen-sharing doesn't work on desktop due to iframe issues

Note: my EC setup broke and I am having trouble testing this...



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Hide screen-sharing button in Element Call on desktop ([\#9423](https://github.com/matrix-org/matrix-react-sdk/pull/9423)).<!-- CHANGELOG_PREVIEW_END -->