### PR TITLE
Improve Voice Broadcast header layout

### DIFF
--- a/res/css/voice-broadcast/atoms/_VoiceBroadcastHeader.pcss
+++ b/res/css/voice-broadcast/atoms/_VoiceBroadcastHeader.pcss
@@ -22,6 +22,7 @@ limitations under the License.
 
 .mx_VoiceBroadcastHeader_content {
     flex-grow: 1;
+    min-width: 0;
 }
 
 .mx_VoiceBroadcastHeader_room {
@@ -38,4 +39,14 @@ limitations under the License.
     font-size: $font-12px;
     display: flex;
     gap: $spacing-4;
+
+    i {
+        flex-shrink: 0;
+    }
+
+    span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }

--- a/res/css/voice-broadcast/atoms/_VoiceBroadcastHeader.pcss
+++ b/res/css/voice-broadcast/atoms/_VoiceBroadcastHeader.pcss
@@ -20,6 +20,10 @@ limitations under the License.
     width: 266px;
 }
 
+.mx_VoiceBroadcastHeader_content {
+    flex-grow: 1;
+}
+
 .mx_VoiceBroadcastHeader_room {
     font-size: $font-12px;
     font-weight: $font-semi-bold;

--- a/src/voice-broadcast/components/atoms/VoiceBroadcastHeader.tsx
+++ b/src/voice-broadcast/components/atoms/VoiceBroadcastHeader.tsx
@@ -47,7 +47,7 @@ export const VoiceBroadcastHeader: React.FC<VoiceBroadcastHeaderProps> = ({
             </div>
             <div className="mx_VoiceBroadcastHeader_line">
                 <Icon type={IconType.Microphone} colour={IconColour.CompoundSecondaryContent} />
-                { sender.name }
+                <span>{ sender.name }</span>
             </div>
             { broadcast }
         </div>

--- a/test/voice-broadcast/components/atoms/__snapshots__/VoiceBroadcastHeader-test.tsx.snap
+++ b/test/voice-broadcast/components/atoms/__snapshots__/VoiceBroadcastHeader-test.tsx.snap
@@ -28,7 +28,9 @@ exports[`VoiceBroadcastHeader when rendering a live broadcast header with broadc
           role="presentation"
           style="mask-image: url(\\"image-file-stub\\");"
         />
-        test user
+        <span>
+          test user
+        </span>
       </div>
       <div
         class="mx_VoiceBroadcastHeader_line"
@@ -85,7 +87,9 @@ exports[`VoiceBroadcastHeader when rendering a non-live broadcast header should 
           role="presentation"
           style="mask-image: url(\\"image-file-stub\\");"
         />
-        test user
+        <span>
+          test user
+        </span>
       </div>
     </div>
   </div>

--- a/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
+++ b/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
@@ -31,7 +31,9 @@ exports[`VoiceBroadcastPlaybackBody when rendering a broadcast should render as 
             role="presentation"
             style="mask-image: url(\\"image-file-stub\\");"
           />
-          @user:example.com
+          <span>
+            @user:example.com
+          </span>
         </div>
         <div
           class="mx_VoiceBroadcastHeader_line"

--- a/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
+++ b/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
@@ -111,7 +111,9 @@ exports[`VoiceBroadcastPlaybackBody when rendering a buffering voice broadcast s
             role="presentation"
             style="mask-image: url(\\"image-file-stub\\");"
           />
-          @user:example.com
+          <span>
+            @user:example.com
+          </span>
         </div>
         <div
           class="mx_VoiceBroadcastHeader_line"

--- a/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastRecordingBody-test.tsx.snap
+++ b/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastRecordingBody-test.tsx.snap
@@ -31,7 +31,9 @@ exports[`VoiceBroadcastRecordingBody when rendering a live broadcast should rend
             role="presentation"
             style="mask-image: url(\\"image-file-stub\\");"
           />
-          @user:example.com
+          <span>
+            @user:example.com
+          </span>
         </div>
       </div>
       <div

--- a/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastRecordingPip-test.tsx.snap
+++ b/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastRecordingPip-test.tsx.snap
@@ -31,7 +31,9 @@ exports[`VoiceBroadcastRecordingPip when rendering should create the expected re
             role="presentation"
             style="mask-image: url(\\"image-file-stub\\");"
           />
-          @user:example.com
+          <span>
+            @user:example.com
+          </span>
         </div>
       </div>
       <div


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

- Fix Live badge position
- Prevent room name / broadcaster name overflow

**Before**

![image](https://user-images.githubusercontent.com/6216686/196199269-cb7d543b-5d00-4776-932f-a32fe3009ba7.png)

**After**

![image](https://user-images.githubusercontent.com/6216686/196209309-7e4c5f9e-cee7-4d42-9b91-b8b2433e2d39.png)

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->