### PR TITLE
Handle voice broadcast last_chunk_sequence

### DIFF
--- a/src/voice-broadcast/utils/VoiceBroadcastChunkEvents.ts
+++ b/src/voice-broadcast/utils/VoiceBroadcastChunkEvents.ts
@@ -97,6 +97,19 @@ export class VoiceBroadcastChunkEvents {
         return this.events.indexOf(event) >= this.events.length - 1;
     }
 
+    public getSequenceForEvent(event: MatrixEvent): number | null {
+        const sequence = parseInt(event.getContent()?.[VoiceBroadcastChunkEventType]?.sequence, 10);
+        if (!isNaN(sequence)) return sequence;
+
+        if (this.events.includes(event)) return this.events.indexOf(event) + 1;
+
+        return null;
+    }
+
+    public getNumberOfEvents(): number {
+        return this.events.length;
+    }
+
     private calculateChunkLength(event: MatrixEvent): number {
         return event.getContent()?.["org.matrix.msc1767.audio"]?.duration || event.getContent()?.info?.duration || 0;
     }

--- a/test/voice-broadcast/utils/VoiceBroadcastChunkEvents-test.ts
+++ b/test/voice-broadcast/utils/VoiceBroadcastChunkEvents-test.ts
@@ -62,6 +62,10 @@ describe("VoiceBroadcastChunkEvents", () => {
             ]);
         });
 
+        it("getNumberOfEvents should return 4", () => {
+            expect(chunkEvents.getNumberOfEvents()).toBe(4);
+        });
+
         it("getLength should return the total length of all chunks", () => {
             expect(chunkEvents.getLength()).toBe(3259);
         });
@@ -110,6 +114,7 @@ describe("VoiceBroadcastChunkEvents", () => {
                     eventSeq3Time2T,
                     eventSeq4Time1,
                 ]);
+                expect(chunkEvents.getNumberOfEvents()).toBe(4);
             });
         });
     });
@@ -129,6 +134,17 @@ describe("VoiceBroadcastChunkEvents", () => {
                 eventSeqUTime3,
                 eventSeq2Time4Dup,
             ]);
+            expect(chunkEvents.getNumberOfEvents()).toBe(5);
+        });
+
+        describe("getSequenceForEvent", () => {
+            it("should return the sequence if provided by the event", () => {
+                expect(chunkEvents.getSequenceForEvent(eventSeq3Time2)).toBe(3);
+            });
+
+            it("should return the index if no sequence provided by event", () => {
+                expect(chunkEvents.getSequenceForEvent(eventSeqUTime3)).toBe(4);
+            });
         });
     });
 });

--- a/test/voice-broadcast/utils/test-utils.ts
+++ b/test/voice-broadcast/utils/test-utils.ts
@@ -24,12 +24,16 @@ import {
 } from "../../../src/voice-broadcast";
 import { mkEvent } from "../../test-utils";
 
+// timestamp incremented on each call to prevent duplicate timestamp
+let timestamp = new Date().getTime();
+
 export const mkVoiceBroadcastInfoStateEvent = (
     roomId: Optional<string>,
     state: Optional<VoiceBroadcastInfoState>,
     senderId: Optional<string>,
     senderDeviceId: Optional<string>,
     startedInfoEvent?: MatrixEvent,
+    lastChunkSequence?: number,
 ): MatrixEvent => {
     const relationContent = {};
 
@@ -39,6 +43,8 @@ export const mkVoiceBroadcastInfoStateEvent = (
             rel_type: "m.reference",
         };
     }
+
+    const lastChunkSequenceContent = lastChunkSequence ? { last_chunk_sequence: lastChunkSequence } : {};
 
     return mkEvent({
         event: true,
@@ -53,7 +59,9 @@ export const mkVoiceBroadcastInfoStateEvent = (
             state,
             device_id: senderDeviceId,
             ...relationContent,
+            ...lastChunkSequenceContent,
         },
+        ts: timestamp++,
     });
 };
 


### PR DESCRIPTION
Improve broadcast end detection when playing live ones.

`last_chunk_sequence` should be added to every broadcast state event and contain the total number of chunks until that point. It should also be robust enough to work when `last_chunk_sequence` is missing.

„Spec“ of `last_chunk_sequence`  in [the discussion](https://github.com/vector-im/element-meta/discussions/632).

PSF-1730

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->