### PR TITLE
Load RTE component only when needed

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { ComponentProps, lazy, Suspense } from "react";
+
+const SendComposer = lazy(() => import("./SendWysiwygComposer"));
+const EditComposer = lazy(() => import("./EditWysiwygComposer"));
+
+export function DynamicImportSendWysiwygComposer(props: ComponentProps<typeof SendComposer>) {
+    return (
+        <Suspense fallback={<div />}>
+            <SendComposer {...props} />
+        </Suspense>
+    );
+}
+
+export function DynamicImportEditWysiwygComposer(props: ComponentProps<typeof EditComposer>) {
+    return (
+        <Suspense fallback={<div />}>
+            <EditComposer {...props} />
+        </Suspense>
+    );
+}

--- a/src/components/views/rooms/wysiwyg_composer/EditWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/EditWysiwygComposer.tsx
@@ -43,32 +43,35 @@ interface EditWysiwygComposerProps {
     className?: string;
 }
 
-export function EditWysiwygComposer({ editorStateTransfer, className, ...props }: EditWysiwygComposerProps) {
+// Default needed for React.lazy
+export default function EditWysiwygComposer({ editorStateTransfer, className, ...props }: EditWysiwygComposerProps) {
     const initialContent = useInitialContent(editorStateTransfer);
     const isReady = !editorStateTransfer || initialContent !== undefined;
 
     const { editMessage, endEditing, onChange, isSaveDisabled } = useEditing(editorStateTransfer, initialContent);
 
+    if (!isReady) {
+        return null;
+    }
+
     return (
-        isReady && (
-            <WysiwygComposer
-                className={classNames("mx_EditWysiwygComposer", className)}
-                initialContent={initialContent}
-                onChange={onChange}
-                onSend={editMessage}
-                {...props}
-            >
-                {(ref) => (
-                    <>
-                        <Content disabled={props.disabled} ref={ref} />
-                        <EditionButtons
-                            onCancelClick={endEditing}
-                            onSaveClick={editMessage}
-                            isSaveDisabled={isSaveDisabled}
-                        />
-                    </>
-                )}
-            </WysiwygComposer>
-        )
+        <WysiwygComposer
+            className={classNames("mx_EditWysiwygComposer", className)}
+            initialContent={initialContent}
+            onChange={onChange}
+            onSend={editMessage}
+            {...props}
+        >
+            {(ref) => (
+                <>
+                    <Content disabled={props.disabled} ref={ref} />
+                    <EditionButtons
+                        onCancelClick={endEditing}
+                        onSaveClick={editMessage}
+                        isSaveDisabled={isSaveDisabled}
+                    />
+                </>
+            )}
+        </WysiwygComposer>
     );
 }

--- a/src/components/views/rooms/wysiwyg_composer/SendWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/SendWysiwygComposer.tsx
@@ -49,7 +49,8 @@ interface SendWysiwygComposerProps {
     menuPosition: AboveLeftOf;
 }
 
-export function SendWysiwygComposer({
+// Default needed for React.lazy
+export default function SendWysiwygComposer({
     isRichTextEnabled,
     e2eStatus,
     menuPosition,

--- a/src/components/views/rooms/wysiwyg_composer/index.ts
+++ b/src/components/views/rooms/wysiwyg_composer/index.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { SendWysiwygComposer } from "./SendWysiwygComposer";
-export { EditWysiwygComposer } from "./EditWysiwygComposer";
+export {
+    DynamicImportSendWysiwygComposer as SendWysiwygComposer,
+    DynamicImportEditWysiwygComposer as EditWysiwygComposer,
+} from "./DynamicImportWysiwygComposer";
 export { sendMessage } from "./utils/message";

--- a/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -73,7 +73,7 @@ describe("EditWysiwygComposer", () => {
 
         rerender(
             <MatrixClientContext.Provider value={mockClient}>
-                <RoomContext.Provider value={getRoomContext(null, {})}>
+                <RoomContext.Provider value={{ ...defaultRoomContext, room: undefined }}>
                     <EditWysiwygComposer disabled={false} editorStateTransfer={editorStateTransfer} />
                 </RoomContext.Provider>
             </MatrixClientContext.Provider>,
@@ -89,8 +89,6 @@ describe("EditWysiwygComposer", () => {
             customRender(false, editorStateTransfer);
 
             // Then
-            expect(screen.queryByRole("textbox")).toBeNull();
-
             await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"), {
                 timeout: 2000,
             });

--- a/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -68,9 +68,14 @@ describe("EditWysiwygComposer", () => {
         it("Should initialize useWysiwyg with html content", async () => {
             // When
             customRender(false, editorStateTransfer);
-            await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"));
 
             // Then
+            expect(screen.queryByRole("textbox")).toBeNull();
+
+            await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"), {
+                timeout: 2000,
+            });
+
             await waitFor(() =>
                 expect(screen.getByRole("textbox")).toContainHTML(mockEvent.getContent()["formatted_body"]),
             );

--- a/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -64,6 +64,25 @@ describe("EditWysiwygComposer", () => {
         );
     };
 
+    it("Should not render the component when not ready", async () => {
+        // When
+        const { rerender } = customRender(false);
+        await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"), {
+            timeout: 2000,
+        });
+
+        rerender(
+            <MatrixClientContext.Provider value={mockClient}>
+                <RoomContext.Provider value={getRoomContext(null, {})}>
+                    <EditWysiwygComposer disabled={false} editorStateTransfer={editorStateTransfer} />
+                </RoomContext.Provider>
+            </MatrixClientContext.Provider>,
+        );
+
+        // Then
+        await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull());
+    });
+
     describe("Initialize with content", () => {
         it("Should initialize useWysiwyg with html content", async () => {
             // When

--- a/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
@@ -24,7 +24,7 @@ import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
 import { IRoomState } from "../../../../../src/components/structures/RoomView";
 import { createTestClient, flushPromises, getRoomContext, mkEvent, mkStubRoom } from "../../../../test-utils";
-import { SendWysiwygComposer } from "../../../../../src/components/views/rooms/wysiwyg_composer";
+import { SendWysiwygComposer } from "../../../../../src/components/views/rooms/wysiwyg_composer/";
 import { aboveLeftOf } from "../../../../../src/components/structures/ContextMenu";
 import { ComposerInsertPayload, ComposerType } from "../../../../../src/dispatcher/payloads/ComposerInsertPayload";
 import { setSelection } from "../../../../../src/components/views/rooms/wysiwyg_composer/utils/selection";
@@ -101,12 +101,12 @@ describe("SendWysiwygComposer", () => {
         );
     };
 
-    it("Should render WysiwygComposer when isRichTextEnabled is at true", () => {
+    it("Should render WysiwygComposer when isRichTextEnabled is at true", async () => {
         // When
         customRender(jest.fn(), jest.fn(), false, true);
 
         // Then
-        expect(screen.getByTestId("WysiwygComposer")).toBeTruthy();
+        await waitFor(() => expect(screen.getByTestId("WysiwygComposer")).toBeTruthy());
     });
 
     it("Should render PlainTextComposer when isRichTextEnabled is at false", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Currently, the RTE lib has only an es6 build and made element-web compatible with es6 browsers.
In the meantime to have a es5 compatible build, we load the wysiwyg component only when needed.

Notes: Load RTE components only when RTE labs is enabled

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Load RTE components only when RTE labs is enabled ([\#9804](https://github.com/matrix-org/matrix-react-sdk/pull/9804)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->