### PR TITLE
Fix getReadReceiptsForEvent for unknown threads

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -835,6 +835,13 @@ export default class MessagePanel extends React.Component<IProps, IState> {
             : room;
 
         const receipts: IReadReceiptProps[] = [];
+
+        if (!receiptDestination) {
+            logger.debug("Discarding request, could not find the receiptDestination for event: "
+                + this.context.threadId);
+            return receipts;
+        }
+
         receiptDestination.getReceiptsForEvent(event).forEach((r) => {
             if (
                 !r.userId ||


### PR DESCRIPTION
This addresses a potential null pointer with this function that is thrown when a thread is unknown to the system.

I do not plan to write tests for this due to the extensive refactor required to test this in isolation and the small benefit it would get.

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->