### PR TITLE
Fix devtools textbox height

### DIFF
--- a/res/css/views/elements/_Field.pcss
+++ b/res/css/views/elements/_Field.pcss
@@ -52,6 +52,10 @@ limitations under the License.
     min-width: 0;
 }
 
+.mx_Field textarea {
+    resize: none;
+}
+
 .mx_Field select {
     -moz-appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22306

although the outer div had fixed dimensions the inner text area was resizable which is fixed

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Type: [Task]

The text area highlighted by red(only for development purpose) was resizable and could be resized to change the height. I have change the CSS to disable the resize option

Before:
<img width="500" alt="Screenshot 2023-02-06 at 11 36 57 PM" src="https://user-images.githubusercontent.com/75848740/217050654-9de59aeb-7066-4d55-9540-366042b7fddb.png">

After:
<img width="500" alt="Screenshot 2023-02-06 at 11 35 07 PM" src="https://user-images.githubusercontent.com/75848740/217050342-e8b6b390-1253-4ccd-800b-c7ee026c34e4.png">

Signed-off-by: Nilootpal Das <nilootpaldas@gmail.com>
<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix devtools textbox height ([\#10082](https://github.com/matrix-org/matrix-react-sdk/pull/10082)). Fixes vector-im/element-web#22306. Contributed by @nilootpal.<!-- CHANGELOG_PREVIEW_END -->