### PR TITLE
Implement beautiful OTP input for adding phone number in registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-blurhash": "^0.1.3",
     "react-dom": "17.0.2",
     "react-focus-lock": "^2.5.1",
+    "react-otp-input": "^2.4.0",
     "react-transition-group": "^4.4.1",
     "rfc4648": "^1.4.0",
     "sanitize-filename": "^1.6.3",

--- a/res/css/views/auth/_InteractiveAuthEntryComponents.pcss
+++ b/res/css/views/auth/_InteractiveAuthEntryComponents.pcss
@@ -19,11 +19,16 @@ limitations under the License.
 }
 
 .mx_InteractiveAuthEntryComponents_msisdnEntry {
-    font-size: 200%;
-    font-weight: bold;
-    border: 1px solid $strong-input-border-color;
-    border-radius: 3px;
-    width: 6em;
+    width: 5rem !important;
+    height: 5rem;
+    margin: 0 2px;
+    font-size: 2rem;
+    border-radius: 4px;
+    border: 2px solid $strong-input-border-color;
+}
+
+.mx_InteractiveAuthEntryComponents_msisdnEntry_error {
+    border: 2px solid #ff0000;
 }
 
 .mx_InteractiveAuthEntryComponents_msisdnEntry:focus {

--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -91,6 +91,8 @@ export interface IConfigOptions {
 
     setting_defaults?: Record<string, any>; // <SettingName, Value>
 
+    otp_length?: number;
+
     integrations_ui_url?: string;
     integrations_rest_url?: string;
     integrations_widgets_urls?: string[];

--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -50,6 +50,7 @@ export const DEFAULTS: IConfigOptions = {
         chunk_length: 2 * 60, // two minutes
         max_length: 4 * 60 * 60, // four hours
     },
+    otp_length: 6,
 };
 
 export default class SdkConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8212,6 +8212,11 @@ react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-otp-input@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-otp-input/-/react-otp-input-2.4.0.tgz#0f0a3de1d8c8d564e2e4fbe5d6b7b56e29e3a6e6"
+  integrity sha512-AIgl7u4sS9BTNCxX1xlaS5fPWay/Zml8Ho5LszXZKXrH1C/TiFsTQGmtl13UecQYO3mSF3HUzG2rrDf0sjEFmg==
+
 react-redux@^7.2.0:
   version "7.2.8"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.8.tgz#a894068315e65de5b1b68899f9c6ee0923dd28de"


### PR DESCRIPTION
Steps to see new UI
1-Go to register
2-add phone number
3-see the OTP input screen.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->