### PR TITLE
Move subscriptions out of RoomView constructor

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { createRef, KeyboardEvent, ReactNode, TransitionEvent } from "react";
+import React, { createRef, ReactNode, TransitionEvent } from "react";
 import ReactDOM from "react-dom";
 import classNames from "classnames";
 import { Room } from "matrix-js-sdk/src/models/room";
@@ -428,7 +428,7 @@ export default class MessagePanel extends React.Component<IProps, IState> {
      *
      * @param {KeyboardEvent} ev: the keyboard event to handle
      */
-    public handleScrollKey(ev: KeyboardEvent): void {
+    public handleScrollKey(ev: KeyboardEvent | React.KeyboardEvent): void {
         if (this.scrollPanel.current) {
             this.scrollPanel.current.handleScrollKey(ev);
         }

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -33,6 +33,7 @@ import { CryptoEvent } from "matrix-js-sdk/src/crypto";
 import { THREAD_RELATION_TYPE } from "matrix-js-sdk/src/models/thread";
 import { HistoryVisibility } from "matrix-js-sdk/src/@types/partials";
 import { ISearchResults } from "matrix-js-sdk/src/@types/search";
+import { IRoomTimelineData } from "matrix-js-sdk/src/models/event-timeline-set";
 
 import shouldHideEvent from "../../shouldHideEvent";
 import { _t } from "../../languageHandler";
@@ -49,7 +50,7 @@ import RoomScrollStateStore, { ScrollState } from "../../stores/RoomScrollStateS
 import WidgetEchoStore from "../../stores/WidgetEchoStore";
 import SettingsStore from "../../settings/SettingsStore";
 import { Layout } from "../../settings/enums/Layout";
-import AccessibleButton from "../views/elements/AccessibleButton";
+import AccessibleButton, { ButtonEvent } from "../views/elements/AccessibleButton";
 import RoomContext, { TimelineRenderingType } from "../../contexts/RoomContext";
 import { E2EStatus, shieldStatusForRoom } from "../../utils/ShieldUtils";
 import { Action } from "../../dispatcher/actions";
@@ -851,7 +852,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         window.addEventListener("beforeunload", this.onPageUnload);
     }
 
-    public shouldComponentUpdate(nextProps, nextState): boolean {
+    public shouldComponentUpdate(nextProps: IRoomProps, nextState: IRoomState): boolean {
         const hasPropsDiff = objectHasDiff(this.props, nextProps);
 
         const { upgradeRecommendation, ...state } = this.state;
@@ -953,7 +954,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         });
     };
 
-    private onPageUnload = (event): string => {
+    private onPageUnload = (event: BeforeUnloadEvent): string => {
         if (ContentMessages.sharedInstance().getCurrentUploads().length > 0) {
             return (event.returnValue = _t("You seem to be uploading files, are you sure you want to quit?"));
         } else if (this.getCallForRoom() && this.state.callState !== "ended") {
@@ -961,7 +962,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         }
     };
 
-    private onReactKeyDown = (ev): void => {
+    private onReactKeyDown = (ev: React.KeyboardEvent): void => {
         let handled = false;
 
         const action = getKeyBindingsManager().getRoomAction(ev);
@@ -1125,7 +1126,13 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         createRoomFromLocalRoom(this.context.client, this.state.room as LocalRoom);
     }
 
-    private onRoomTimeline = (ev: MatrixEvent, room: Room | null, toStartOfTimeline: boolean, removed, data): void => {
+    private onRoomTimeline = (
+        ev: MatrixEvent,
+        room: Room | null,
+        toStartOfTimeline: boolean,
+        removed: boolean,
+        data?: IRoomTimelineData,
+    ): void => {
         if (this.unmounted) return;
 
         // ignore events for other rooms or the notification timeline set
@@ -1145,7 +1152,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         // ignore anything but real-time updates at the end of the room:
         // updates from pagination will happen when the paginate completes.
-        if (toStartOfTimeline || !data || !data.liveEvent) return;
+        if (toStartOfTimeline || !data?.liveEvent) return;
 
         // no point handling anything while we're waiting for the join to finish:
         // we'll only be showing a spinner.
@@ -1697,7 +1704,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     // update the read marker to match the read-receipt
-    private forgetReadMarker = (ev): void => {
+    private forgetReadMarker = (ev: ButtonEvent): void => {
         ev.stopPropagation();
         this.messagePanel.forgetReadMarker();
     };
@@ -1770,7 +1777,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
      *
      * We pass it down to the scroll panel.
      */
-    public handleScrollKey = (ev): void => {
+    public handleScrollKey = (ev: React.KeyboardEvent | KeyboardEvent): void => {
         let panel: ScrollPanel | TimelinePanel;
         if (this.searchResultsPanel.current) {
             panel = this.searchResultsPanel.current;
@@ -1793,7 +1800,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
     // this has to be a proper method rather than an unnamed function,
     // otherwise react calls it with null on each update.
-    private gatherTimelinePanelRef = (r): void => {
+    private gatherTimelinePanelRef = (r?: TimelinePanel): void => {
         this.messagePanel = r;
     };
 

--- a/src/components/structures/ScrollPanel.tsx
+++ b/src/components/structures/ScrollPanel.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { createRef, CSSProperties, ReactNode, KeyboardEvent } from "react";
+import React, { createRef, CSSProperties, ReactNode } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import SettingsStore from "../../settings/SettingsStore";
@@ -587,7 +587,7 @@ export default class ScrollPanel extends React.Component<IProps> {
      * Scroll up/down in response to a scroll key
      * @param {object} ev the keyboard event
      */
-    public handleScrollKey = (ev: KeyboardEvent): void => {
+    public handleScrollKey = (ev: KeyboardEvent | React.KeyboardEvent): void => {
         const roomAction = getKeyBindingsManager().getRoomAction(ev);
         switch (roomAction) {
             case KeyBindingAction.ScrollUp:

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -1264,7 +1264,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
      *
      * returns null if we are not mounted.
      */
-    public getScrollState = (): IScrollState => {
+    public getScrollState = (): IScrollState | null => {
         if (!this.messagePanel.current) {
             return null;
         }
@@ -1316,7 +1316,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
      *
      * We pass it down to the scroll panel.
      */
-    public handleScrollKey = (ev: React.KeyboardEvent): void => {
+    public handleScrollKey = (ev: KeyboardEvent | React.KeyboardEvent): void => {
         if (!this.messagePanel.current) return;
 
         // jump to the live timeline on ctrl-end, rather than the end of the

--- a/src/components/views/elements/Measured.tsx
+++ b/src/components/views/elements/Measured.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import UIStore, { UI_EVENTS } from "../../../stores/UIStore";
 
 interface IProps {
-    sensor: Element;
+    sensor?: Element;
     breakpoint: number;
     onMeasurement(narrow: boolean): void;
 }

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -466,7 +466,7 @@ export interface IProps {
     onInviteClick: (() => void) | null;
     onForgetClick: (() => void) | null;
     onAppsClick: (() => void) | null;
-    e2eStatus: E2EStatus;
+    e2eStatus?: E2EStatus;
     appsShown: boolean;
     searchInfo?: ISearchInfo;
     excludedRightPanelPhaseButtons?: Array<RightPanelPhases>;

--- a/src/components/views/rooms/SearchBar.tsx
+++ b/src/components/views/rooms/SearchBar.tsx
@@ -27,7 +27,7 @@ import SearchWarning, { WarningKind } from "../elements/SearchWarning";
 
 interface IProps {
     onCancelClick: () => void;
-    onSearch: (query: string, scope: string) => void;
+    onSearch: (query: string, scope: SearchScope) => void;
     searchInProgress?: boolean;
     isRoomEncrypted?: boolean;
 }

--- a/src/stores/RoomScrollStateStore.ts
+++ b/src/stores/RoomScrollStateStore.ts
@@ -38,12 +38,13 @@ export class RoomScrollStateStore {
     //        from the focussedEvent.
     private scrollStateMap = new Map<string, ScrollState>();
 
-    public getScrollState(roomId: string): ScrollState {
+    public getScrollState(roomId: string): ScrollState | undefined {
         return this.scrollStateMap.get(roomId);
     }
 
-    public setScrollState(roomId: string, scrollState: ScrollState): void {
-        this.scrollStateMap.set(roomId, scrollState);
+    public setScrollState(roomId: string, scrollState: ScrollState | undefined): void {
+        if (scrollState === undefined) this.scrollStateMap.delete(roomId);
+        else this.scrollStateMap.set(roomId, scrollState);
     }
 }
 

--- a/test/components/structures/RoomView-test.tsx
+++ b/test/components/structures/RoomView-test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022 - 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,27 +15,19 @@ limitations under the License.
 */
 
 import React from "react";
-// eslint-disable-next-line deprecate/import
-import { mount, ReactWrapper } from "enzyme";
-import { mocked, MockedObject } from "jest-mock";
-import { ClientEvent, MatrixClient } from "matrix-js-sdk/src/client";
+import { ClientEvent } from "matrix-js-sdk/src/client";
 import { Room, RoomEvent } from "matrix-js-sdk/src/models/room";
 import { MatrixEvent } from "matrix-js-sdk/src/models/event";
-import { EventType } from "matrix-js-sdk/src/matrix";
+import { EventType, MsgType } from "matrix-js-sdk/src/matrix";
 import { MEGOLM_ALGORITHM } from "matrix-js-sdk/src/crypto/olmlib";
 import { fireEvent, render } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 
-import {
-    stubClient,
-    mockPlatformPeg,
-    unmockPlatformPeg,
-    wrapInMatrixClientContext,
-    flushPromises,
-} from "../../test-utils";
-import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
+import type { MatrixClient } from "matrix-js-sdk/src/client";
+import { stubClient, mockPlatformPeg, wrapInMatrixClientContext, flushPromises, filterConsole } from "../../test-utils";
 import { Action } from "../../../src/dispatcher/actions";
 import { defaultDispatcher } from "../../../src/dispatcher/dispatcher";
-import { ViewRoomPayload } from "../../../src/dispatcher/payloads/ViewRoomPayload";
+import type { ViewRoomPayload } from "../../../src/dispatcher/payloads/ViewRoomPayload";
 import { RoomView as _RoomView } from "../../../src/components/structures/RoomView";
 import ResizeNotifier from "../../../src/utils/ResizeNotifier";
 import SettingsStore from "../../../src/settings/SettingsStore";
@@ -43,7 +35,8 @@ import { SettingLevel } from "../../../src/settings/SettingLevel";
 import DMRoomMap from "../../../src/utils/DMRoomMap";
 import { NotificationState } from "../../../src/stores/notifications/NotificationState";
 import { RightPanelPhases } from "../../../src/stores/right-panel/RightPanelStorePhases";
-import { LocalRoom, LocalRoomState } from "../../../src/models/LocalRoom";
+import type { LocalRoom } from "../../../src/models/LocalRoom";
+import { LocalRoomState } from "../../../src/models/LocalRoom";
 import { DirectoryMember } from "../../../src/utils/direct-messages";
 import { createDmLocalRoom } from "../../../src/utils/dm/createDmLocalRoom";
 import { UPDATE_EVENT } from "../../../src/stores/AsyncStore";
@@ -53,15 +46,21 @@ import VoipUserMapper from "../../../src/VoipUserMapper";
 const RoomView = wrapInMatrixClientContext(_RoomView);
 
 describe("RoomView", () => {
-    let cli: MockedObject<MatrixClient>;
+    let cli: jest.Mocked<MatrixClient>;
     let room: Room;
     let roomCount = 0;
     let stores: SdkContextClass;
 
+    filterConsole(
+        "does not have an m.room.create event",
+        "Current version: ",
+        "Version capability: ",
+        "checkForPreJoinUISI",
+    );
+
     beforeEach(async () => {
         mockPlatformPeg({ reload: () => {} });
-        stubClient();
-        cli = mocked(MatrixClientPeg.get());
+        cli = stubClient() as jest.Mocked<MatrixClient>;
 
         room = new Room(`!${roomCount++}:example.org`, cli, "@alice:example.org");
         room.getPendingEvents = () => [];
@@ -76,48 +75,9 @@ describe("RoomView", () => {
         stores.rightPanelStore.useUnitTestClient(cli);
 
         jest.spyOn(VoipUserMapper.sharedInstance(), "getVirtualRoomForRoom").mockResolvedValue(null);
+
+        room.updateMyMembership("join");
     });
-
-    afterEach(async () => {
-        unmockPlatformPeg();
-        jest.restoreAllMocks();
-    });
-
-    const mountRoomView = async (): Promise<ReactWrapper> => {
-        if (stores.roomViewStore.getRoomId() !== room.roomId) {
-            const switchedRoom = new Promise<void>((resolve) => {
-                const subFn = () => {
-                    if (stores.roomViewStore.getRoomId()) {
-                        stores.roomViewStore.off(UPDATE_EVENT, subFn);
-                        resolve();
-                    }
-                };
-                stores.roomViewStore.on(UPDATE_EVENT, subFn);
-            });
-
-            defaultDispatcher.dispatch<ViewRoomPayload>({
-                action: Action.ViewRoom,
-                room_id: room.roomId,
-                metricsTrigger: undefined,
-            });
-
-            await switchedRoom;
-        }
-
-        const roomView = mount(
-            <SDKContext.Provider value={stores}>
-                <RoomView
-                    // threepidInvite should be optional on RoomView props
-                    // it is treated as optional in RoomView
-                    threepidInvite={undefined as any}
-                    resizeNotifier={new ResizeNotifier()}
-                    forceTimeline={false}
-                />
-            </SDKContext.Provider>,
-        );
-        await flushPromises();
-        return roomView;
-    };
 
     const renderRoomView = async (): Promise<ReturnType<typeof render>> => {
         if (stores.roomViewStore.getRoomId() !== room.roomId) {
@@ -152,18 +112,38 @@ describe("RoomView", () => {
                 />
             </SDKContext.Provider>,
         );
-        await flushPromises();
+        await act(async () => {
+            await flushPromises();
+        });
+
+        // Want to make sure we aren't just rendering an error screen
+        expect(roomView.container.querySelector(".mx_ErrorBoundary")).toBeNull();
+        expect(roomView.container.innerHTML).not.toContain("Can't load this message");
+
         return roomView;
     };
-    const getRoomViewInstance = async (): Promise<_RoomView> =>
-        (await mountRoomView()).find(_RoomView).instance() as _RoomView;
 
     it("updates url preview visibility on encryption state change", async () => {
+        room.addLiveEvents([
+            new MatrixEvent({
+                type: EventType.RoomMessage,
+                event_id: "$link-msg",
+                sender: `@link.sender:example.com`,
+                room_id: room.roomId,
+                origin_server_ts: 999_999,
+                content: {
+                    body: "go to https://www.example.org/",
+                    msgtype: MsgType.Text,
+                    formatted_body: `go to <a href="https://www.example.org/">https://www.example.org/</a>`,
+                },
+            }),
+        ]);
+
         // we should be starting unencrypted
         expect(cli.isCryptoEnabled()).toEqual(false);
         expect(cli.isRoomEncrypted(room.roomId)).toEqual(false);
 
-        const roomViewInstance = await getRoomViewInstance();
+        const { container } = await renderRoomView();
 
         // in a default (non-encrypted room, it should start out with url previews enabled)
         // This is a white-box test in that we're asserting things about the state, which
@@ -173,33 +153,35 @@ describe("RoomView", () => {
         // This also relies on the default settings being URL previews on normally and
         // off for e2e rooms because 1) it's probably useful to assert this and
         // 2) SettingsStore is a static class and so very hard to mock out.
-        expect(roomViewInstance.state.showUrlPreview).toBe(true);
+        expect(container.querySelector(".mx_LinkPreviewGroup")).not.toBeNull();
 
-        // now enable encryption
-        cli.isCryptoEnabled.mockReturnValue(true);
-        cli.isRoomEncrypted.mockReturnValue(true);
+        act(() => {
+            // now enable encryption
+            cli.isCryptoEnabled.mockReturnValue(true);
+            cli.isRoomEncrypted.mockReturnValue(true);
 
-        // and fake an encryption event into the room to prompt it to re-check
-        room.addLiveEvents([
-            new MatrixEvent({
-                type: "m.room.encryption",
-                sender: cli.getUserId()!,
-                content: {},
-                event_id: "someid",
-                room_id: room.roomId,
-            }),
-        ]);
+            // and fake an encryption event into the room to prompt it to re-check
+            room.addLiveEvents([
+                new MatrixEvent({
+                    type: "m.room.encryption",
+                    sender: cli.getUserId()!,
+                    content: {},
+                    event_id: "someid",
+                    room_id: room.roomId,
+                }),
+            ]);
+        });
 
         // URL previews should now be disabled
-        expect(roomViewInstance.state.showUrlPreview).toBe(false);
+        expect(container.querySelector(".mx_LinkPreviewGroup")).toBeNull();
     });
 
     it("updates live timeline when a timeline reset happens", async () => {
-        const roomViewInstance = await getRoomViewInstance();
-        const oldTimeline = roomViewInstance.state.liveTimeline;
+        const { container } = await renderRoomView();
+        const oldTimeline = container.innerHTML;
 
         room.getUnfilteredTimelineSet().resetLiveTimeline();
-        expect(roomViewInstance.state.liveTimeline).not.toEqual(oldTimeline);
+        expect(container.innerHTML).not.toEqual(oldTimeline);
     });
 
     describe("with virtual rooms", () => {
@@ -212,13 +194,15 @@ describe("RoomView", () => {
         });
 
         it("checks for a virtual room on room event", async () => {
+            const mock = VoipUserMapper.sharedInstance().getVirtualRoomForRoom as unknown as jest.SpyInstance;
             await renderRoomView();
-            expect(VoipUserMapper.sharedInstance().getVirtualRoomForRoom).toHaveBeenCalledWith(room.roomId);
+            expect(mock).toHaveBeenCalledWith(room.roomId);
 
+            mock.mockReset();
             cli.emit(ClientEvent.Room, room);
 
             // called again after room event
-            expect(VoipUserMapper.sharedInstance().getVirtualRoomForRoom).toHaveBeenCalledTimes(2);
+            expect(mock).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -231,13 +215,13 @@ describe("RoomView", () => {
 
         it("normally doesn't open the chat panel", async () => {
             jest.spyOn(NotificationState.prototype, "isUnread", "get").mockReturnValue(false);
-            await mountRoomView();
+            await renderRoomView();
             expect(stores.rightPanelStore.isOpen).toEqual(false);
         });
 
         it("opens the chat panel if there are unread messages", async () => {
             jest.spyOn(NotificationState.prototype, "isUnread", "get").mockReturnValue(true);
-            await mountRoomView();
+            await renderRoomView();
             expect(stores.rightPanelStore.isOpen).toEqual(true);
             expect(stores.rightPanelStore.currentCard.phase).toEqual(RightPanelPhases.Timeline);
         });
@@ -247,7 +231,13 @@ describe("RoomView", () => {
         let localRoom: LocalRoom;
 
         beforeEach(async () => {
+            cli.getClientWellKnown.mockReturnValue({
+                "io.element.e2ee": {
+                    default: false,
+                },
+            });
             localRoom = room = await createDmLocalRoom(cli, [new DirectoryMember({ user_id: "@user:example.com" })]);
+            expect(localRoom.encrypted).toBe(false);
             cli.store.storeRoom(room);
         });
 
@@ -265,7 +255,7 @@ describe("RoomView", () => {
 
             describe("that is encrypted", () => {
                 beforeEach(() => {
-                    mocked(cli.isRoomEncrypted).mockReturnValue(true);
+                    cli.isRoomEncrypted.mockReturnValue(true);
                     localRoom.encrypted = true;
                     localRoom.currentState.setStateEvents([
                         new MatrixEvent({

--- a/test/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -191,25 +191,6 @@ exports[`RoomView for a local room in state ERROR should match the snapshot 1`] 
               <li
                 class="mx_NewRoomIntro"
               >
-                <div
-                  class="mx_EventTileBubble mx_cryptoEvent mx_cryptoEvent_icon_warning"
-                >
-                  <div
-                    class="mx_EventTileBubble_title"
-                  >
-                    End-to-end encryption isn't enabled
-                  </div>
-                  <div
-                    class="mx_EventTileBubble_subtitle"
-                  >
-                    <span>
-                       
-                      Your private messages are normally encrypted, but this room isn't. Usually this is due to an unsupported device or method being used, like email invites.
-                       
-                       
-                    </span>
-                  </div>
-                </div>
                 <span
                   aria-label="Avatar"
                   aria-live="off"
@@ -386,25 +367,6 @@ exports[`RoomView for a local room in state NEW should match the snapshot 1`] = 
               <li
                 class="mx_NewRoomIntro"
               >
-                <div
-                  class="mx_EventTileBubble mx_cryptoEvent mx_cryptoEvent_icon_warning"
-                >
-                  <div
-                    class="mx_EventTileBubble_title"
-                  >
-                    End-to-end encryption isn't enabled
-                  </div>
-                  <div
-                    class="mx_EventTileBubble_subtitle"
-                  >
-                    <span>
-                       
-                      Your private messages are normally encrypted, but this room isn't. Usually this is due to an unsupported device or method being used, like email invites.
-                       
-                       
-                    </span>
-                  </div>
-                </div>
                 <span
                   aria-label="Avatar"
                   aria-live="off"

--- a/test/components/views/rooms/LinkPreviewGroup-test.tsx
+++ b/test/components/views/rooms/LinkPreviewGroup-test.tsx
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { render, RenderResult } from "@testing-library/react";
+import { IPreviewUrlResponse, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { act } from "react-dom/test-utils";
+
+import LinkPreviewGroup from "../../../../src/components/views/rooms/LinkPreviewGroup";
+import { flushPromises, mkMessage, stubClient } from "../../../test-utils";
+import MatrixClientContext from "../../../../src/contexts/MatrixClientContext";
+
+type Props = React.ComponentPropsWithoutRef<typeof LinkPreviewGroup>;
+
+describe("<LinkPreviewGroup >", () => {
+    let client: jest.Mocked<MatrixClient>;
+
+    beforeEach(() => {
+        client = stubClient() as jest.Mocked<MatrixClient>;
+    });
+
+    function renderComponent(props: Partial<Props>): RenderResult {
+        return render(
+            <MatrixClientContext.Provider value={client}>
+                <LinkPreviewGroup
+                    mxEvent={mkMessage({
+                        event: true,
+                        user: "@user:example.com",
+                        room: "!room:example.com",
+                    })}
+                    links={[]}
+                    onCancelClick={jest.fn()}
+                    onHeightChanged={jest.fn()}
+                    {...props}
+                />
+            </MatrixClientContext.Provider>,
+        );
+    }
+
+    function mockResponses(map: Record<string, IPreviewUrlResponse>) {
+        client.getUrlPreview.mockImplementation((url) => {
+            const value = map[url];
+            if (!value) return Promise.reject(new Error());
+            return Promise.resolve(value);
+        });
+    }
+
+    function finishLoading(): Promise<void> {
+        return act(async () => {
+            await flushPromises();
+        });
+    }
+
+    it("should render", async () => {
+        mockResponses({
+            "https://www.example.com/file.txt": {
+                "og:title": "File",
+                "og:type": "text",
+                "og:url": "n/a",
+            },
+            "https://www.example.com/website.html": {
+                "og:title": "My Cool Website",
+                "og:type": "website",
+                "og:url": "n/a",
+            },
+        });
+
+        const { container } = renderComponent({
+            links: ["https://www.example.com/file.txt", "https://www.example.com/website.html"],
+        });
+
+        await finishLoading();
+
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/test/components/views/rooms/__snapshots__/LinkPreviewGroup-test.tsx.snap
+++ b/test/components/views/rooms/__snapshots__/LinkPreviewGroup-test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LinkPreviewGroup > should render 1`] = `
+<div>
+  <div
+    class="mx_LinkPreviewGroup"
+  >
+    <div
+      class="mx_LinkPreviewWidget"
+    >
+      <div
+        class="mx_LinkPreviewWidget_wrapImageCaption"
+      >
+        <div
+          class="mx_LinkPreviewWidget_caption"
+        >
+          <div
+            class="mx_LinkPreviewWidget_title"
+          >
+            <a
+              href="https://www.example.com/file.txt"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              File
+            </a>
+          </div>
+          <div
+            class="mx_LinkPreviewWidget_description"
+          />
+        </div>
+      </div>
+      <div
+        aria-label="Close preview"
+        class="mx_AccessibleButton mx_LinkPreviewGroup_hide"
+        role="button"
+        tabindex="0"
+      >
+        <img
+          alt=""
+          class="mx_filterFlipColor"
+          height="18"
+          role="presentation"
+          src="image-file-stub"
+          width="18"
+        />
+      </div>
+    </div>
+    <div
+      class="mx_LinkPreviewWidget"
+    >
+      <div
+        class="mx_LinkPreviewWidget_wrapImageCaption"
+      >
+        <div
+          class="mx_LinkPreviewWidget_caption"
+        >
+          <div
+            class="mx_LinkPreviewWidget_title"
+          >
+            <a
+              href="https://www.example.com/website.html"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              My Cool Website
+            </a>
+          </div>
+          <div
+            class="mx_LinkPreviewWidget_description"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/test/stores/RoomScrollStateStore-test.ts
+++ b/test/stores/RoomScrollStateStore-test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RoomScrollStateStore, ScrollState } from "../../src/stores/RoomScrollStateStore";
+
+describe("RoomScrollStateStore", () => {
+    let store: RoomScrollStateStore;
+
+    beforeEach(() => {
+        store = new RoomScrollStateStore();
+    });
+
+    it("should return undefined for unknown states", () => {
+        expect(store.getScrollState("!room1:example.com")).toBeUndefined();
+        expect(store.getScrollState("!room2:example.com")).toBeUndefined();
+    });
+
+    it("should return the state after setting", () => {
+        const room = "!room:example.com";
+        const state: ScrollState = { focussedEvent: "$1", pixelOffset: 0 };
+        store.setScrollState(room, state);
+        expect(store.getScrollState(room)).toBe(state);
+    });
+
+    it("should support 'unsetting'", () => {
+        const room = "!room2:example.com";
+        store.setScrollState(room, { focussedEvent: "$1", pixelOffset: 0 });
+        store.setScrollState(room, undefined);
+        expect(store.getScrollState(room)).toBeUndefined();
+    });
+});

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -109,7 +109,7 @@ export function createTestClient(): MatrixClient {
 
         crypto: {
             deviceList: {
-                downloadKeys: jest.fn(),
+                downloadKeys: jest.fn().mockReturnValue({}),
             },
         },
 
@@ -155,6 +155,7 @@ export function createTestClient(): MatrixClient {
         sendMessage: jest.fn().mockResolvedValue({}),
         sendStateEvent: jest.fn().mockResolvedValue(undefined),
         getSyncState: jest.fn().mockReturnValue("SYNCING"),
+        getSyncStateData: jest.fn().mockReturnValue({}),
         generateClientSecret: () => "t35tcl1Ent5ECr3T",
         isGuest: jest.fn().mockReturnValue(false),
         getRoomHierarchy: jest.fn().mockReturnValue({
@@ -186,7 +187,7 @@ export function createTestClient(): MatrixClient {
         isCryptoEnabled: jest.fn().mockReturnValue(false),
         hasLazyLoadMembersEnabled: jest.fn().mockReturnValue(false),
         isInitialSyncComplete: jest.fn().mockReturnValue(true),
-        downloadKeys: jest.fn(),
+        downloadKeys: jest.fn().mockReturnValue({}),
         fetchRoomEvent: jest.fn().mockRejectedValue({}),
         makeTxnId: jest.fn().mockImplementation(() => `t${txnId++}`),
         sendToDevice: jest.fn().mockResolvedValue(undefined),
@@ -208,6 +209,12 @@ export function createTestClient(): MatrixClient {
         setPassword: jest.fn().mockRejectedValue({}),
         groupCallEventHandler: { groupCalls: new Map<string, GroupCall>() },
         redactEvent: jest.fn(),
+
+        getUrlPreview: jest.fn().mockResolvedValue({
+            "og:title": "title",
+            "og:type": "type",
+            "og:url": "url",
+        }),
     } as unknown as MatrixClient;
 
     client.reEmitter = new ReEmitter(client);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
[Motivation](https://github.com/vector-im/element-web/issues/24236#issuecomment-1397428515).

Submitting this separately from the other instances since it's... a bit hairy. Best reviewed one commit at a time, I reckon.

My objective is to move the subscription registration out of `RoomView`'s constructor. React doesn't guarantee that `componentWillUmount` (i.e. 'the cleanup function') will be called _unless_ `componentDidMount` was called. This means all those subscriptions were possibly not being cleaned up, i.e. leaking.

In order to get there, I had to get `RoomView.ts` (at least) to pass the CI checks, namely the `--noImplicitAny` and `--strict` checks. Since #9940 is a thing, and in order to minimize conflicts, I pulled those changes pretty much directly. I had to touch a few signatures in other files, so CI will still probably complain.

This may fix vector-im/element-web#10826

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->