### PR TITLE
Add PiP move threshold

### DIFF
--- a/src/components/structures/PictureInPictureDragger.tsx
+++ b/src/components/structures/PictureInPictureDragger.tsx
@@ -70,6 +70,8 @@ export default class PictureInPictureDragger extends React.Component<IProps> {
         () => this.animationCallback(),
         () => requestAnimationFrame(() => this.scheduledUpdate.trigger()),
     );
+    private startingPositionX = 0;
+    private startingPositionY = 0;
 
     private _moving = false;
     public get moving(): boolean {
@@ -192,10 +194,21 @@ export default class PictureInPictureDragger extends React.Component<IProps> {
         event.stopPropagation();
 
         this.mouseHeld = true;
+        this.startingPositionX = event.clientX;
+        this.startingPositionY = event.clientY;
     };
 
     private onMoving = (event: MouseEvent): void => {
         if (!this.mouseHeld) return;
+
+        if (
+            Math.abs(this.startingPositionX - event.clientX) < 5 &&
+            Math.abs(this.startingPositionY - event.clientY) < 5
+        ) {
+            // User needs to move the widget by at least five pixels.
+            // Improves click detection when using a touchpad or with nervous hands.
+            return;
+        }
 
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
This PR adds a small threshold of 5px to the drag detection of the PiP window.
→ Clicks with touchpads and nervous hands should now work more reliable

closes https://github.com/vector-im/element-web/issues/24371

PSF-1881

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Improved click detection within PiP windows

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improved click detection within PiP windows ([\#10040](https://github.com/matrix-org/matrix-react-sdk/pull/10040)). Fixes vector-im/element-web#24371.<!-- CHANGELOG_PREVIEW_END -->