### PR TITLE
Tweak voice broadcast play icon

### DIFF
--- a/res/css/voice-broadcast/atoms/_VoiceBroadcastControl.pcss
+++ b/res/css/voice-broadcast/atoms/_VoiceBroadcastControl.pcss
@@ -28,3 +28,8 @@ limitations under the License.
 .mx_VoiceBroadcastControl-recording {
     color: $alert;
 }
+
+.mx_VoiceBroadcastControl-play .mx_Icon {
+    left: 1px;
+    position: relative;
+}

--- a/src/voice-broadcast/components/molecules/VoiceBroadcastPlaybackBody.tsx
+++ b/src/voice-broadcast/components/molecules/VoiceBroadcastPlaybackBody.tsx
@@ -62,14 +62,17 @@ export const VoiceBroadcastPlaybackBody: React.FC<VoiceBroadcastPlaybackBodyProp
     } else {
         let controlIcon: React.FC<React.SVGProps<SVGSVGElement>>;
         let controlLabel: string;
+        let className = "";
 
         switch (playbackState) {
             case VoiceBroadcastPlaybackState.Stopped:
                 controlIcon = PlayIcon;
+                className = "mx_VoiceBroadcastControl-play";
                 controlLabel = _t("play voice broadcast");
                 break;
             case VoiceBroadcastPlaybackState.Paused:
                 controlIcon = PlayIcon;
+                className = "mx_VoiceBroadcastControl-play";
                 controlLabel = _t("resume voice broadcast");
                 break;
             case VoiceBroadcastPlaybackState.Playing:
@@ -79,6 +82,7 @@ export const VoiceBroadcastPlaybackBody: React.FC<VoiceBroadcastPlaybackBodyProp
         }
 
         control = <VoiceBroadcastControl
+            className={className}
             label={controlLabel}
             icon={controlIcon}
             onClick={toggle}

--- a/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
+++ b/test/voice-broadcast/components/molecules/__snapshots__/VoiceBroadcastPlaybackBody-test.tsx.snap
@@ -57,7 +57,7 @@ exports[`VoiceBroadcastPlaybackBody when rendering a 0/not-live broadcast should
       </div>
       <div
         aria-label="resume voice broadcast"
-        class="mx_AccessibleButton mx_VoiceBroadcastControl"
+        class="mx_AccessibleButton mx_VoiceBroadcastControl mx_VoiceBroadcastControl-play"
         role="button"
         tabindex="0"
       >
@@ -460,7 +460,7 @@ exports[`VoiceBroadcastPlaybackBody when rendering a stopped broadcast should re
     >
       <div
         aria-label="play voice broadcast"
-        class="mx_AccessibleButton mx_VoiceBroadcastControl"
+        class="mx_AccessibleButton mx_VoiceBroadcastControl mx_VoiceBroadcastControl-play"
         role="button"
         tabindex="0"
       >


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

The Play icon did not look centred

Before

![image](https://user-images.githubusercontent.com/6216686/204003698-b58bd2a4-5f69-43a8-b3ef-6d017589ccb1.png)

After

![image](https://user-images.githubusercontent.com/6216686/204003559-2d36a812-7175-496d-acde-6fbb978e7d51.png)

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->