### PR TITLE
Remove location buttons if no map server is configured

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -59,6 +59,7 @@ import {
     VoiceBroadcastRecordingsStore,
 } from '../../../voice-broadcast';
 import { WysiwygComposer } from './wysiwyg_composer/WysiwygComposer';
+import { findMapStyleUrl } from '../../../utils/location';
 
 let instanceCount = 0;
 
@@ -494,6 +495,15 @@ export default class MessageComposer extends React.Component<IProps, IState> {
 
         const showSendButton = !this.state.isComposerEmpty || this.state.haveRecording;
 
+        let isMapConfigured;
+        try {
+            findMapStyleUrl();
+            isMapConfigured = true;
+        } catch (e) {
+            isMapConfigured = false;
+        }
+        const showLocationButton = !window.electron && isMapConfigured;
+
         const classes = classNames({
             "mx_MessageComposer": true,
             "mx_MessageComposer--compact": this.props.compact,
@@ -524,7 +534,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                                 }
                             }}
                             setStickerPickerOpen={this.setStickerPickerOpen}
-                            showLocationButton={!window.electron}
+                            showLocationButton={showLocationButton}
                             showPollsButton={this.state.showPollsButton}
                             showStickersButton={this.showStickersButton}
                             toggleButtonMenu={this.toggleButtonMenu}

--- a/test/components/views/rooms/MessageComposer-test.tsx
+++ b/test/components/views/rooms/MessageComposer-test.tsx
@@ -40,6 +40,7 @@ import { E2EStatus } from "../../../../src/utils/ShieldUtils";
 import { addTextToComposer } from "../../../test-utils/composer";
 import UIStore, { UI_EVENTS } from "../../../../src/stores/UIStore";
 import { WysiwygComposer } from "../../../../src/components/views/rooms/wysiwyg_composer/WysiwygComposer";
+import SdkConfig from '../../../../src/SdkConfig';
 
 // The wysiwyg fetch wasm bytes and a specific workaround is needed to make it works in a node (jest) environnement
 // See https://github.com/matrix-org/matrix-wysiwyg/blob/main/platforms/web/test.setup.ts
@@ -171,6 +172,21 @@ describe("MessageComposer", () => {
                         });
                     });
                 });
+            });
+        });
+
+        describe("location button", () => {
+            it("should not be rendered when the map server is not configured", () => {
+                const wrapper = wrapAndRender({ room });
+                expect(wrapper.find(MessageComposerButtons).props().showLocationButton).toBe(false);
+            });
+
+            it("should be rendered when the map server is configured", () => {
+                SdkConfig.put({
+                    map_style_url: "hello",
+                });
+                const wrapper = wrapAndRender({ room });
+                expect(wrapper.find(MessageComposerButtons).props().showLocationButton).toBe(true);
             });
         });
 

--- a/test/components/views/rooms/MessageComposer-test.tsx
+++ b/test/components/views/rooms/MessageComposer-test.tsx
@@ -176,6 +176,10 @@ describe("MessageComposer", () => {
         });
 
         describe("location button", () => {
+            afterEach(function() {
+                SdkConfig.unset(); // we touch the config, so clean up
+            });
+
             it("should not be rendered when the map server is not configured", () => {
                 const wrapper = wrapAndRender({ room });
                 expect(wrapper.find(MessageComposerButtons).props().showLocationButton).toBe(false);
@@ -183,7 +187,7 @@ describe("MessageComposer", () => {
 
             it("should be rendered when the map server is configured", () => {
                 SdkConfig.put({
-                    map_style_url: "hello",
+                    map_style_url: "https://my-map-server.example.org",
                 });
                 const wrapper = wrapAndRender({ room });
                 expect(wrapper.find(MessageComposerButtons).props().showLocationButton).toBe(true);


### PR DESCRIPTION
Problem solved by this PR :
When no map-server is configured (either in wellknown or in SdkConfig), no location sharing is possible.
Expected : the "Location" button in MessageComposer is not displayed. 
Obtained : the button is present, I go through the next clicks, and eventually get an error message that no map server is configured.

This PR removes the "Location" button in MessageComposer when map server is not configured.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
Signed-off-by: Estelle Comment <estelle.comment@beta.gouv.fr>

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove location buttons if no map server is configured ([\#9481](https://github.com/matrix-org/matrix-react-sdk/pull/9481)). Contributed by @estellecomment.<!-- CHANGELOG_PREVIEW_END -->