### PR TITLE
Make thread replies trigger a room list re-ordering

### DIFF
--- a/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
+++ b/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
@@ -73,7 +73,7 @@ export const sortRooms = (rooms: Room[]): Room[] => {
 };
 
 const getLastTs = (r: Room, userId: string) => {
-    const ts = (() => {
+    const mainTimelineLastTs = (() => {
         // Apparently we can have rooms without timelines, at least under testing
         // environments. Just return MAX_INT when this happens.
         if (!r?.timeline) {
@@ -108,7 +108,13 @@ const getLastTs = (r: Room, userId: string) => {
         // This is better than just assuming the last event was forever ago.
         return r.timeline[0]?.getTs() ?? Number.MAX_SAFE_INTEGER;
     })();
-    return ts;
+
+    const threadLastEventTimestamps = r.getThreads().map(thread => {
+        const event = thread.replyToEvent ?? thread.rootEvent;
+        return event?.getTs() ?? 0;
+    });
+
+    return Math.max(mainTimelineLastTs, ...threadLastEventTimestamps);
 };
 
 /**

--- a/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
+++ b/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
@@ -111,7 +111,7 @@ const getLastTs = (r: Room, userId: string) => {
 
     const threadLastEventTimestamps = r.getThreads().map(thread => {
         const event = thread.replyToEvent ?? thread.rootEvent;
-        return event?.getTs() ?? 0;
+        return event!.getTs();
     });
 
     return Math.max(mainTimelineLastTs, ...threadLastEventTimestamps);

--- a/test/stores/room-list/algorithms/RecentAlgorithm-test.ts
+++ b/test/stores/room-list/algorithms/RecentAlgorithm-test.ts
@@ -174,7 +174,7 @@ describe("RecentAlgorithm", () => {
                 // replies are 1ms after each other
                 ts: 50,
             });
-            room2.addLiveEvents([threadReply]);
+            room1.addLiveEvents([threadReply]);
 
             expect(algorithm.sortRooms([room1, room2])).toEqual([room1, room2]);
         });

--- a/test/stores/room-list/algorithms/RecentAlgorithm-test.ts
+++ b/test/stores/room-list/algorithms/RecentAlgorithm-test.ts
@@ -21,6 +21,7 @@ import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import "../../../../src/stores/room-list/RoomListStore";
 import { RecentAlgorithm } from "../../../../src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
 import { EffectiveMembership } from "../../../../src/utils/membership";
+import { makeThreadEvent, mkThread } from "../../../test-utils/threads";
 
 describe("RecentAlgorithm", () => {
     let algorithm;
@@ -122,6 +123,60 @@ describe("RecentAlgorithm", () => {
             room1.addLiveEvents([evt]);
 
             expect(algorithm.sortRooms([room2, room1])).toEqual([room2, room1]);
+
+            const { events } = mkThread({
+                room: room1,
+                client: cli,
+                authorId: "@bob:matrix.org",
+                participantUserIds: ["@bob:matrix.org"],
+                ts: 12,
+            });
+
+            room1.addLiveEvents(events);
+        });
+
+        it("orders rooms based on thread replies too", () => {
+            const room1 = new Room("room1", cli, "@bob:matrix.org");
+            const room2 = new Room("room2", cli, "@bob:matrix.org");
+
+            room1.getMyMembership = () => "join";
+            room2.getMyMembership = () => "join";
+
+            const { rootEvent, events: events1 } = mkThread({
+                room: room1,
+                client: cli,
+                authorId: "@bob:matrix.org",
+                participantUserIds: ["@bob:matrix.org"],
+                ts: 12,
+                length: 5,
+            });
+            room1.addLiveEvents(events1);
+
+            const { events: events2 } = mkThread({
+                room: room2,
+                client: cli,
+                authorId: "@bob:matrix.org",
+                participantUserIds: ["@bob:matrix.org"],
+                ts: 14,
+                length: 10,
+            });
+            room2.addLiveEvents(events2);
+
+            expect(algorithm.sortRooms([room1, room2])).toEqual([room2, room1]);
+
+            const threadReply = makeThreadEvent({
+                user: "@bob:matrix.org",
+                room: room1.roomId,
+                event: true,
+                msg: `hello world`,
+                rootEventId: rootEvent.getId(),
+                replyToEventId: rootEvent.getId(),
+                // replies are 1ms after each other
+                ts: 50,
+            });
+            room2.addLiveEvents([threadReply]);
+
+            expect(algorithm.sortRooms([room1, room2])).toEqual([room1, room2]);
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21700

Now thread messages will cause a room list to be bumped to the top of the sublist when the `RecentAlgorithm` is used.

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make thread replies trigger a room list re-ordering ([\#9510](https://github.com/matrix-org/matrix-react-sdk/pull/9510)). Fixes vector-im/element-web#21700.<!-- CHANGELOG_PREVIEW_END -->