### PR TITLE
replace .at() with array.length-1

### DIFF
--- a/src/Unread.ts
+++ b/src/Unread.ts
@@ -85,7 +85,7 @@ export function doesRoomOrThreadHaveUnreadMessages(roomOrThread: Room | Thread):
     //             https://github.com/vector-im/element-web/issues/2427
     // ...and possibly some of the others at
     //             https://github.com/vector-im/element-web/issues/3363
-    if (roomOrThread.timeline.at(-1)?.getSender() === myUserId) {
+    if (roomOrThread.timeline[roomOrThread.timeline.length - 1]?.getSender() === myUserId) {
         return false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/element-web-rageshakes/issues/19281

Might need to hotfix that, and also, we need to investigate why babel is not doing its job properly in transpiling that

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * replace .at() with array.length-1 ([\#9933](https://github.com/matrix-org/matrix-react-sdk/pull/9933)). Fixes matrix-org/element-web-rageshakes#19281.<!-- CHANGELOG_PREVIEW_END -->