### PR TITLE
Fix cursor position when new line is created by pressing enter (RTE)

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -168,13 +168,15 @@ function handleInputEvent(event: InputEvent, send: Send, isCtrlEnterToSend: bool
         case "insertParagraph":
             if (!isCtrlEnterToSend) {
                 send();
+                return null;
             }
-            return null;
+            break;
         case "sendMessage":
             if (isCtrlEnterToSend) {
                 send();
+                return null;
             }
-            return null;
+            break;
     }
 
     return event;

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -149,8 +149,10 @@ describe("WysiwygComposer", () => {
 
         it("Should not call onSend when Enter is pressed", async () => {
             // When
+            const textbox = screen.getByRole("textbox");
+
             fireEvent(
-                screen.getByRole("textbox"),
+                textbox,
                 new InputEvent("input", {
                     inputType: "insertParagraph",
                 }),
@@ -158,6 +160,22 @@ describe("WysiwygComposer", () => {
 
             // Then it does not send a message
             await waitFor(() => expect(onSend).toBeCalledTimes(0));
+
+            fireEvent(
+                textbox,
+                new InputEvent("input", {
+                    inputType: "insertText",
+                    data: "other",
+                }),
+            );
+
+            // The focus is on the last text node
+            await waitFor(() => {
+                const selection = document.getSelection();
+                if (selection) {
+                    expect(selection.focusNode?.textContent).toEqual("other");
+                }
+            });
         });
 
         it("Should send a message when Ctrl+Enter is pressed", async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

When the settings `ctrl+enter` to send is enabled, when enter is pressed to add a new line, the cursor stays on the previous line.

Instead of letting the enter event going through the RTE model, we stopped it (by returning null). I made the changes to return null only when we want to by pass the RTE behaviour (ie: send the message).

Before

https://user-images.githubusercontent.com/2621378/216391377-45ab800e-841b-4b6d-989e-1f670be62d06.mov

After

https://user-images.githubusercontent.com/2621378/216391125-f7697d9f-f145-422c-96fc-b69ae6232e22.mov

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix cursor position when new line is created by pressing enter (RTE) ([\#10064](https://github.com/matrix-org/matrix-react-sdk/pull/10064)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->