### PR TITLE
Fix cypress RTE flaky test

### DIFF
--- a/cypress/e2e/composer/composer.spec.ts
+++ b/cypress/e2e/composer/composer.spec.ts
@@ -120,9 +120,8 @@ describe("Composer", () => {
 
             // Type another
             cy.get("div[contenteditable=true]").type("my message 1");
-            // Press enter. Would be nice to just use {enter} but we can't because Cypress
-            // does not trigger an insertParagraph when you do that.
-            cy.get("div[contenteditable=true]").trigger("input", { inputType: "insertParagraph" });
+            // Send message
+            cy.get("div[contenteditable=true]").type("{enter}");
             // It was sent
             cy.contains(".mx_EventTile_body", "my message 1");
         });
@@ -141,7 +140,7 @@ describe("Composer", () => {
             it("only sends when you press Ctrl+Enter", () => {
                 // Type a message and press Enter
                 cy.get("div[contenteditable=true]").type("my message 3");
-                cy.get("div[contenteditable=true]").trigger("input", { inputType: "insertParagraph" });
+                cy.get("div[contenteditable=true]").type("{enter}");
                 // It has not been sent yet
                 cy.contains(".mx_EventTile_body", "my message 3").should("not.exist");
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@matrix-org/analytics-events": "^0.4.0",
-        "@matrix-org/matrix-wysiwyg": "^0.16.0",
+        "@matrix-org/matrix-wysiwyg": "^0.19.0",
         "@matrix-org/react-sdk-module-api": "^0.0.3",
         "@sentry/browser": "^7.0.0",
         "@sentry/tracing": "^7.0.0",

--- a/test/components/views/rooms/wysiwyg_composer/components/FormattingButtons-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/FormattingButtons-test.tsx
@@ -36,7 +36,7 @@ const mockWysiwyg = {
 const openLinkModalSpy = jest.spyOn(LinkModal, "openLinkModal");
 
 const testCases: Record<
-    Exclude<ActionTypes, "undo" | "redo" | "clear">,
+    Exclude<ActionTypes, "undo" | "redo" | "clear" | "codeBlock">,
     { label: string; mockFormatFn: jest.Func | jest.SpyInstance }
 > = {
     bold: { label: "Bold", mockFormatFn: mockWysiwyg.bold },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,10 +1589,10 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.2.tgz#a09d0fea858e817da971a3c9f904632ef7b49eb6"
   integrity sha512-oVkBCh9YP7H9i4gAoQbZzswniczfo/aIptNa4dxRi4Ff9lSvUCFv6Hvzi7C+90c0/PWZLXjIDTIAWZYmwyd2fA==
 
-"@matrix-org/matrix-wysiwyg@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-wysiwyg/-/matrix-wysiwyg-0.16.0.tgz#2eb81899cedc740f522bd7c2839bd9151d67a28e"
-  integrity sha512-w+/bUQ5x4lVRncrYSmdxy5ww4kkgXeSg4aFfby9c7c6o/+o4gfV6/XBdoJ71nhStyIYIweKAz8i3zA3rKonyvw==
+"@matrix-org/matrix-wysiwyg@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-wysiwyg/-/matrix-wysiwyg-0.19.0.tgz#5ffbabf8a59317ecdb45ba5fa1d06fff150ede40"
+  integrity sha512-1iL/+kjwWAlpWAq64DbkDkE7KGxvR5lNojZgCKMIyuvuKWv8Ikqxa9VOOYFtovKvSqgGRJaYN7/OkKWxZjiDcw==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Fix  https://github.com/vector-im/element-web/issues/24231

- The @matrix-org/matrix-wysiwig update should fix some racing issues.
- Using {enter} instead of an input event in the cypress test

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->