### PR TITLE
Make calls automatically disconnect if the widget disappears

### DIFF
--- a/test/models/Call-test.ts
+++ b/test/models/Call-test.ts
@@ -784,6 +784,13 @@ describe("ElementCall", () => {
             expect(call.connectionState).toBe(ConnectionState.Connected);
         });
 
+        it("disconnects if the widget dies", async () => {
+            await call.connect();
+            expect(call.connectionState).toBe(ConnectionState.Connected);
+            WidgetMessagingStore.instance.stopMessaging(widget, room.roomId);
+            expect(call.connectionState).toBe(ConnectionState.Disconnected);
+        });
+
         it("tracks participants in room state", async () => {
             expect(call.participants).toEqual(new Map());
 


### PR DESCRIPTION
If something goes wrong with the widget, there's no way we can continue the call, so this acts as a safeguard against stuck calls in cases where the widget crashes or disconnects weirdly.

Closes https://github.com/vector-im/element-web/issues/23664

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make calls automatically disconnect if the widget disappears ([\#9862](https://github.com/matrix-org/matrix-react-sdk/pull/9862)). Fixes vector-im/element-web#23664.<!-- CHANGELOG_PREVIEW_END -->