### PR TITLE
Do not resume voice broadcasts on seek

### DIFF
--- a/src/voice-broadcast/models/VoiceBroadcastPlayback.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastPlayback.ts
@@ -387,7 +387,7 @@ export class VoiceBroadcastPlayback
         const offsetInChunk = time - this.chunkEvents.getLengthTo(event);
         await skipToPlayback.skipTo(offsetInChunk / 1000);
 
-        if (currentPlayback !== skipToPlayback) {
+        if (this.state === VoiceBroadcastPlaybackState.Playing && !skipToPlayback.isPlaying) {
             await skipToPlayback.play();
         }
 

--- a/test/voice-broadcast/models/VoiceBroadcastPlayback-test.ts
+++ b/test/voice-broadcast/models/VoiceBroadcastPlayback-test.ts
@@ -407,6 +407,17 @@ describe("VoiceBroadcastPlayback", () => {
             describe("and calling stop", () => {
                 stopPlayback();
                 itShouldSetTheStateTo(VoiceBroadcastPlaybackState.Stopped);
+
+                describe("and skipping to somewhere in the middle of the first chunk", () => {
+                    beforeEach(async () => {
+                        mocked(chunk1Playback.play).mockClear();
+                        await playback.skipTo(1);
+                    });
+
+                    it("should not start the playback", () => {
+                        expect(chunk1Playback.play).not.toHaveBeenCalled();
+                    });
+                });
             });
 
             describe("and calling destroy", () => {


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/23282

Before: Seeking to a position starts the broadcast
After: Paused/Stopped keeps in this state

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->