### PR TITLE
Fix: Move "Leave Space" option to the bottom of space context menu

### DIFF
--- a/src/components/views/context_menus/SpaceContextMenu.tsx
+++ b/src/components/views/context_menus/SpaceContextMenu.tsx
@@ -261,9 +261,9 @@ const SpaceContextMenu = ({ space, hideHeader, onFinished, ...props }: IProps) =
                 label={_t("Preferences")}
                 onClick={onPreferencesClick}
             />
+            { devtoolsOption }
             { settingsOption }
             { leaveOption }
-            { devtoolsOption }
             { newRoomSection }
         </IconizedContextMenuOptionList>
     </IconizedContextMenu>;


### PR DESCRIPTION
Fixes an opened issue in element-web here: https://github.com/vector-im/element-web/issues/23627 

Note: fix move "leave space" to the bottom of space context menu.

Before: 
<img width="323" alt="Screenshot 2022-11-02 at 10 38 41 PM" src="https://user-images.githubusercontent.com/19797958/199609164-373e20ae-c8c8-4e3a-a048-fba8b6a11621.png">

After:
<img width="323" alt="Screenshot 2022-11-02 at 10 39 00 PM" src="https://user-images.githubusercontent.com/19797958/199609256-50d0f09a-6d4d-4e1f-94ab-7df68760aec7.png">

Before the fix, this order applies:
-> settings
-> leave space
-> dev tools

After the fix, this order applies:
-> devtools
-> settings
-> leave space

type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Fix: Move "Leave Space" option to the bottom of space context menu ([\#9535](https://github.com/matrix-org/matrix-react-sdk/pull/9535)). Contributed by @hanadi92.<!-- CHANGELOG_PREVIEW_END -->