### PR TITLE
Fix seekbar in voice broadcast pip

### DIFF
--- a/src/components/views/audio_messages/SeekBar.tsx
+++ b/src/components/views/audio_messages/SeekBar.tsx
@@ -93,6 +93,11 @@ export default class SeekBar extends React.PureComponent<IProps, IState> {
         this.props.playback.skipTo(Number(ev.target.value) * this.props.playback.durationSeconds);
     };
 
+    private onMouseDown = (event: React.MouseEvent<Element, MouseEvent>) => {
+        // do not propagate mouse down events, because these should be handled by the seekbar
+        event.stopPropagation();
+    };
+
     public render(): ReactNode {
         // We use a range input to avoid having to re-invent accessibility handling on
         // a custom set of divs.
@@ -101,6 +106,7 @@ export default class SeekBar extends React.PureComponent<IProps, IState> {
             className='mx_SeekBar'
             tabIndex={this.props.tabIndex}
             onChange={this.onChange}
+            onMouseDown={this.onMouseDown}
             min={0}
             max={1}
             value={this.state.percentage}


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

Before

![pip_seekbar](https://user-images.githubusercontent.com/6216686/204306903-637e2daf-91aa-47fa-bd56-3149f5026dc5.gif)

After

![seekbar_after](https://user-images.githubusercontent.com/6216686/204307050-7112ab81-4722-4394-82a1-75ddb5fb758b.gif)

Also tested, that the audio player seekbar is still working

![seekbar_player](https://user-images.githubusercontent.com/6216686/204307276-5f05f000-7d2f-42a4-8cf4-3b2c25cea3b2.gif)

PSF-1760

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->