### PR TITLE
Implement voice broadcast `last_chunk_sequence`

### DIFF
--- a/src/voice-broadcast/index.ts
+++ b/src/voice-broadcast/index.ts
@@ -56,6 +56,7 @@ export interface VoiceBroadcastInfoEventContent {
     device_id: string;
     state: VoiceBroadcastInfoState;
     chunk_length?: number;
+    last_chunk_sequence?: number;
     ["m.relates_to"]?: {
         rel_type: RelationType;
         event_id: string;

--- a/src/voice-broadcast/models/VoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastRecording.ts
@@ -21,6 +21,7 @@ import { TypedEventEmitter } from "matrix-js-sdk/src/models/typed-event-emitter"
 import {
     ChunkRecordedPayload,
     createVoiceBroadcastRecorder,
+    VoiceBroadcastInfoEventContent,
     VoiceBroadcastInfoEventType,
     VoiceBroadcastInfoState,
     VoiceBroadcastRecorder,
@@ -207,11 +208,12 @@ export class VoiceBroadcastRecording
             {
                 device_id: this.client.getDeviceId(),
                 state,
+                last_chunk_sequence: this.sequence,
                 ["m.relates_to"]: {
                     rel_type: RelationType.Reference,
                     event_id: this.infoEvent.getId(),
                 },
-            },
+            } as VoiceBroadcastInfoEventContent,
             this.client.getUserId(),
         );
     }

--- a/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
@@ -92,20 +92,20 @@ describe("VoiceBroadcastRecording", () => {
         });
     };
 
-    const itShouldSendAnInfoEvent = (state: VoiceBroadcastInfoState) => {
+    const itShouldSendAnInfoEvent = (state: VoiceBroadcastInfoState, lastChunkSequence: number) => {
         it(`should send a ${state} info event`, () => {
             expect(client.sendStateEvent).toHaveBeenCalledWith(
                 roomId,
                 VoiceBroadcastInfoEventType,
                 {
-
                     device_id: client.getDeviceId(),
                     state,
+                    last_chunk_sequence: lastChunkSequence,
                     ["m.relates_to"]: {
                         rel_type: RelationType.Reference,
                         event_id: infoEvent.getId(),
                     },
-                },
+                } as VoiceBroadcastInfoEventContent,
                 client.getUserId(),
             );
         });
@@ -203,22 +203,7 @@ describe("VoiceBroadcastRecording", () => {
                 voiceBroadcastRecording.stop();
             });
 
-            it("should send a stopped Voice Broadcast Info event", () => {
-                expect(mocked(client.sendStateEvent)).toHaveBeenCalledWith(
-                    roomId,
-                    VoiceBroadcastInfoEventType,
-                    {
-                        device_id: client.getDeviceId(),
-                        state: VoiceBroadcastInfoState.Stopped,
-                        ["m.relates_to"]: {
-                            rel_type: RelationType.Reference,
-                            event_id: infoEvent.getId(),
-                        },
-                    },
-                    client.getUserId(),
-                );
-            });
-
+            itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Stopped, 1);
             itShouldBeInState(VoiceBroadcastInfoState.Stopped);
 
             it("should emit a stopped state changed event", () => {
@@ -383,7 +368,7 @@ describe("VoiceBroadcastRecording", () => {
                 });
 
                 itShouldBeInState(VoiceBroadcastInfoState.Paused);
-                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Paused);
+                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Paused, 1);
 
                 it("should stop the recorder", () => {
                     expect(mocked(voiceBroadcastRecorder.stop)).toHaveBeenCalled();
@@ -424,7 +409,7 @@ describe("VoiceBroadcastRecording", () => {
                 });
 
                 itShouldBeInState(VoiceBroadcastInfoState.Resumed);
-                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Resumed);
+                itShouldSendAnInfoEvent(VoiceBroadcastInfoState.Resumed, 1);
 
                 it("should start the recorder", () => {
                     expect(mocked(voiceBroadcastRecorder.start)).toHaveBeenCalled();


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

Add `last_chunk_sequence` according to https://github.com/vector-im/element-meta/discussions/632

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->