### PR TITLE
Fix ongoing broadcast recording after connection error

### DIFF
--- a/src/voice-broadcast/audio/VoiceBroadcastRecorder.ts
+++ b/src/voice-broadcast/audio/VoiceBroadcastRecorder.ts
@@ -65,14 +65,18 @@ export class VoiceBroadcastRecorder
         this.voiceRecording.liveData.onUpdate((data: IRecordingUpdate) => {
             this.setCurrentChunkLength(data.timeSeconds - this.previousChunkEndTimePosition);
         });
-        return;
     }
 
     /**
      * Stops the recording and returns the remaining chunk (if any).
      */
     public async stop(): Promise<Optional<ChunkRecordedPayload>> {
-        await this.voiceRecording.stop();
+        try {
+            await this.voiceRecording.stop();
+        } catch {
+            // Ignore if the recording raises any error.
+        }
+
         // forget about that call, so that we can stop it again later
         Singleflight.forgetAllFor(this.voiceRecording);
         const chunk = this.extractChunk();

--- a/src/voice-broadcast/models/VoiceBroadcastRecording.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastRecording.ts
@@ -333,7 +333,7 @@ export class VoiceBroadcastRecording
      * It sets the connection error state and stops the recorder.
      */
     private async onConnectionError(): Promise<void> {
-        await this.stopRecorder();
+        await this.stopRecorder(false);
         this.setState("connection_error");
     }
 
@@ -418,14 +418,14 @@ export class VoiceBroadcastRecording
         }
     }
 
-    private async stopRecorder(): Promise<void> {
+    private async stopRecorder(emit = true): Promise<void> {
         if (!this.recorder) {
             return;
         }
 
         try {
             const lastChunk = await this.recorder.stop();
-            if (lastChunk) {
+            if (lastChunk && emit) {
                 await this.onChunkRecorded(lastChunk);
             }
         } catch (err) {

--- a/test/voice-broadcast/audio/VoiceBroadcastRecorder-test.ts
+++ b/test/voice-broadcast/audio/VoiceBroadcastRecorder-test.ts
@@ -205,6 +205,22 @@ describe("VoiceBroadcastRecorder", () => {
                     });
                 });
             });
+
+            describe("and calling stop() with recording.stop error)", () => {
+                let stopPayload: ChunkRecordedPayload;
+
+                beforeEach(async () => {
+                    mocked(voiceRecording.stop).mockRejectedValue("Error");
+                    stopPayload = await voiceBroadcastRecorder.stop();
+                });
+
+                it("should return the remaining chunk", () => {
+                    expect(stopPayload).toEqual({
+                        buffer: concat(headers1, headers2, chunk1),
+                        length: 23,
+                    });
+                });
+            });
         });
 
         describe("when some chunks have been received", () => {


### PR DESCRIPTION
- A `try/catch` to prevent `VoiceBroadcastRecorder` ending up in a broken state
- Not emitting a broadcast chunk on connection error

closes https://github.com/vector-im/element-web/issues/24295

PSF-1871

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->