### PR TITLE
Fix the size of the 'Private space' icon

### DIFF
--- a/res/css/views/rooms/_RoomInfoLine.pcss
+++ b/res/css/views/rooms/_RoomInfoLine.pcss
@@ -36,8 +36,8 @@ limitations under the License.
     }
 
     &.mx_RoomInfoLine_private::before {
-        width: 14px;
-        mask-size: 14px;
+        width: 10px;
+        mask-size: 10px;
         mask-image: url("$(res)/img/element-icons/lock.svg");
     }
 


### PR DESCRIPTION
It's apparently been enlarged ever since https://github.com/matrix-org/matrix-react-sdk/pull/8499.

Before|After
-|-
![Screenshot 2022-11-28 at 17-32-38 Element 11 Toaq](https://user-images.githubusercontent.com/48614497/204394959-eaf1007f-2126-435f-a92e-91bc3c6ac196.png)|![Screenshot 2022-11-28 at 17-32-27 Element 11 Toaq](https://user-images.githubusercontent.com/48614497/204394961-214bf234-85c1-4f05-98cb-9bf446f6ec03.png)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the size of the 'Private space' icon ([\#9638](https://github.com/matrix-org/matrix-react-sdk/pull/9638)).<!-- CHANGELOG_PREVIEW_END -->