### PR TITLE
Don't double-add events to threads in tests

### DIFF
--- a/test/test-utils/threads.ts
+++ b/test/test-utils/threads.ts
@@ -137,7 +137,6 @@ export const mkThread = ({
     const thread = room.createThread(rootEvent.getId(), rootEvent, events, true);
     // So that we do not have to mock the thread loading
     thread.initialEventsFetched = true;
-    thread.addEvents(events, false);
 
     return { thread, rootEvent, events };
 };


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

https://github.com/matrix-org/matrix-js-sdk/pull/2951 already adds the events during thread creation.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->