### PR TITLE
Don't show call banners in video rooms

### DIFF
--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -734,7 +734,7 @@ export default class RoomHeader extends React.Component<IProps, IState> {
                     { betaPill }
                     { buttons }
                 </div>
-                <RoomCallBanner roomId={this.props.room.roomId} />
+                { !isVideoRoom && <RoomCallBanner roomId={this.props.room.roomId} /> }
                 <RoomLiveShareWarning roomId={this.props.room.roomId} />
             </header>
         );


### PR DESCRIPTION
They're not meant to appear there, and also this could cause a soft crash in Jitsi video rooms.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't show call banners in video rooms ([\#9441](https://github.com/matrix-org/matrix-react-sdk/pull/9441)).<!-- CHANGELOG_PREVIEW_END -->