### PR TITLE
Fix broken threads list timestamp layout

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -884,6 +884,7 @@ $left-gutter: 64px;
 
     &::before {
         inset: 0;
+        pointer-events: none; /* ensures the title for the sender name can be correctly displayed */
     }
 
     /* Display notification dot */

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -927,8 +927,14 @@ $left-gutter: 64px;
         inset: $padding auto auto $padding;
     }
 
+    .mx_EventTile_details {
+        overflow: hidden;
+    }
+
     .mx_DisambiguatedProfile {
         display: inline-flex;
+        align-items: center;
+        flex: 1;
 
         .mx_DisambiguatedProfile_displayName,
         .mx_DisambiguatedProfile_mxid {
@@ -979,7 +985,9 @@ $left-gutter: 64px;
 
     .mx_MessageTimestamp {
         font-size: $font-12px;
-        max-width: var(--MessageTimestamp-max-width);
+        width: unset; /* Cancel the default width */
+        overflow: hidden; /* ensure correct overflow behavior */
+        text-overflow: ellipsis;
         position: initial;
         margin-left: auto; /* to ensure it's end-aligned even if it's the only element of its parent */
     }

--- a/src/components/views/messages/DisambiguatedProfile.tsx
+++ b/src/components/views/messages/DisambiguatedProfile.tsx
@@ -18,8 +18,8 @@ limitations under the License.
 import React from "react";
 import { RoomMember } from "matrix-js-sdk/src/models/room-member";
 import classNames from "classnames";
-import { _t } from "../../../languageHandler";
 
+import { _t } from "../../../languageHandler";
 import { getUserNameColorClass } from "../../../utils/FormattingUtils";
 import UserIdentifier from "../../../customisations/UserIdentifier";
 
@@ -54,7 +54,7 @@ export default class DisambiguatedProfile extends React.Component<IProps> {
 
         let title: string;
         if (mxid) {
-            title = _t('%(displayName)s (%(identifier)s)', {
+            title = _t('%(displayName)s (%(matrixId)s)', {
                 displayName: rawDisplayName,
                 matrixId: UserIdentifier.getDisplayUserIdentifier(mxid, {
                     withDisplayName: true,

--- a/src/components/views/messages/DisambiguatedProfile.tsx
+++ b/src/components/views/messages/DisambiguatedProfile.tsx
@@ -1,6 +1,6 @@
 /*
 Copyright 2021 Šimon Brandner <simon.bra.ag@gmail.com>
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022-2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ limitations under the License.
 import React from "react";
 import { RoomMember } from "matrix-js-sdk/src/models/room-member";
 import classNames from "classnames";
+import { _t } from "../../../languageHandler";
 
 import { getUserNameColorClass } from "../../../utils/FormattingUtils";
 import UserIdentifier from "../../../customisations/UserIdentifier";
@@ -28,11 +29,12 @@ interface IProps {
     onClick?(): void;
     colored?: boolean;
     emphasizeDisplayName?: boolean;
+    withTooltip?: boolean;
 }
 
 export default class DisambiguatedProfile extends React.Component<IProps> {
     public render(): JSX.Element {
-        const { fallbackName, member, colored, emphasizeDisplayName, onClick } = this.props;
+        const { fallbackName, member, colored, emphasizeDisplayName, withTooltip, onClick } = this.props;
         const rawDisplayName = member?.rawDisplayName || fallbackName;
         const mxid = member?.userId;
 
@@ -50,13 +52,24 @@ export default class DisambiguatedProfile extends React.Component<IProps> {
             );
         }
 
+        let title: string;
+        if (mxid) {
+            title = _t('%(displayName)s (%(identifier)s)', {
+                displayName: rawDisplayName,
+                matrixId: UserIdentifier.getDisplayUserIdentifier(mxid, {
+                    withDisplayName: true,
+                    roomId: member.roomId
+                }),
+            });
+        }
+
         const displayNameClasses = classNames({
             mx_DisambiguatedProfile_displayName: emphasizeDisplayName,
             [colorClass]: true,
         });
 
         return (
-            <div className="mx_DisambiguatedProfile" onClick={onClick}>
+            <div className="mx_DisambiguatedProfile" title={withTooltip ? title : undefined} onClick={onClick}>
                 <span className={displayNameClasses} dir="auto">
                     {rawDisplayName}
                 </span>

--- a/src/components/views/messages/DisambiguatedProfile.tsx
+++ b/src/components/views/messages/DisambiguatedProfile.tsx
@@ -38,34 +38,32 @@ export default class DisambiguatedProfile extends React.Component<IProps> {
         const rawDisplayName = member?.rawDisplayName || fallbackName;
         const mxid = member?.userId;
 
-        let colorClass;
+        let colorClass: string | undefined;
         if (colored) {
             colorClass = getUserNameColorClass(fallbackName);
         }
 
         let mxidElement;
-        if (member?.disambiguate && mxid) {
-            mxidElement = (
-                <span className="mx_DisambiguatedProfile_mxid">
-                    {UserIdentifier.getDisplayUserIdentifier(mxid, { withDisplayName: true, roomId: member.roomId })}
-                </span>
-            );
-        }
+        let title: string | undefined;
 
-        let title: string;
         if (mxid) {
+            const identifier = UserIdentifier.getDisplayUserIdentifier?.(mxid, {
+                withDisplayName: true,
+                roomId: member.roomId
+            }) ?? mxid;
+            if (member?.disambiguate) {
+                mxidElement = (
+                    <span className="mx_DisambiguatedProfile_mxid">{ identifier }</span>
+                );
+            }
             title = _t('%(displayName)s (%(matrixId)s)', {
                 displayName: rawDisplayName,
-                matrixId: UserIdentifier.getDisplayUserIdentifier(mxid, {
-                    withDisplayName: true,
-                    roomId: member.roomId
-                }),
+                matrixId: identifier,
             });
         }
 
-        const displayNameClasses = classNames({
+        const displayNameClasses = classNames(colorClass, {
             mx_DisambiguatedProfile_displayName: emphasizeDisplayName,
-            [colorClass]: true,
         });
 
         return (

--- a/src/components/views/messages/DisambiguatedProfile.tsx
+++ b/src/components/views/messages/DisambiguatedProfile.tsx
@@ -47,16 +47,15 @@ export default class DisambiguatedProfile extends React.Component<IProps> {
         let title: string | undefined;
 
         if (mxid) {
-            const identifier = UserIdentifier.getDisplayUserIdentifier?.(mxid, {
-                withDisplayName: true,
-                roomId: member.roomId
-            }) ?? mxid;
+            const identifier =
+                UserIdentifier.getDisplayUserIdentifier?.(mxid, {
+                    withDisplayName: true,
+                    roomId: member.roomId,
+                }) ?? mxid;
             if (member?.disambiguate) {
-                mxidElement = (
-                    <span className="mx_DisambiguatedProfile_mxid">{ identifier }</span>
-                );
+                mxidElement = <span className="mx_DisambiguatedProfile_mxid">{identifier}</span>;
             }
-            title = _t('%(displayName)s (%(matrixId)s)', {
+            title = _t("%(displayName)s (%(matrixId)s)", {
                 displayName: rawDisplayName,
                 matrixId: identifier,
             });

--- a/src/components/views/messages/SenderProfile.tsx
+++ b/src/components/views/messages/SenderProfile.tsx
@@ -1,4 +1,5 @@
 /*
+ Copyright 2023 The Matrix.org Foundation C.I.C.
  Copyright 2015, 2016 OpenMarket Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,9 +25,10 @@ import { useRoomMemberProfile } from "../../../hooks/room/useRoomMemberProfile";
 interface IProps {
     mxEvent: MatrixEvent;
     onClick?(): void;
+    withTooltip?: boolean;
 }
 
-export default function SenderProfile({ mxEvent, onClick }: IProps): JSX.Element {
+export default function SenderProfile({ mxEvent, onClick, withTooltip }: IProps): JSX.Element {
     const member = useRoomMemberProfile({
         userId: mxEvent.getSender(),
         member: mxEvent.sender,
@@ -39,6 +41,7 @@ export default function SenderProfile({ mxEvent, onClick }: IProps): JSX.Element
             member={member}
             colored={true}
             emphasizeDisplayName={true}
+            withTooltip={withTooltip}
         />
     ) : null;
 }

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1091,9 +1091,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 this.context.timelineRenderingType === TimelineRenderingType.Thread
             ) {
                 sender = <SenderProfile onClick={this.onSenderProfileClick} mxEvent={this.props.mxEvent} />;
-            } else if (
-                this.context.timelineRenderingType === TimelineRenderingType.ThreadsList
-            ) {
+            } else if (this.context.timelineRenderingType === TimelineRenderingType.ThreadsList) {
                 sender = <SenderProfile mxEvent={this.props.mxEvent} withTooltip />;
             } else {
                 sender = <SenderProfile mxEvent={this.props.mxEvent} />;

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1094,7 +1094,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             } else if (
                 this.context.timelineRenderingType === TimelineRenderingType.ThreadsList
             ) {
-                sender = <SenderProfile mxEvent={this.props.mxEvent} withTooltip/>;
+                sender = <SenderProfile mxEvent={this.props.mxEvent} withTooltip />;
             } else {
                 sender = <SenderProfile mxEvent={this.props.mxEvent} />;
             }

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 - 2022 The Matrix.org Foundation C.I.C.
+Copyright 2015 - 2023 The Matrix.org Foundation C.I.C.
 Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -1091,6 +1091,10 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 this.context.timelineRenderingType === TimelineRenderingType.Thread
             ) {
                 sender = <SenderProfile onClick={this.onSenderProfileClick} mxEvent={this.props.mxEvent} />;
+            } else if (
+                this.context.timelineRenderingType === TimelineRenderingType.ThreadsList
+            ) {
+                sender = <SenderProfile mxEvent={this.props.mxEvent} withTooltip/>;
             } else {
                 sender = <SenderProfile mxEvent={this.props.mxEvent} />;
             }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2316,6 +2316,7 @@
     "Last month": "Last month",
     "The beginning of the room": "The beginning of the room",
     "Jump to date": "Jump to date",
+    "%(displayName)s (%(matrixId)s)": "%(displayName)s (%(matrixId)s)",
     "Downloading": "Downloading",
     "Decrypting": "Decrypting",
     "Download": "Download",


### PR DESCRIPTION
Type: Defect
Fixes: https://github.com/vector-im/element-web/issues/24243
Fixes: https://github.com/vector-im/element-web/issues/24191

Previously, thread list timestamps would overflow into the unread messages bubble on the right.

This is fixed by resetting the width of the timestamp and ensuring both the timestamp and the display name can shrink if necessary. Both now also use ellipses if necessary.

I prioritized shrinking the display name before shrinking the timestamp.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix broken threads list timestamp layout ([\#9922](https://github.com/matrix-org/matrix-react-sdk/pull/9922)). Fixes vector-im/element-web#24243 and vector-im/element-web#24191. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->