### PR TITLE
Rename RoomPredecessorTile

### DIFF
--- a/src/components/views/messages/RoomPredecessorTile.tsx
+++ b/src/components/views/messages/RoomPredecessorTile.tsx
@@ -40,7 +40,7 @@ interface IProps {
  * A message tile showing that this room was created as an upgrade of a previous
  * room.
  */
-export const RoomCreate: React.FC<IProps> = ({ mxEvent, timestamp }) => {
+export const RoomPredecessorTile: React.FC<IProps> = ({ mxEvent, timestamp }) => {
     const msc3946ProcessDynamicPredecessor = SettingsStore.getValue("feature_dynamic_room_predecessors");
 
     // Note: we ask the room for its predecessor here, instead of directly using
@@ -74,13 +74,14 @@ export const RoomCreate: React.FC<IProps> = ({ mxEvent, timestamp }) => {
 
     if (!roomContext.room || roomContext.room.roomId !== mxEvent.getRoomId()) {
         logger.warn(
-            "RoomCreate unexpectedly used outside of the context of the room containing this m.room.create event.",
+            "RoomPredecessorTile unexpectedly used outside of the context of the" +
+                "room containing this m.room.create event.",
         );
         return <></>;
     }
 
     if (!predecessor) {
-        logger.warn("RoomCreate unexpectedly used in a room with no predecessor.");
+        logger.warn("RoomPredecessorTile unexpectedly used in a room with no predecessor.");
         return <div />;
     }
 

--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -34,7 +34,7 @@ import LegacyCallEvent from "../components/views/messages/LegacyCallEvent";
 import { CallEvent } from "../components/views/messages/CallEvent";
 import TextualEvent from "../components/views/messages/TextualEvent";
 import EncryptionEvent from "../components/views/messages/EncryptionEvent";
-import { RoomCreate } from "../components/views/messages/RoomCreate";
+import { RoomPredecessorTile } from "../components/views/messages/RoomPredecessorTile";
 import RoomAvatarEvent from "../components/views/messages/RoomAvatarEvent";
 import { WIDGET_LAYOUT_EVENT_TYPE } from "../stores/widgets/WidgetLayoutStore";
 import { ALL_RULE_TYPES } from "../mjolnir/BanList";
@@ -92,7 +92,7 @@ const HiddenEventFactory: Factory = (ref, props) => <HiddenBody ref={ref} {...pr
 // These factories are exported for reference comparison against pickFactory()
 export const JitsiEventFactory: Factory = (ref, props) => <MJitsiWidgetEvent ref={ref} {...props} />;
 export const JSONEventFactory: Factory = (ref, props) => <ViewSourceEvent ref={ref} {...props} />;
-export const RoomCreateEventFactory: Factory = (ref, props) => <RoomCreate {...props} />;
+export const RoomCreateEventFactory: Factory = (_ref, props) => <RoomPredecessorTile {...props} />;
 
 const EVENT_TILE_TYPES = new Map<string, Factory>([
     [EventType.RoomMessage, MessageEventFactory], // note that verification requests are handled in pickFactory()

--- a/test/components/views/messages/RoomPredecessorTile-test.tsx
+++ b/test/components/views/messages/RoomPredecessorTile-test.tsx
@@ -22,7 +22,7 @@ import { EventType, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 
 import dis from "../../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { RoomCreate } from "../../../../src/components/views/messages/RoomCreate";
+import { RoomPredecessorTile } from "../../../../src/components/views/messages/RoomPredecessorTile";
 import { stubClient, upsertRoomStateEvents } from "../../../test-utils/test-utils";
 import { Action } from "../../../../src/dispatcher/actions";
 import RoomContext from "../../../../src/contexts/RoomContext";
@@ -31,7 +31,7 @@ import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 
 jest.mock("../../../../src/dispatcher/dispatcher");
 
-describe("<RoomCreate />", () => {
+describe("<RoomPredecessorTile />", () => {
     const userId = "@alice:server.org";
     const roomId = "!room:server.org";
     const createEvent = new MatrixEvent({
@@ -97,21 +97,21 @@ describe("<RoomCreate />", () => {
         jest.spyOn(SettingsStore, "setValue").mockRestore();
     });
 
-    function renderRoomCreate(room: Room) {
+    function renderTile(room: Room) {
         return render(
             <RoomContext.Provider value={getRoomContext(room, {})}>
-                <RoomCreate mxEvent={createEvent} />
+                <RoomPredecessorTile mxEvent={createEvent} />
             </RoomContext.Provider>,
         );
     }
 
     it("Renders as expected", () => {
-        const roomCreate = renderRoomCreate(roomJustCreate);
+        const roomCreate = renderTile(roomJustCreate);
         expect(roomCreate.asFragment()).toMatchSnapshot();
     });
 
     it("Links to the old version of the room", () => {
-        renderRoomCreate(roomJustCreate);
+        renderTile(roomJustCreate);
         expect(screen.getByText("Click here to see older messages.")).toHaveAttribute(
             "href",
             "https://matrix.to/#/old_room_id/tombstone_event_id",
@@ -119,12 +119,12 @@ describe("<RoomCreate />", () => {
     });
 
     it("Shows an empty div if there is no predecessor", () => {
-        renderRoomCreate(roomNoPredecessors);
+        renderTile(roomNoPredecessors);
         expect(screen.queryByText("Click here to see older messages.", { exact: false })).toBeNull();
     });
 
     it("Opens the old room on click", async () => {
-        renderRoomCreate(roomJustCreate);
+        renderTile(roomJustCreate);
         const link = screen.getByText("Click here to see older messages.");
 
         await act(() => userEvent.click(link));
@@ -142,7 +142,7 @@ describe("<RoomCreate />", () => {
     });
 
     it("Ignores m.predecessor if labs flag is off", () => {
-        renderRoomCreate(roomCreateAndPredecessor);
+        renderTile(roomCreateAndPredecessor);
         expect(screen.getByText("Click here to see older messages.")).toHaveAttribute(
             "href",
             "https://matrix.to/#/old_room_id/tombstone_event_id",
@@ -161,7 +161,7 @@ describe("<RoomCreate />", () => {
         });
 
         it("Uses the create event if there is no m.predecessor", () => {
-            renderRoomCreate(roomJustCreate);
+            renderTile(roomJustCreate);
             expect(screen.getByText("Click here to see older messages.")).toHaveAttribute(
                 "href",
                 "https://matrix.to/#/old_room_id/tombstone_event_id",
@@ -169,7 +169,7 @@ describe("<RoomCreate />", () => {
         });
 
         it("Uses m.predecessor when it's there", () => {
-            renderRoomCreate(roomCreateAndPredecessor);
+            renderTile(roomCreateAndPredecessor);
             expect(screen.getByText("Click here to see older messages.")).toHaveAttribute(
                 "href",
                 "https://matrix.to/#/old_room_id_from_predecessor",
@@ -177,7 +177,7 @@ describe("<RoomCreate />", () => {
         });
 
         it("Links to the event in the room if event ID is provided", () => {
-            renderRoomCreate(roomCreateAndPredecessorWithEventId);
+            renderTile(roomCreateAndPredecessorWithEventId);
             expect(screen.getByText("Click here to see older messages.")).toHaveAttribute(
                 "href",
                 "https://matrix.to/#/old_room_id_from_predecessor/tombstone_event_id_from_predecessor",

--- a/test/components/views/messages/__snapshots__/RoomPredecessorTile-test.tsx.snap
+++ b/test/components/views/messages/__snapshots__/RoomPredecessorTile-test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RoomCreate /> Renders as expected 1`] = `
+exports[`<RoomPredecessorTile /> Renders as expected 1`] = `
 <DocumentFragment>
   <div
     class="mx_EventTileBubble mx_CreateEvent"


### PR DESCRIPTION
`RoomPredecessorTile` (previously `RoomCreate`) only shows up if this room has a predecessor, and it shows a link to the predecessor, and it no longer always represents a create event. And it's a tile. Hence the new name.



<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->