### PR TITLE
Use flex-start instead of start in several places

### DIFF
--- a/res/css/views/dialogs/_SpotlightDialog.pcss
+++ b/res/css/views/dialogs/_SpotlightDialog.pcss
@@ -247,7 +247,7 @@ limitations under the License.
                 }
 
                 &.mx_SpotlightDialog_result_multiline {
-                    align-items: start;
+                    align-items: flex-start;
 
                     .mx_AccessibleButton {
                         padding: $spacing-4 $spacing-20;

--- a/res/css/views/elements/_UseCaseSelection.pcss
+++ b/res/css/views/elements/_UseCaseSelection.pcss
@@ -65,7 +65,7 @@ limitations under the License.
     .mx_UseCaseSelection_skip {
         display: flex;
         flex-direction: column;
-        align-self: start;
+        align-self: flex-start;
     }
 }
 

--- a/res/css/views/rooms/wysiwyg_composer/components/_FormattingButtons.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_FormattingButtons.pcss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_FormattingButtons {
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
 
     .mx_FormattingButtons_Button {
         --size: 28px;


### PR DESCRIPTION
To keep webpack quiet about it, since apparently it has "mixed browser support".

Fixes https://github.com/vector-im/element-web/issues/23595


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->