### PR TITLE
Device manager - prune client information events after remote sign out

### DIFF
--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -177,8 +177,13 @@ export const useOwnDevices = (): DevicesState => {
     }, [refreshDevices]);
 
     useEffect(() => {
-        pruneClientInformation(Object.keys(devices), matrixClient);
-    }, [devices]);
+        const deviceIds = Object.keys(devices);
+        // empty devices means devices have not been fetched yet
+        // as there is always at least the current device
+        if (deviceIds.length) {
+            pruneClientInformation(Object.keys(devices), matrixClient);
+        }
+    }, [devices, matrixClient]);
 
     useEventEmitter(matrixClient, CryptoEvent.DevicesUpdated, (users: string[]): void => {
         if (users.includes(userId)) {

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -35,7 +35,7 @@ import { CryptoEvent } from "matrix-js-sdk/src/crypto";
 
 import MatrixClientContext from "../../../../contexts/MatrixClientContext";
 import { _t } from "../../../../languageHandler";
-import { getDeviceClientInformation } from "../../../../utils/device/clientInformation";
+import { getDeviceClientInformation, pruneClientInformation } from "../../../../utils/device/clientInformation";
 import { DevicesDictionary, ExtendedDevice, ExtendedDeviceAppInfo } from "./types";
 import { useEventEmitter } from "../../../../hooks/useEventEmitter";
 import { parseUserAgent } from "../../../../utils/device/parseUserAgent";
@@ -175,6 +175,10 @@ export const useOwnDevices = (): DevicesState => {
     useEffect(() => {
         refreshDevices();
     }, [refreshDevices]);
+
+    useEffect(() => {
+        pruneClientInformation(Object.keys(devices), matrixClient);
+    }, [devices]);
 
     useEventEmitter(matrixClient, CryptoEvent.DevicesUpdated, (users: string[]): void => {
         if (users.includes(userId)) {

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -116,8 +116,8 @@ export type DevicesState = {
 export const useOwnDevices = (): DevicesState => {
     const matrixClient = useContext(MatrixClientContext);
 
-    const currentDeviceId = matrixClient.getDeviceId();
-    const userId = matrixClient.getUserId();
+    const currentDeviceId = matrixClient.getDeviceId()!;
+    const userId = matrixClient.getSafeUserId();
 
     const [devices, setDevices] = useState<DevicesState["devices"]>({});
     const [pushers, setPushers] = useState<DevicesState["pushers"]>([]);
@@ -138,11 +138,6 @@ export const useOwnDevices = (): DevicesState => {
     const refreshDevices = useCallback(async () => {
         setIsLoadingDeviceList(true);
         try {
-            // realistically we should never hit this
-            // but it satisfies types
-            if (!userId) {
-                throw new Error("Cannot fetch devices without user id");
-            }
             const devices = await fetchDevicesWithVerification(matrixClient, userId);
             setDevices(devices);
 

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -176,7 +176,7 @@ export const useOwnDevices = (): DevicesState => {
         // empty devices means devices have not been fetched yet
         // as there is always at least the current device
         if (deviceIds.length) {
-            pruneClientInformation(Object.keys(devices), matrixClient);
+            pruneClientInformation(deviceIds, matrixClient);
         }
     }, [devices, matrixClient]);
 

--- a/src/utils/device/clientInformation.ts
+++ b/src/utils/device/clientInformation.ts
@@ -52,7 +52,7 @@ export const recordClientInformation = async (
     sdkConfig: IConfigOptions,
     platform: BasePlatform,
 ): Promise<void> => {
-    const deviceId = matrixClient.getDeviceId();
+    const deviceId = matrixClient.getDeviceId()!;
     const { brand } = sdkConfig;
     const version = await platform.getAppVersion();
     const type = getClientInformationEventType(deviceId);
@@ -88,7 +88,7 @@ export const pruneClientInformation = async (validDeviceIds: string[], matrixCli
  * Remove extra client information for current device
  */
 export const removeClientInformation = async (matrixClient: MatrixClient): Promise<void> => {
-    const deviceId = matrixClient.getDeviceId();
+    const deviceId = matrixClient.getDeviceId()!;
     const type = getClientInformationEventType(deviceId);
     const clientInformation = getDeviceClientInformation(matrixClient, deviceId);
 

--- a/src/utils/device/clientInformation.ts
+++ b/src/utils/device/clientInformation.ts
@@ -70,17 +70,15 @@ export const recordClientInformation = async (
  * @param validDeviceIds - ids of current devices,
  *                      client information for devices NOT in this list will be removed
  */
-export const pruneClientInformation = async (validDeviceIds: string[], matrixClient: MatrixClient): Promise<void> => {
-    const orphanClientInformationEvents = Object.values(matrixClient.store.accountData).filter((event) => {
-        if (event.getType().startsWith(clientInformationEventPrefix)) {
-            const [, deviceId] = event.getType().split(clientInformationEventPrefix);
-            return deviceId && !validDeviceIds.includes(deviceId);
+export const pruneClientInformation = (validDeviceIds: string[], matrixClient: MatrixClient): void => {
+    Object.values(matrixClient.store.accountData).forEach((event) => {
+        if (!event.getType().startsWith(clientInformationEventPrefix)) {
+            return;
         }
-        return false;
-    });
-
-    orphanClientInformationEvents.forEach((event) => {
-        matrixClient.deleteAccountData(event.getType());
+        const [, deviceId] = event.getType().split(clientInformationEventPrefix);
+        if (deviceId && !validDeviceIds.includes(deviceId)) {
+            matrixClient.deleteAccountData(event.getType());
+        }
     });
 };
 

--- a/src/utils/device/clientInformation.ts
+++ b/src/utils/device/clientInformation.ts
@@ -74,7 +74,6 @@ export const pruneClientInformation = async (validDeviceIds: string[], matrixCli
     const orphanClientInformationEvents = Object.values(matrixClient.store.accountData).filter((event) => {
         if (event.getType().startsWith(clientInformationEventPrefix)) {
             const [, deviceId] = event.getType().split(clientInformationEventPrefix);
-            console.log('YO', deviceId, validDeviceIds)
             return deviceId && !validDeviceIds.includes(deviceId);
         }
         return false;

--- a/src/utils/device/clientInformation.ts
+++ b/src/utils/device/clientInformation.ts
@@ -74,6 +74,7 @@ export const pruneClientInformation = async (validDeviceIds: string[], matrixCli
     const orphanClientInformationEvents = Object.values(matrixClient.store.accountData).filter((event) => {
         if (event.getType().startsWith(clientInformationEventPrefix)) {
             const [, deviceId] = event.getType().split(clientInformationEventPrefix);
+            console.log('YO', deviceId, validDeviceIds)
             return deviceId && !validDeviceIds.includes(deviceId);
         }
         return false;

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -93,6 +93,8 @@ describe("<SessionManagerTab />", () => {
         setLocalNotificationSettings: jest.fn(),
         getVersions: jest.fn().mockResolvedValue({}),
     });
+    // @ts-ignore mock
+    mockClient.store = { accountData: {} };
 
     const defaultProps = {};
     const getComponent = (props = {}): React.ReactElement => (

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -46,6 +46,7 @@ import LogoutDialog from "../../../../../../src/components/views/dialogs/LogoutD
 import { DeviceSecurityVariation, ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types";
 import { INACTIVE_DEVICE_AGE_MS } from "../../../../../../src/components/views/settings/devices/filter";
 import SettingsStore from "../../../../../../src/settings/SettingsStore";
+import { getClientInformationEventType } from "../../../../../../src/utils/device/clientInformation";
 
 mockPlatformPeg();
 
@@ -87,14 +88,13 @@ describe("<SessionManagerTab />", () => {
         generateClientSecret: jest.fn(),
         setDeviceDetails: jest.fn(),
         getAccountData: jest.fn(),
+        deleteAccountData: jest.fn(),
         doesServerSupportUnstableFeature: jest.fn().mockResolvedValue(true),
         getPushers: jest.fn(),
         setPusher: jest.fn(),
         setLocalNotificationSettings: jest.fn(),
         getVersions: jest.fn().mockResolvedValue({}),
     });
-    // @ts-ignore mock
-    mockClient.store = { accountData: {} };
 
     const defaultProps = {};
     const getComponent = (props = {}): React.ReactElement => (
@@ -183,6 +183,9 @@ describe("<SessionManagerTab />", () => {
                 }),
             ],
         });
+
+        // @ts-ignore mock
+        mockClient.store = { accountData: {} };
 
         mockClient.getAccountData.mockReset().mockImplementation((eventType) => {
             if (eventType.startsWith(LOCAL_NOTIFICATION_SETTINGS_PREFIX.name)) {
@@ -667,6 +670,45 @@ describe("<SessionManagerTab />", () => {
                 [alicesMobileDevice.device_id, alicesOlderMobileDevice.device_id],
                 undefined,
             );
+        });
+
+        it("removes account data events for devices after sign out", async () => {
+            const mobileDeviceClientInfo = new MatrixEvent({
+                type: getClientInformationEventType(alicesMobileDevice.device_id),
+                content: {
+                    name: 'test'
+                }
+            })
+            // @ts-ignore setup mock
+            mockClient.store = {
+                // @ts-ignore setup mock
+                accountData: {
+                    [mobileDeviceClientInfo.getType()]: mobileDeviceClientInfo
+                }
+            }
+
+            mockClient.getDevices.mockResolvedValueOnce({
+                    devices: [alicesDevice, alicesMobileDevice, alicesOlderMobileDevice],
+                }).mockResolvedValueOnce({
+                    // refreshed devices after sign out
+                    devices: [alicesDevice],
+                });
+
+            const { getByTestId, getByLabelText } = render(getComponent());
+
+            await act(async () => {
+                await flushPromises();
+            });
+
+            expect(mockClient.deleteAccountData).not.toHaveBeenCalled();
+
+            fireEvent.click(getByTestId("current-session-menu"));
+            fireEvent.click(getByLabelText("Sign out of all other sessions (2)"));
+            await confirmSignout(getByTestId);
+
+            // only called once for signed out device with account data event
+            expect(mockClient.deleteAccountData).toHaveBeenCalledTimes(1);
+            expect(mockClient.deleteAccountData).toHaveBeenCalledWith(mobileDeviceClientInfo.getType());
         });
 
         describe("other devices", () => {

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -676,20 +676,22 @@ describe("<SessionManagerTab />", () => {
             const mobileDeviceClientInfo = new MatrixEvent({
                 type: getClientInformationEventType(alicesMobileDevice.device_id),
                 content: {
-                    name: 'test'
-                }
-            })
+                    name: "test",
+                },
+            });
             // @ts-ignore setup mock
             mockClient.store = {
                 // @ts-ignore setup mock
                 accountData: {
-                    [mobileDeviceClientInfo.getType()]: mobileDeviceClientInfo
-                }
-            }
+                    [mobileDeviceClientInfo.getType()]: mobileDeviceClientInfo,
+                },
+            };
 
-            mockClient.getDevices.mockResolvedValueOnce({
+            mockClient.getDevices
+                .mockResolvedValueOnce({
                     devices: [alicesDevice, alicesMobileDevice, alicesOlderMobileDevice],
-                }).mockResolvedValueOnce({
+                })
+                .mockResolvedValueOnce({
                     // refreshed devices after sign out
                     devices: [alicesDevice],
                 });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Device manager - prune client information events after remote sign out ([\#9874](https://github.com/matrix-org/matrix-react-sdk/pull/9874)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->