### PR TITLE
Fix a crash when removing persistent widgets

### DIFF
--- a/src/components/structures/PipContainer.tsx
+++ b/src/components/structures/PipContainer.tsx
@@ -192,10 +192,7 @@ class PipContainerInner extends React.Component<IProps, IState> {
     };
 
     private onWidgetPersistence = (): void => {
-        this.updateShowWidgetInPip(
-            ActiveWidgetStore.instance.getPersistentWidgetId(),
-            ActiveWidgetStore.instance.getPersistentRoomId(),
-        );
+        this.updateShowWidgetInPip();
     };
 
     private onWidgetDockChanges = (): void => {
@@ -234,11 +231,10 @@ class PipContainerInner extends React.Component<IProps, IState> {
         }
     };
 
-    // Accepts a persistentWidgetId to be able to skip awaiting the setState for persistentWidgetId
-    public updateShowWidgetInPip(
-        persistentWidgetId = this.state.persistentWidgetId,
-        persistentRoomId = this.state.persistentRoomId,
-    ): void {
+    private updateShowWidgetInPip(): void {
+        const persistentWidgetId = ActiveWidgetStore.instance.getPersistentWidgetId();
+        const persistentRoomId = ActiveWidgetStore.instance.getPersistentRoomId();
+
         let fromAnotherRoom = false;
         let notDocked = false;
         // Sanity check the room - the widget may have been destroyed between render cycles, and


### PR DESCRIPTION
When a persistent widget is removed, multiple calls to `updateShowWidgetInPip` happen in succession as each of the widget stores emit updates. But by depending on `this.state.persistentWidgetId` at the time of the call rather than passing an update function to `setState`, this had the effect that the removal of the widget could be reverted in the component's state, and so it could end up passing the ID of a removed widget to `WidgetPip`.

Closes https://github.com/vector-im/element-web/issues/24412

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix a crash when removing persistent widgets ([\#10063](https://github.com/matrix-org/matrix-react-sdk/pull/10063)). Fixes vector-im/element-web#24412.<!-- CHANGELOG_PREVIEW_END -->