### PR TITLE
Fix {enter} press in RTE

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -29,9 +29,14 @@ export function useInputEventProcessor(onSend: () => void): (event: WysiwygEvent
 
             const isKeyboardEvent = event instanceof KeyboardEvent;
             const isEnterPress =
-                !isCtrlEnter && (isKeyboardEvent ? event.key === "Enter" : event.inputType === "insertParagraph");
+                !isCtrlEnter &&
+                (isKeyboardEvent
+                    ? // Ugly but here we need to send the message only if Enter is pressed
+                      // And we need to stop the event propagation on enter to avoid the composer to grow
+                      event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey
+                    : event.inputType === "insertParagraph");
             // sendMessage is sent when ctrl+enter is pressed
-            const isSendMessage = !isKeyboardEvent && event.inputType === "sendMessage";
+            const isSendMessage = !isKeyboardEvent && isCtrlEnter && event.inputType === "sendMessage";
 
             if (isEnterPress || isSendMessage) {
                 event.stopPropagation?.();

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -35,10 +35,11 @@ export function useInputEventProcessor(onSend: () => void): (event: WysiwygEvent
 
             const isKeyboardEvent = event instanceof KeyboardEvent;
             const isEnterPress = !isCtrlEnter && isKeyboardEvent && isEnterPressed(event);
+            const isInsertParagraph = !isCtrlEnter && !isKeyboardEvent && event.inputType === "insertParagraph";
             // sendMessage is sent when cmd+enter is pressed
             const isSendMessage = isCtrlEnter && !isKeyboardEvent && event.inputType === "sendMessage";
 
-            if (isEnterPress || isSendMessage) {
+            if (isEnterPress || isInsertParagraph || isSendMessage) {
                 event.stopPropagation?.();
                 event.preventDefault?.();
                 onSend();

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -19,6 +19,12 @@ import { useCallback } from "react";
 
 import { useSettingValue } from "../../../../../hooks/useSettings";
 
+function isEnterPressed(event: KeyboardEvent): boolean {
+    // Ugly but here we need to send the message only if Enter is pressed
+    // And we need to stop the event propagation on enter to avoid the composer to grow
+    return event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+}
+
 export function useInputEventProcessor(onSend: () => void): (event: WysiwygEvent) => WysiwygEvent | null {
     const isCtrlEnter = useSettingValue<boolean>("MessageComposerInput.ctrlEnterToSend");
     return useCallback(
@@ -28,15 +34,9 @@ export function useInputEventProcessor(onSend: () => void): (event: WysiwygEvent
             }
 
             const isKeyboardEvent = event instanceof KeyboardEvent;
-            const isEnterPress =
-                !isCtrlEnter &&
-                (isKeyboardEvent
-                    ? // Ugly but here we need to send the message only if Enter is pressed
-                      // And we need to stop the event propagation on enter to avoid the composer to grow
-                      event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey
-                    : event.inputType === "insertParagraph");
-            // sendMessage is sent when ctrl+enter is pressed
-            const isSendMessage = !isKeyboardEvent && isCtrlEnter && event.inputType === "sendMessage";
+            const isEnterPress = !isCtrlEnter && isKeyboardEvent && isEnterPressed(event);
+            // sendMessage is sent when cmd+enter is pressed
+            const isSendMessage = isCtrlEnter && !isKeyboardEvent && event.inputType === "sendMessage";
 
             if (isEnterPress || isSendMessage) {
                 event.stopPropagation?.();

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import "@testing-library/jest-dom";
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { WysiwygComposer } from "../../../../../../src/components/views/rooms/wysiwyg_composer/components/WysiwygComposer";
 import SettingsStore from "../../../../../../src/settings/SettingsStore";
@@ -86,6 +87,45 @@ describe("WysiwygComposer", () => {
 
             // Then it sends a message
             await waitFor(() => expect(onSend).toBeCalledTimes(1));
+        });
+
+        it("Should not call onSend when Shift+Enter is pressed ", async () => {
+            //When
+            await userEvent.type(screen.getByRole("textbox"), "{shift>}{enter}");
+
+            // Then it sends a message
+            await waitFor(() => expect(onSend).toBeCalledTimes(0));
+        });
+
+        it("Should not call onSend when ctrl+Enter is pressed ", async () => {
+            //When
+            // Using userEvent.type or .keyboard wasn't working as expected in the case of ctrl+enter
+            fireEvent(
+                screen.getByRole("textbox"),
+                new KeyboardEvent("keydown", {
+                    ctrlKey: true,
+                    code: "Enter",
+                }),
+            );
+
+            // Then it sends a message
+            await waitFor(() => expect(onSend).toBeCalledTimes(0));
+        });
+
+        it("Should not call onSend when alt+Enter is pressed ", async () => {
+            //When
+            await userEvent.type(screen.getByRole("textbox"), "{alt>}{enter}");
+
+            // Then it sends a message
+            await waitFor(() => expect(onSend).toBeCalledTimes(0));
+        });
+
+        it("Should not call onSend when meta+Enter is pressed ", async () => {
+            //When
+            await userEvent.type(screen.getByRole("textbox"), "{meta>}{enter}");
+
+            // Then it sends a message
+            await waitFor(() => expect(onSend).toBeCalledTimes(0));
         });
     });
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->

The current bug is happening when enter and a modifier key are pressed. The RTE is sending a message when shift/alt/meta/ctrl + enter is pressed instead to send only when enter is pressed (according to `ctrlEnterToSend` settings).

The fix it's a big ugly but I need to check if only the `enter` key is pressed.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix {enter} press in RTE ([\#9927](https://github.com/matrix-org/matrix-react-sdk/pull/9927)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->