### PR TITLE
Pass the current language to Element Call

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -42,6 +42,7 @@ import WidgetStore from "../stores/WidgetStore";
 import { WidgetMessagingStore, WidgetMessagingStoreEvent } from "../stores/widgets/WidgetMessagingStore";
 import ActiveWidgetStore, { ActiveWidgetStoreEvent } from "../stores/ActiveWidgetStore";
 import PlatformPeg from "../PlatformPeg";
+import { getCurrentLanguage } from "../languageHandler";
 
 const TIMEOUT_MS = 16000;
 
@@ -626,7 +627,7 @@ export class ElementCall extends Call {
 
     private constructor(public readonly groupCall: MatrixEvent, client: MatrixClient) {
         // Splice together the Element Call URL for this call
-        const url = new URL(SdkConfig.get("element_call").url ?? DEFAULTS.element_call.url);
+        const url = new URL(SdkConfig.get("element_call").url ?? DEFAULTS.element_call.url!);
         url.pathname = "/room";
         const params = new URLSearchParams({
             embed: "",
@@ -635,6 +636,7 @@ export class ElementCall extends Call {
             userId: client.getUserId()!,
             deviceId: client.getDeviceId(),
             roomId: groupCall.getRoomId()!,
+            lang: getCurrentLanguage().replace("_", "-"),
         });
         // Currently, the screen-sharing support is the same is it is for Jitsi
         if (!PlatformPeg.get().supportsJitsiScreensharing()) {


### PR DESCRIPTION
This allows the Element Call interface to appear in the language used by the rest of the app.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Pass the current language to Element Call ([\#9427](https://github.com/matrix-org/matrix-react-sdk/pull/9427)).<!-- CHANGELOG_PREVIEW_END -->