### PR TITLE
Fix NotificationBadge unsent color

### DIFF
--- a/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
@@ -51,7 +51,7 @@ export function StatelessNotificationBadge({
     const classes = classNames({
         'mx_NotificationBadge': true,
         'mx_NotificationBadge_visible': isEmptyBadge ? true : hasUnreadCount,
-        'mx_NotificationBadge_highlighted': color === NotificationColor.Red,
+        'mx_NotificationBadge_highlighted': color >= NotificationColor.Red,
         'mx_NotificationBadge_dot': isEmptyBadge,
         'mx_NotificationBadge_2char': symbol?.length > 0 && symbol?.length < 3,
         'mx_NotificationBadge_3char': symbol?.length > 2,

--- a/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
+++ b/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { render } from "@testing-library/react";
+
+import {
+    StatelessNotificationBadge,
+} from "../../../../../src/components/views/rooms/NotificationBadge/StatelessNotificationBadge";
+import { NotificationColor } from "../../../../../src/stores/notifications/NotificationColor";
+
+describe("StatelessNotificationBadge", () => {
+    it("is highlighted when unsent", () => {
+        const { container } = render(
+            <StatelessNotificationBadge
+                symbol="!"
+                count={0}
+                color={NotificationColor.Unsent}
+            />,
+        );
+        expect(
+            container.querySelector("mx_NotificationBadge_highlighted"),
+        ).not.toBe(null);
+    });
+});

--- a/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
+++ b/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
@@ -32,7 +32,7 @@ describe("StatelessNotificationBadge", () => {
             />,
         );
         expect(
-            container.querySelector("mx_NotificationBadge_highlighted"),
+            container.querySelector(".mx_NotificationBadge_highlighted"),
         ).not.toBe(null);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23646

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix NotificationBadge unsent color ([\#9522](https://github.com/matrix-org/matrix-react-sdk/pull/9522)). Fixes vector-im/element-web#23646.<!-- CHANGELOG_PREVIEW_END -->