### PR TITLE
Enable tsc --strict CI to prevent gaining more errors

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -37,6 +37,41 @@ jobs:
       - name: Typecheck (release mode)
         run: "yarn run lint:types"
 
+  tsc-strict:
+    name: Typescript Strict Error Checker
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get diff lines
+        id: diff
+        uses: Equip-Collaboration/diff-line-numbers@v1.0.0
+        with:
+          include: '["\\.tsx?$"]'
+
+      - name: Detecting files changed
+        id: files
+        uses: futuratrepadeira/changed-files@v4.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: '^.*\.tsx?$'
+
+      - uses: t3chguy/typescript-check-action@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          use-check: false
+          check-fail-mode: added
+          output-behaviour: annotate
+          ts-extra-args: '--strict'
+          files-changed: ${{ steps.files.outputs.files_updated }}
+          files-added: ${{ steps.files.outputs.files_created }}
+          files-deleted: ${{ steps.files.outputs.files_deleted }}
+          line-numbers: ${{ steps.diff.outputs.lineNumbers }}
+
   i18n_lint:
     name: "i18n Check"
     uses: matrix-org/matrix-react-sdk/.github/workflows/i18n_check.yml@develop


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->