### PR TITLE
Fix: inline links selecting radio button

### DIFF
--- a/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
@@ -19,7 +19,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 
 import { _t } from "../../../../../languageHandler";
 import { MatrixClientPeg } from "../../../../../MatrixClientPeg";
-import AccessibleButton from "../../../elements/AccessibleButton";
+import AccessibleButton, { ButtonEvent } from "../../../elements/AccessibleButton";
 import Notifier from "../../../../../Notifier";
 import SettingsStore from '../../../../../settings/SettingsStore';
 import { SettingLevel } from "../../../../../settings/SettingLevel";
@@ -163,7 +163,9 @@ export default class NotificationsSettingsTab extends React.Component<IProps, IS
         this.forceUpdate();
     };
 
-    private onOpenSettingsClick = () => {
+    private onOpenSettingsClick = (event: ButtonEvent) => {
+        // avoid selecting the radio button
+        event.preventDefault();
         this.props.closeSettingsFn();
         defaultDispatcher.dispatch({
             action: Action.ViewUserSettings,

--- a/test/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
+import { MatrixClient } from "matrix-js-sdk/src/client";
+
+import NotificationSettingsTab from "../../../../../../src/components/views/settings/tabs/room/NotificationSettingsTab";
+import { mkStubRoom, stubClient } from "../../../../../test-utils";
+import { MatrixClientPeg } from "../../../../../../src/MatrixClientPeg";
+
+describe("NotificatinSettingsTab", () => {
+    const roomId = "!room:example.com";
+    let cli: MatrixClient;
+
+    const renderTab = (): RenderResult => {
+        return render(<NotificationSettingsTab roomId={roomId} closeSettingsFn={() => { }} />);
+    };
+
+    const getElementOfSelector = (tab: RenderResult, selector: string) => {
+        return tab.container.querySelector(selector);
+    };
+
+    beforeEach(() => {
+        stubClient();
+        cli = MatrixClientPeg.get();
+        mkStubRoom(roomId, "test room", cli);
+
+        NotificationSettingsTab.contextType = React.createContext(cli);
+    });
+
+    it("should prevent »Settings« link click from bubbling up to radio buttons", async () => {
+        const tab = renderTab();
+        const event = new MouseEvent("click", { bubbles: true });
+        Object.assign(event, { preventDefault: jest.fn() });
+
+        fireEvent(getElementOfSelector(tab, "div.mx_AccessibleButton"), event);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
@@ -30,10 +30,6 @@ describe("NotificatinSettingsTab", () => {
         return render(<NotificationSettingsTab roomId={roomId} closeSettingsFn={() => { }} />);
     };
 
-    const getElementOfSelector = (tab: RenderResult, selector: string) => {
-        return tab.container.querySelector(selector);
-    };
-
     beforeEach(() => {
         stubClient();
         cli = MatrixClientPeg.get();
@@ -42,12 +38,15 @@ describe("NotificatinSettingsTab", () => {
         NotificationSettingsTab.contextType = React.createContext(cli);
     });
 
-    it("should prevent »Settings« link click from bubbling up to radio buttons", async () => {
+    it("should prevent »Settings« link click from bubbling up to radio buttons", () => {
         const tab = renderTab();
         const event = new MouseEvent("click", { bubbles: true });
         Object.assign(event, { preventDefault: jest.fn() });
 
-        fireEvent(getElementOfSelector(tab, "div.mx_AccessibleButton"), event);
+        const settingsLink = tab.container.querySelector("div.mx_AccessibleButton");
+        if (!settingsLink) throw new Error("settings link does not exist.");
+
+        fireEvent(settingsLink, event);
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Fixes this: https://github.com/vector-im/element-web/issues/23391

![](https://user-images.githubusercontent.com/10872136/193464965-9f909981-1686-4376-b82a-58ebf4269df1.png)

Before:
Clicking on "settings" inline link in the radio button shows the settings and **selects the parent radio button**.

After:
Clicking on "settings" inline link in the radio button shows the settings and **does not** select the parent radio button.

Type: Defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: inline links selecting radio button ([\#9543](https://github.com/matrix-org/matrix-react-sdk/pull/9543)). Contributed by @hanadi92.<!-- CHANGELOG_PREVIEW_END -->