### PR TITLE
Gitter sunsetting: Use findPredecessor in EventTileFactory

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -250,7 +250,7 @@ describe("Timeline", () => {
             cy.contains(".mx_RoomView_body .mx_EventTile[data-scroll-tokens]", "MessageEdit").should("exist");
 
             // Click top left of the event toggle, which should not be covered by MessageActionBar's safe area
-            cy.get(".mx_EventTile .mx_ViewSourceEvent")
+            cy.get(".mx_EventTile:not(:first-child) .mx_ViewSourceEvent")
                 .should("exist")
                 .realHover()
                 .within(() => {

--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -92,6 +92,7 @@ const HiddenEventFactory: Factory = (ref, props) => <HiddenBody ref={ref} {...pr
 // These factories are exported for reference comparison against pickFactory()
 export const JitsiEventFactory: Factory = (ref, props) => <MJitsiWidgetEvent ref={ref} {...props} />;
 export const JSONEventFactory: Factory = (ref, props) => <ViewSourceEvent ref={ref} {...props} />;
+export const RoomCreateEventFactory: Factory = (ref, props) => <RoomCreate {...props} />;
 
 const EVENT_TILE_TYPES = new Map<string, Factory>([
     [EventType.RoomMessage, MessageEventFactory], // note that verification requests are handled in pickFactory()
@@ -106,7 +107,7 @@ const EVENT_TILE_TYPES = new Map<string, Factory>([
 const STATE_EVENT_TILE_TYPES = new Map<string, Factory>([
     [EventType.RoomEncryption, (ref, props) => <EncryptionEvent ref={ref} {...props} />],
     [EventType.RoomCanonicalAlias, TextualEventFactory],
-    [EventType.RoomCreate, (_ref, props) => <RoomCreate {...props} />],
+    [EventType.RoomCreate, RoomCreateEventFactory],
     [EventType.RoomMember, TextualEventFactory],
     [EventType.RoomName, TextualEventFactory],
     [EventType.RoomAvatar, (ref, props) => <RoomAvatarEvent ref={ref} {...props} />],

--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -21,8 +21,8 @@ import { Optional } from "matrix-events-sdk";
 import { M_POLL_START } from "matrix-js-sdk/src/@types/polls";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 import { GroupCallIntent } from "matrix-js-sdk/src/webrtc/groupCall";
-import SettingsStore from "../settings/SettingsStore";
 
+import SettingsStore from "../settings/SettingsStore";
 import EditorStateTransfer from "../utils/EditorStateTransfer";
 import { RoomPermalinkCreator } from "../utils/permalinks/Permalinks";
 import LegacyCallEventGrouper from "../components/structures/LegacyCallEventGrouper";

--- a/test/components/structures/MessagePanel-test.tsx
+++ b/test/components/structures/MessagePanel-test.tsx
@@ -468,7 +468,7 @@ describe("MessagePanel", function () {
         const events = mkCreationEvents();
         const createEvent = events.find((event) => event.getType() === "m.room.create");
         const encryptionEvent = events.find((event) => event.getType() === "m.room.encryption");
-        client.getRoom.mockImplementation((id) => (id === createEvent.getRoomId() ? room : null));
+        client.getRoom.mockImplementation((id) => (id === createEvent!.getRoomId() ? room : null));
         TestUtilsMatrix.upsertRoomStateEvents(room, events);
 
         const { container } = render(getComponent({ events }));
@@ -512,7 +512,7 @@ describe("MessagePanel", function () {
     it("should hide read-marker at the end of creation event summary", function () {
         const events = mkCreationEvents();
         const createEvent = events.find((event) => event.getType() === "m.room.create");
-        client.getRoom.mockImplementation((id) => (id === createEvent.getRoomId() ? room : null));
+        client.getRoom.mockImplementation((id) => (id === createEvent!.getRoomId() ? room : null));
         TestUtilsMatrix.upsertRoomStateEvents(room, events);
 
         const { container } = render(

--- a/test/components/structures/MessagePanel-test.tsx
+++ b/test/components/structures/MessagePanel-test.tsx
@@ -468,7 +468,7 @@ describe("MessagePanel", function () {
         const events = mkCreationEvents();
         const createEvent = events.find((event) => event.getType() === "m.room.create");
         const encryptionEvent = events.find((event) => event.getType() === "m.room.encryption");
-        client.getRoom.mockImplementation(id => id === createEvent.getRoomId() ? room : null);
+        client.getRoom.mockImplementation((id) => (id === createEvent.getRoomId() ? room : null));
         TestUtilsMatrix.upsertRoomStateEvents(room, events);
 
         const { container } = render(getComponent({ events }));
@@ -512,7 +512,7 @@ describe("MessagePanel", function () {
     it("should hide read-marker at the end of creation event summary", function () {
         const events = mkCreationEvents();
         const createEvent = events.find((event) => event.getType() === "m.room.create");
-        client.getRoom.mockImplementation(id => id === createEvent.getRoomId() ? room : null);
+        client.getRoom.mockImplementation((id) => (id === createEvent.getRoomId() ? room : null));
         TestUtilsMatrix.upsertRoomStateEvents(room, events);
 
         const { container } = render(

--- a/test/components/structures/MessagePanel-test.tsx
+++ b/test/components/structures/MessagePanel-test.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../test-utils";
 import ResizeNotifier from "../../../src/utils/ResizeNotifier";
 import { IRoomState } from "../../../src/components/structures/RoomView";
+import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
 
 jest.mock("../../../src/utils/beacon", () => ({
     useBeacon: jest.fn(),
@@ -58,6 +59,7 @@ describe("MessagePanel", function () {
         getRoom: jest.fn(),
         getClientWellKnown: jest.fn().mockReturnValue({}),
     });
+    jest.spyOn(MatrixClientPeg, "get").mockReturnValue(client);
 
     const room = new Room(roomId, client, userId);
 
@@ -464,11 +466,12 @@ describe("MessagePanel", function () {
 
     it("should collapse creation events", function () {
         const events = mkCreationEvents();
-        TestUtilsMatrix.upsertRoomStateEvents(room, events);
-        const { container } = render(getComponent({ events }));
-
         const createEvent = events.find((event) => event.getType() === "m.room.create");
         const encryptionEvent = events.find((event) => event.getType() === "m.room.encryption");
+        client.getRoom.mockImplementation(id => id === createEvent.getRoomId() ? room : null);
+        TestUtilsMatrix.upsertRoomStateEvents(room, events);
+
+        const { container } = render(getComponent({ events }));
 
         // we expect that
         // - the room creation event, the room encryption event, and Alice inviting Bob,
@@ -508,6 +511,8 @@ describe("MessagePanel", function () {
 
     it("should hide read-marker at the end of creation event summary", function () {
         const events = mkCreationEvents();
+        const createEvent = events.find((event) => event.getType() === "m.room.create");
+        client.getRoom.mockImplementation(id => id === createEvent.getRoomId() ? room : null);
         TestUtilsMatrix.upsertRoomStateEvents(room, events);
 
         const { container } = render(

--- a/test/events/EventTileFactory-test.ts
+++ b/test/events/EventTileFactory-test.ts
@@ -18,8 +18,10 @@ import {
     JSONEventFactory,
     MessageEventFactory,
     pickFactory,
+    RoomCreateEventFactory,
     TextualEventFactory,
 } from "../../src/events/EventTileFactory";
+import SettingsStore from "../../src/settings/SettingsStore";
 import { VoiceBroadcastChunkEventType, VoiceBroadcastInfoState } from "../../src/voice-broadcast";
 import { createTestClient, mkEvent } from "../test-utils";
 import { mkVoiceBroadcastInfoStateEvent } from "../voice-broadcast/utils/test-utils";
@@ -27,23 +29,64 @@ import { mkVoiceBroadcastInfoStateEvent } from "../voice-broadcast/utils/test-ut
 const roomId = "!room:example.com";
 
 describe("pickFactory", () => {
+    let client: MatrixClient;
+    let room: Room;
+
+    let createEventWithPredecessor: MatrixEvent;
+    let createEventWithoutPredecessor: MatrixEvent;
+    let dynamicPredecessorEvent: MatrixEvent;
+
     let voiceBroadcastStartedEvent: MatrixEvent;
     let voiceBroadcastStoppedEvent: MatrixEvent;
     let voiceBroadcastChunkEvent: MatrixEvent;
     let utdEvent: MatrixEvent;
     let utdBroadcastChunkEvent: MatrixEvent;
     let audioMessageEvent: MatrixEvent;
-    let client: MatrixClient;
 
     beforeAll(() => {
         client = createTestClient();
 
-        const room = new Room(roomId, client, client.getSafeUserId());
+        room = new Room(roomId, client, client.getSafeUserId());
         mocked(client.getRoom).mockImplementation((getRoomId: string): Room | null => {
             if (getRoomId === room.roomId) return room;
             return null;
         });
 
+        createEventWithoutPredecessor = mkEvent({
+            event: true,
+            type: EventType.RoomCreate,
+            user: client.getUserId()!,
+            room: roomId,
+            content: {
+                "creator": client.getUserId()!,
+                "room_version": "9"
+            },
+        });
+        createEventWithPredecessor = mkEvent({
+            event: true,
+            type: EventType.RoomCreate,
+            user: client.getUserId()!,
+            room: roomId,
+            content: {
+                "creator": client.getUserId()!,
+                "room_version": "9",
+                "predecessor": {
+                    "room_id": "roomid1",
+                    "event_id": null,
+                },
+            },
+        });
+        dynamicPredecessorEvent = mkEvent({
+            event: true,
+            type: EventType.RoomPredecessor,
+            user: client.getUserId()!,
+            room: roomId,
+            skey: "",
+            content: {
+                "predecessor_room_id": "roomid2",
+                "last_known_event_id": null
+            },
+        })
         voiceBroadcastStartedEvent = mkVoiceBroadcastInfoStateEvent(
             roomId,
             VoiceBroadcastInfoState.Started,
@@ -117,6 +160,15 @@ describe("pickFactory", () => {
             expect(pickFactory(voiceBroadcastChunkEvent, client, true)).toBe(JSONEventFactory);
         });
 
+        it("should return a JSONEventFactory for a room create event without predecessor", () => {
+            room.currentState.events.set(
+                EventType.RoomCreate,
+                new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+            );
+            room.currentState.events.set(EventType.RoomPredecessor, new Map());
+            expect(pickFactory(createEventWithoutPredecessor, client, true)).toBe(JSONEventFactory);
+        });
+
         it("should return a TextualEventFactory for a voice broadcast stopped event", () => {
             expect(pickFactory(voiceBroadcastStoppedEvent, client, true)).toBe(TextualEventFactory);
         });
@@ -131,6 +183,64 @@ describe("pickFactory", () => {
     });
 
     describe("when not showing hidden events", () => {
+        describe("without dynamic predecessor support", () => {
+            beforeEach(() => {
+                jest.spyOn(SettingsStore, "getValue").mockReset();
+            });
+
+            it("should return undefined for a room without predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor, new Map());
+                expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
+            });
+
+            it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor, new Map());
+                expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
+            });
+
+            it("should return undefined for a room with dynamic predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor,
+                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]));
+                expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
+            });
+        });
+
+        describe("with dynamic predecessor support", () => {
+            beforeEach(() => {
+                jest.spyOn(SettingsStore, "getValue")
+                    .mockReset()
+                    .mockImplementation((settingName) => settingName === "feature_dynamic_room_predecessors");
+            });
+
+            it("should return undefined for a room without predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor, new Map());
+                expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
+            });
+
+            it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor, new Map());
+                expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
+            });
+
+            it("should return a RoomCreateFactory for a room with dynamic predecessor", () => {
+                room.currentState.events.set(EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(EventType.RoomPredecessor,
+                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]));
+                expect(pickFactory(createEventWithoutPredecessor, client, false)).toBe(RoomCreateEventFactory);
+            });
+        });
+
         it("should return undefined for a voice broadcast event", () => {
             expect(pickFactory(voiceBroadcastChunkEvent, client, false)).toBeUndefined();
         });

--- a/test/events/EventTileFactory-test.ts
+++ b/test/events/EventTileFactory-test.ts
@@ -163,7 +163,7 @@ describe("pickFactory", () => {
         it("should return a JSONEventFactory for a room create event without predecessor", () => {
             room.currentState.events.set(
                 EventType.RoomCreate,
-                new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                new Map([[createEventWithoutPredecessor.getStateKey()!, createEventWithoutPredecessor]]),
             );
             room.currentState.events.set(EventType.RoomPredecessor, new Map());
             expect(pickFactory(createEventWithoutPredecessor, client, true)).toBe(JSONEventFactory);
@@ -191,7 +191,7 @@ describe("pickFactory", () => {
             it("should return undefined for a room without predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                    new Map([[createEventWithoutPredecessor.getStateKey()!, createEventWithoutPredecessor]]),
                 );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
@@ -200,7 +200,7 @@ describe("pickFactory", () => {
             it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]),
+                    new Map([[createEventWithPredecessor.getStateKey()!, createEventWithPredecessor]]),
                 );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
@@ -209,11 +209,11 @@ describe("pickFactory", () => {
             it("should return undefined for a room with dynamic predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                    new Map([[createEventWithoutPredecessor.getStateKey()!, createEventWithoutPredecessor]]),
                 );
                 room.currentState.events.set(
                     EventType.RoomPredecessor,
-                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]),
+                    new Map([[dynamicPredecessorEvent.getStateKey()!, dynamicPredecessorEvent]]),
                 );
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
             });
@@ -229,7 +229,7 @@ describe("pickFactory", () => {
             it("should return undefined for a room without predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                    new Map([[createEventWithoutPredecessor.getStateKey()!, createEventWithoutPredecessor]]),
                 );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
@@ -238,7 +238,7 @@ describe("pickFactory", () => {
             it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]),
+                    new Map([[createEventWithPredecessor.getStateKey()!, createEventWithPredecessor]]),
                 );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
@@ -247,11 +247,11 @@ describe("pickFactory", () => {
             it("should return a RoomCreateFactory for a room with dynamic predecessor", () => {
                 room.currentState.events.set(
                     EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                    new Map([[createEventWithoutPredecessor.getStateKey()!, createEventWithoutPredecessor]]),
                 );
                 room.currentState.events.set(
                     EventType.RoomPredecessor,
-                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]),
+                    new Map([[dynamicPredecessorEvent.getStateKey()!, dynamicPredecessorEvent]]),
                 );
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBe(RoomCreateEventFactory);
             });

--- a/test/events/EventTileFactory-test.ts
+++ b/test/events/EventTileFactory-test.ts
@@ -58,8 +58,8 @@ describe("pickFactory", () => {
             user: client.getUserId()!,
             room: roomId,
             content: {
-                "creator": client.getUserId()!,
-                "room_version": "9"
+                creator: client.getUserId()!,
+                room_version: "9",
             },
         });
         createEventWithPredecessor = mkEvent({
@@ -68,11 +68,11 @@ describe("pickFactory", () => {
             user: client.getUserId()!,
             room: roomId,
             content: {
-                "creator": client.getUserId()!,
-                "room_version": "9",
-                "predecessor": {
-                    "room_id": "roomid1",
-                    "event_id": null,
+                creator: client.getUserId()!,
+                room_version: "9",
+                predecessor: {
+                    room_id: "roomid1",
+                    event_id: null,
                 },
             },
         });
@@ -83,10 +83,10 @@ describe("pickFactory", () => {
             room: roomId,
             skey: "",
             content: {
-                "predecessor_room_id": "roomid2",
-                "last_known_event_id": null
+                predecessor_room_id: "roomid2",
+                last_known_event_id: null,
             },
-        })
+        });
         voiceBroadcastStartedEvent = mkVoiceBroadcastInfoStateEvent(
             roomId,
             VoiceBroadcastInfoState.Started,
@@ -189,24 +189,32 @@ describe("pickFactory", () => {
             });
 
             it("should return undefined for a room without predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
             });
 
             it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]),
+                );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
             });
 
             it("should return undefined for a room with dynamic predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
-                room.currentState.events.set(EventType.RoomPredecessor,
-                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                );
+                room.currentState.events.set(
+                    EventType.RoomPredecessor,
+                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]),
+                );
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
             });
         });
@@ -219,24 +227,32 @@ describe("pickFactory", () => {
             });
 
             it("should return undefined for a room without predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBeUndefined();
             });
 
             it("should return a RoomCreateFactory for a room with fixed predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithPredecessor.getStateKey(), createEventWithPredecessor]]),
+                );
                 room.currentState.events.set(EventType.RoomPredecessor, new Map());
                 expect(pickFactory(createEventWithPredecessor, client, false)).toBe(RoomCreateEventFactory);
             });
 
             it("should return a RoomCreateFactory for a room with dynamic predecessor", () => {
-                room.currentState.events.set(EventType.RoomCreate,
-                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]));
-                room.currentState.events.set(EventType.RoomPredecessor,
-                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]));
+                room.currentState.events.set(
+                    EventType.RoomCreate,
+                    new Map([[createEventWithoutPredecessor.getStateKey(), createEventWithoutPredecessor]]),
+                );
+                room.currentState.events.set(
+                    EventType.RoomPredecessor,
+                    new Map([[dynamicPredecessorEvent.getStateKey(), dynamicPredecessorEvent]]),
+                );
                 expect(pickFactory(createEventWithoutPredecessor, client, false)).toBe(RoomCreateEventFactory);
             });
         });


### PR DESCRIPTION
Type: Task
Fixes: https://github.com/vector-im/element-web/issues/24327

After this, rooms with no predecessor in the create event can still show a RoomPredecessor tile, and it allows jumping back to the old room.

![rec-2023-02-03_15 17 27](https://user-images.githubusercontent.com/76812/216639591-646743a5-b771-4f7c-901e-750261f9579f.gif)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->