### PR TITLE
Fix export with attachments on formats txt and json

### DIFF
--- a/src/utils/exportUtils/Exporter.ts
+++ b/src/utils/exportUtils/Exporter.ts
@@ -92,7 +92,7 @@ export default abstract class Exporter {
 
     protected async downloadZIP(): Promise<string | void> {
         const filename = this.destinationFileName;
-        const filenameWithoutExt = filename.substring(0, filename.length - 4); // take off the .zip
+        const filenameWithoutExt = filename.substring(0, filename.lastIndexOf('.')); // take off the extension
         const { default: JSZip } = await import("jszip");
 
         const zip = new JSZip();
@@ -103,8 +103,7 @@ export default abstract class Exporter {
         for (const file of this.files) zip.file(filenameWithoutExt + "/" + file.name, file.blob);
 
         const content = await zip.generateAsync({ type: "blob" });
-
-        saveAs(content, filename);
+        saveAs(content, filenameWithoutExt + ".zip");
     }
 
     protected cleanUp(): string {

--- a/src/utils/exportUtils/Exporter.ts
+++ b/src/utils/exportUtils/Exporter.ts
@@ -92,7 +92,7 @@ export default abstract class Exporter {
 
     protected async downloadZIP(): Promise<string | void> {
         const filename = this.destinationFileName;
-        const filenameWithoutExt = filename.substring(0, filename.lastIndexOf('.')); // take off the extension
+        const filenameWithoutExt = filename.substring(0, filename.lastIndexOf(".")); // take off the extension
         const { default: JSZip } = await import("jszip");
 
         const zip = new JSZip();


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24130

Turns out it was correctly exporting attachments but with the wrong extension.

Signed-off-by: [grimhilt@users.noreply.github.com](mailto:grimhilt@users.noreply.github.com)

type: Defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix export with attachments on formats txt and json ([\#9851](https://github.com/matrix-org/matrix-react-sdk/pull/9851)). Fixes vector-im/element-web#24130. Contributed by @grimhilt.<!-- CHANGELOG_PREVIEW_END -->