### PR TITLE
Better accommodate long room names in call toasts

### DIFF
--- a/res/css/views/toasts/_IncomingCallToast.pcss
+++ b/res/css/views/toasts/_IncomingCallToast.pcss
@@ -21,11 +21,14 @@ limitations under the License.
     pointer-events: initial; /* restore pointer events so the user can accept/decline */
     width: 250px;
 
+    $closeButtonSize: 16px;
+
     .mx_IncomingCallToast_content {
         display: flex;
         flex-direction: column;
         margin-left: 8px;
         width: 100%;
+        overflow: hidden;
 
         .mx_IncomingCallToast_info {
             margin-bottom: $spacing-16;
@@ -33,10 +36,12 @@ limitations under the License.
             .mx_IncomingCallToast_room {
                 display: inline-block;
 
-                font-weight: bold;
+                font-weight: 600;
                 font-size: $font-15px;
                 line-height: $font-24px;
 
+                /* Prevent overlap with the close button */
+                width: calc(100% - $closeButtonSize - 2 * $spacing-4);
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
@@ -86,8 +91,8 @@ limitations under the License.
         right: $spacing-4;
 
         display: flex;
-        height: 16px;
-        width: 16px;
+        height: $closeButtonSize;
+        width: $closeButtonSize;
 
         &::before {
             content: '';

--- a/res/css/views/toasts/_IncomingCallToast.pcss
+++ b/res/css/views/toasts/_IncomingCallToast.pcss
@@ -36,7 +36,7 @@ limitations under the License.
             .mx_IncomingCallToast_room {
                 display: inline-block;
 
-                font-weight: 600;
+                font-weight: $font-semi-bold;
                 font-size: $font-15px;
                 line-height: $font-24px;
 


### PR DESCRIPTION
Before|After
-|-
![Screenshot 2022-10-14 at 12-42-50 Element 10 Robin's video room 1](https://user-images.githubusercontent.com/48614497/195898759-87246d26-d234-48be-9497-1079b43e7918.png)|![Screenshot 2022-10-14 at 12-42-38 Element 10 Robin's video room 1](https://user-images.githubusercontent.com/48614497/195898757-a2b7e1b6-6af8-420a-b81a-bae35e14a4f8.png)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Better accommodate long room names in call toasts ([\#9426](https://github.com/matrix-org/matrix-react-sdk/pull/9426)).<!-- CHANGELOG_PREVIEW_END -->