### PR TITLE
Fix broadcast pre-recording check

### DIFF
--- a/src/voice-broadcast/utils/setUpVoiceBroadcastPreRecording.ts
+++ b/src/voice-broadcast/utils/setUpVoiceBroadcastPreRecording.ts
@@ -24,14 +24,14 @@ import {
     VoiceBroadcastRecordingsStore,
 } from "..";
 
-export const setUpVoiceBroadcastPreRecording = (
+export const setUpVoiceBroadcastPreRecording = async (
     room: Room,
     client: MatrixClient,
     playbacksStore: VoiceBroadcastPlaybacksStore,
     recordingsStore: VoiceBroadcastRecordingsStore,
     preRecordingStore: VoiceBroadcastPreRecordingStore,
-): VoiceBroadcastPreRecording | null => {
-    if (!checkVoiceBroadcastPreConditions(room, client, recordingsStore)) {
+): Promise<VoiceBroadcastPreRecording | null> => {
+    if (!(await checkVoiceBroadcastPreConditions(room, client, recordingsStore))) {
         return null;
     }
 


### PR DESCRIPTION
Fixes missing `await` for broadcast preconditions check

closes https://github.com/vector-im/element-web/issues/24099

PSF-1814

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->