### PR TITLE
Fix predecessor tests broken

### DIFF
--- a/test/RoomNotifs-test.ts
+++ b/test/RoomNotifs-test.ts
@@ -113,10 +113,10 @@ describe("RoomNotifs test", () => {
                     event: true,
                     type: "m.room.create",
                     room: ROOM_ID,
-                    user: client.getUserId()!,
+                    user: "@zoe:localhost",
                     content: {
                         ...(predecessorId ? { predecessor: { room_id: predecessorId, event_id: "$someevent" } } : {}),
-                        creator: client.getUserId(),
+                        creator: "@zoe:localhost",
                         room_version: "5",
                     },
                     ts: Date.now(),
@@ -128,7 +128,7 @@ describe("RoomNotifs test", () => {
                     event: true,
                     type: EventType.RoomPredecessor,
                     room: ROOM_ID,
-                    user: client.getUserId()!,
+                    user: "@zoe:localhost",
                     skey: "",
                     content: {
                         predecessor_room_id: predecessorId,

--- a/test/components/views/settings/Notifications-test.tsx
+++ b/test/components/views/settings/Notifications-test.tsx
@@ -226,6 +226,7 @@ describe("<Notifications />", () => {
         setAccountData: jest.fn(),
         sendReadReceipt: jest.fn(),
         supportsThreads: jest.fn().mockReturnValue(true),
+        isInitialSyncComplete: jest.fn().mockReturnValue(false),
     });
     mockClient.getPushRules.mockResolvedValue(pushRules);
 

--- a/test/stores/RoomViewStore-test.ts
+++ b/test/stores/RoomViewStore-test.ts
@@ -94,7 +94,7 @@ describe("RoomViewStore", function () {
         getDeviceId: jest.fn().mockReturnValue("ABC123"),
         sendStateEvent: jest.fn().mockResolvedValue({}),
         supportsThreads: jest.fn(),
-        isInitialSyncComplete: jest.fn(),
+        isInitialSyncComplete: jest.fn().mockResolvedValue(false),
         relations: jest.fn(),
     });
     const room = new Room(roomId, mockClient, userId);


### PR DESCRIPTION
Sending an event now clears notifications, the test was broken because we create mock event with the sender being the logged in user

See https://github.com/matrix-org/matrix-js-sdk/pull/3139

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->