### PR TITLE
Enable wysiwyg to convert between rich and plain text

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import React, { createRef, ReactNode } from "react";
+import { htmlToMarkdown } from "@matrix-org/matrix-wysiwyg";
 import classNames from "classnames";
 import { IEventRelation, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
@@ -57,7 +58,6 @@ import { VoiceMessageRecording } from "../../../audio/VoiceMessageRecording";
 import { VoiceBroadcastRecordingsStore } from "../../../voice-broadcast";
 import { SendWysiwygComposer, sendMessage } from "./wysiwyg_composer/";
 import { MatrixClientProps, withMatrixClientHOC } from "../../../contexts/MatrixClientContext";
-import { htmlToPlainText } from "../../../utils/room/htmlToPlaintext";
 import { setUpVoiceBroadcastPreRecording } from "../../../voice-broadcast/utils/setUpVoiceBroadcastPreRecording";
 import { SdkContextClass } from "../../../contexts/SDKContext";
 
@@ -359,13 +359,14 @@ export class MessageComposer extends React.Component<IProps, IState> {
         });
     };
 
-    private onRichTextToggle = () => {
+    private onRichTextToggle = async () => {
+        let initialComposerContent = this.state.composerContent;
+        if (this.state.isRichTextEnabled) {
+            initialComposerContent = await htmlToMarkdown(this.state.composerContent);
+        }
         this.setState((state) => ({
             isRichTextEnabled: !state.isRichTextEnabled,
-            initialComposerContent: !state.isRichTextEnabled
-                ? state.composerContent
-                : // TODO when available use rust model plain text
-                  htmlToPlainText(state.composerContent),
+            initialComposerContent,
         }));
     };
 

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { createRef, ReactNode } from "react";
-import { htmlToMarkdown } from "@matrix-org/matrix-wysiwyg";
+import { htmlToMarkdown, markdownToHtml } from "@matrix-org/matrix-wysiwyg";
 import classNames from "classnames";
 import { IEventRelation, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
@@ -360,14 +360,21 @@ export class MessageComposer extends React.Component<IProps, IState> {
     };
 
     private onRichTextToggle = async () => {
-        let initialComposerContent = this.state.composerContent;
         if (this.state.isRichTextEnabled) {
-            initialComposerContent = await htmlToMarkdown(this.state.composerContent);
+            const contentAsMarkdown = await htmlToMarkdown(this.state.composerContent);
+            this.setState({
+                isRichTextEnabled: false,
+                composerContent: contentAsMarkdown,
+                initialComposerContent: contentAsMarkdown,
+            });
+        } else {
+            const contentAsHtml = await markdownToHtml(this.state.composerContent);
+            this.setState({
+                isRichTextEnabled: true,
+                composerContent: contentAsHtml,
+                initialComposerContent: contentAsHtml,
+            });
         }
-        this.setState((state) => ({
-            isRichTextEnabled: !state.isRichTextEnabled,
-            initialComposerContent,
-        }));
     };
 
     private onVoiceStoreUpdate = () => {

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { createRef, ReactNode } from "react";
-import { htmlToMarkdown, markdownToHtml } from "@matrix-org/matrix-wysiwyg";
+import { richToPlain, plainToRich } from "@matrix-org/matrix-wysiwyg";
 import classNames from "classnames";
 import { IEventRelation, MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
@@ -359,22 +359,15 @@ export class MessageComposer extends React.Component<IProps, IState> {
         });
     };
 
-    private onRichTextToggle = async () => {
-        if (this.state.isRichTextEnabled) {
-            const contentAsMarkdown = await htmlToMarkdown(this.state.composerContent);
-            this.setState({
-                isRichTextEnabled: false,
-                composerContent: contentAsMarkdown,
-                initialComposerContent: contentAsMarkdown,
-            });
-        } else {
-            const contentAsHtml = await markdownToHtml(this.state.composerContent);
-            this.setState({
-                isRichTextEnabled: true,
-                composerContent: contentAsHtml,
-                initialComposerContent: contentAsHtml,
-            });
-        }
+    private onRichTextToggle = () => {
+        this.setState(({ isRichTextEnabled, composerContent }) => {
+            const convertedContent = isRichTextEnabled ? richToPlain(composerContent) : plainToRich(composerContent);
+            return {
+                isRichTextEnabled: !isRichTextEnabled,
+                composerContent: convertedContent,
+                initialComposerContent: convertedContent,
+            };
+        });
     };
 
     private onVoiceStoreUpdate = () => {

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -359,14 +359,16 @@ export class MessageComposer extends React.Component<IProps, IState> {
         });
     };
 
-    private onRichTextToggle = () => {
-        this.setState(({ isRichTextEnabled, composerContent }) => {
-            const convertedContent = isRichTextEnabled ? richToPlain(composerContent) : plainToRich(composerContent);
-            return {
-                isRichTextEnabled: !isRichTextEnabled,
-                composerContent: convertedContent,
-                initialComposerContent: convertedContent,
-            };
+    private onRichTextToggle = async () => {
+        const { isRichTextEnabled, composerContent } = this.state;
+        const convertedContent = isRichTextEnabled
+            ? await richToPlain(composerContent)
+            : await plainToRich(composerContent);
+
+        this.setState({
+            isRichTextEnabled: !isRichTextEnabled,
+            composerContent: convertedContent,
+            initialComposerContent: convertedContent,
         });
     };
 

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -47,7 +47,7 @@ export function usePlainTextListeners(
     const onInput = useCallback(
         (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
             if (isDivElement(event.target)) {
-                setText(event.target.innerHTML);
+                setText(event.target.textContent);
             }
         },
         [setText],

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -47,7 +47,7 @@ export function usePlainTextListeners(
     const onInput = useCallback(
         (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
             if (isDivElement(event.target)) {
-                setText(event.target.innerText);
+                setText(event.target.innerHTML);
             }
         },
         [setText],

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -47,7 +47,7 @@ export function usePlainTextListeners(
     const onInput = useCallback(
         (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
             if (isDivElement(event.target)) {
-                setText(event.target.textContent);
+                setText(event.target.innerText);
             }
         },
         [setText],


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
This change uses new utility functions from the rich text editor repo ([~~dependent on this PR~~](https://github.com/matrix-org/matrix-rich-text-editor/pull/400) now merged, commit [a32fb8](https://github.com/matrix-org/matrix-rich-text-editor/tree/a32fb88c019e20e65b0b3162af202c10029812e8)) to let the wysiwyg editor convert rich to plain text inside the composer.

Example of conversion from rich to plain:
In rich text editor
![Element___Alun_Turner_and_MessageComposer_tsx_—_matrix-react-sdk](https://user-images.githubusercontent.com/56027671/207664667-ff7b43b5-25c0-4642-a884-d87d0e3a65d3.png)

In plain text editor
![Element___Alun_Turner_and_MessageComposer_tsx_—_matrix-react-sdk](https://user-images.githubusercontent.com/56027671/207664767-e13f8353-74c6-4c1b-add3-092425c6a5f5.png)

## Checklist

-   [x] Tests written for new code - new code is unit tested in the rich-text-editor repo
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->