### PR TITLE
Backport:  Prevent starting another voice broadcast #9457 

### DIFF
--- a/src/voice-broadcast/utils/startNewVoiceBroadcastRecording.tsx
+++ b/src/voice-broadcast/utils/startNewVoiceBroadcastRecording.tsx
@@ -113,6 +113,11 @@ export const startNewVoiceBroadcastRecording = async (
     client: MatrixClient,
     recordingsStore: VoiceBroadcastRecordingsStore,
 ): Promise<VoiceBroadcastRecording | null> => {
+    if (recordingsStore.getCurrent()) {
+        showAlreadyRecordingDialog();
+        return null;
+    }
+
     const currentUserId = client.getUserId();
 
     if (!room.currentState.maySendStateEvent(VoiceBroadcastInfoEventType, currentUserId)) {

--- a/test/voice-broadcast/utils/__snapshots__/startNewVoiceBroadcastRecording-test.ts.snap
+++ b/test/voice-broadcast/utils/__snapshots__/startNewVoiceBroadcastRecording-test.ts.snap
@@ -23,7 +23,30 @@ exports[`startNewVoiceBroadcastRecording when the current user is allowed to sen
 }
 `;
 
-exports[`startNewVoiceBroadcastRecording when the current user is allowed to send voice broadcast info state events when there already is a live broadcast of the current user should show an info dialog 1`] = `
+exports[`startNewVoiceBroadcastRecording when the current user is allowed to send voice broadcast info state events when there already is a live broadcast of the current user in the room should show an info dialog 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      [Function],
+      Object {
+        "description": <p>
+          You are already recording a voice broadcast. Please end your current voice broadcast to start a new one.
+        </p>,
+        "hasCloseButton": true,
+        "title": "Can't start a new voice broadcast",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`startNewVoiceBroadcastRecording when the current user is allowed to send voice broadcast info state events when there is already a current voice broadcast should show an info dialog 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
@@ -67,6 +67,7 @@ describe("startNewVoiceBroadcastRecording", () => {
 
         recordingsStore = {
             setCurrent: jest.fn(),
+            getCurrent: jest.fn(),
         } as unknown as VoiceBroadcastRecordingsStore;
 
         infoEvent = mkVoiceBroadcastInfoStateEvent(roomId, VoiceBroadcastInfoState.Started, client.getUserId());
@@ -132,7 +133,25 @@ describe("startNewVoiceBroadcastRecording", () => {
             });
         });
 
-        describe("when there already is a live broadcast of the current user", () => {
+        describe("when there is already a current voice broadcast", () => {
+            beforeEach(async () => {
+                mocked(recordingsStore.getCurrent).mockReturnValue(
+                    new VoiceBroadcastRecording(infoEvent, client),
+                );
+
+                result = await startNewVoiceBroadcastRecording(room, client, recordingsStore);
+            });
+
+            it("should not start a voice broadcast", () => {
+                expect(result).toBeNull();
+            });
+
+            it("should show an info dialog", () => {
+                expect(Modal.createDialog).toMatchSnapshot();
+            });
+        });
+
+        describe("when there already is a live broadcast of the current user in the room", () => {
             beforeEach(async () => {
                 room.currentState.setStateEvents([
                     mkVoiceBroadcastInfoStateEvent(roomId, VoiceBroadcastInfoState.Running, client.getUserId()),


### PR DESCRIPTION
Backport of #9457 

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->