### PR TITLE
Fix the background color flashing when joining a call

### DIFF
--- a/res/css/views/voip/_CallView.pcss
+++ b/res/css/views/voip/_CallView.pcss
@@ -31,6 +31,8 @@ limitations under the License.
         width: auto;
         height: 100%;
         border: none;
+        border-radius: inherit;
+        background-color: $call-lobby-background;
     }
 
     /* While the lobby is shown, the widget needs to stay loaded but hidden in the background */


### PR DESCRIPTION
Because the persisted widget element takes an extra layout tick to be moved into place, you would briefly see the background color of the call view flash into view when joining a call. Giving the widget tile a background fixes this.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the background color flashing when joining a call ([\#9640](https://github.com/matrix-org/matrix-react-sdk/pull/9640)).<!-- CHANGELOG_PREVIEW_END -->