### PR TITLE
Support rendering of extensible events v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "lodash": "^4.17.20",
         "maplibre-gl": "^2.0.0",
         "matrix-encrypt-attachment": "^1.0.3",
-        "matrix-events-sdk": "0.0.1",
+        "matrix-events-sdk": "^2.0.0",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
         "matrix-widget-api": "^1.1.1",
         "minimist": "^1.2.5",

--- a/src/components/views/messages/IBodyProps.ts
+++ b/src/components/views/messages/IBodyProps.ts
@@ -54,5 +54,8 @@ export interface IBodyProps {
     // helper function to access relations for this event
     getRelationsForEvent?: GetRelationsForEvent;
 
+    // if true, the **unstable** extensible event functionality will be used to parse the event
+    forceUnstableExtensibleRendering?: boolean;
+
     ref?: React.RefObject<any> | LegacyRef<any>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,6 +2564,11 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+ajv-errors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
+  integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -2583,6 +2588,16 @@ ajv@^8.0.1, ajv@^8.6.2:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
   integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.11.2:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -6480,6 +6495,14 @@ matrix-events-sdk@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
+
+matrix-events-sdk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-2.0.0.tgz#f5f8dafbe4eae07fdbb628627f430ca5b1fd8c7a"
+  integrity sha512-UZbifYIO2o9+sNn4YuGjhMof/88TG68PyecKnH/pt8V3MFq0RZsbBUe+3/k5ZeVcEtr0pQLmcKB7d8aQVsVO/w==
+  dependencies:
+    ajv "^8.11.2"
+    ajv-errors "^3.0.0"
 
 "matrix-js-sdk@github:matrix-org/matrix-js-sdk#develop":
   version "23.0.0"


### PR DESCRIPTION
**Requires https://github.com/matrix-org/matrix-js-sdk/pull/3067**

See https://github.com/matrix-org/matrix-js-sdk/pull/3067 for details.

This looks and acts horribly broken because, well, it is:

![image](https://user-images.githubusercontent.com/1190097/212435573-8a8e8417-553f-485e-b2fd-dbdf6ab8de75.png)

Known issues:
* Messages look like that
* Sending a message causes a tile crash
* These events cannot be reacted to, replied to, made a thread from, etc
* etc

None of these issues are fixed in this PR, deliberately. The whole feature is gated by a room version, which means you also get this lovely warning at the top of the room you can't get rid of:
![image](https://user-images.githubusercontent.com/1190097/212435743-d18b0653-f926-4407-a0ac-013df8f5f89d.png)

This should be enough to consider the room version similar to a labs flag, thus making the bugs expected/reasonable.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support rendering of extensible events v2 ([\#9915](https://github.com/matrix-org/matrix-react-sdk/pull/9915)).<!-- CHANGELOG_PREVIEW_END -->