### PR TITLE
Improve the tooltips on the call lobby join button

### DIFF
--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -246,9 +246,9 @@ export const Lobby: FC<LobbyProps> = ({ room, joinCallButtonDisabled, joinCallBu
             kind="primary"
             disabled={connecting || joinCallButtonDisabled}
             onClick={onConnectClick}
-            title={_t("Join")}
             label={_t("Join")}
             tooltip={connecting ? _t("Connecting") : joinCallButtonTooltip}
+            alignment={Alignment.Bottom}
         />
     </div>;
 };


### PR DESCRIPTION
Currently they display a redundant 'Join' tooltip on hover, and place the tooltip on the left. This removes the redundant tooltip and places the tooltip below the button, which looks a bit more balanced.

![mpv-shot0004](https://user-images.githubusercontent.com/48614497/196096469-58cd7373-084b-438d-85ac-3fba86ebc41d.jpg)
![mpv-shot0003](https://user-images.githubusercontent.com/48614497/196096473-01bffcdf-86ce-4c37-bfea-827ca9f82986.jpg)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve the tooltips on the call lobby join button ([\#9428](https://github.com/matrix-org/matrix-react-sdk/pull/9428)).<!-- CHANGELOG_PREVIEW_END -->