### PR TITLE
Only highlight focused menu item if focus is supposed to be visible

### DIFF
--- a/res/css/views/context_menus/_IconizedContextMenu.pcss
+++ b/res/css/views/context_menus/_IconizedContextMenu.pcss
@@ -84,7 +84,7 @@ limitations under the License.
             align-items: center;
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 background-color: $menu-selected-color;
             }
 


### PR DESCRIPTION
This fixes https://github.com/vector-im/element-web/issues/23582 by only showing the highlight on a focused menu item if the browser indicates that focus has been made visible.

Before|After
-|-
![Screenshot from 2023-01-19 21-05-28](https://user-images.githubusercontent.com/48614497/213602671-8a80bb99-d8c3-4797-9e08-8b06e6b4d6c2.png)![Screenshot from 2023-01-19 21-05-32](https://user-images.githubusercontent.com/48614497/213602669-1be01b46-916c-423e-9c3c-5fa35683fef6.png)|![Screenshot 2023-01-19 at 21-04-07 Element 5 Test room](https://user-images.githubusercontent.com/48614497/213602674-586f5607-bb38-4d07-9c43-bc2bf3b1eefb.png)![Screenshot from 2023-01-19 21-05-07](https://user-images.githubusercontent.com/48614497/213602672-f30c9591-84bf-477a-aec5-2b1808c0b89a.png)

Closes https://github.com/vector-im/element-web/issues/23582

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Only highlight focused menu item if focus is supposed to be visible ([\#9945](https://github.com/matrix-org/matrix-react-sdk/pull/9945)). Fixes vector-im/element-web#23582.<!-- CHANGELOG_PREVIEW_END -->