### PR TITLE
Fix flaky test crypto/decryption-failure.spec.ts "Decryption Failure Bar"

### DIFF
--- a/cypress/e2e/crypto/decryption-failure.spec.ts
+++ b/cypress/e2e/crypto/decryption-failure.spec.ts
@@ -113,9 +113,8 @@ describe("Decryption Failure Bar", () => {
                 })
                 .then(() => {
                     cy.botSendMessage(bot, roomId, "test");
-                    cy.wait(5000);
-                    cy.get(".mx_DecryptionFailureBar .mx_DecryptionFailureBar_message_headline").should(
-                        "have.text",
+                    cy.contains(
+                        ".mx_DecryptionFailureBar .mx_DecryptionFailureBar_message_headline",
                         "Verify this device to access all messages",
                     );
 
@@ -172,9 +171,8 @@ describe("Decryption Failure Bar", () => {
             );
 
             cy.botSendMessage(bot, roomId, "test");
-            cy.wait(5000);
-            cy.get(".mx_DecryptionFailureBar .mx_DecryptionFailureBar_message_headline").should(
-                "have.text",
+            cy.contains(
+                ".mx_DecryptionFailureBar .mx_DecryptionFailureBar_message_headline",
                 "Reset your keys to prevent future decryption errors",
             );
 

--- a/cypress/e2e/crypto/decryption-failure.spec.ts
+++ b/cypress/e2e/crypto/decryption-failure.spec.ts
@@ -125,6 +125,7 @@ describe("Decryption Failure Bar", () => {
 
                     const verificationRequestPromise = waitForVerificationRequest(otherDevice);
                     cy.get(".mx_CompleteSecurity_actionRow .mx_AccessibleButton").click();
+                    cy.contains("To proceed, please accept the verification request on your other device.");
                     cy.wrap(verificationRequestPromise).then((verificationRequest: VerificationRequest) => {
                         cy.wrap(verificationRequest.accept());
                         handleVerificationRequest(verificationRequest).then((emojis) => {

--- a/cypress/e2e/crypto/decryption-failure.spec.ts
+++ b/cypress/e2e/crypto/decryption-failure.spec.ts
@@ -52,6 +52,8 @@ const handleVerificationRequest = (request: VerificationRequest): Chainable<Emoj
             verifier.on("show_sas", onShowSas);
             verifier.verify();
         }),
+        // extra timeout, as this sometimes takes a while
+        { timeout: 30_000 },
     );
 };
 

--- a/cypress/support/bot.ts
+++ b/cypress/support/bot.ts
@@ -163,6 +163,8 @@ function setupBotClient(
                     }
                 })
                 .then(() => cli),
+            // extra timeout, as this sometimes takes a while
+            { timeout: 30_000 },
         );
     });
 }


### PR DESCRIPTION
Should be reviewed commit-wise.

I am pretty sure there is still a race condition somewhere.
At least it is recovering from this with the increased timeouts.

Cannot reproduce the failure of `cy.wait("@keyRequest");` from the issue.
I will be monitoring the Cypress runs over the next few days.

closes https://github.com/vector-im/element-web/issues/24351

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->