### PR TITLE
Improve avatar settings accessibility

### DIFF
--- a/src/components/views/settings/AvatarSetting.tsx
+++ b/src/components/views/settings/AvatarSetting.tsx
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import classNames from "classnames";
 
 import { _t } from "../../../languageHandler";
-import AccessibleButton from "../elements/AccessibleButton";
+import AccessibleButton, { ButtonEvent } from "../elements/AccessibleButton";
 
 interface IProps {
     avatarUrl?: string;
     avatarName: string; // name of user/room the avatar belongs to
-    uploadAvatar?: (e: React.MouseEvent) => void;
-    removeAvatar?: (e: React.MouseEvent) => void;
+    uploadAvatar?: (e: ButtonEvent) => void;
+    removeAvatar?: (e: ButtonEvent) => void;
     avatarAltText: string;
 }
 
@@ -34,13 +34,16 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
         onMouseEnter: () => setIsHovering(true),
         onMouseLeave: () => setIsHovering(false),
     };
+    // TODO: Use useId() as soon as we're using React 18.
+    // Prevents ID collisions when this component is used more than once on the same page.
+    const a11yId = useRef(`hover-text-${Math.random()}`);
 
     let avatarElement = (
         <AccessibleButton
             element="div"
             onClick={uploadAvatar}
             className="mx_AvatarSetting_avatarPlaceholder"
-            aria-labelledby="hover-text"
+            aria-labelledby={a11yId.current}
             {...hoveringProps}
         />
     );
@@ -64,7 +67,7 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
             <AccessibleButton
                 onClick={uploadAvatar}
                 className="mx_AvatarSetting_uploadButton"
-                aria-labelledby="hover-text"
+                aria-labelledby={a11yId.current}
                 {...hoveringProps}
             />
         );
@@ -88,7 +91,7 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
             {avatarElement}
             <div className="mx_AvatarSetting_hover" aria-hidden="true">
                 <div className="mx_AvatarSetting_hoverBg" />
-                <span id="hover-text">{_t("Upload")}</span>
+                <span id={a11yId.current}>{_t("Upload")}</span>
             </div>
             {uploadAvatarBtn}
             {removeAvatarBtn}

--- a/src/components/views/settings/AvatarSetting.tsx
+++ b/src/components/views/settings/AvatarSetting.tsx
@@ -41,7 +41,7 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
     let avatarElement = (
         <AccessibleButton
             element="div"
-            onClick={uploadAvatar}
+            onClick={uploadAvatar ?? null}
             className="mx_AvatarSetting_avatarPlaceholder"
             aria-labelledby={a11yId.current}
             {...hoveringProps}
@@ -54,7 +54,7 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
                 src={avatarUrl}
                 alt={avatarAltText}
                 aria-label={avatarAltText}
-                onClick={uploadAvatar}
+                onClick={uploadAvatar ?? null}
                 {...hoveringProps}
             />
         );

--- a/src/components/views/settings/AvatarSetting.tsx
+++ b/src/components/views/settings/AvatarSetting.tsx
@@ -40,6 +40,7 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
             element="div"
             onClick={uploadAvatar}
             className="mx_AvatarSetting_avatarPlaceholder"
+            aria-labelledby="hover-text"
             {...hoveringProps}
         />
     );
@@ -60,7 +61,12 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
     if (uploadAvatar) {
         // insert an empty div to be the host for a css mask containing the upload.svg
         uploadAvatarBtn = (
-            <AccessibleButton onClick={uploadAvatar} className="mx_AvatarSetting_uploadButton" {...hoveringProps} />
+            <AccessibleButton
+                onClick={uploadAvatar}
+                className="mx_AvatarSetting_uploadButton"
+                aria-labelledby="hover-text"
+                {...hoveringProps}
+            />
         );
     }
 
@@ -80,9 +86,9 @@ const AvatarSetting: React.FC<IProps> = ({ avatarUrl, avatarAltText, avatarName,
     return (
         <div className={avatarClasses}>
             {avatarElement}
-            <div className="mx_AvatarSetting_hover">
+            <div className="mx_AvatarSetting_hover" aria-hidden="true">
                 <div className="mx_AvatarSetting_hoverBg" />
-                <span>{_t("Upload")}</span>
+                <span id="hover-text">{_t("Upload")}</span>
             </div>
             {uploadAvatarBtn}
             {removeAvatarBtn}

--- a/test/components/views/settings/AvatarSetting-test.tsx
+++ b/test/components/views/settings/AvatarSetting-test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/components/views/settings/AvatarSetting-test.tsx
+++ b/test/components/views/settings/AvatarSetting-test.tsx
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import React from "react";
+import { render } from "@testing-library/react";
+
+import AvatarSetting from "../../../../src/components/views/settings/AvatarSetting";
+
+describe("<AvatarSetting />", () => {
+    it("renders avatar with specified alt text", async () => {
+        const { queryByAltText } = render(
+            <AvatarSetting
+                avatarName="Peter Fox"
+                avatarAltText="Avatar of Peter Fox"
+                avatarUrl="https://avatar.fictional/my-avatar"
+            />,
+        );
+
+        const imgElement = queryByAltText("Avatar of Peter Fox");
+        expect(imgElement).toBeInTheDocument();
+    });
+
+    it("renders avatar with remove button", async () => {
+        const { queryByText } = render(
+            <AvatarSetting
+                avatarName="Peter Fox"
+                avatarAltText="Avatar of Peter Fox"
+                avatarUrl="https://avatar.fictional/my-avatar"
+                removeAvatar={jest.fn()}
+            />,
+        );
+
+        const removeButton = queryByText("Remove");
+        expect(removeButton).toBeInTheDocument();
+    });
+
+    it("renders avatar without remove button", async () => {
+        const { queryByText } = render(<AvatarSetting avatarName="Peter Fox" avatarAltText="Avatar of Peter Fox" />);
+
+        const removeButton = queryByText("Remove");
+        expect(removeButton).toBeNull();
+    });
+});


### PR DESCRIPTION
This PR improves screen reader prompts for the avatar upload.

### Previous behaviour:
- Both the avatar placeholder and the icon in the bottom right corner were announced as "Button"
- When tabbing through the elements, the `div` used for the hover effect was focusable and the text was announce as "Text element, Upload" (screenshot for reference)
- Both interaction elements were just announced as "Button"

![Screenshot 2023-01-24 at 13 57 09](https://user-images.githubusercontent.com/20201936/214504343-3f674eb2-c4d9-4800-8e6f-7040f7c5024c.png)

### Improved behaviour:
The underlying `div` which is used for the hover effect is not focusable anymore (`aria-hidden="true"`). However the text shown when hovering (Currently: Upload) is used to announce the two interaction elements (`aria-labelledby="upload-text"`), which are now both announced as "Upload button".

![Screenshot 2023-01-24 at 13 54 17](https://user-images.githubusercontent.com/20201936/214504382-bfe132cd-0bb1-421e-a277-7bf819ef9cd3.png)
![Screenshot 2023-01-24 at 13 54 40](https://user-images.githubusercontent.com/20201936/214504384-92b8a442-3791-4665-9d9c-7bd10574ba49.png)

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Improves a11y for avatar uploads

Signed-off-by: Marco Bartelt marco.bartelt.ext@bwi.de



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improves a11y for avatar uploads ([\#9985](https://github.com/matrix-org/matrix-react-sdk/pull/9985)). Contributed by @GoodGuyMarco.<!-- CHANGELOG_PREVIEW_END -->