### PR TITLE
Add way to create a user notice via config.json

### DIFF
--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -183,6 +183,12 @@ export interface IConfigOptions {
         // length per voice chunk in seconds
         chunk_length?: number;
     };
+
+    user_notice?: {
+        title: string;
+        description: string;
+        show_once?: boolean;
+    };
 }
 
 export interface ISsoRedirectOptions {

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -139,6 +139,8 @@ import { isLocalRoom } from '../../utils/localRoom/isLocalRoom';
 import { SdkContextClass, SDKContext } from '../../contexts/SDKContext';
 import { viewUserDeviceSettings } from '../../actions/handlers/viewUserDeviceSettings';
 import { VoiceBroadcastResumer } from '../../voice-broadcast';
+import GenericToast from "../views/toasts/GenericToast";
+import { Linkify } from "../views/elements/Linkify";
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1331,6 +1333,28 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             // The toast contains further logic to detect mobile platforms,
             // check if it has been dismissed before, etc.
             showMobileGuideToast();
+        }
+
+        const userNotice = SdkConfig.get("user_notice");
+        if (userNotice) {
+            const key = "user_notice_" + userNotice.title;
+            if (!userNotice.show_once || !localStorage.getItem(key)) {
+                ToastStore.sharedInstance().addOrReplaceToast({
+                    key,
+                    title: userNotice.title,
+                    props: {
+                        description: <Linkify>{ userNotice.description }</Linkify>,
+                        acceptLabel: _t("OK"),
+                        onAccept: () => {
+                            ToastStore.sharedInstance().dismissToast(key);
+                            localStorage.setItem(key, "1");
+                        },
+                    },
+                    component: GenericToast,
+                    className: "mx_AnalyticsToast",
+                    priority: 100,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Requires https://github.com/vector-im/element-web/pull/23738

![image](https://user-images.githubusercontent.com/2403652/200794717-27760ed4-1d5a-45b0-bd16-9abf6267f857.png)

This will be used to sunset riot.im/develop

MatrixChat is currently infeasible to write unit tests for

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add way to create a user notice via config.json ([\#9559](https://github.com/matrix-org/matrix-react-sdk/pull/9559)).<!-- CHANGELOG_PREVIEW_END -->