### PR TITLE
Cut off broadcast time left at 0 seconds

### DIFF
--- a/src/voice-broadcast/models/VoiceBroadcastPlayback.ts
+++ b/src/voice-broadcast/models/VoiceBroadcastPlayback.ts
@@ -441,7 +441,9 @@ export class VoiceBroadcastPlayback
     }
 
     public get timeLeftSeconds(): number {
-        return Math.round(this.durationSeconds) - this.timeSeconds;
+        // Sometimes the meta data and the audio files are a little bit out of sync.
+        // Be sure it never returns a negative value.
+        return Math.max(0, Math.round(this.durationSeconds) - this.timeSeconds);
     }
 
     public async skipTo(timeSeconds: number): Promise<void> {

--- a/test/voice-broadcast/models/VoiceBroadcastPlayback-test.tsx
+++ b/test/voice-broadcast/models/VoiceBroadcastPlayback-test.tsx
@@ -525,6 +525,20 @@ describe("VoiceBroadcastPlayback", () => {
 
                 it("should update the time", () => {
                     expect(playback.timeSeconds).toBe(11);
+                    expect(playback.timeLeftSeconds).toBe(2);
+                });
+            });
+
+            describe("and the chunk playback progresses across the actual time", () => {
+                // This can be the case if the meta data is out of sync with the actual audio data.
+
+                beforeEach(() => {
+                    chunk1Playback.clockInfo.liveData.update([15]);
+                });
+
+                it("should update the time", () => {
+                    expect(playback.timeSeconds).toBe(15);
+                    expect(playback.timeLeftSeconds).toBe(0);
                 });
             });
 


### PR DESCRIPTION
Sometimes the meta data and the actual audio data are a bit out of sync.
This can lead to „-2 seconds left“ (always a small number of seconds).
We decided to work around the problem by cutting off the remaining time at 0 seconds.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Prevent the remaining broadcast time from being exceeded

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent the remaining broadcast time from being exceeded ([\#10070](https://github.com/matrix-org/matrix-react-sdk/pull/10070)).<!-- CHANGELOG_PREVIEW_END -->