### PR TITLE
Remember SpacePanel collapsed state between loads

### DIFF
--- a/src/components/views/spaces/SpacePanel.tsx
+++ b/src/components/views/spaces/SpacePanel.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 - 2022 The Matrix.org Foundation C.I.C.
+Copyright 2021 - 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ import SettingsStore from "../../../settings/SettingsStore";
 import { SettingLevel } from "../../../settings/SettingLevel";
 import UIStore from "../../../stores/UIStore";
 import QuickSettingsButton from "./QuickSettingsButton";
-import { useSettingValue } from "../../../hooks/useSettings";
+import { useSetting, useSettingValue } from "../../../hooks/useSettings";
 import UserMenu from "../../structures/UserMenu";
 import IndicatorScrollbar from "../../structures/IndicatorScrollbar";
 import { IS_MAC, Key } from "../../../Keyboard";
@@ -329,12 +329,15 @@ const InnerSpacePanel = React.memo<IInnerSpacePanelProps>(
 );
 
 const SpacePanel = () => {
-    const [isPanelCollapsed, setPanelCollapsed] = useState(true);
-    const ref = useRef<HTMLDivElement>();
+    const [isPanelCollapsed, setPanelCollapsed] = useSetting<boolean>("space_panel_collapsed");
+
+    const ref = useRef<HTMLDivElement>(null);
     useLayoutEffect(() => {
+        if (!ref.current) return;
+
         UIStore.instance.trackElementDimensions("SpacePanel", ref.current);
         return () => UIStore.instance.stopTrackingElementDimensions("SpacePanel");
-    }, []);
+    }, [ ref ]);
 
     useDispatcher(defaultDispatcher, (payload: ActionPayload) => {
         if (payload.action === Action.ToggleSpacePanel) {
@@ -359,6 +362,7 @@ const SpacePanel = () => {
                         <UserMenu isPanelCollapsed={isPanelCollapsed}>
                             <AccessibleTooltipButton
                                 className={classNames("mx_SpacePanel_toggleCollapse", { expanded: !isPanelCollapsed })}
+                                data-testid="collapse-space-panel-button"
                                 onClick={() => setPanelCollapsed(!isPanelCollapsed)}
                                 title={isPanelCollapsed ? _t("Expand") : _t("Collapse")}
                                 tooltip={

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@ limitations under the License.
 
 import { useEffect, useState } from "react";
 
+import { SettingLevel } from "../settings/SettingLevel";
 import SettingsStore from "../settings/SettingsStore";
 
+/** Async version of {@link React.Dispatch} */
+type DispatchAsync<A> = (value: A) => Promise<void>;
+
 // Hook to fetch the value of a setting and dynamically update when it changes
-export const useSettingValue = <T>(settingName: string, roomId: string = null, excludeDefault = false) => {
+export const useSettingValue = <T>(settingName: string, roomId: string | null = null, excludeDefault = false) => {
     const [value, setValue] = useState(SettingsStore.getValue<T>(settingName, roomId, excludeDefault));
 
     useEffect(() => {
@@ -35,8 +39,37 @@ export const useSettingValue = <T>(settingName: string, roomId: string = null, e
     return value;
 };
 
+/**
+ * Hook for retrieving a setting's value, along with a function to update it.
+ * Similar to {@link useState}, but for settings.
+ *
+ * The setter (i.e. the second value in the returned tuple), returns a promise
+ * that resolves when the setting has been fully flushed.
+ *
+ * @see {@link useSettingValue} if updating is not necessary
+ * @see {@link SettingsStore}
+ */
+export function useSetting<T>(
+    settingName: string,
+    roomId: string | null = null,
+    excludeDefault = false,
+    settingLevel = SettingLevel.DEVICE,
+): [T, DispatchAsync<React.SetStateAction<T>>] {
+    const value = useSettingValue<T>(settingName, roomId, excludeDefault);
+
+    function set(updater: T | ((oldValue: T) => T)) {
+        const newValue: T =
+            typeof updater === "function"
+                ? (updater as ((oldValue: T) => T))(value)
+                : updater;
+        return SettingsStore.setValue(settingName, roomId, settingLevel, newValue);
+    }
+
+    return [value, set];
+}
+
 // Hook to fetch whether a feature is enabled and dynamically update when that changes
-export const useFeatureEnabled = (featureName: string, roomId: string = null): boolean => {
+export const useFeatureEnabled = (featureName: string, roomId: string | null = null): boolean => {
     const [enabled, setEnabled] = useState(SettingsStore.getValue<boolean>(featureName, roomId));
 
     useEffect(() => {

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -768,6 +768,11 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         supportedLevels: [SettingLevel.ACCOUNT],
         default: [], // list of room IDs, most recent first
     },
+    "space_panel_collapsed": {
+        // not really a setting
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        default: true,
+    },
     "room_directory_servers": {
         supportedLevels: [SettingLevel.ACCOUNT],
         default: [],

--- a/test/components/views/spaces/SpacePanel-test.tsx
+++ b/test/components/views/spaces/SpacePanel-test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,17 +15,16 @@ limitations under the License.
 */
 
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { mocked } from "jest-mock";
-import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import UnwrappedSpacePanel from "../../../../src/components/views/spaces/SpacePanel";
-import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import { SpaceKey } from "../../../../src/stores/spaces";
 import { shouldShowComponent } from "../../../../src/customisations/helpers/UIComponents";
 import { UIComponent } from "../../../../src/settings/UIFeature";
-import { wrapInSdkContext } from "../../../test-utils";
+import { stubClient, wrapInSdkContext } from "../../../test-utils";
 import { SdkContextClass } from "../../../../src/contexts/SDKContext";
+import AbstractLocalStorageSettingsHandler from "../../../../src/settings/handlers/AbstractLocalStorageSettingsHandler";
 
 jest.mock("../../../../src/stores/spaces/SpaceStore", () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -46,15 +45,10 @@ jest.mock("../../../../src/customisations/helpers/UIComponents", () => ({
 }));
 
 describe("<SpacePanel />", () => {
-    const mockClient = {
-        getUserId: jest.fn().mockReturnValue("@test:test"),
-        isGuest: jest.fn(),
-        getAccountData: jest.fn(),
-    } as unknown as MatrixClient;
     const SpacePanel = wrapInSdkContext(UnwrappedSpacePanel, SdkContextClass.instance);
 
     beforeAll(() => {
-        jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
+        stubClient();
     });
 
     beforeEach(() => {
@@ -78,6 +72,36 @@ describe("<SpacePanel />", () => {
             render(<SpacePanel />);
             fireEvent.click(screen.getByTestId("create-space-button"));
             screen.getByTestId("create-space-button");
+        });
+    });
+
+    describe("collapsing", () => {
+        const clickCollapse = () => fireEvent.click(screen.getByTestId("collapse-space-panel-button"));
+
+        beforeEach(() => {
+            localStorage.clear();
+            AbstractLocalStorageSettingsHandler.clear();
+        });
+
+        it("should expand", () => {
+            const res = render(<SpacePanel />);
+            const panel = res.baseElement.querySelector(".mx_SpacePanel");
+            expect(panel).toHaveClass("collapsed");
+
+            clickCollapse();
+            expect(panel).not.toHaveClass("collapsed");
+        });
+
+        it("should remember its collapsed state", () => {
+            // Render a panel and expand it
+            render(<SpacePanel />);
+            clickCollapse();
+            cleanup();
+
+            // Re-render
+            const res = render(<SpacePanel />);
+            const newPanel = res.baseElement.querySelector(".mx_SpacePanel");
+            expect(newPanel).not.toHaveClass("collapsed");
         });
     });
 });

--- a/test/hooks/useSettings-test.ts
+++ b/test/hooks/useSettings-test.ts
@@ -1,0 +1,58 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "varsIgnorePattern": "^_" }] */
+
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import { useSetting } from "../../src/hooks/useSettings";
+import { SETTINGS } from "../../src/settings/Settings";
+import SettingsStore from "../../src/settings/SettingsStore";
+
+describe("useSetting", () => {
+    it("should return the default value", () => {
+        const settingId = "alwaysShowTimestamps";
+        const { result } = renderHook(() => useSetting<boolean>(settingId));
+        const [value, _set] = result.current;
+        expect(value).toBe(SETTINGS[settingId].default);
+    });
+
+    it("should update the actual setting", async () => {
+        const settingId = "language";
+        const { result } = renderHook(() => useSetting<string>(settingId));
+
+        const newValue = "es-ES";
+        await act(async () => {
+            const [_value, set] = result.current;
+            return await set(newValue);
+        });
+
+        expect(SettingsStore.getValue(settingId)).toBe(newValue);
+    });
+
+    it("should rerender on update", async () => {
+        const settingId = "autocompleteDelay";
+        const { result } = renderHook(() => useSetting<number>(settingId));
+        const beforeLength = result.all.length;
+
+        await act(async () => {
+            const [_value, set] = result.current;
+            return await set((old) => old + 1);
+        });
+
+        expect(result.all).toHaveLength(beforeLength + 1);
+    });
+});


### PR DESCRIPTION
Fixes vector-im/element-web#23172

This introduces a new boolean setting, `space_panel_collapsed`, which will control whether or not `<SpacePanel />` will be collapsed on mount. The setting is device only, so it's only persisted to `localStorage`, but I reckon that should be okay.

One thing that I'm not positive about is how the [`ToggleSpacePanel` action](https://github.com/matrix-org/matrix-react-sdk/blob/f58d62d339f534416cf1df2283bd6c7c20e90810/src/components/views/spaces/SpacePanel.tsx#L339-L343) should be handled (if at all). Is it still appropriate for `<SpacePanel />` to be listening for it, and syncing with the setting? Should the users of that action be migrated to just using the setting directly? The action is only dispatched when the hotkey for collapsing is detected.

This is my first contribution to this repository, and, as such, I'm open to any and all feedback! I've done my best to follow the guidelines and documented code style, but I'm happy to adjust if I've messed up.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: The Spaces Panel will now remember whether or not it was expanded. See https://github.com/vector-im/element-web/issues/23172.
<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->