### PR TITLE
Don't allow group calls to be unterminated

### DIFF
--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -47,6 +47,7 @@ import { shouldDisplayAsBeaconTile } from "../utils/beacon/timeline";
 import { shouldDisplayAsVoiceBroadcastTile } from "../voice-broadcast/utils/shouldDisplayAsVoiceBroadcastTile";
 import { ElementCall } from "../models/Call";
 import { VoiceBroadcastChunkEventType } from "../voice-broadcast";
+import { GroupCallIntent } from "matrix-js-sdk/src/webrtc/groupCall";
 
 // Subset of EventTile's IProps plus some mixins
 export interface EventTileTypeProps {
@@ -412,13 +413,9 @@ export function haveRendererForEvent(mxEvent: MatrixEvent, showHiddenEvents: boo
         return Boolean(mxEvent.getContent()['predecessor']);
     } else if (ElementCall.CALL_EVENT_TYPE.names.some(eventType => handler === STATE_EVENT_TILE_TYPES.get(eventType))) {
         const intent = mxEvent.getContent()['m.intent'];
-        const prevContent = mxEvent.getPrevContent();
-        // If the call became unterminated or previously had invalid contents,
-        // then this event marks the start of the call
-        const newlyStarted = 'm.terminated' in prevContent
-            || !('m.intent' in prevContent) || !('m.type' in prevContent);
+        const newlyStarted = Object.keys(mxEvent.getPrevContent()).length === 0
         // Only interested in events that mark the start of a non-room call
-        return typeof intent === 'string' && intent !== 'm.room' && newlyStarted;
+        return newlyStarted && typeof intent === 'string' && intent !== GroupCallIntent.Room;
     } else if (handler === JSONEventFactory) {
         return false;
     } else {


### PR DESCRIPTION
If group calls can be unterminated, this makes it very difficult to determine the duration of past calls. This was also causing duplicate event tiles to be rendered if multiple people tried to terminate a call simultaneously.