### PR TITLE
Pass the homeserver's base URL to Element Call

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -636,6 +636,7 @@ export class ElementCall extends Call {
             userId: client.getUserId()!,
             deviceId: client.getDeviceId(),
             roomId: groupCall.getRoomId()!,
+            baseUrl: client.baseUrl,
             lang: getCurrentLanguage().replace("_", "-"),
         });
         // Currently, the screen-sharing support is the same is it is for Jitsi


### PR DESCRIPTION
This will allow Element Call to perform media repo lookups, for example for avatars.

Closes https://github.com/vector-im/element-web/issues/23301

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Pass the homeserver's base URL to Element Call ([\#9429](https://github.com/matrix-org/matrix-react-sdk/pull/9429)). Fixes vector-im/element-web#23301.<!-- CHANGELOG_PREVIEW_END -->