### PR TITLE
Fixes empty content type during upload

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -303,7 +303,7 @@ export async function uploadFile(
             progressHandler,
             abortController,
             includeFilename: false,
-            type: "application/octet-stream"
+            type: "application/octet-stream",
         });
         if (abortController.signal.aborted) throw new UploadCanceledError();
 

--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -303,6 +303,7 @@ export async function uploadFile(
             progressHandler,
             abortController,
             includeFilename: false,
+            type: "application/octet-stream"
         });
         if (abortController.signal.aborted) throw new UploadCanceledError();
 

--- a/test/ContentMessages-test.ts
+++ b/test/ContentMessages-test.ts
@@ -312,7 +312,7 @@ describe("uploadFile", () => {
             expect.objectContaining({
                 progressHandler,
                 includeFilename: false,
-                type: "application/octet-stream"
+                type: "application/octet-stream",
             }),
         );
         expect(mocked(client.uploadContent).mock.calls[0][0]).not.toBe(file);

--- a/test/ContentMessages-test.ts
+++ b/test/ContentMessages-test.ts
@@ -312,6 +312,7 @@ describe("uploadFile", () => {
             expect.objectContaining({
                 progressHandler,
                 includeFilename: false,
+                type: "application/octet-stream"
             }),
         );
         expect(mocked(client.uploadContent).mock.calls[0][0]).not.toBe(file);


### PR DESCRIPTION
fixes [#element-web/24119
](https://github.com/vector-im/element-web/issues/24119#issue-1514032428)

By default a `Blob` has a empty string as a content type, so that type ends up being used as the request content type - causing encrypted uploads to also have have a empty content type. 
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [X] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
Notes: Fixed empty `Content-Type` for encrypted uploads

Signed-off-by: Mia Pigal <m@yarn.network>

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fixed empty `Content-Type` for encrypted uploads ([\#9848](https://github.com/matrix-org/matrix-react-sdk/pull/9848)). Contributed by @K3das.<!-- CHANGELOG_PREVIEW_END -->