### PR TITLE
Allow creating permalinks for unknown predecessor rooms (even though unlikely to be successful)

### DIFF
--- a/src/components/views/messages/RoomPredecessorTile.tsx
+++ b/src/components/views/messages/RoomPredecessorTile.tsx
@@ -86,12 +86,12 @@ export const RoomPredecessorTile: React.FC<IProps> = ({ mxEvent, timestamp }) =>
     }
 
     const prevRoom = MatrixClientPeg.get().getRoom(predecessor.roomId);
-    if (!prevRoom) {
-        logger.warn(`Failed to find predecessor room with id ${predecessor.roomId}`);
-        return <></>;
-    }
     const permalinkCreator = new RoomPermalinkCreator(prevRoom, predecessor.roomId);
-    permalinkCreator.load();
+    if (prevRoom) {
+        permalinkCreator.load();
+    } else {
+        logger.warn(`Creating permalink for unknown predecessor room ${predecessor.roomId}, unlikely to be successful`);
+    }
     let predecessorPermalink: string;
     if (predecessor.eventId) {
         predecessorPermalink = permalinkCreator.forEvent(predecessor.eventId);

--- a/src/components/views/messages/RoomPredecessorTile.tsx
+++ b/src/components/views/messages/RoomPredecessorTile.tsx
@@ -90,7 +90,8 @@ export const RoomPredecessorTile: React.FC<IProps> = ({ mxEvent, timestamp }) =>
     if (prevRoom) {
         permalinkCreator.load();
     } else {
-        logger.warn(`Creating permalink for unknown predecessor room ${predecessor.roomId}, unlikely to be successful`);
+        logger.warn(`Creating permalink for unknown predecessor room ${predecessor.roomId},`+
+            'unlikely to be successful as rooms without via servers are usually not routable');
     }
     let predecessorPermalink: string;
     if (predecessor.eventId) {


### PR DESCRIPTION
Type: Defect
Partially fixes: https://github.com/vector-im/element-web/issues/24453
Reopens: https://github.com/vector-im/element-web/issues/2925

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Allow creating permalinks for unknown predecessor rooms (even though unlikely to be successful) ([\#10113](https://github.com/matrix-org/matrix-react-sdk/pull/10113)). Fixes vector-im/element-web#24453. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->