### PR TITLE
Indicate unread messages in tab title

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -139,6 +139,7 @@ import GenericToast from "../views/toasts/GenericToast";
 import RovingSpotlightDialog, { Filter } from "../views/dialogs/spotlight/SpotlightDialog";
 import { findDMForUser } from "../../utils/dm/findDMForUser";
 import { Linkify } from "../../HtmlUtils";
+import { NotificationColor } from "../../stores/notifications/NotificationColor";
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1961,6 +1962,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         }
         if (numUnreadRooms > 0) {
             this.subTitleStatus += `[${numUnreadRooms}]`;
+        } else if (notificationState.color >= NotificationColor.Bold) {
+            this.subTitleStatus += `*`;
         }
 
         this.setPageSubtitle();


### PR DESCRIPTION
Adds an asterisk to the tab title when there are unread messages.

I find this really helpful for following conversations in the background without notifications.

|before|after|
|---|---|
|![there are unread messages, and the tab title is "Element \| another room"](https://user-images.githubusercontent.com/47184774/216870221-a7a936b0-53a5-49e1-b606-294a7639b011.png)|![the tab title is "Element * \| another room"](https://user-images.githubusercontent.com/47184774/216870252-212d5ba5-7fa5-4ec4-b9a8-de7fc3b68e75.png)|

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible) ([I asked on #element-dev](https://matrix.to/#/!bEWtlqtDwCLFIAKAcv:matrix.org/$cE-N7agkatysysk7FfwnIi5XWB8DBqQpbWYcfIikYzw?via=matrix.org&via=element.io&via=envs.net))
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Indicate unread messages in tab title ([\#10096](https://github.com/matrix-org/matrix-react-sdk/pull/10096)). Contributed by @tnt7864.<!-- CHANGELOG_PREVIEW_END -->