### PR TITLE
Deflake new edited-event test

### DIFF
--- a/cypress/e2e/editing/editing.spec.ts
+++ b/cypress/e2e/editing/editing.spec.ts
@@ -108,7 +108,7 @@ describe("Editing", () => {
             // send a load of padding events. We make them large, so that they fill the whole screen
             // and the client doesn't end up paginating into the event we want.
             let i = 0;
-            while (i < 20) {
+            while (i < 10) {
                 await bob.sendMessage(room.room_id, mkPadding(i++));
             }
 
@@ -127,7 +127,7 @@ describe("Editing", () => {
             cy.log(`Bot user sent edit event ${editEventId}`);
 
             // ... then a load more padding ...
-            while (i < 40) {
+            while (i < 20) {
                 await bob.sendMessage(room.room_id, mkPadding(i++));
             }
         });


### PR DESCRIPTION
We don't need to send as many padding events as we were; reducing the spam
speeds up the test and deflakes it.

Fixes https://github.com/vector-im/element-web/issues/24221

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->