### PR TITLE
Change ul list style to disc when editing message

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -635,7 +635,7 @@ $left-gutter: 64px;
         }
 
         /* Make list type disc to match rich text editor */
-        > ul {
+        ul {
             list-style-type: disc;
         }
 

--- a/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
@@ -58,6 +58,11 @@ limitations under the License.
             padding-inline-start: $spacing-28;
         }
 
+        /* Make list type disc to match rich text editor */
+        > ul {
+            list-style-type: disc;
+        }
+
         blockquote {
             color: #777;
             border-left: 2px solid $blockquote-bar-color;

--- a/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
@@ -59,7 +59,7 @@ limitations under the License.
         }
 
         /* Make list type disc to match rich text editor */
-        > ul {
+        ul {
             list-style-type: disc;
         }
 


### PR DESCRIPTION
Tiny CSS change to bring the editor display in line with both the timeline and the composer (when using the rich text editor)

An image of the current behaviour can be seen in the conversation - regardless of the level of nesting, all bulletpoints are discs (ie filled circles)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Change ul list style to disc when editing message ([\#10043](https://github.com/matrix-org/matrix-react-sdk/pull/10043)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->