### PR TITLE
Exclude devtools view from coverage checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,5 +10,5 @@ sonar.exclusions=__mocks__,docs
 
 sonar.typescript.tsconfigPath=./tsconfig.json
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.coverage.exclusions=test/**/*,cypress/**/*
+sonar.coverage.exclusions=test/**/*,cypress/**/*,src/components/views/dialogs/devtools/**/*
 sonar.testExecutionReportPaths=coverage/jest-sonar-report.xml


### PR DESCRIPTION
Useful to exclude that folder so that we can write devtools without the overhead of testing as this is not critical for the product to function.

See https://github.com/matrix-org/matrix-react-sdk/pull/10042

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->