### PR TITLE
Listen for and update the notification state when they change

### DIFF
--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -51,10 +51,9 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     public destroy(): void {
         super.destroy();
         this.room.removeListener(RoomEvent.Receipt, this.handleReadReceipt);
-        this.room.removeListener(RoomEvent.Timeline, this.handleRoomEventUpdate);
-        this.room.removeListener(RoomEvent.Redaction, this.handleRoomEventUpdate);
         this.room.removeListener(RoomEvent.MyMembership, this.handleMembershipUpdate);
         this.room.removeListener(RoomEvent.LocalEchoUpdated, this.handleLocalEchoUpdated);
+        this.room.removeListener(RoomEvent.UnreadNotifications, this.handleNotificationCountUpdate);
         if (this.threadsState) {
             this.threadsState.removeListener(NotificationStateEvents.Update, this.handleThreadsUpdate);
         }
@@ -88,12 +87,6 @@ export class RoomNotificationState extends NotificationState implements IDestroy
 
     private onEventDecrypted = (event: MatrixEvent) => {
         if (event.getRoomId() !== this.room.roomId) return; // ignore - not for us or notifications timeline
-
-        this.updateNotificationState();
-    };
-
-    private handleRoomEventUpdate = (event: MatrixEvent, room: Room | null) => {
-        if (room?.roomId !== this.room.roomId) return; // ignore - not for us or notifications timeline
 
         this.updateNotificationState();
     };

--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -32,17 +32,15 @@ import { ThreadsRoomNotificationState } from "./ThreadsRoomNotificationState";
 export class RoomNotificationState extends NotificationState implements IDestroyable {
     constructor(public readonly room: Room, private readonly threadsState?: ThreadsRoomNotificationState) {
         super();
-        this.room.on(RoomEvent.Receipt, this.handleReadReceipt);
-        this.room.on(RoomEvent.Timeline, this.handleRoomEventUpdate);
-        this.room.on(RoomEvent.Redaction, this.handleRoomEventUpdate);
-        this.room.on(RoomEvent.MyMembership, this.handleMembershipUpdate);
-        this.room.on(RoomEvent.LocalEchoUpdated, this.handleLocalEchoUpdated);
-        this.room.on(RoomEvent.UnreadNotifications, this.handleNotificationCountUpdate);
+        this.room.on(RoomEvent.Receipt, this.handleReadReceipt); // for unread indicators
+        this.room.on(RoomEvent.MyMembership, this.handleMembershipUpdate); // for redness on invites
+        this.room.on(RoomEvent.LocalEchoUpdated, this.handleLocalEchoUpdated); // for redness on unsent messages
+        this.room.on(RoomEvent.UnreadNotifications, this.handleNotificationCountUpdate); // for server-sent counts
         if (threadsState) {
             threadsState.on(NotificationStateEvents.Update, this.handleThreadsUpdate);
         }
-        MatrixClientPeg.get().on(MatrixEventEvent.Decrypted, this.onEventDecrypted);
-        MatrixClientPeg.get().on(ClientEvent.AccountData, this.handleAccountDataUpdate);
+        MatrixClientPeg.get().on(MatrixEventEvent.Decrypted, this.onEventDecrypted); // for local count calculation
+        MatrixClientPeg.get().on(ClientEvent.AccountData, this.handleAccountDataUpdate); // for push rules
         this.updateNotificationState();
     }
 

--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -37,6 +37,7 @@ export class RoomNotificationState extends NotificationState implements IDestroy
         this.room.on(RoomEvent.Redaction, this.handleRoomEventUpdate);
         this.room.on(RoomEvent.MyMembership, this.handleMembershipUpdate);
         this.room.on(RoomEvent.LocalEchoUpdated, this.handleLocalEchoUpdated);
+        this.room.on(RoomEvent.UnreadNotifications, this.handleNotificationCountUpdate);
         if (threadsState) {
             threadsState.on(NotificationStateEvents.Update, this.handleThreadsUpdate);
         }
@@ -80,6 +81,10 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     };
 
     private handleMembershipUpdate = () => {
+        this.updateNotificationState();
+    };
+
+    private handleNotificationCountUpdate = () => {
         this.updateNotificationState();
     };
 


### PR DESCRIPTION
This is required for sliding sync because currently the proxy does not send read receipts, which would otherwise update the unread counts. Without this, when you read a room (setting the counter to 0) on a different device, it does not live update.

Notes: update the room unread notification counter when the server changes the value without any related read receipt

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * update the room unread notification counter when the server changes the value without any related read receipt ([\#9438](https://github.com/matrix-org/matrix-react-sdk/pull/9438)).<!-- CHANGELOG_PREVIEW_END -->