### PR TITLE
Fix new line for inline code

### DIFF
--- a/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
@@ -95,6 +95,11 @@ limitations under the License.
             border-radius: 4px;
             padding: $spacing-2;
         }
+
+        code:empty {
+            border: unset;
+            padding: unset;
+        }
     }
 
     .mx_WysiwygComposer_Editor_content_placeholder::before {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

On chrome, when adding a new line when inline code formatting is activated, the caret stay on the previous line.
The fix is a bit weird, but I think that Chrome as an issue to put the caret at the good position when the code tag is empty but with a height/width (given by padding and border)

Before

https://user-images.githubusercontent.com/2621378/216366843-6943d250-7238-46a9-abc3-eeed8c9874f4.mov

After

https://user-images.githubusercontent.com/2621378/216366590-09aaecae-e6f3-4d75-bd1c-d18be22fd840.mov

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix new line for inline code ([\#10062](https://github.com/matrix-org/matrix-react-sdk/pull/10062)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->