### PR TITLE
Improve fetch mock setup

### DIFF
--- a/test/setup/setupLanguage.ts
+++ b/test/setup/setupLanguage.ts
@@ -20,10 +20,6 @@ import * as languageHandler from "../../src/languageHandler";
 import en from "../../src/i18n/strings/en_EN.json";
 import de from "../../src/i18n/strings/de_DE.json";
 
-fetchMock.config.overwriteRoutes = false;
-fetchMock.catch("");
-window.fetch = fetchMock.sandbox();
-
 const lv = {
     "Save": "Saglabāt",
     "Uploading %(filename)s and %(count)s others|one": "Качване на %(filename)s и %(count)s друг",

--- a/test/setup/setupManualMocks.ts
+++ b/test/setup/setupManualMocks.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import fetchMock from "fetch-mock-jest";
 import { TextDecoder, TextEncoder } from "util";
 
 // jest 27 removes setImmediate from jsdom
@@ -54,3 +55,9 @@ global.TextDecoder = TextDecoder;
 
 // prevent errors whenever a component tries to manually scroll.
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+// set up fetch API mock
+fetchMock.config.overwriteRoutes = false;
+fetchMock.catch("");
+fetchMock.get("/image-file-stub", "image file stub");
+window.fetch = fetchMock.sandbox();


### PR DESCRIPTION
- Move from language to mock setup file
- Add mock rule for stub image requests

→ get rid of all the 

```
  console.warn
    Unmatched GET to /image-file-stub

      36 |     if (DOWNLOAD_ICON_URL) return; // cached already
      37 |     // eslint-disable-next-line @typescript-eslint/no-var-requires
    > 38 |     const svg = await fetch(require('../../../../res/img/download.svg').default).then(r => r.text());
         |                       ^
      39 |     DOWNLOAD_ICON_URL = "data:image/svg+xml;base64," + window.btoa(svg);
      40 | }
      41 |

      at Object.<anonymous>.FetchMock.executeRouter (node_modules/fetch-mock/cjs/lib/fetch-handler.js:221:11)
      at Object.<anonymous>.FetchMock._fetchHandler (node_modules/fetch-mock/cjs/lib/fetch-handler.js:144:34)
      at Object.<anonymous>.FetchMock.fetchHandler (node_modules/fetch-mock/cjs/lib/fetch-handler.js:135:14)
      at fetch (node_modules/fetch-mock-jest/jestify.js:27:18)
      at cacheDownloadIcon (src/components/views/messages/MFileBody.tsx:38:23)
      at Object.<anonymous> (src/components/views/messages/MFileBody.tsx:44:1)

```

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->