### PR TITLE
Get user confirmation before listening to a broadcast while recording

### DIFF
--- a/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
@@ -59,6 +59,7 @@ describe("startNewVoiceBroadcastRecording", () => {
 
             return null;
         });
+
         mocked(client.sendStateEvent).mockImplementation(
             (sendRoomId: string, eventType: string, content: any, stateKey: string): Promise<ISendEventResponse> => {
                 if (sendRoomId === roomId && eventType === VoiceBroadcastInfoEventType) {

--- a/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
+++ b/test/voice-broadcast/utils/startNewVoiceBroadcastRecording-test.ts
@@ -134,6 +134,7 @@ describe("startNewVoiceBroadcastRecording", () => {
                         return { event_id: infoEvent.getId()! };
                     },
                 );
+
                 const recording = await startNewVoiceBroadcastRecording(room, client, playbacksStore, recordingsStore);
                 expect(recording).not.toBeNull();
 


### PR DESCRIPTION
closes #24077

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->