### PR TITLE
Support MSC3946 in RoomListStore

### DIFF
--- a/test/stores/room-list/RoomListStore-test.ts
+++ b/test/stores/room-list/RoomListStore-test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { EventType, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 
 import { MatrixDispatcher } from "../../../src/dispatcher/dispatcher";
+import SettingsStore from "../../../src/settings/SettingsStore";
 import { ListAlgorithm, SortAlgorithm } from "../../../src/stores/room-list/algorithms/models";
 import { OrderedDefaultTagIDs, RoomUpdateCause } from "../../../src/stores/room-list/models";
 import RoomListStore, { RoomListStoreClass } from "../../../src/stores/room-list/RoomListStore";
@@ -24,14 +25,14 @@ import { stubClient, upsertRoomStateEvents } from "../../test-utils";
 
 describe("RoomListStore", () => {
     const client = stubClient();
-    const roomWithCreatePredecessorId = "!roomid:example.com";
+    const newRoomId = "!roomid:example.com";
     const roomNoPredecessorId = "!roomnopreid:example.com";
     const oldRoomId = "!oldroomid:example.com";
     const userId = "@user:example.com";
     const createWithPredecessor = new MatrixEvent({
         type: EventType.RoomCreate,
         sender: userId,
-        room_id: roomWithCreatePredecessorId,
+        room_id: newRoomId,
         content: {
             predecessor: { room_id: oldRoomId, event_id: "tombstone_event_id" },
         },
@@ -41,19 +42,32 @@ describe("RoomListStore", () => {
     const createNoPredecessor = new MatrixEvent({
         type: EventType.RoomCreate,
         sender: userId,
-        room_id: roomWithCreatePredecessorId,
+        room_id: newRoomId,
         content: {},
         event_id: "$create",
         state_key: "",
     });
-    const roomWithCreatePredecessor = new Room(roomWithCreatePredecessorId, client, userId, {});
+    const predecessor = new MatrixEvent({
+        type: EventType.RoomPredecessor,
+        sender: userId,
+        room_id: newRoomId,
+        content: {
+            predecessor_room_id: oldRoomId,
+            last_known_event_id: "tombstone_event_id",
+        },
+        event_id: "$pred",
+        state_key: "",
+    });
+    const roomWithPredecessorEvent = new Room(newRoomId, client, userId, {});
+    upsertRoomStateEvents(roomWithPredecessorEvent, [predecessor]);
+    const roomWithCreatePredecessor = new Room(newRoomId, client, userId, {});
     upsertRoomStateEvents(roomWithCreatePredecessor, [createWithPredecessor]);
     const roomNoPredecessor = new Room(roomNoPredecessorId, client, userId, {});
     upsertRoomStateEvents(roomNoPredecessor, [createNoPredecessor]);
     const oldRoom = new Room(oldRoomId, client, userId, {});
     client.getRoom = jest.fn().mockImplementation((roomId) => {
         switch (roomId) {
-            case roomWithCreatePredecessorId:
+            case newRoomId:
                 return roomWithCreatePredecessor;
             case oldRoomId:
                 return oldRoom;
@@ -122,5 +136,37 @@ describe("RoomListStore", () => {
         expect(handleRoomUpdate).toHaveBeenCalledWith(roomNoPredecessor, RoomUpdateCause.NewRoom);
         // And no other updates happen
         expect(handleRoomUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    describe("When feature_dynamic_room_predecessors = true", () => {
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "getValue").mockImplementation(
+                (settingName) => settingName === "feature_dynamic_room_predecessors",
+            );
+        });
+
+        afterEach(() => {
+            jest.spyOn(SettingsStore, "getValue").mockReset();
+        });
+
+        it("Removes old room if it finds a predecessor in the m.predecessor event", () => {
+            // Given a store we can spy on
+            const { store, handleRoomUpdate } = createStore();
+
+            // When we tell it we joined a new room that has an old room as
+            // predecessor in the create event
+            const payload = {
+                oldMembership: "invite",
+                membership: "join",
+                room: roomWithPredecessorEvent,
+            };
+            store.onDispatchMyMembership(payload);
+
+            // Then the old room is removed
+            expect(handleRoomUpdate).toHaveBeenCalledWith(oldRoom, RoomUpdateCause.RoomRemoved);
+
+            // And the new room is added
+            expect(handleRoomUpdate).toHaveBeenCalledWith(roomWithPredecessorEvent, RoomUpdateCause.NewRoom);
+        });
     });
 });


### PR DESCRIPTION
This means that when a new room appears replacing an old one, and the replacement uses MSC3946 dynamic room predecessor, the old room disappears from the room list.

Part of [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

Closes https://github.com/vector-im/element-web/issues/24325

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support MSC3946 in RoomListStore ([\#10054](https://github.com/matrix-org/matrix-react-sdk/pull/10054)). Fixes vector-im/element-web#24325. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->