### PR TITLE
Make hotkeys usable on whitespaces

### DIFF
--- a/src/editor/operations.ts
+++ b/src/editor/operations.ts
@@ -37,11 +37,6 @@ export function formatRange(range: Range, action: Formatting): void {
         range.trim();
     }
 
-    // Edge case when just selecting whitespace or new line.
-    // There should be no reason to format whitespace, so we can just return.
-    if (range.length === 0) {
-        return;
-    }
 
     switch (action) {
         case Formatting.Bold:
@@ -301,6 +296,13 @@ export function toggleInlineFormat(range: Range, prefix: string, suffix = prefix
     // If the user didn't select something initially, we want to just restore
     // the caret position instead of making a new selection.
     if (range.wasInitializedEmpty() && prefix === suffix) {
+
+    // Edge case when just selecting whitespace or new line.
+    
+    if (range.length === 0) {
+        parts.splice(0, 0, partCreator.plain(suffix)); // splice in the later one first to not change offset
+        parts.splice(1, 0, partCreator.plain(prefix));
+    }
         // Check if we need to add a offset for a toggle or untoggle
         const hasFormatting = range.text.startsWith(prefix) && range.text.endsWith(suffix);
         replaceRangeAndAutoAdjustCaret(range, parts, hasFormatting, prefix.length);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist


-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->Users can now insert the markdown elements for formatting text (e.g. __ for italics, **** for bold) whenever the hotkeys are pressed, not just when the cursor is on a word, but also when on a blank space, so they can be activated before typing a word.
-->closes https://github.com/vector-im/element-web/issues/24358 issue


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make hotkeys usable on whitespaces ([\#10025](https://github.com/matrix-org/matrix-react-sdk/pull/10025)). Fixes vector-im/element-web#24358. Contributed by @SatyarajRana.<!-- CHANGELOG_PREVIEW_END -->