### PR TITLE
Implement MSC3946 for AdvancedRoomSettingsTab

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -955,6 +955,8 @@
     "New group call experience": "New group call experience",
     "Live Location Sharing": "Live Location Sharing",
     "Temporary implementation. Locations persist in room history.": "Temporary implementation. Locations persist in room history.",
+    "Dynamic room predecessors": "Dynamic room predecessors",
+    "Enable MSC3946 (to support late-arriving room archives)": "Enable MSC3946 (to support late-arriving room archives)",
     "Favourite Messages": "Favourite Messages",
     "Under active development.": "Under active development.",
     "Force 15s voice broadcast chunk length": "Force 15s voice broadcast chunk length",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -439,6 +439,15 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         shouldWarn: true,
         default: false,
     },
+    "feature_dynamic_room_predecessors": {
+        isFeature: true,
+        labsGroup: LabGroup.Rooms,
+        supportedLevels: LEVELS_FEATURE,
+        displayName: _td("Dynamic room predecessors"),
+        description: _td("Enable MSC3946 (to support late-arriving room archives)"),
+        shouldWarn: true,
+        default: false,
+    },
     "feature_favourite_messages": {
         isFeature: true,
         labsGroup: LabGroup.Messaging,

--- a/test/components/views/settings/tabs/room/AdvancedRoomSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/room/AdvancedRoomSettingsTab-test.tsx
@@ -26,6 +26,7 @@ import { mkEvent, mkStubRoom, stubClient } from "../../../../../test-utils";
 import dis from "../../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../../src/dispatcher/actions";
 import { MatrixClientPeg } from "../../../../../../src/MatrixClientPeg";
+import SettingsStore from "../../../../../../src/settings/SettingsStore";
 
 jest.mock("../../../../../../src/dispatcher/dispatcher");
 
@@ -43,6 +44,12 @@ describe("AdvancedRoomSettingsTab", () => {
         cli = MatrixClientPeg.get();
         room = mkStubRoom(roomId, "test room", cli);
         mocked(cli.getRoom).mockReturnValue(room);
+        mocked(dis.dispatch).mockReset();
+        mocked(room.findPredecessor).mockImplementation((msc3946: boolean) =>
+            msc3946
+                ? { roomId: "old_room_id_via_predecessor", eventId: null }
+                : { roomId: "old_room_id", eventId: "tombstone_event_id" },
+        );
     });
 
     it("should render as expected", () => {
@@ -71,6 +78,17 @@ describe("AdvancedRoomSettingsTab", () => {
             room: room.roomId,
         });
 
+        // Because we're mocking Room.findPredecessor, it may not be necessary
+        // to provide the actual event here, but we do need the create event,
+        // and in future this may be needed, so included for symmetry.
+        const predecessorEvent = mkEvent({
+            event: true,
+            user: "@a:b.com",
+            type: EventType.RoomPredecessor,
+            content: { predecessor_room_id: "old_room_id_via_predecessor" },
+            room: room.roomId,
+        });
+
         type GetStateEvents2Args = (eventType: EventType | string, stateKey: string) => MatrixEvent | null;
 
         const getStateEvents = jest.spyOn(
@@ -82,6 +100,8 @@ describe("AdvancedRoomSettingsTab", () => {
             switch (eventType) {
                 case EventType.RoomCreate:
                     return createEvent;
+                case EventType.RoomPredecessor:
+                    return predecessorEvent;
                 default:
                     return null;
             }
@@ -99,6 +119,28 @@ describe("AdvancedRoomSettingsTab", () => {
             room_id: "old_room_id",
             metricsTrigger: "WebPredecessorSettings",
             metricsViaKeyboard: false,
+        });
+    });
+
+    describe("When MSC3946 support is enabled", () => {
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "getValue")
+                .mockReset()
+                .mockImplementation((settingName) => settingName === "feature_dynamic_room_predecessors");
+        });
+
+        it("should link to predecessor room via MSC3946 if enabled", async () => {
+            mockStateEvents(room);
+            const tab = renderTab();
+            const link = await tab.findByText("View older messages in test room.");
+            fireEvent.click(link);
+            expect(dis.dispatch).toHaveBeenCalledWith({
+                action: Action.ViewRoom,
+                event_id: null,
+                room_id: "old_room_id_via_predecessor",
+                metricsTrigger: "WebPredecessorSettings",
+                metricsViaKeyboard: false,
+            });
         });
     });
 });


### PR DESCRIPTION
Adds a labs flag and uses it in AdvancedRoomSettingsTab. Other places coming soon.

Closes https://github.com/vector-im/element-web/issues/24322

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement MSC3946 for AdvancedRoomSettingsTab ([\#9995](https://github.com/matrix-org/matrix-react-sdk/pull/9995)). Fixes vector-im/element-web#24322. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->