### PR TITLE
Update eslint-plugin-matrix-org to 0.8.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,10 @@ module.exports = {
                 "plugin:matrix-org/react",
             ],
             rules: {
+                // temporary disabled
+                "@typescript-eslint/explicit-function-return-type": "off",
+                "@typescript-eslint/explicit-member-accessibility": "off",
+
                 // Things we do that break the ideal style
                 "prefer-promise-reject-errors": "off",
                 "quotes": "off",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "eslint-plugin-deprecate": "^0.7.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-matrix-org": "0.7.0",
+    "eslint-plugin-matrix-org": "0.8.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-unicorn": "^45.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4105,10 +4105,10 @@ eslint-plugin-jsx-a11y@^6.5.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
-eslint-plugin-matrix-org@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-matrix-org/-/eslint-plugin-matrix-org-0.7.0.tgz#4b7456b31e30e7575b62c2aada91915478829f88"
-  integrity sha512-FLmwE4/cRalB7J+J1BBuTccaXvKtRgAoHlbqSCbdsRqhh27xpxEWXe08KlNiET7drEnnz+xMHXdmvW469gch7g==
+eslint-plugin-matrix-org@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-matrix-org/-/eslint-plugin-matrix-org-0.8.0.tgz#daa1396900a8cb1c1d88f1a370e45fc32482cd9e"
+  integrity sha512-/Poz/F8lXYDsmQa29iPSt+kO+Jn7ArvRdq10g0CCk8wbRS0sb2zb6fvd9xL1BgR5UDQL771V0l8X32etvY5yKA==
 
 eslint-plugin-react-hooks@^4.3.0:
   version "4.6.0"


### PR DESCRIPTION
Prettier preparation. Not great to disable rules from .8 but this is blocking prettier

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->