### PR TITLE
Fix RTE focus behaviour in threads

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -336,7 +336,10 @@ export class MessageComposer extends React.Component<IProps, IState> {
             const { permalinkCreator, relation, replyToEvent } = this.props;
             const composerContent = this.state.composerContent;
             this.setState({ composerContent: "", initialComposerContent: "" });
-            dis.dispatch({ action: Action.ClearAndFocusSendMessageComposer });
+            dis.dispatch({
+                action: Action.ClearAndFocusSendMessageComposer,
+                timelineRenderingType: this.context.timelineRenderingType,
+            });
             await sendMessage(composerContent, this.state.isRichTextEnabled, {
                 mxClient: this.props.mxClient,
                 roomContext: this.context,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useWysiwygSendActionHandler.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useWysiwygSendActionHandler.ts
@@ -50,6 +50,9 @@ export function useWysiwygSendActionHandler(
                     focusComposer(composerElement, context, roomContext, timeoutId);
                     break;
                 case Action.ClearAndFocusSendMessageComposer:
+                    // When a thread is opened, prevent the main composer to steal the thread composer focus
+                    if (payload.timelineRenderingType !== roomContext.timelineRenderingType) break;
+
                     composerFunctions.clear();
                     focusComposer(composerElement, context, roomContext, timeoutId);
                     break;

--- a/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
@@ -153,7 +153,7 @@ describe("SendWysiwygComposer", () => {
                 // When we send the right action
                 defaultDispatcher.dispatch({
                     action: Action.ClearAndFocusSendMessageComposer,
-                    context: null,
+                    timelineRenderingType: defaultRoomContext.timelineRenderingType,
                 });
 
                 // Then the component gets the focus


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))
 
Fix https://github.com/vector-im/element-web/issues/23755

When the thread panel is opened, two composers are running and they are listening to the same events.
When a message is sent in the thread, the main composer is stealing the focus! 

So I used the same logic than in the `ComposerInsert` event,  I check the `timelineRenderingType` to know what is the current context of the composer.

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix RTE focus behaviour in threads ([\#9969](https://github.com/matrix-org/matrix-react-sdk/pull/9969)). Fixes vector-im/element-web#23755. Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->