### PR TITLE
Do not filter users post search

### DIFF
--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -408,7 +408,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                         !entry.query?.some(q => q.includes(lcQuery))
                     ) return; // bail, does not match query
                 } else if (isMemberResult(entry)) {
-                    if (!entry.query?.some(q => q.includes(lcQuery))) return; // bail, does not match query
+                    // Do not filter users
                 } else if (isPublicRoomResult(entry)) {
                     if (!entry.query?.some(q => q.includes(lcQuery))) return; // bail, does not match query
                 } else {


### PR DESCRIPTION
Signed-off-by: Maximilian Malek <maximilian.malek@uni-graz.at>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Make sure users returned by the homeserver search API are displayed. Don't silently drop any.

Currently, Element only displays search results that contain the search term as substring, which is IMHO an anti-feature. This one-line change removes the filter for the people search and displays all results sent by the homeserver.

Pros:
- Makes fuzzy search, regex search, etc possible (if handled by the server)
- Actually displays what was returned by the API; does not silently drop legitimate search results
- More control for homeservers

Cons:
- Malicious homeservers may send garbage that is then actually shown

Ideally those other substring filters nearby should be removed entirely, but the user search is the biggest problem on my end right now so I've kept this PR to the minimum.

Background: I'm [working](https://github.com/maxmalek/ugreg/tree/master/src/maiden) on an identity server & search provider similar to [ma1sd](https://github.com/ma1uta/ma1sd) that bypasses the `_matrix/client/r0/user_directory/search` endpoint via reverse proxy.
This means I'm able to inject users into the search that are not returned by synapse.
We've been using ma1sd's LDAP-based search extensively, but I ended up writing my own since ma1sd is too slow. Added fuzzy search, then realized element silently drops results it doesn't like.
