### PR TITLE
Checkout PR head for strict error checker

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -53,7 +53,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
               with:
-                ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Install Deps
               run: "scripts/ci/layered.sh"

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -52,6 +52,8 @@ jobs:
                     - "--noImplicitAny"
         steps:
             - uses: actions/checkout@v3
+              with:
+                ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Install Deps
               run: "scripts/ci/layered.sh"


### PR DESCRIPTION
On https://github.com/matrix-org/matrix-react-sdk/pull/10083 I currently have the issue that the typescript strict check fails complaining about violations in files that I didn't touch in the PR. I _think_ this is because by default the `checkout` action checks out the repository's default branch and then merges the PR branch into it before running the checks. This might be desirable in other contexts but I think for the strict mode checks we really just care about issues in files that the PR actually touched.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->