### PR TITLE
Fix slightly noisy warning when switching spaces

### DIFF
--- a/src/components/views/rooms/RoomListHeader.tsx
+++ b/src/components/views/rooms/RoomListHeader.tsx
@@ -379,7 +379,7 @@ const RoomListHeader = ({ onVisibilityChange }: IProps) => {
             isExpanded={mainMenuDisplayed}
             className="mx_RoomListHeader_contextMenuButton"
             title={activeSpace
-                ? _t("%(spaceName)s menu", { spaceName })
+                ? _t("%(spaceName)s menu", { spaceName: spaceName ?? activeSpace.name })
                 : _t("Home options")}
         >
             { title }


### PR DESCRIPTION
Sometimes `spaceName` can be `undefined` because of function timing - use a different method for getting the space's name when this happens.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->