### PR TITLE
Remove broadcast under development note

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -459,7 +459,6 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         labsGroup: LabGroup.Messaging,
         supportedLevels: LEVELS_FEATURE,
         displayName: _td("Voice broadcast"),
-        description: _td("Under active development"),
         default: false,
     },
     [Features.VoiceBroadcastForceSmallChunks]: {


### PR DESCRIPTION
Removes the „Under active development note“ for broadcasts. For background info ask me directly.

![image](https://user-images.githubusercontent.com/6216686/210330195-9d3f7e14-58ae-4be4-8cfe-6a5c0a97392a.png)

PSF-1823

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))