### PR TITLE
Replace voice broadcast running state with resumed

### DIFF
--- a/src/voice-broadcast/hooks/useVoiceBroadcastRecording.tsx
+++ b/src/voice-broadcast/hooks/useVoiceBroadcastRecording.tsx
@@ -68,7 +68,7 @@ export const useVoiceBroadcastRecording = (recording: VoiceBroadcastRecording) =
     const live = [
         VoiceBroadcastInfoState.Started,
         VoiceBroadcastInfoState.Paused,
-        VoiceBroadcastInfoState.Running,
+        VoiceBroadcastInfoState.Resumed,
     ].includes(recordingState);
 
     return {

--- a/src/voice-broadcast/index.ts
+++ b/src/voice-broadcast/index.ts
@@ -49,7 +49,7 @@ export const VoiceBroadcastChunkEventType = "io.element.voice_broadcast_chunk";
 export enum VoiceBroadcastInfoState {
     Started = "started",
     Paused = "paused",
-    Running = "running",
+    Resumed = "resumed",
     Stopped = "stopped",
 }
 

--- a/src/voice-broadcast/models/VoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastRecording.ts
@@ -105,15 +105,15 @@ export class VoiceBroadcastRecording
     public async resume(): Promise<void> {
         if (this.state !== VoiceBroadcastInfoState.Paused) return;
 
-        this.setState(VoiceBroadcastInfoState.Running);
+        this.setState(VoiceBroadcastInfoState.Resumed);
         await this.getRecorder().start();
-        await this.sendInfoStateEvent(VoiceBroadcastInfoState.Running);
+        await this.sendInfoStateEvent(VoiceBroadcastInfoState.Resumed);
     }
 
     public toggle = async (): Promise<void> => {
         if (this.getState() === VoiceBroadcastInfoState.Paused) return this.resume();
 
-        if ([VoiceBroadcastInfoState.Started, VoiceBroadcastInfoState.Running].includes(this.getState())) {
+        if ([VoiceBroadcastInfoState.Started, VoiceBroadcastInfoState.Resumed].includes(this.getState())) {
             return this.pause();
         }
     };

--- a/test/voice-broadcast/components/molecules/VoiceBroadcastRecordingBody-test.tsx
+++ b/test/voice-broadcast/components/molecules/VoiceBroadcastRecordingBody-test.tsx
@@ -50,7 +50,7 @@ describe("VoiceBroadcastRecordingBody", () => {
             room: roomId,
             user: userId,
         });
-        recording = new VoiceBroadcastRecording(infoEvent, client, VoiceBroadcastInfoState.Running);
+        recording = new VoiceBroadcastRecording(infoEvent, client, VoiceBroadcastInfoState.Resumed);
     });
 
     describe("when rendering a live broadcast", () => {

--- a/test/voice-broadcast/components/molecules/VoiceBroadcastRecordingPip-test.tsx
+++ b/test/voice-broadcast/components/molecules/VoiceBroadcastRecordingPip-test.tsx
@@ -118,7 +118,7 @@ describe("VoiceBroadcastRecordingPip", () => {
             });
 
             it("should resume the recording", () => {
-                expect(recording.getState()).toBe(VoiceBroadcastInfoState.Running);
+                expect(recording.getState()).toBe(VoiceBroadcastInfoState.Resumed);
             });
         });
     });

--- a/test/voice-broadcast/models/VoiceBroadcastPlayback-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastPlayback-test.ts
@@ -190,9 +190,9 @@ describe("VoiceBroadcastPlayback", () => {
         onStateChanged = jest.fn();
     });
 
