### PR TITLE
Pause voice broadcast on calls

### DIFF
--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -283,8 +283,8 @@ export class StopGapWidget extends EventEmitter {
         this.messaging.on("capabilitiesNotified", () => this.emit("capabilitiesNotified"));
         this.messaging.on(`action:${WidgetApiFromWidgetAction.OpenModalWidget}`, this.onOpenModal);
         this.messaging.on(`action:${ElementWidgetActions.JoinCall}`, () => {
-            // stop voice broadcast recording when any widget sends a "join"
-            VoiceBroadcastRecordingsStore.instance().getCurrent()?.stop();
+            // pause voice broadcast recording when any widget sends a "join"
+            VoiceBroadcastRecordingsStore.instance().getCurrent()?.pause();
         });
 
         // Always attach a handler for ViewRoom, but permission check it internally

--- a/src/voice-broadcast/models/VoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastRecording.ts
@@ -222,8 +222,8 @@ export class VoiceBroadcastRecording
     private onAction = (payload: ActionPayload) => {
         if (payload.action !== "call_state") return;
 
-        // stop on any call action
-        this.stop();
+        // pause on any call action
+        this.pause();
     };
 
     private setState(state: VoiceBroadcastInfoState): void {

--- a/test/stores/widgets/StopGapWidget-test.ts
+++ b/test/stores/widgets/StopGapWidget-test.ts
@@ -89,7 +89,7 @@ describe("StopGapWidget", () => {
                 content: {},
             });
             voiceBroadcastRecording = new VoiceBroadcastRecording(voiceBroadcastInfoEvent, client);
-            jest.spyOn(voiceBroadcastRecording, "stop");
+            jest.spyOn(voiceBroadcastRecording, "pause");
             jest.spyOn(VoiceBroadcastRecordingsStore.instance(), "getCurrent").mockReturnValue(voiceBroadcastRecording);
         });
 
@@ -105,8 +105,8 @@ describe("StopGapWidget", () => {
                 );
             });
 
-            it("should stop the current voice broadcast recording", () => {
-                expect(voiceBroadcastRecording.stop).toHaveBeenCalled();
+            it("should pause the current voice broadcast recording", () => {
+                expect(voiceBroadcastRecording.pause).toHaveBeenCalled();
             });
         });
     });

--- a/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastRecording-test.ts
@@ -296,7 +296,7 @@ describe("VoiceBroadcastRecording", () => {
                     }, true);
                 });
 
-                itShouldBeInState(VoiceBroadcastInfoState.Stopped);
+                itShouldBeInState(VoiceBroadcastInfoState.Paused);
             });
 
             describe("and a chunk time update occurs", () => {


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

Pausing a call is the wanted behaviour. Stop on call was implemented for the first delivery. At this time we were not able to pause recordings at all.

PSF-1750

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->