### PR TITLE
resolved emoji description text overflowing issue (element-web/issue/22126)

### DIFF
--- a/res/css/views/emojipicker/_EmojiPicker.pcss
+++ b/res/css/views/emojipicker/_EmojiPicker.pcss
@@ -224,6 +224,9 @@ limitations under the License.
 
 .mx_EmojiPicker_preview_text {
     display: flex;
+    width: 78%;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
     flex-direction: column;
 }
 
@@ -233,6 +236,7 @@ limitations under the License.
 
 .mx_EmojiPicker_shortcode {
     color: $light-fg-color;
+    overflow-wrap: break-word;
     font-size: $font-14px;
 
     &::before,

--- a/res/css/views/emojipicker/_EmojiPicker.pcss
+++ b/res/css/views/emojipicker/_EmojiPicker.pcss
@@ -224,9 +224,9 @@ limitations under the License.
 
 .mx_EmojiPicker_preview_text {
     display: flex;
-    width: 78%;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    flex:1;
+    overflow:hidden;
+    margin-right:25px;
     flex-direction: column;
 }
 
@@ -236,7 +236,6 @@ limitations under the License.
 
 .mx_EmojiPicker_shortcode {
     color: $light-fg-color;
-    overflow-wrap: break-word;
     font-size: $font-14px;
 
     &::before,


### PR DESCRIPTION
Resolves <a>https://github.com/vector-im/element-web/issues/22126</a> reported by @robintown

from @fahadNoufal

If i only add      flex: 1 and overflow: hidden
it will look like this 
![Screenshot from 2023-01-31 20-34-18](https://user-images.githubusercontent.com/102273041/215804937-4530250a-b7c7-4f22-9b42-1687bdab9889.png)
there wont be enough spacing in the right side .

to resolve this , i added a maring to the right of 25 px ;
### After
![Screenshot from 2023-01-31 20-45-47](https://user-images.githubusercontent.com/102273041/215805279-425d6b31-0165-4bac-a991-c30ca3c000ef.png)
![Screenshot from 2023-01-31 20-46-18](https://user-images.githubusercontent.com/102273041/215805311-19b23c98-72e3-4aae-b919-c0bdf0a4b7a9.png)

this hard coded value might not affect on different screen size because the size of its parent container is also a hard coded value

![Screenshot from 2023-01-31 20-35-42](https://user-images.githubusercontent.com/102273041/215805703-a580a6e8-dab9-4d28-88b0-c5d8501b05dc.png)

Hope this resolves the issue . Please let me know if there is any suggestions.