### PR TITLE
Fix: Poll replies overflow when not enough space

### DIFF
--- a/res/css/views/rooms/_ReplyTile.pcss
+++ b/res/css/views/rooms/_ReplyTile.pcss
@@ -32,11 +32,12 @@ limitations under the License.
         grid-template:
             "sender" auto
             "message" auto
-            / auto;
+            / 100%;
         text-decoration: none;
         color: $secondary-content;
         transition: color ease 0.15s;
         gap: 2px;
+        max-width: 100%; // avoid overflow with wide content
 
         &:hover {
             color: $primary-content;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes: https://github.com/vector-im/element-web/issues/24227

Before:
<img width="427" alt="Screenshot 2023-01-18 at 14 04 15" src="https://user-images.githubusercontent.com/3055605/213056003-dd7cd27c-341f-408b-9e80-376a1ddbefb8.png">
<img width="592" alt="Screenshot 2023-01-18 at 14 03 57" src="https://user-images.githubusercontent.com/3055605/213056010-3d4342fa-5c5e-4c7c-8ca0-203aabac3a88.png">


After:

<img width="443" alt="Screenshot 2023-01-18 at 14 05 29" src="https://user-images.githubusercontent.com/3055605/213056030-0007029d-193f-44e2-9b45-695974705f64.png">
<img width="603" alt="Screenshot 2023-01-18 at 14 05 07" src="https://user-images.githubusercontent.com/3055605/213056047-9fbe3b17-ce29-427e-be54-3699ffa18148.png">
<img width="429" alt="Screenshot 2023-01-18 at 14 05 01" src="https://user-images.githubusercontent.com/3055605/213056050-c59c65c0-4eb1-49fe-b6bc-1461d1ccd7e6.png">

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: Poll replies overflow when not enough space ([\#9924](https://github.com/matrix-org/matrix-react-sdk/pull/9924)). Fixes vector-im/element-web#24227. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->