### PR TITLE
Fix seekbar position for zero length audio

### DIFF
--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -38,5 +38,6 @@ export function percentageWithin(pct: number, min: number, max: number): number 
 }
 
 export function percentageOf(val: number, min: number, max: number): number {
-    return (val - min) / (max - min);
+    const percentage = (val - min) / (max - min);
+    return Number.isNaN(percentage) ? 0 : percentage;
 }

--- a/test/components/views/audio_messages/SeekBar-test.tsx
+++ b/test/components/views/audio_messages/SeekBar-test.tsx
@@ -34,15 +34,29 @@ describe("SeekBar", () => {
             frameRequestCallback = callback;
             return 0;
         });
-        playback = createTestPlayback();
     });
 
     afterEach(() => {
         mocked(window.requestAnimationFrame).mockRestore();
     });
 
+    describe("when rendering a SeekBar for an empty playback", () => {
+        beforeEach(() => {
+            playback = createTestPlayback({
+                durationSeconds: 0,
+                timeSeconds: 0,
+            });
+            renderResult = render(<SeekBar ref={seekBarRef} playback={playback} />);
+        });
+
+        it("should render correctly", () => {
+            expect(renderResult.container).toMatchSnapshot();
+        });
+    });
+
     describe("when rendering a SeekBar", () => {
         beforeEach(() => {
+            playback = createTestPlayback();
             renderResult = render(<SeekBar ref={seekBarRef} playback={playback} />);
         });
 

--- a/test/components/views/audio_messages/__snapshots__/SeekBar-test.tsx.snap
+++ b/test/components/views/audio_messages/__snapshots__/SeekBar-test.tsx.snap
@@ -15,6 +15,21 @@ exports[`SeekBar when rendering a SeekBar and the playback proceeds should rende
 </div>
 `;
 
+exports[`SeekBar when rendering a SeekBar for an empty playback should render correctly 1`] = `
+<div>
+  <input
+    class="mx_SeekBar"
+    max="1"
+    min="0"
+    step="0.001"
+    style="--fillTo: 0;"
+    tabindex="0"
+    type="range"
+    value="0"
+  />
+</div>
+`;
+
 exports[`SeekBar when rendering a SeekBar should render the initial position 1`] = `
 <div>
   <input

--- a/test/test-utils/audio.ts
+++ b/test/test-utils/audio.ts
@@ -22,7 +22,7 @@ import { PlaybackClock } from "../../src/audio/PlaybackClock";
 import { UPDATE_EVENT } from "../../src/stores/AsyncStore";
 import { PublicInterface } from "../@types/common";
 
-export const createTestPlayback = (): Playback => {
+export const createTestPlayback = (overrides: Partial<Playback> = {}): Playback => {
     const eventEmitter = new EventEmitter();
 
     return {
@@ -63,6 +63,7 @@ export const createTestPlayback = (): Playback => {
         liveData: new SimpleObservable<number[]>(),
         durationSeconds: 31415,
         timeSeconds: 3141,
+        ...overrides,
     } as PublicInterface<Playback> as Playback;
 };
 

--- a/test/utils/numbers-test.ts
+++ b/test/utils/numbers-test.ts
@@ -160,5 +160,9 @@ describe("numbers", () => {
             const result = percentageOf(14.28, 10.2, 20.4);
             expect(result).toBe(0.4);
         });
+
+        it("should return 0 for values that cause a division by zero", () => {
+            expect(percentageOf(0, 0, 0)).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/6216686/213702357-aaab0d34-a3e5-4b3f-b8d3-bc6620fbd15a.png)

After

![image](https://user-images.githubusercontent.com/6216686/213702305-7c90180c-a47d-402e-8691-48f727705218.png)

closes https://github.com/vector-im/element-web/issues/24248

PSF-1859

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix seekbar position for zero length audio ([\#9949](https://github.com/matrix-org/matrix-react-sdk/pull/9949)). Fixes vector-im/element-web#24248.<!-- CHANGELOG_PREVIEW_END -->