### PR TITLE
Resilience fix for homeserver without thread notification support

### DIFF
--- a/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -135,7 +135,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
         RightPanelPhases.ThreadPanel,
         RightPanelPhases.ThreadView,
     ];
-    private threadNotificationState: ThreadsRoomNotificationState;
+    private threadNotificationState: ThreadsRoomNotificationState | null;
     private globalNotificationState: SummarizedNotificationState;
 
     private get supportsThreadNotifications(): boolean {
@@ -146,9 +146,9 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
     constructor(props: IProps) {
         super(props, HeaderKind.Room);
 
-        if (!this.supportsThreadNotifications) {
-            this.threadNotificationState = RoomNotificationStateStore.instance.getThreadsRoomState(this.props.room);
-        }
+        this.threadNotificationState = !this.supportsThreadNotifications && this.props.room
+            ? RoomNotificationStateStore.instance.getThreadsRoomState(this.props.room)
+            : null;
         this.globalNotificationState = RoomNotificationStateStore.instance.globalState;
     }
 
@@ -176,7 +176,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
     private onNotificationUpdate = (): void => {
         let threadNotificationColor: NotificationColor;
         if (!this.supportsThreadNotifications) {
-            threadNotificationColor = this.threadNotificationState.color;
+            threadNotificationColor = this.threadNotificationState?.color ?? NotificationColor.None;
         } else {
             threadNotificationColor = this.notificationColor;
         }
@@ -189,7 +189,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
     };
 
     private get notificationColor(): NotificationColor {
-        switch (this.props.room.threadsAggregateNotificationType) {
+        switch (this.props.room?.threadsAggregateNotificationType) {
             case NotificationCountType.Highlight:
                 return NotificationColor.Red;
             case NotificationCountType.Total:

--- a/test/components/views/right_panel/RoomHeaderButtons-test.tsx
+++ b/test/components/views/right_panel/RoomHeaderButtons-test.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { render } from "@testing-library/react";
 import { MatrixClient, PendingEventOrdering } from "matrix-js-sdk/src/client";
+import { Feature, ServerSupport } from "matrix-js-sdk/src/feature";
 import { NotificationCountType, Room } from "matrix-js-sdk/src/models/room";
 import React from "react";
 
@@ -34,7 +35,7 @@ describe("RoomHeaderButtons-test.tsx", function() {
 
         stubClient();
         client = MatrixClientPeg.get();
-        room = new Room(ROOM_ID, client, client.getUserId(), {
+        room = new Room(ROOM_ID, client, client.getUserId() ?? "", {
             pendingEventOrdering: PendingEventOrdering.Detached,
         });
 
@@ -43,7 +44,7 @@ describe("RoomHeaderButtons-test.tsx", function() {
         });
     });
 
-    function getComponent(room: Room) {
+    function getComponent(room?: Room) {
         return render(<RoomHeaderButtons
             room={room}
             excludedRightPanelPhaseButtons={[]}
@@ -93,5 +94,10 @@ describe("RoomHeaderButtons-test.tsx", function() {
         room.setThreadUnreadNotificationCount("$123", NotificationCountType.Highlight, 0);
 
         expect(container.querySelector(".mx_RightPanel_threadsButton .mx_Indicator")).toBeNull();
+    });
+
+    it("does not explode without a room", () => {
+        client.canSupport.set(Feature.ThreadUnreadNotifications, ServerSupport.Unsupported);
+        expect(() => getComponent()).not.toThrow();
     });
 });


### PR DESCRIPTION
Addresses multiple rageshakes we have received

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Resilience fix for homeserver without thread notification support ([\#9565](https://github.com/matrix-org/matrix-react-sdk/pull/9565)).<!-- CHANGELOG_PREVIEW_END -->