-    describe("when there is a running broadcast without chunks yet", () => {
+    describe(`when there is a ${VoiceBroadcastInfoState.Resumed} broadcast without chunks yet`, () => {
         beforeEach(() => {
-            infoEvent = mkInfoEvent(VoiceBroadcastInfoState.Running);
+            infoEvent = mkInfoEvent(VoiceBroadcastInfoState.Resumed);
             playback = mkPlayback();
             setUpChunkEvents([]);
         });
@@ -236,9 +236,9 @@ describe("VoiceBroadcastPlayback", () => {
         });
     });
 
-    describe("when there is a running voice broadcast with some chunks", () => {
+    describe(`when there is a ${VoiceBroadcastInfoState.Resumed} voice broadcast with some chunks`, () => {
         beforeEach(() => {
-            infoEvent = mkInfoEvent(VoiceBroadcastInfoState.Running);
+            infoEvent = mkInfoEvent(VoiceBroadcastInfoState.Resumed);
             playback = mkPlayback();
             setUpChunkEvents([chunk2Event, chunk0Event, chunk1Event]);
         });

--- a/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
@@ -423,15 +423,15 @@ describe("VoiceBroadcastRecording", () => {
                     await action();
                 });
 
-                itShouldBeInState(VoiceBroadcastInfoState.Running);
-                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Running);
+                itShouldBeInState(VoiceBroadcastInfoState.Resumed);
+                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Resumed);
 
                 it("should start the recorder", () => {
                     expect(mocked(voiceBroadcastRecorder.start)).toHaveBeenCalled();
                 });
 
-                it("should emit a running state changed event", () => {
-                    expect(onStateChanged).toHaveBeenCalledWith(VoiceBroadcastInfoState.Running);
+                it(`should emit a ${VoiceBroadcastInfoState.Resumed} state changed event`, () => {
+                    expect(onStateChanged).toHaveBeenCalledWith(VoiceBroadcastInfoState.Resumed);
                 });
             });
         });

--- a/test/voice-broadcast/utils/hasRoomLiveVoiceBroadcast-test.ts
+++ b/test/voice-broadcast/utils/hasRoomLiveVoiceBroadcast-test.ts
@@ -121,7 +121,7 @@ describe("hasRoomLiveVoiceBroadcast", () => {
         // all there are kind of live states
         VoiceBroadcastInfoState.Started,
         VoiceBroadcastInfoState.Paused,
-        VoiceBroadcastInfoState.Running,
+        VoiceBroadcastInfoState.Resumed,
     ])("when there is a live broadcast (%s) from the current user", (state: VoiceBroadcastInfoState) => {
         beforeEach(() => {
             addVoiceBroadcastInfoEvent(state, client.getUserId());
@@ -132,7 +132,7 @@ describe("hasRoomLiveVoiceBroadcast", () => {
 
     describe("when there was a live broadcast, that has been stopped", () => {
         beforeEach(() => {
-            addVoiceBroadcastInfoEvent(VoiceBroadcastInfoState.Running, client.getUserId());
+            addVoiceBroadcastInfoEvent(VoiceBroadcastInfoState.Resumed, client.getUserId());
             addVoiceBroadcastInfoEvent(VoiceBroadcastInfoState.Stopped, client.getUserId());
         });
 
@@ -141,7 +141,7 @@ describe("hasRoomLiveVoiceBroadcast", () => {
 
     describe("when there is a live broadcast from another user", () => {
         beforeEach(() => {
-            addVoiceBroadcastInfoEvent(VoiceBroadcastInfoState.Running, otherUserId);
+            addVoiceBroadcastInfoEvent(VoiceBroadcastInfoState.Resumed, otherUserId);
         });
 
         itShouldReturnTrueFalse();

--- a/test/voice-broadcast/utils/shouldDisplayAsVoiceBroadcastRecordingTile-test.ts
+++ b/test/voice-broadcast/utils/shouldDisplayAsVoiceBroadcastRecordingTile-test.ts
@@ -40,7 +40,7 @@ const testCases = [
     [
         "@user1:example.com",
         "@user1:example.com",
-        VoiceBroadcastInfoState.Running,
+        VoiceBroadcastInfoState.Resumed,
         true,
     ],
     [

--- a/test/voice-broadcast/utils/shouldDisplayAsVoiceBroadcastTile-test.ts
+++ b/test/voice-broadcast/utils/shouldDisplayAsVoiceBroadcastTile-test.ts
@@ -128,7 +128,7 @@ describe("shouldDisplayAsVoiceBroadcastTile", () => {
     describe.each(
         [
             VoiceBroadcastInfoState.Paused,
-            VoiceBroadcastInfoState.Running,
+            VoiceBroadcastInfoState.Resumed,
             VoiceBroadcastInfoState.Stopped,
         ],
     )("when a voice broadcast info event in state %s occurs", (state: VoiceBroadcastInfoState) => {

--- a/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
@@ -161,7 +161,7 @@ describe("startNewVoiceBroadcastRecording", () => {
                 room.currentState.setStateEvents([
                     mkVoiceBroadcastInfoStateEvent(
                         roomId,
-                        VoiceBroadcastInfoState.Running,
+                        VoiceBroadcastInfoState.Resumed,
                         client.getUserId(),
                         client.getDeviceId(),
                     ),
@@ -184,7 +184,7 @@ describe("startNewVoiceBroadcastRecording", () => {
                 room.currentState.setStateEvents([
                     mkVoiceBroadcastInfoStateEvent(
                         roomId,
-                        VoiceBroadcastInfoState.Running,
+                        VoiceBroadcastInfoState.Resumed,
                         otherUserId,
                         "ASD123",
                     ),


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

Adapt the resumed state event according to [the „spec“](https://github.com/vector-im/element-meta/discussions/632)

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))