### PR TITLE
Update netlify.yaml GHA to not refer to workflow name

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -35,7 +35,6 @@ jobs:
             - name: 📥 Download artifact
               uses: dawidd6/action-download-artifact@v2
               with:
-                  workflow: element-build-and-test.yaml
                   run_id: ${{ github.event.workflow_run.id }}
                   name: previewbuild
                   path: webapp


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24071

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->