### PR TITLE
Don't wrap list elements in paragraph tags

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -67,6 +67,21 @@ function isMultiLine(node: commonmark.Node): boolean {
     return par.firstChild != par.lastChild;
 }
 
+/*
+ * Returns true if node is part of a list
+ * or false otherwise.
+ */
+function isNodeInList(node: commonmark.Node): boolean {
+    let par = node;
+    while (par.parent) {
+        if (par.type === "list") {
+            return true;
+        }
+        par = par.parent;
+    }
+    return false;
+}
+
 function getTextUntilEndOrLinebreak(node: commonmark.Node) {
     let currentNode = node;
     let text = '';
@@ -278,7 +293,9 @@ export default class Markdown {
             // However, if it's a blockquote, adds a p tag anyway
             // in order to avoid deviation to commonmark and unexpected
             // results when parsing the formatted HTML.
-            if (node.parent.type === 'block_quote'|| isMultiLine(node)) {
+            // If the node is part of a list, avoid wrapping each node element
+            // in a p tag.
+            if (node.parent.type === 'block_quote'|| (isMultiLine(node) && !isNodeInList(node))) {
                 realParagraph.call(this, node, entering);
             }
         };


### PR DESCRIPTION
Under certain circumstances (see issue linked below), the content of list elements are wrapped in paragraph tags, resulting in unintentional styling. This PR provides a workaround by not allowing nodes in a "list" to get wrapped in paragraph tags.

To be honest, I do not think this is a terribly good solution. But it is at least a solution that can hopefully prove at least as a starting point on how to resolve the accompanying issue. Or someone can maybe point out that this is the wrong part of the code and issue can be found elsewhere :)

Resolves: https://github.com/vector-im/element-web/issues/23507

Signed-off-by: Arne Wilken arnepokemon@yahoo.de

type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->