### PR TITLE
Fix error when viewing source of redacted events

### DIFF
--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -1,7 +1,6 @@
 /*
-Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2015, 2016, 2019, 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -77,9 +76,13 @@ export default class ViewSource extends React.Component<IProps, IState> {
                         <summary>
                             <span className="mx_ViewSource_heading">{_t("Decrypted event source")}</span>
                         </summary>
-                        <CopyableText getTextToCopy={copyDecryptedFunc}>
-                            <SyntaxHighlight language="json">{stringify(decryptedEventSource)}</SyntaxHighlight>
-                        </CopyableText>
+                        {decryptedEventSource ? (
+                            <CopyableText getTextToCopy={copyDecryptedFunc}>
+                                <SyntaxHighlight language="json">{stringify(decryptedEventSource)}</SyntaxHighlight>
+                            </CopyableText>
+                        ) : (
+                            <div>{_t("Decrypted source unavailable")}</div>
+                        )}
                     </details>
                     <details className="mx_ViewSource_details">
                         <summary>

--- a/src/components/views/elements/SyntaxHighlight.tsx
+++ b/src/components/views/elements/SyntaxHighlight.tsx
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Michael Telatynski <7t3chguy@gmail.com>
+Copyright 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ interface IProps {
 export default class SyntaxHighlight extends React.PureComponent<IProps> {
     public render(): JSX.Element {
         const { children: content, language } = this.props;
-        const highlighted = language ? hljs.highlight(language, content) : hljs.highlightAuto(content);
+        const highlighted = language ? hljs.highlight(content, { language }) : hljs.highlightAuto(content);
 
         return (
             <pre className={`mx_SyntaxHighlight hljs language-${highlighted.language}`}>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3452,6 +3452,7 @@
     "User menu": "User menu",
     "Could not load user profile": "Could not load user profile",
     "Decrypted event source": "Decrypted event source",
+    "Decrypted source unavailable": "Decrypted source unavailable",
     "Original event source": "Original event source",
     "Event ID: %(eventId)s": "Event ID: %(eventId)s",
     "Thread root ID: %(threadRootId)s": "Thread root ID: %(threadRootId)s",

--- a/test/components/structures/ViewSource-test.tsx
+++ b/test/components/structures/ViewSource-test.tsx
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { render } from "@testing-library/react";
+import { EventType, MatrixEvent } from "matrix-js-sdk/src/matrix";
+import React from "react";
+
+import ViewSource from "../../../src/components/structures/ViewSource";
+import { mkEvent, stubClient } from "../../test-utils/test-utils";
+
+describe("ThreadView", () => {
+    const ROOM_ID = "!roomId:example.org";
+    const SENDER = "@alice:example.org";
+
+    let messageEvent: MatrixEvent;
+
+    const redactionEvent = mkEvent({
+        user: SENDER,
+        event: true,
+        type: EventType.RoomRedaction,
+        content: {},
+    });
+
+    beforeEach(() => {
+        messageEvent = new MatrixEvent({
+            type: EventType.RoomMessageEncrypted,
+            room_id: ROOM_ID,
+            sender: SENDER,
+            content: {},
+            state_key: undefined,
+        });
+        messageEvent.makeRedacted(redactionEvent);
+    });
+
+    beforeEach(stubClient);
+
+    // See https://github.com/vector-im/element-web/issues/24165
+    it("doesn't error when viewing redacted encrypted messages", () => {
+        // Sanity checks
+        expect(messageEvent.isEncrypted()).toBeTruthy();
+        // @ts-ignore clearEvent is private, but it's being used directly <ViewSource />
+        expect(messageEvent.clearEvent).toBe(undefined);
+
+        expect(() => render(<ViewSource mxEvent={messageEvent} onFinished={() => {}} />)).not.toThrow();
+    });
+});

--- a/test/components/views/elements/SyntaxHighlight-test.tsx
+++ b/test/components/views/elements/SyntaxHighlight-test.tsx
@@ -1,0 +1,38 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "varsIgnorePattern": "^_" }] */
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { render } from "@testing-library/react";
+import hljs, { type HighlightOptions } from "highlight.js";
+import React from "react";
+
+import SyntaxHighlight from "../../../../src/components/views/elements/SyntaxHighlight";
+
+describe("<SyntaxHighlight />", () => {
+    it("renders", () => {
+        const { container } = render(<SyntaxHighlight>console.log("Hello, World!");</SyntaxHighlight>);
+        expect(container).toMatchSnapshot();
+    });
+
+    it.each(["json", "javascript", "css"])("uses the provided language", (lang) => {
+        const mock = jest.spyOn(hljs, "highlight");
+
+        render(<SyntaxHighlight language={lang}>// Hello, World</SyntaxHighlight>);
+
+        const [_lang, opts] = mock.mock.lastCall!;
+        expect((opts as HighlightOptions)["language"]).toBe(lang);
+    });
+});

--- a/test/components/views/elements/__snapshots__/SyntaxHighlight-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/SyntaxHighlight-test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SyntaxHighlight /> renders 1`] = `
+<div>
+  <pre
+    class="mx_SyntaxHighlight hljs language-arcade"
+  >
+    <code>
+      <span
+        class="hljs-built_in"
+      >
+        console
+      </span>
+      .
+      <span
+        class="hljs-built_in"
+      >
+        log
+      </span>
+      (
+      <span
+        class="hljs-string"
+      >
+        "Hello, World!"
+      </span>
+      );
+    </code>
+  </pre>
+</div>
+`;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24165

Clicking 'View source' on a redacted message was erroring out, due to [`MatrixEvent.clearEvent`](https://github.com/matrix-org/matrix-js-sdk/blob/7b10fa367df357b51c2e78e220d39e5e7967f9e3/src/models/event.ts#L219) being set to `undefined` in [`MatrixEvent.makeRedacted`](https://github.com/matrix-org/matrix-js-sdk/blob/7b10fa367df357b51c2e78e220d39e5e7967f9e3/src/models/event.ts#L1093-L1144). highlight.js did not like receiving `undefined` as its input.

The fix was to check for falsiness within `<ViewSource />` before handing off to `<SyntaxHighlight />`.

Resulting UX:
<img width="761" alt="View Source Redacted Event" src="https://user-images.githubusercontent.com/439978/212430891-d3e2790d-395e-41c0-9a53-93a8eeb94f5a.png">

Additionally, I noticed that highlight.js was logging warnings about using a deprecated call, so I updated that as well.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix error when viewing source of redacted events ([\#9914](https://github.com/matrix-org/matrix-react-sdk/pull/9914)). Fixes vector-im/element-web#24165. Contributed by @clarkf.<!-- CHANGELOG_PREVIEW_END -->