### PR TITLE
Font Setting - Added draggable slider

### DIFF
--- a/res/css/views/elements/_Slider.pcss
+++ b/res/css/views/elements/_Slider.pcss
@@ -61,6 +61,17 @@ limitations under the License.
     z-index: 10;
 }
 
+.mx_Slider_selectionDotInner {
+  position: absolute;
+  width: 100%;
+  height: 100%;  
+  border-radius: 50%;
+  /* background-color: white; */
+  background-color: $accent;  
+  z-index: 10;
+  pointer-events: all;
+}
+
 .mx_Slider_selectionText {
     color: $muted-fg-color;
     font-size: $font-14px;
@@ -68,6 +79,9 @@ limitations under the License.
     text-align: center;
     top: 30px;
     width: 100%;
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
 }
 
 .mx_Slider_selection > hr {

--- a/src/components/views/elements/Slider.tsx
+++ b/src/components/views/elements/Slider.tsx
@@ -108,7 +108,10 @@ export default class Slider extends React.Component<IProps> {
             //put the inner dot to the correct position
             const innerDot = target.parentNode as any;
             if (!innerDot) return null;
-            innerDot.style.left = `${this.state.percent}%`;
+            // innerDot.style.left = `${this.state.percent}%`;
+            const offset = this.offset(this.props.values, this.props.values[value]);
+            innerDot.style.left = `calc(-1.195em + " + ${offset} + "%)`;
+
         };
 
         const onDragEnd = (e: any) => {
@@ -120,12 +123,14 @@ export default class Slider extends React.Component<IProps> {
             const slider = parent.parentNode as HTMLElement;
             const rect = slider.getBoundingClientRect();
             const x = e.clientX - rect.left; //x position within the element.
+            // console.log(x);
+            if(x < -10 || x > rect.width + 10)  return null;
             const width = rect.width;
 
             const percent = x / width;
             const value = Math.round(percent * (this.props.values.length - 1));
             const offset = this.offset(this.props.values, this.props.values[value]);
-            innerDot.style.left = `${offset}%`;
+            innerDot.style.left = `calc(-1.195em + " + ${offset} + "%)`;
             this.props.onSelectionChange(this.props.values[value]);
         };
 

--- a/src/components/views/elements/Slider.tsx
+++ b/src/components/views/elements/Slider.tsx
@@ -90,7 +90,6 @@ export default class Slider extends React.Component<IProps> {
         let selection = null;
 
         const onDrag = (e: React.DragEvent) => {
-            //  console.log(e.target.parentNode.parentNode)
 
             const target = e.target as HTMLElement;
             if (!target.parentNode) return null;

--- a/src/components/views/elements/Slider.tsx
+++ b/src/components/views/elements/Slider.tsx
@@ -152,10 +152,6 @@ export default class Slider extends React.Component<IProps> {
             );
         }
 
-        //todo:
-        //make a new element for dragging
-        //immplement drag
-
         return (
             <div className="mx_Slider">
                 <div>

--- a/src/components/views/elements/Slider.tsx
+++ b/src/components/views/elements/Slider.tsx
@@ -107,7 +107,6 @@ export default class Slider extends React.Component<IProps> {
             //put the inner dot to the correct position
             const innerDot = target.parentNode as any;
             if (!innerDot) return null;
-            // innerDot.style.left = `${this.state.percent}%`;
             const offset = this.offset(this.props.values, this.props.values[value]);
             innerDot.style.left = `calc(-1.195em + " + ${offset} + "%)`;
 


### PR DESCRIPTION
Signed-off-by: Shubham-Rasal <bluequbits@gmail.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

element-web notes: none

Type: enhancement

Fixes [vector-im/element-web/issues/20168](https://github.com/vector-im/element-web/issues/20168) 

In element/web the font slider in the user settings is not draggable. This is a natural user response to drag a slider , but here it just selects the text.

### This is the before image as mentioned in the issue:
![image](https://user-images.githubusercontent.com/95695273/217877456-ae024c9e-b1fa-457f-bc5b-5568731862ed.png)


### This is the result after the changes :  

https://user-images.githubusercontent.com/95695273/217887041-f5ffa203-f897-4c58-ad56-0df650b08c08.mp4




<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Font Setting - Added draggable slider ([\#10126](https://github.com/matrix-org/matrix-react-sdk/pull/10126)). Contributed by @Shubham-Rasal.<!-- CHANGELOG_PREVIEW_END -->