### PR TITLE
Fix link creation with backward selection

### DIFF
--- a/cypress/e2e/composer/composer.spec.ts
+++ b/cypress/e2e/composer/composer.spec.ts
@@ -98,7 +98,7 @@ describe("Composer", () => {
         });
     });
 
-    describe("WYSIWYG", () => {
+    describe("Rich text editor", () => {
         beforeEach(() => {
             cy.enableLabsFeature("feature_wysiwyg_composer");
             cy.initTestUser(homeserver, "Janet").then(() => {
@@ -163,6 +163,26 @@ describe("Composer", () => {
                 cy.get("div[contenteditable=true]").type("{ctrl+enter}");
                 // It was sent
                 cy.contains(".mx_EventTile_body", "my message 3");
+            });
+        });
+
+        describe("links", () => {
+            it("create link with a forward selection", () => {
+                // Type a message
+                cy.get("div[contenteditable=true]").type("my message 0{selectAll}");
+
+                // Open link modal
+                cy.get('button[aria-label="Link"]').click();
+                // Fill the link field
+                cy.get('input[label="Link"]').type("https://matrix.org/");
+                // Click on save
+                cy.get('button[type="submit"]').click();
+                // Send the message
+                cy.get('div[aria-label="Send message"]').click();
+
+                // It was sent
+                cy.contains(".mx_EventTile_body a", "my message 0");
+                cy.get(".mx_EventTile_body a").should("have.attr", "href").and("include", "https://matrix.org/");
             });
         });
     });

--- a/src/components/views/rooms/wysiwyg_composer/ComposerContext.ts
+++ b/src/components/views/rooms/wysiwyg_composer/ComposerContext.ts
@@ -20,7 +20,7 @@ import { SubSelection } from "./types";
 
 export function getDefaultContextValue(): { selection: SubSelection } {
     return {
-        selection: { anchorNode: null, anchorOffset: 0, focusNode: null, focusOffset: 0 },
+        selection: { anchorNode: null, anchorOffset: 0, focusNode: null, focusOffset: 0, isForward: true },
     };
 }
 

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useComposerFunctions.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useComposerFunctions.ts
@@ -44,6 +44,7 @@ export function useComposerFunctions(
                         anchorOffset: anchorOffset + text.length,
                         focusNode: ref.current.firstChild,
                         focusOffset: focusOffset + text.length,
+                        isForward: true,
                     });
                     setContent(ref.current.innerHTML);
                 }

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useSelection.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useSelection.ts
@@ -23,11 +23,15 @@ function setSelectionContext(composerContext: ComposerContextState): void {
     const selection = document.getSelection();
 
     if (selection) {
+        const range = selection.getRangeAt(0);
+        const isForward = range.startContainer === selection.anchorNode && range.startOffset === selection.anchorOffset;
+
         composerContext.selection = {
             anchorNode: selection.anchorNode,
             anchorOffset: selection.anchorOffset,
             focusNode: selection.focusNode,
             focusOffset: selection.focusOffset,
+            isForward,
         };
     }
 }

--- a/src/components/views/rooms/wysiwyg_composer/types.ts
+++ b/src/components/views/rooms/wysiwyg_composer/types.ts
@@ -19,4 +19,6 @@ export type ComposerFunctions = {
     insertText: (text: string) => void;
 };
 
-export type SubSelection = Pick<Selection, "anchorNode" | "anchorOffset" | "focusNode" | "focusOffset">;
+export type SubSelection = Pick<Selection, "anchorNode" | "anchorOffset" | "focusNode" | "focusOffset"> & {
+    isForward: boolean;
+};

--- a/src/components/views/rooms/wysiwyg_composer/utils/selection.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/selection.ts
@@ -19,9 +19,14 @@ import { SubSelection } from "../types";
 export function setSelection(selection: SubSelection): Promise<void> {
     if (selection.anchorNode && selection.focusNode) {
         const range = new Range();
-        range.setStart(selection.anchorNode, selection.anchorOffset);
-        range.setEnd(selection.focusNode, selection.focusOffset);
 
+        if (selection.isForward) {
+            range.setStart(selection.anchorNode, selection.anchorOffset);
+            range.setEnd(selection.focusNode, selection.focusOffset);
+        } else {
+            range.setStart(selection.focusNode, selection.focusOffset);
+            range.setEnd(selection.anchorNode, selection.anchorOffset);
+        }
         document.getSelection()?.removeAllRanges();
         document.getSelection()?.addRange(range);
     }

--- a/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
@@ -299,6 +299,7 @@ describe("SendWysiwygComposer", () => {
                     anchorOffset: 2,
                     focusNode: textNode,
                     focusOffset: 2,
+                    isForward: true,
                 });
                 // the event is not automatically fired by jest
                 document.dispatchEvent(new CustomEvent("selectionchange"));

--- a/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
@@ -309,6 +309,32 @@ describe("SendWysiwygComposer", () => {
                 // Then
                 await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent(/wo🦫rd/));
             });
+
+            it("Should add an emoji when a word is selected", async () => {
+                // When
+                screen.getByRole("textbox").focus();
+                screen.getByRole("textbox").innerHTML = "word";
+                fireEvent.input(screen.getByRole("textbox"), {
+                    data: "word",
+                    inputType: "insertText",
+                });
+
+                const textNode = screen.getByRole("textbox").firstChild;
+                await setSelection({
+                    anchorNode: textNode,
+                    anchorOffset: 3,
+                    focusNode: textNode,
+                    focusOffset: 2,
+                    isForward: false,
+                });
+                // the event is not automatically fired by jest
+                document.dispatchEvent(new CustomEvent("selectionchange"));
+
+                emojiButton.click();
+
+                // Then
+                await waitFor(() => expect(screen.getByRole("textbox")).toHaveTextContent(/wo🦫d/));
+            });
         },
     );
 });

--- a/test/components/views/rooms/wysiwyg_composer/components/LinkModal-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/LinkModal-test.tsx
@@ -35,6 +35,7 @@ describe("LinkModal", () => {
         anchorNode: null,
         focusOffset: 3,
         anchorOffset: 4,
+        isForward: true,
     };
 
     const customRender = (isTextEnabled: boolean, onClose: () => void, isEditing = false) => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Fix: https://github.com/vector-im/element-web/issues/24315

I tried to add a backward selection test for link in cypress but I can't achieve to create a backward selection. Tried to play with the keyboard or to create manually a selection without success.

**Before**

https://user-images.githubusercontent.com/2621378/214618371-3d54b0b5-6d68-4c44-84c6-0dfb864c695d.mov

**After**

https://user-images.githubusercontent.com/2621378/214618332-a8777496-ec1f-4010-a6be-feb5dba96788.mov


<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix link creation with backward selection ([\#9986](https://github.com/matrix-org/matrix-react-sdk/pull/9986)). Fixes vector-im/element-web#24315. Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->