### PR TITLE
Update cypress.yaml GHA to not refer to workflow name.

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -96,7 +96,6 @@ jobs:
       - name: 📥 Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: element-build.yaml
           run_id: ${{ github.event.workflow_run.id }}
           name: previewbuild
           path: webapp

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: 📥 Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: element-build-and-test.yaml
+          workflow: element-build.yaml
           run_id: ${{ github.event.workflow_run.id }}
           name: previewbuild
           path: webapp


### PR DESCRIPTION
More of a nit than a bugfix, that I came across trying to infer how this build worked on a fork.

The previous workflow name is not a reference to a current workflow in the codebase (it was a reference to a previous one). The action still works though, so didn't require the name to be correct.

From https://github.com/dawidd6/action-download-artifact#usage it seems to infer the workflow name from the run_id - so I think we shouldn't pass it to the action so we can avoid confusion.

[Example of it running already](https://github.com/michaelkaye/matrix-react-sdk/actions/runs/3575791960/jobs/6012783455)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [X] Tests written for new code (and old code if feasible) -- no tests written as fairly minimal CI change
* [X] Linter and other CI checks pass
* [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:



or specify alternative text:

element-web notes: Add super cool feature
-->

Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->