### PR TITLE
Migrate RoomView to support MSC3946

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -223,6 +223,7 @@ export interface IRoomState {
     narrow: boolean;
     // List of undecryptable events currently visible on-screen
     visibleDecryptionFailures?: MatrixEvent[];
+    msc3946ProcessDynamicPredecessor: boolean;
 }
 
 interface LocalRoomViewProps {
@@ -416,6 +417,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             liveTimeline: undefined,
             narrow: false,
             visibleDecryptionFailures: [],
+            msc3946ProcessDynamicPredecessor: SettingsStore.getValue("feature_dynamic_room_predecessors"),
         };
 
         this.dispatcherRef = dis.register(this.onAction);
@@ -467,6 +469,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             ),
             SettingsStore.watchSetting("urlPreviewsEnabled", null, this.onUrlPreviewsEnabledChange),
             SettingsStore.watchSetting("urlPreviewsEnabled_e2ee", null, this.onUrlPreviewsEnabledChange),
+            SettingsStore.watchSetting("feature_dynamic_room_predecessors", null, (...[, , , value]) =>
+                this.setState({ msc3946ProcessDynamicPredecessor: value as boolean }),
+            ),
         ];
     }
 
@@ -1798,10 +1803,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private getOldRoom(): Room | null {
-        const createEvent = this.state.room.currentState.getStateEvents(EventType.RoomCreate, "");
-        if (!createEvent || !createEvent.getContent()["predecessor"]) return null;
-
-        return this.context.client.getRoom(createEvent.getContent()["predecessor"]["room_id"]);
+        const { roomId } = this.state.room.findPredecessor(this.state.msc3946ProcessDynamicPredecessor) || {};
+        return this.context.client.getRoom(roomId);
     }
 
     public getHiddenHighlightCount(): number {

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1803,8 +1803,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private getOldRoom(): Room | null {
-        const { roomId } = this.state.room.findPredecessor(this.state.msc3946ProcessDynamicPredecessor) || {};
-        return this.context.client.getRoom(roomId);
+        const { roomId } = this.state.room?.findPredecessor(this.state.msc3946ProcessDynamicPredecessor) || {};
+        return this.context.client?.getRoom(roomId) || null;
     }
 
     public getHiddenHighlightCount(): number {

--- a/src/contexts/RoomContext.ts
+++ b/src/contexts/RoomContext.ts
@@ -65,6 +65,7 @@ const RoomContext = createContext<IRoomState>({
     liveTimeline: undefined,
     narrow: false,
     activeCall: null,
+    msc3946ProcessDynamicPredecessor: false,
 });
 RoomContext.displayName = "RoomContext";
 export default RoomContext;

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -78,6 +78,7 @@ describe("<SendMessageComposer/>", () => {
         resizing: false,
         narrow: false,
         activeCall: null,
+        msc3946ProcessDynamicPredecessor: false,
     };
     describe("createMessageContent", () => {
         const permalinkCreator = jest.fn() as any;

--- a/test/test-utils/room.ts
+++ b/test/test-utils/room.ts
@@ -86,6 +86,7 @@ export function getRoomContext(room: Room, override: Partial<IRoomState>): IRoom
         resizing: false,
         narrow: false,
         activeCall: null,
+        msc3946ProcessDynamicPredecessor: false,
 
         ...override,
     };


### PR DESCRIPTION
Jest tests are not great. They should be improved when migrating `RoomView-test` to react testing library.

Tested in the application

![prede](https://user-images.githubusercontent.com/6216686/216973828-d58d3721-47bc-43e0-91c5-3f4e60ad9e88.png)

closes https://github.com/vector-im/element-web/issues/24324

PSF-1896

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->