### PR TITLE
Tweak broadcast pre recording state

### DIFF
--- a/src/voice-broadcast/components/molecules/VoiceBroadcastPreRecordingPip.tsx
+++ b/src/voice-broadcast/components/molecules/VoiceBroadcastPreRecordingPip.tsx
@@ -28,33 +28,19 @@ interface Props {
     voiceBroadcastPreRecording: VoiceBroadcastPreRecording;
 }
 
-interface State {
-    showDeviceSelect: boolean;
-    disableStartButton: boolean;
-}
-
 export const VoiceBroadcastPreRecordingPip: React.FC<Props> = ({ voiceBroadcastPreRecording }) => {
     const pipRef = useRef<HTMLDivElement | null>(null);
     const { currentDevice, currentDeviceLabel, devices, setDevice } = useAudioDeviceSelection();
-    const [state, setState] = useState<State>({
-        showDeviceSelect: false,
-        disableStartButton: false,
-    });
+    const [disableStartButton, setDisableStartButton] = useState<boolean>(false);
+    const [showDeviceSelect, setShowDeviceSelect] = useState<boolean>(false);
 
     const onDeviceSelect = (device: MediaDeviceInfo): void => {
-        setState((state) => ({
-            ...state,
-            showDeviceSelect: false,
-        }));
+        setShowDeviceSelect(() => false);
         setDevice(device);
     };
 
     const onStartBroadcastClick = (): void => {
-        setState((state) => ({
-            ...state,
-            disableStartButton: true,
-        }));
-
+        setDisableStartButton(() => true);
         voiceBroadcastPreRecording.start();
     };
 
@@ -63,7 +49,7 @@ export const VoiceBroadcastPreRecordingPip: React.FC<Props> = ({ voiceBroadcastP
             <VoiceBroadcastHeader
                 linkToRoom={true}
                 onCloseClick={voiceBroadcastPreRecording.cancel}
-                onMicrophoneLineClick={(): void => setState({ ...state, showDeviceSelect: true })}
+                onMicrophoneLineClick={(): void => setShowDeviceSelect(() => true)}
                 room={voiceBroadcastPreRecording.room}
                 microphoneLabel={currentDeviceLabel}
                 showClose={true}
@@ -72,12 +58,12 @@ export const VoiceBroadcastPreRecordingPip: React.FC<Props> = ({ voiceBroadcastP
                 className="mx_VoiceBroadcastBody_blockButton"
                 kind="danger"
                 onClick={onStartBroadcastClick}
-                disabled={state.disableStartButton}
+                disabled={disableStartButton}
             >
                 <LiveIcon className="mx_Icon mx_Icon_16" />
                 {_t("Go live")}
             </AccessibleButton>
-            {state.showDeviceSelect && (
+            {showDeviceSelect && (
                 <DevicesContextMenu
                     containerRef={pipRef}
                     currentDevice={currentDevice}

--- a/test/voice-broadcast/components/molecules/VoiceBroadcastPreRecordingPip-test.tsx
+++ b/test/voice-broadcast/components/molecules/VoiceBroadcastPreRecordingPip-test.tsx
@@ -115,7 +115,8 @@ describe("VoiceBroadcastPreRecordingPip", () => {
                 });
             });
 
-            it("should call start once", () => {
+            it("should dissable the button and call start once", () => {
+                expect(screen.getByText("Go live")).toHaveAttribute("disabled");
                 expect(preRecording.start).toHaveBeenCalledTimes(1);
             });
         });


### PR DESCRIPTION
closes https://github.com/vector-im/element-web/issues/24371

PSF-1881

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Tweak broadcast pre recording state ([\#10029](https://github.com/matrix-org/matrix-react-sdk/pull/10029)). Fixes vector-im/element-web#24371.<!-- CHANGELOG_PREVIEW_END -->