### PR TITLE
Fix TimelineReset handling when no room associated

### DIFF
--- a/src/indexing/EventIndex.ts
+++ b/src/indexing/EventIndex.ts
@@ -241,9 +241,7 @@ export default class EventIndex extends EventEmitter {
      * Listens for timeline resets that are caused by a limited timeline to
      * re-add checkpoints for rooms that need to be crawled again.
      */
-    private onTimelineReset = async (
-        room: Room | undefined | null,
-    ) => {
+    private onTimelineReset = async (room: Room | undefined) => {
         if (!room) return;
         if (!MatrixClientPeg.get().isRoomEncrypted(room.roomId)) return;
 

--- a/src/indexing/EventIndex.ts
+++ b/src/indexing/EventIndex.ts
@@ -241,8 +241,10 @@ export default class EventIndex extends EventEmitter {
      * Listens for timeline resets that are caused by a limited timeline to
      * re-add checkpoints for rooms that need to be crawled again.
      */
-    private onTimelineReset = async (room: Room, timelineSet: EventTimelineSet, resetAllTimelines: boolean) => {
-        if (room === null) return;
+    private onTimelineReset = async (
+        room: Room | undefined | null,
+    ) => {
+        if (!room) return;
         if (!MatrixClientPeg.get().isRoomEncrypted(room.roomId)) return;
 
         logger.log("EventIndex: Adding a checkpoint because of a limited timeline",


### PR DESCRIPTION
`room` can be `undefined`, and the implementation does not take that into account https://github.com/matrix-org/matrix-js-sdk/blob/a20d6630032215751d9c329c8ae838931c2d8e85/src/models/event-timeline-set.ts#L86

That would have been caught by the strict mode in TypeScript

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix TimelineReset handling when no room associated ([\#9553](https://github.com/matrix-org/matrix-react-sdk/pull/9553)).<!-- CHANGELOG_PREVIEW_END -->