### PR TITLE
Rewrite `cy.all` implementation

### DIFF
--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022-2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,12 +16,6 @@ limitations under the License.
 
 /// <reference types="cypress" />
 
-// @see https://github.com/cypress-io/cypress/issues/915#issuecomment-475862672
-// Modified due to changes to `cy.queue` https://github.com/cypress-io/cypress/pull/17448
-// Note: this DOES NOT run Promises in parallel like `Promise.all` due to the nature
-// of Cypress promise-like objects and command queue. This only makes it convenient to use the same
-// API but runs the commands sequentially.
-
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
@@ -31,16 +25,9 @@ declare global {
             all<T extends Cypress.Chainable[] | []>(
                 commands: T,
             ): Cypress.Chainable<{ [P in keyof T]: ChainableValue<T[P]> }>;
-            queue: any;
-        }
-
-        interface Chainable {
-            chainerId: string;
         }
     }
 }
-
-const chainStart = Symbol("chainStart");
 
 /**
  * @description Returns a single Chainable that resolves when all of the Chainables pass.
@@ -48,34 +35,25 @@ const chainStart = Symbol("chainStart");
  * @returns {Cypress.Chainable} Cypress when all Chainables are resolved.
  */
 cy.all = function all(commands): Cypress.Chainable {
-    const chain = cy.wrap(null, { log: false });
-    const stopCommand = Cypress._.find(cy.queue.get(), {
-        attributes: { chainerId: chain.chainerId },
+    const resultArray = [];
+
+    // as each command completes, push the result onto resultArray
+    for (const cmd of commands) {
+        cmd.then((val) => {
+            resultArray.push(val);
+        });
+    }
+
+    // add an entry to the log which, when clicked, will write the results to the console.
+    Cypress.log({
+        name: "all",
+        consoleProps: () => ({ Results: resultArray }),
     });
-    const startCommand = Cypress._.find(cy.queue.get(), {
-        attributes: { chainerId: commands[0].chainerId },
-    });
-    const p = chain.then(() => {
-        return cy.wrap(
-            // @see https://lodash.com/docs/4.17.15#lodash
-            Cypress._(commands)
-                .map((cmd) => {
-                    return cmd[chainStart]
-                        ? cmd[chainStart].attributes
-                        : Cypress._.find(cy.queue.get(), {
-                              attributes: { chainerId: cmd.chainerId },
-                          }).attributes;
-                })
-                .concat(stopCommand.attributes)
-                .slice(1)
-                .map((cmd) => {
-                    return cmd.prev.get("subject");
-                })
-                .value(),
-        );
-    });
-    p[chainStart] = startCommand;
-    return p;
+
+    // return a chainable which wraps the resultArray. Although this doesn't have a direct dependency on the input
+    // commands, cypress won't process it until the commands that precede it on the command queue (which must include
+    // the input commands) have passed.
+    return cy.wrap(resultArray, { log: false });
 };
 
 // Needed to make this file a module

--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -37,10 +37,10 @@ declare global {
 cy.all = function all(commands): Cypress.Chainable {
     const resultArray = [];
 
-    // as each command completes, push the result onto resultArray
-    for (const cmd of commands) {
-        cmd.then((val) => {
-            resultArray.push(val);
+    // as each command completes, store the result in the corresponding location of resultArray.
+    for (let i = 0; i < commands.length; i++) {
+        commands[i].then((val) => {
+            resultArray[i] = val;
         });
     }
 


### PR DESCRIPTION
The previous implementation was indecipherable, and didn't actually work.

@andybalaam and I spent a couple of hours trying to decipher the implementation of `cy.all()`. The general idea seemed to be:
 * add a new command to the cypress queue
 * for (each input command except the first, plus the new command), find the entry in the queue that corresponded to it (with some magic specific to previous calls to `.all()`)
 * for each entry thus found, find the *previous* command on the queue, and get its result.

This fails if the input commands are either queued in a different order, or if there are other commands queued before the call to `.all()`. It also seems... baroque (why do we bother indirecting via `.prev`?) and depends on Cypress internals.

(On closer inspection, the existing implementation appears to have been cargo-culted from https://github.com/cypress-io/cypress/issues/915#issuecomment-475862672. )

This is a much simpler implementation which appears to do much the same thing.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->