### PR TITLE
Fix notif panel exception around accessing roomId of undefined

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -798,7 +798,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
         if (this.unmounted) return;
 
         // ignore events for other rooms
-        if (replacedEvent.getRoomId() !== this.props.timelineSet.room.roomId) return;
+        if (replacedEvent.getRoomId() !== this.props.timelineSet.room?.roomId) return;
 
         // we could skip an update if the event isn't in our timeline,
         // but that's probably an early optimisation.


### PR DESCRIPTION
Didn't have any user facing effects other than a logged error, room is optional, notif panel timeline mixes room doesn't have one

![image](https://user-images.githubusercontent.com/2403652/200025710-e1b45795-21e3-4c37-b026-0dbb56c06113.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->