### PR TITLE
Remove extensible events v1 experimental rendering

### DIFF
--- a/src/TextForEvent.tsx
+++ b/src/TextForEvent.tsx
@@ -20,11 +20,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { removeDirectionOverrideChars } from "matrix-js-sdk/src/utils";
 import { GuestAccess, HistoryVisibility, JoinRule } from "matrix-js-sdk/src/@types/partials";
 import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
-import {
-    M_POLL_START,
-    M_POLL_END,
-    PollStartEvent,
-} from "matrix-events-sdk";
+import { M_POLL_START, M_POLL_END, PollStartEvent } from "matrix-events-sdk";
 
 import { _t } from "./languageHandler";
 import * as Roles from "./Roles";

--- a/src/TextForEvent.tsx
+++ b/src/TextForEvent.tsx
@@ -21,10 +21,6 @@ import { removeDirectionOverrideChars } from "matrix-js-sdk/src/utils";
 import { GuestAccess, HistoryVisibility, JoinRule } from "matrix-js-sdk/src/@types/partials";
 import { EventType, MsgType } from "matrix-js-sdk/src/@types/event";
 import {
-    M_EMOTE,
-    M_NOTICE,
-    M_MESSAGE,
-    MessageEvent,
     M_POLL_START,
     M_POLL_END,
     PollStartEvent,
@@ -345,17 +341,6 @@ function textForMessageEvent(ev: MatrixEvent): () => string | null {
         let message = ev.getContent().body;
         if (ev.isRedacted()) {
             message = textForRedactedPollAndMessageEvent(ev);
-        }
-
-        if (SettingsStore.isEnabled("feature_extensible_events")) {
-            const extev = ev.unstableExtensibleEvent as MessageEvent;
-            if (extev) {
-                if (extev.isEquivalentTo(M_EMOTE)) {
-                    return `* ${senderDisplayName} ${extev.text}`;
-                } else if (extev.isEquivalentTo(M_NOTICE) || extev.isEquivalentTo(M_MESSAGE)) {
-                    return `${senderDisplayName}: ${extev.text}`;
-                }
-            }
         }
 
         if (ev.getContent().msgtype === MsgType.Emote) {

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -18,7 +18,6 @@ import React, { createRef, SyntheticEvent, MouseEvent, ReactNode } from "react";
 import ReactDOM from "react-dom";
 import highlight from "highlight.js";
 import { MsgType } from "matrix-js-sdk/src/@types/event";
-import { isEventLike, LegacyMsgType, M_MESSAGE, MessageEvent } from "matrix-events-sdk";
 
 import * as HtmlUtils from "../../../HtmlUtils";
 import { formatDate } from "../../../DateUtils";
@@ -579,29 +578,6 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
         // only strip reply if this is the original replying event, edits thereafter do not have the fallback
         const stripReply = !mxEvent.replacingEvent() && !!getParentEventId(mxEvent);
         let body: ReactNode;
-        if (SettingsStore.isEnabled("feature_extensible_events")) {
-            const extev = this.props.mxEvent.unstableExtensibleEvent as MessageEvent;
-            if (extev?.isEquivalentTo(M_MESSAGE)) {
-                isEmote = isEventLike(extev.wireFormat, LegacyMsgType.Emote);
-                isNotice = isEventLike(extev.wireFormat, LegacyMsgType.Notice);
-                body = HtmlUtils.bodyToHtml(
-                    {
-                        body: extev.text,
-                        format: extev.html ? "org.matrix.custom.html" : undefined,
-                        formatted_body: extev.html,
-                        msgtype: MsgType.Text,
-                    },
-                    this.props.highlights,
-                    {
-                        disableBigEmoji: isEmote || !SettingsStore.getValue<boolean>("TextualBody.enableBigEmoji"),
-                        // Part of Replies fallback support
-                        stripReplyFallback: stripReply,
-                        ref: this.contentRef,
-                        returnString: false,
-                    },
-                );
-            }
-        }
         if (!body) {
             isEmote = content.msgtype === MsgType.Emote;
             isNotice = content.msgtype === MsgType.Notice;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -938,7 +938,6 @@
     "Show message previews for reactions in DMs": "Show message previews for reactions in DMs",
     "Show message previews for reactions in all rooms": "Show message previews for reactions in all rooms",
     "Offline encrypted messaging using dehydrated devices": "Offline encrypted messaging using dehydrated devices",
-    "Show extensible event representation of events": "Show extensible event representation of events",
     "Show current avatar and name for users in message history": "Show current avatar and name for users in message history",
     "Show HTML representation of room topics": "Show HTML representation of room topics",
     "Show info about bridges in room settings": "Show info about bridges in room settings",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -340,13 +340,6 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         supportedLevels: LEVELS_FEATURE,
         default: false,
     },
-    "feature_extensible_events": {
-        isFeature: true,
-        labsGroup: LabGroup.Developer, // developer for now, eventually Messaging and default on
-        supportedLevels: LEVELS_FEATURE,
-        displayName: _td("Show extensible event representation of events"),
-        default: false,
-    },
     "useOnlyCurrentProfiles": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("Show current avatar and name for users in message history"),


### PR DESCRIPTION
With the changes to extensible events in v2 largely being contained to a room version, we don't need to have this code or the labs flag anymore. If the labs flag becomes useful in the future, it will be re-added.

. o ( should we have a changelog type for "feature removal"? )

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove extensible events v1 experimental rendering ([\#9881](https://github.com/matrix-org/matrix-react-sdk/pull/9881)).<!-- CHANGELOG_PREVIEW_END -->