### PR TITLE
Fix unexpected composer growing

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@matrix-org/analytics-events": "^0.3.0",
-        "@matrix-org/matrix-wysiwyg": "^0.14.0",
+        "@matrix-org/matrix-wysiwyg": "^0.16.0",
         "@matrix-org/react-sdk-module-api": "^0.0.3",
         "@sentry/browser": "^7.0.0",
         "@sentry/tracing": "^7.0.0",

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { WysiwygInputEvent } from "@matrix-org/matrix-wysiwyg";
+import { WysiwygEvent } from "@matrix-org/matrix-wysiwyg";
 import { useCallback } from "react";
 
 import { useSettingValue } from "../../../../../hooks/useSettings";
@@ -22,12 +22,20 @@ import { useSettingValue } from "../../../../../hooks/useSettings";
 export function useInputEventProcessor(onSend: () => void) {
     const isCtrlEnter = useSettingValue<boolean>("MessageComposerInput.ctrlEnterToSend");
     return useCallback(
-        (event: WysiwygInputEvent) => {
+        (event: WysiwygEvent) => {
             if (event instanceof ClipboardEvent) {
                 return event;
             }
 
-            if ((event.inputType === "insertParagraph" && !isCtrlEnter) || event.inputType === "sendMessage") {
+            const isKeyboardEvent = event instanceof KeyboardEvent;
+            const isEnterPress =
+                !isCtrlEnter && (isKeyboardEvent ? event.key === "Enter" : event.inputType === "insertParagraph");
+            // sendMessage is sent when ctrl+enter is pressed
+            const isSendMessage = !isKeyboardEvent && event.inputType === "sendMessage";
+
+            if (isEnterPress || isSendMessage) {
+                event.stopPropagation?.();
+                event.preventDefault?.();
                 onSend();
                 return null;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,10 +1525,10 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.2.tgz#a09d0fea858e817da971a3c9f904632ef7b49eb6"
   integrity sha512-oVkBCh9YP7H9i4gAoQbZzswniczfo/aIptNa4dxRi4Ff9lSvUCFv6Hvzi7C+90c0/PWZLXjIDTIAWZYmwyd2fA==
 
-"@matrix-org/matrix-wysiwyg@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-wysiwyg/-/matrix-wysiwyg-0.14.0.tgz#359fabf5af403b3f128fe6ede3bff9754a9e18c4"
-  integrity sha512-iSwIR7kS/zwAzy/8S5cUMv2aceoJl/vIGhqmY9hSU0gVyzmsyaVnx00uNMvVDBUFiiPT2gonN8R3+dxg58TPaQ==
+"@matrix-org/matrix-wysiwyg@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-wysiwyg/-/matrix-wysiwyg-0.16.0.tgz#2eb81899cedc740f522bd7c2839bd9151d67a28e"
+  integrity sha512-w+/bUQ5x4lVRncrYSmdxy5ww4kkgXeSg4aFfby9c7c6o/+o4gfV6/XBdoJ71nhStyIYIweKAz8i3zA3rKonyvw==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


When I'm pressing enter:
- With content: the composer is growing before sending the message
- Without content: the composer is growing and getting back it's original height

When enter is pressed (or ctrl+enter according to settings), the composer shouldn't grow.

To avoid the composer growing, the enter keyDown event needs to be prevented. To do it:
- In the matrix-wysiwyg, the inputEventProcessor is called also in the keyDown event
- In the inputEventProcessor, the event can be a `KeyBoardEvent` or a `WysiwygInputEvent` and we handle the two cases

About the test, I added some of them in `matrix-wysiwyg`. But here, I already have tests which are covering the inputEventProcessor. 

Maybe cypress test  ?

Before

https://user-images.githubusercontent.com/2621378/211840767-5adf1ddf-e41c-457d-811e-7270e0fca9f1.mov

After

https://user-images.githubusercontent.com/2621378/211841211-a8f5b45f-2df7-4a3a-bc9a-bfd51dd109d0.mov

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix unexpected composer growing ([\#9889](https://github.com/matrix-org/matrix-react-sdk/pull/9889)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->