### PR TITLE
Allow IndexedDB cleanup operations to fail

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -2,7 +2,7 @@
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 Copyright 2018 New Vector Ltd
-Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -926,7 +926,13 @@ async function clearStorage(opts?: { deleteEverything?: boolean }): Promise<void
     });
 
     await EventIndexPeg.deleteEventIndex();
-    await cli.clearStores();
+    try {
+        await cli.clearStores();
+    } catch (_) {
+        // Clearing the stores failed, which is probably okay, they were
+        // supposed to be cleared anyway. Any relevant errors were already
+        // logged.
+    }
 }
 
 /**

--- a/test/Lifecycle-test.ts
+++ b/test/Lifecycle-test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as Lifecycle from "../src/Lifecycle";
+import { mockPlatformPeg } from "./test-utils";
+
+/**
+ * Create a fake IndexedDB that mimics Firefox's 'disabled' implementation.
+ */
+function brokenIDB(): IDBFactory {
+    return {
+        deleteDatabase: () => {
+            // Return an IDBOpenDBRequest that immediately errors
+            const resp = { onerror: undefined } as IDBOpenDBRequest;
+            setTimeout(() => resp.onerror?.(new ErrorEvent("")), 1);
+            return resp;
+        },
+    } as unknown as IDBFactory;
+}
+
+describe("Lifecycle", () => {
+    describe("onLoggedOut", () => {
+        beforeAll(() => mockPlatformPeg());
+
+        it("allows IndexedDB failures", async () => {
+            // Ensure that the indexedDB error is not propagated.
+            globalThis.indexedDB = brokenIDB();
+            await Lifecycle.onLoggedOut();
+        });
+    });
+});


### PR DESCRIPTION
Firefox ships with a preference (`dom.indexedDB.privateBrowsing.enabled`, defaults to `false`) which causes `window.indexedDB` to fail on all requests, including `deleteDatabase`. Because of that, recent builds fail to load entirely in private browsing windows. This can be verified by opening [develop.element.io](https://develop.element.io/) (or any build after https://github.com/matrix-org/matrix-js-sdk/commit/15ef8fabb7d3deae7ff098bf4a9f4687d1602995) in a Firefox private browsing window.

[`MatrixClient#clearStores`](https://github.com/matrix-org/matrix-js-sdk/blob/d23c3cb8b2f618e007776b38fcdb8ea6ba2e9309/src/client.ts#L1655-L1707) will resolve to a rejected promise if any of its operations fails, which seems correct – it's unable to complete its tasks. So, to keep from erroring out during initialization, the errors have to be discarded during the lifecycle operations.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->