### PR TITLE
Add --noImplicitAny to strict CI check

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -69,7 +69,7 @@ jobs:
           use-check: false
           check-fail-mode: added
           output-behaviour: annotate
-          ts-extra-args: '--strict'
+          ts-extra-args: '--strict --noImplicitAny'
           files-changed: ${{ steps.files.outputs.files_updated }}
           files-added: ${{ steps.files.outputs.files_created }}
           files-deleted: ${{ steps.files.outputs.files_deleted }}


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->