### PR TITLE
Allow call and broadcast PiP at the same time

### DIFF
--- a/res/css/views/voip/_LegacyCallPreview.pcss
+++ b/res/css/views/voip/_LegacyCallPreview.pcss
@@ -15,8 +15,12 @@ limitations under the License.
 */
 
 .mx_LegacyCallPreview {
-    position: fixed;
+    align-items: flex-end;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-16;
     left: 0;
+    position: fixed;
     top: 0;
 
     pointer-events: initial; /* restore pointer events so the user can leave/interact */

--- a/src/components/views/voip/PictureInPictureDragger.tsx
+++ b/src/components/views/voip/PictureInPictureDragger.tsx
@@ -47,7 +47,7 @@ interface IChildrenOptions {
 
 interface IProps {
     className?: string;
-    children: CreatePipChildren;
+    children: Array<CreatePipChildren>;
     draggable: boolean;
     onDoubleClick?: () => void;
     onMove?: () => void;
@@ -208,6 +208,13 @@ export default class PictureInPictureDragger extends React.Component<IProps> {
             transform: `translateX(${this.translationX}px) translateY(${this.translationY}px)`,
         };
 
+        const children = this.props.children.map((create: CreatePipChildren) => {
+            return create({
+                onStartMoving: this.onStartMoving,
+                onResize: this.onResize,
+            });
+        });
+
         return (
             <aside
                 className={this.props.className}
@@ -215,10 +222,7 @@ export default class PictureInPictureDragger extends React.Component<IProps> {
                 ref={this.callViewWrapper}
                 onDoubleClick={this.props.onDoubleClick}
             >
-                {this.props.children({
-                    onStartMoving: this.onStartMoving,
-                    onResize: this.onResize,
-                })}
+                {children}
             </aside>
         );
     }

--- a/src/components/views/voip/PipView.tsx
+++ b/src/components/views/voip/PipView.tsx
@@ -373,24 +373,20 @@ class PipView extends React.Component<IProps, IState> {
 
     public render() {
         const pipMode = true;
-        let pipContent: CreatePipChildren | null = null;
-
-        if (this.props.voiceBroadcastPlayback) {
-            pipContent = this.createVoiceBroadcastPlaybackPipContent(this.props.voiceBroadcastPlayback);
-        }
-
-        if (this.props.voiceBroadcastPreRecording) {
-            pipContent = this.createVoiceBroadcastPreRecordingPipContent(this.props.voiceBroadcastPreRecording);
-        }
+        let pipContent: Array<CreatePipChildren> = [];
 
         if (this.props.voiceBroadcastRecording) {
-            pipContent = this.createVoiceBroadcastRecordingPipContent(this.props.voiceBroadcastRecording);
+            pipContent = [this.createVoiceBroadcastRecordingPipContent(this.props.voiceBroadcastRecording)];
+        } else if (this.props.voiceBroadcastPreRecording) {
+            pipContent = [this.createVoiceBroadcastPreRecordingPipContent(this.props.voiceBroadcastPreRecording)];
+        } else if (this.props.voiceBroadcastPlayback) {
+            pipContent = [this.createVoiceBroadcastPlaybackPipContent(this.props.voiceBroadcastPlayback)];
         }
 
         if (this.state.primaryCall) {
             // get a ref to call inside the current scope
             const call = this.state.primaryCall;
-            pipContent = ({ onStartMoving, onResize }) => (
+            pipContent.push(({ onStartMoving, onResize }) => (
                 <LegacyCallView
                     onMouseDownOnHeader={onStartMoving}
                     call={call}
@@ -398,7 +394,7 @@ class PipView extends React.Component<IProps, IState> {
                     pipMode={pipMode}
                     onResize={onResize}
                 />
-            );
+            ));
         }
 
         if (this.state.showWidgetInPip) {
@@ -412,7 +408,7 @@ class PipView extends React.Component<IProps, IState> {
             const viewingCallRoom = this.state.viewedRoomId === roomId;
             const isCall = CallStore.instance.getActiveCall(roomId) !== null;
 
-            pipContent = ({ onStartMoving }) => (
+            pipContent.push(({ onStartMoving }) => (
                 <div className={pipViewClasses}>
                     <LegacyCallViewHeader
                         onPipMouseDown={(event) => {
@@ -432,10 +428,10 @@ class PipView extends React.Component<IProps, IState> {
                         movePersistedElement={this.movePersistedElement}
                     />
                 </div>
-            );
+            ));
         }
 
-        if (!!pipContent) {
+        if (pipContent.length) {
             return (
                 <PictureInPictureDragger
                     className="mx_LegacyCallPreview"

--- a/test/components/views/voip/PictureInPictureDragger-test.tsx
+++ b/test/components/views/voip/PictureInPictureDragger-test.tsx
@@ -24,18 +24,22 @@ import PictureInPictureDragger, {
 describe("PictureInPictureDragger", () => {
     let renderResult: RenderResult;
 
-    const mkContent1: CreatePipChildren = () => {
-        return <div>content 1</div>;
-    };
+    const mkContent1: Array<CreatePipChildren> = [
+        () => {
+            return <div>content 1</div>;
+        },
+    ];
 
-    const mkContent2: CreatePipChildren = () => {
-        return (
-            <div>
-                content 2<br />
-                content 2.2
-            </div>
-        );
-    };
+    const mkContent2: Array<CreatePipChildren> = [
+        () => {
+            return (
+                <div>
+                    content 2<br />
+                    content 2.2
+                </div>
+            );
+        },
+    ];
 
     describe("when rendering the dragger with PiP content 1", () => {
         beforeEach(() => {
@@ -64,6 +68,18 @@ describe("PictureInPictureDragger", () => {
             it("should update the PiP content", () => {
                 expect(renderResult.container).toMatchSnapshot();
             });
+        });
+    });
+
+    describe("when rendering the dragger with PiP content 1 and 2", () => {
+        beforeEach(() => {
+            renderResult = render(
+                <PictureInPictureDragger draggable={true}>{[...mkContent1, ...mkContent2]}</PictureInPictureDragger>,
+            );
+        });
+
+        it("should render both contents", () => {
+            expect(renderResult.container).toMatchSnapshot();
         });
     });
 });

--- a/test/components/views/voip/PipView-test.tsx
+++ b/test/components/views/voip/PipView-test.tsx
@@ -279,8 +279,17 @@ describe("PipView", () => {
         });
 
         it("should render the voice broadcast recording PiP", () => {
-            // check for the „Live“ badge
+            // check for the „Live“ badge to be present
             expect(screen.queryByText("Live")).toBeInTheDocument();
+        });
+
+        it("and a call it should show both, the call and the recording", async () => {
+            await withCall(async () => {
+                // Broadcast: Check for the „Live“ badge to be present
+                expect(screen.queryByText("Live")).toBeInTheDocument();
+                // Call: Check for the „Fill screen“ button to be present
+                expect(screen.queryByLabelText("Fill screen")).toBeInTheDocument();
+            });
         });
     });
 

--- a/test/components/views/voip/__snapshots__/PictureInPictureDragger-test.tsx.snap
+++ b/test/components/views/voip/__snapshots__/PictureInPictureDragger-test.tsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PictureInPictureDragger when rendering the dragger with PiP content 1 and 2 should render both contents 1`] = `
+<div>
+  <aside
+    style="transform: translateX(680px) translateY(478px);"
+  >
+    <div>
+      content 1
+    </div>
+    <div>
+      content 2
+      <br />
+      content 2.2
+    </div>
+  </aside>
+</div>
+`;
+
 exports[`PictureInPictureDragger when rendering the dragger with PiP content 1 and rendering PiP content 2 should update the PiP content 1`] = `
 <div>
   <aside


### PR DESCRIPTION
closes https://github.com/vector-im/element-web/issues/24076

Both can currently only be dragged together at the same time. Alignment is always the same.

![2pip](https://user-images.githubusercontent.com/6216686/209668940-7291387b-d9ff-400b-aaf6-6713df3cbf0c.png)

PSF-1807

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->