### PR TITLE
enforced key backup setup

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -357,7 +357,11 @@ export default class DeviceListener {
         }
         // returns null when key backup status hasn't finished being checked
         const isKeyBackupEnabled = MatrixClientPeg.get().getKeyBackupEnabled();
-        this.keyBackupStatusChecked = isKeyBackupEnabled !== null;
+
+        // Ensure user can't dismiss the toast if secure backup is required
+        if (isKeyBackupEnabled === false && !isSecureBackupRequired()) {
+            this.keyBackupStatusChecked = isKeyBackupEnabled !== null;
+        }
 
         if (isKeyBackupEnabled === false) {
             dis.dispatch({ action: Action.ReportKeyBackupNotEnabled });

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -65,7 +65,6 @@ enum Phase {
 const PASSWORD_MIN_SCORE = 4; // So secure, many characters, much complex, wow, etc, etc.
 
 interface IProps extends IDialogProps {
-    hasCancel: boolean;
     accountPassword: string;
     forceReset: boolean;
 }
@@ -96,7 +95,6 @@ interface IState {
  */
 export default class CreateSecretStorageDialog extends React.PureComponent<IProps, IState> {
     public static defaultProps: Partial<IProps> = {
-        hasCancel: true,
         forceReset: false,
     };
     private recoveryKey: IRecoveryKey;
@@ -871,7 +869,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                 onFinished={this.props.onFinished}
                 title={this.titleForPhase(this.state.phase)}
                 titleClass={titleClass}
-                hasCancel={this.props.hasCancel && [Phase.Passphrase].includes(this.state.phase)}
+                hasCancel={this.state.canSkip}
                 fixedWidth={false}
             >
                 <div>

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -141,6 +141,7 @@ import { VoiceBroadcastResumer } from '../../voice-broadcast';
 import GenericToast from "../views/toasts/GenericToast";
 import { Linkify } from "../views/elements/Linkify";
 import RovingSpotlightDialog, { Filter } from '../views/dialogs/spotlight/SpotlightDialog';
+import { isSecureBackupRequired } from '../../utils/WellKnownUtils';
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -825,6 +826,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             case Action.PseudonymousAnalyticsReject:
                 hideAnalyticsToast();
                 SettingsStore.setValue("pseudonymousAnalyticsOptIn", null, SettingLevel.ACCOUNT, false);
+                break;
+            case Action.ReportKeyBackupNotEnabled:
+                if (isSecureBackupRequired()) {
+                    this.setStateForNewView({ view: Views.COMPLETE_SECURITY });
+                }
                 break;
             case Action.ShowThread: {
                 const {

--- a/src/components/structures/auth/CompleteSecurity.tsx
+++ b/src/components/structures/auth/CompleteSecurity.tsx
@@ -22,6 +22,7 @@ import SetupEncryptionBody from "./SetupEncryptionBody";
 import AccessibleButton from '../../views/elements/AccessibleButton';
 import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
 import AuthPage from "../../views/auth/AuthPage";
+import { isSecureBackupRequired } from '../../../utils/WellKnownUtils';
 
 interface IProps {
     onFinished: () => void;
@@ -91,7 +92,7 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
         }
 
         let skipButton;
-        if (phase === Phase.Intro || phase === Phase.ConfirmReset) {
+        if ((phase === Phase.Intro || phase === Phase.ConfirmReset) && !isSecureBackupRequired()) {
             skipButton = (
                 <AccessibleButton onClick={this.onSkipClick} className="mx_CompleteSecurity_skip" aria-label={_t("Skip verification for now")} />
             );


### PR DESCRIPTION
This PR is an example of how https://github.com/vector-im/element-web/issues/23810 issue could be fixed. 
I am not adding tests for the purpose of seeing if this might gain tracking in the community

In terms of functionality it has two-fold:
1. Redirect to encryption setup steps if the backup isn't set;
2. hired "skip" buttons inside the backup flow windows.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->