### PR TITLE
Add a customisation point for widget permissions to preapprove embedding

### DIFF
--- a/src/components/views/context_menus/WidgetContextMenu.tsx
+++ b/src/components/views/context_menus/WidgetContextMenu.tsx
@@ -34,6 +34,8 @@ import { WidgetType } from "../../../widgets/WidgetType";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { Container, WidgetLayoutStore } from "../../../stores/widgets/WidgetLayoutStore";
 import { getConfigLivestreamUrl, startJitsiAudioLivestream } from "../../../Livestream";
+import { WidgetPermissionCustomisations } from "../../../customisations/WidgetPermissions";
+import { ElementWidget } from "../../../stores/widgets/StopGapWidget";
 
 interface IProps extends React.ComponentProps<typeof IconizedContextMenu> {
     app: IApp;
@@ -157,7 +159,12 @@ const WidgetContextMenu: React.FC<IProps> = ({
 
     const isLocalWidget = WidgetType.JITSI.matches(app.type);
     let revokeButton;
-    if (!userWidget && !isLocalWidget && isAllowedWidget) {
+    if (
+        !userWidget &&
+        !isLocalWidget &&
+        isAllowedWidget &&
+        !WidgetPermissionCustomisations.isEmbeddingPreapproved?.(new ElementWidget(app))
+    ) {
         const onRevokeClick = (): void => {
             logger.info("Revoking permission for widget to load: " + app.eventId);
             const current = SettingsStore.getValue("allowedWidgets", roomId);

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -50,6 +50,7 @@ import { Action } from "../../../dispatcher/actions";
 import { ElementWidgetCapabilities } from "../../../stores/widgets/ElementWidgetCapabilities";
 import { WidgetMessagingStore } from "../../../stores/widgets/WidgetMessagingStore";
 import { SdkContextClass } from "../../../contexts/SDKContext";
+import { WidgetPermissionCustomisations } from "../../../customisations/WidgetPermissions";
 
 interface IProps {
     app: IApp;
@@ -162,6 +163,7 @@ export default class AppTile extends React.Component<IProps, IState> {
     private hasPermissionToLoad = (props: IProps): boolean => {
         if (this.usingLocalWidget()) return true;
         if (!props.room) return true; // user widgets always have permissions
+        if (WidgetPermissionCustomisations.isEmbeddingPreapproved?.(new ElementWidget(this.props.app))) return true;
 
         const currentlyAllowedWidgets = SettingsStore.getValue("allowedWidgets", props.room.roomId);
         const allowed = props.app.eventId !== undefined && (currentlyAllowedWidgets[props.app.eventId] ?? false);

--- a/src/customisations/WidgetPermissions.ts
+++ b/src/customisations/WidgetPermissions.ts
@@ -36,11 +36,23 @@ async function preapproveCapabilities(
     return new Set(); // no additional capabilities approved
 }
 
+/**
+ * Approves the widget embedding.
+ * This will be used to embed certain widgets without prompting the user.
+ * @param {Widget} widget The widget to approve embedding for.
+ * @returns {boolean} true if embedding is preapproved, false otherwise
+ */
+function isEmbeddingPreapproved(widget: Widget): boolean {
+    return false;
+}
+
 // This interface summarises all available customisation points and also marks
 // them all as optional. This allows customisers to only define and export the
 // customisations they need while still maintaining type safety.
 export interface IWidgetPermissionCustomisations {
     preapproveCapabilities?: typeof preapproveCapabilities;
+
+    isEmbeddingPreapproved?: typeof isEmbeddingPreapproved;
 }
 
 // A real customisation module will define and export one or more of the


### PR DESCRIPTION
A new customization point for widget permissions to allow preapproval of embeddings for the widgets.

This will allow forks customization and consistent with https://github.com/matrix-org/matrix-react-sdk/pull/9910, https://github.com/matrix-org/matrix-react-sdk/pull/5439

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a customisation point for widget permissions to preapprove embedding ([\#9931](https://github.com/matrix-org/matrix-react-sdk/pull/9931)). Contributed by @maheichyk.<!-- CHANGELOG_PREVIEW_END -->