### PR TITLE
Examine all m.direct rooms to find a DM as fallback

### DIFF
--- a/src/utils/DMRoomMap.ts
+++ b/src/utils/DMRoomMap.ts
@@ -192,6 +192,16 @@ export default class DMRoomMap {
             .reduce((obj, r) => (obj[r.userId] = r.room) && obj, {});
     }
 
+    /**
+     * @returns all room Ids from m.direct
+     */
+    public getRoomIds(): Set<string> {
+        return Object.values(this.mDirectEvent).reduce((prevRoomIds: Set<string>, roomIds: string[]): Set<string> => {
+            roomIds.forEach((roomId) => prevRoomIds.add(roomId));
+            return prevRoomIds;
+        }, new Set<string>());
+    }
+
     private getUserToRooms(): { [key: string]: string[] } {
         if (!this.userToRooms) {
             const userToRooms = this.mDirectEvent;

--- a/src/utils/dm/findDMForUser.ts
+++ b/src/utils/dm/findDMForUser.ts
@@ -29,8 +29,8 @@ import { getFunctionalMembers } from "../room/getFunctionalMembers";
  * @returns {Room} Room if found
  */
 export function findDMForUser(client: MatrixClient, userId: string): Room {
-    const roomIds = DMRoomMap.shared().getDMRoomsForUserId(userId);
-    const rooms = roomIds.map((id) => client.getRoom(id));
+    const roomIds = DMRoomMap.shared().getRoomIds();
+    const rooms = Array.from(roomIds).map((id) => client.getRoom(id));
     const suitableDMRooms = rooms
         .filter((r) => {
             // Validate that we are joined and the other person is also joined. We'll also make sure

--- a/src/utils/dm/findDMForUser.ts
+++ b/src/utils/dm/findDMForUser.ts
@@ -21,17 +21,8 @@ import { isLocalRoom } from "../localRoom/isLocalRoom";
 import { isJoinedOrNearlyJoined } from "../membership";
 import { getFunctionalMembers } from "../room/getFunctionalMembers";
 
-/**
- * Tries to find a DM room with a specific user.
- *
- * @param {MatrixClient} client
- * @param {string} userId ID of the user to find the DM for
- * @returns {Room} Room if found
- */
-export function findDMForUser(client: MatrixClient, userId: string): Room {
-    const roomIds = DMRoomMap.shared().getRoomIds();
-    const rooms = Array.from(roomIds).map((id) => client.getRoom(id));
-    const suitableDMRooms = rooms
+function extractSuitableRoom(rooms: Room[], userId: string): Room | undefined {
+    const suitableRooms = rooms
         .filter((r) => {
             // Validate that we are joined and the other person is also joined. We'll also make sure
             // that the room also looks like a DM (until we have canonical DMs to tell us). For now,
@@ -54,7 +45,32 @@ export function findDMForUser(client: MatrixClient, userId: string): Room {
         .sort((r1, r2) => {
             return r2.getLastActiveTimestamp() - r1.getLastActiveTimestamp();
         });
-    if (suitableDMRooms.length) {
-        return suitableDMRooms[0];
+
+    if (suitableRooms.length) {
+        return suitableRooms[0];
     }
+
+    return undefined;
+}
+
+/**
+ * Tries to find a DM room with a specific user.
+ *
+ * @param {MatrixClient} client
+ * @param {string} userId ID of the user to find the DM for
+ * @returns {Room | undefined} Room if found
+ */
+export function findDMForUser(client: MatrixClient, userId: string): Room | undefined {
+    const roomIdsForUserId = DMRoomMap.shared().getDMRoomsForUserId(userId);
+    const roomsForUserId = roomIdsForUserId.map((id) => client.getRoom(id));
+    const suitableRoomForUserId = extractSuitableRoom(roomsForUserId, userId);
+
+    if (suitableRoomForUserId) {
+        return suitableRoomForUserId;
+    }
+
+    // Try to find in all rooms as a fallback
+    const allRoomIds = DMRoomMap.shared().getRoomIds();
+    const allRooms = Array.from(allRoomIds).map((id) => client.getRoom(id));
+    return extractSuitableRoom(allRooms, userId);
 }

--- a/src/utils/dm/findDMForUser.ts
+++ b/src/utils/dm/findDMForUser.ts
@@ -35,7 +35,7 @@ function extractSuitableRoom(rooms: Room[], userId: string): Room | undefined {
                 const functionalUsers = getFunctionalMembers(r);
                 const members = r.currentState.getMembers();
                 const joinedMembers = members.filter(
-                    (m) => !functionalUsers.includes(m.userId) && isJoinedOrNearlyJoined(m.membership),
+                    (m) => !functionalUsers.includes(m.userId) && m.membership && isJoinedOrNearlyJoined(m.membership),
                 );
                 const otherMember = joinedMembers.find((m) => m.userId === userId);
                 return otherMember && joinedMembers.length === 2;
@@ -62,7 +62,7 @@ function extractSuitableRoom(rooms: Room[], userId: string): Room | undefined {
  */
 export function findDMForUser(client: MatrixClient, userId: string): Room | undefined {
     const roomIdsForUserId = DMRoomMap.shared().getDMRoomsForUserId(userId);
-    const roomsForUserId = roomIdsForUserId.map((id) => client.getRoom(id));
+    const roomsForUserId = roomIdsForUserId.map((id) => client.getRoom(id)).filter((r): r is Room => r !== null);
     const suitableRoomForUserId = extractSuitableRoom(roomsForUserId, userId);
 
     if (suitableRoomForUserId) {
@@ -71,6 +71,8 @@ export function findDMForUser(client: MatrixClient, userId: string): Room | unde
 
     // Try to find in all rooms as a fallback
     const allRoomIds = DMRoomMap.shared().getRoomIds();
-    const allRooms = Array.from(allRoomIds).map((id) => client.getRoom(id));
+    const allRooms = Array.from(allRoomIds)
+        .map((id) => client.getRoom(id))
+        .filter((r): r is Room => r !== null);
     return extractSuitableRoom(allRooms, userId);
 }

--- a/src/utils/dm/findDMRoom.ts
+++ b/src/utils/dm/findDMRoom.ts
@@ -29,7 +29,7 @@ import { findDMForUser } from "./findDMForUser";
  */
 export function findDMRoom(client: MatrixClient, targets: Member[]): Room | null {
     const targetIds = targets.map((t) => t.userId);
-    let existingRoom: Room;
+    let existingRoom: Room | undefined;
     if (targetIds.length === 1) {
         existingRoom = findDMForUser(client, targetIds[0]);
     } else {

--- a/test/LegacyCallHandler-test.ts
+++ b/test/LegacyCallHandler-test.ts
@@ -225,8 +225,18 @@ describe("LegacyCallHandler", () => {
                     return null;
                 }
             },
-            getRoomIds: () => {
-                return [NATIVE_ROOM_ALICE, NATIVE_ROOM_BOB, NATIVE_ROOM_CHARLIE, VIRTUAL_ROOM_BOB];
+            getDMRoomsForUserId: (userId: string) => {
+                if (userId === NATIVE_ALICE) {
+                    return [NATIVE_ROOM_ALICE];
+                } else if (userId === NATIVE_BOB) {
+                    return [NATIVE_ROOM_BOB];
+                } else if (userId === NATIVE_CHARLIE) {
+                    return [NATIVE_ROOM_CHARLIE];
+                } else if (userId === VIRTUAL_BOB) {
+                    return [VIRTUAL_ROOM_BOB];
+                } else {
+                    return [];
+                }
             },
         } as unknown as DMRoomMap;
         DMRoomMap.setShared(dmRoomMap);

--- a/test/LegacyCallHandler-test.ts
+++ b/test/LegacyCallHandler-test.ts
@@ -225,20 +225,10 @@ describe("LegacyCallHandler", () => {
                     return null;
                 }
             },
-            getDMRoomsForUserId: (userId: string) => {
-                if (userId === NATIVE_ALICE) {
-                    return [NATIVE_ROOM_ALICE];
-                } else if (userId === NATIVE_BOB) {
-                    return [NATIVE_ROOM_BOB];
-                } else if (userId === NATIVE_CHARLIE) {
-                    return [NATIVE_ROOM_CHARLIE];
-                } else if (userId === VIRTUAL_BOB) {
-                    return [VIRTUAL_ROOM_BOB];
-                } else {
-                    return [];
-                }
+            getRoomIds: () => {
+                return [NATIVE_ROOM_ALICE, NATIVE_ROOM_BOB, NATIVE_ROOM_CHARLIE, VIRTUAL_ROOM_BOB];
             },
-        } as DMRoomMap;
+        } as unknown as DMRoomMap;
         DMRoomMap.setShared(dmRoomMap);
 
         pstnLookup = null;

--- a/test/utils/DMRoomMap-test.ts
+++ b/test/utils/DMRoomMap-test.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { mocked, Mocked } from "jest-mock";
+import { EventType, IContent, MatrixClient } from "matrix-js-sdk/src/matrix";
+
+import DMRoomMap from "../../src/utils/DMRoomMap";
+import { mkEvent, stubClient } from "../test-utils";
+
+describe("DMRoomMap", () => {
+    const roomId1 = "!room1:example.com";
+    const roomId2 = "!room2:example.com";
+    const roomId3 = "!room3:example.com";
+    const roomId4 = "!room4:example.com";
+
+    const mDirectContent = {
+        "user@example.com": [roomId1, roomId2],
+        "@user:example.com": [roomId1, roomId3, roomId4],
+        "@user2:example.com": [] as string[],
+    } satisfies IContent;
+
+    let client: Mocked<MatrixClient>;
+    let dmRoomMap: DMRoomMap;
+
+    beforeEach(() => {
+        client = mocked(stubClient());
+
+        const mDirectEvent = mkEvent({
+            event: true,
+            type: EventType.Direct,
+            user: client.getSafeUserId(),
+            content: mDirectContent,
+        });
+        client.getAccountData.mockReturnValue(mDirectEvent);
+        dmRoomMap = new DMRoomMap(client);
+    });
+
+    it("getRoomIds should return the room Ids", () => {
+        expect(dmRoomMap.getRoomIds()).toEqual(new Set([roomId1, roomId2, roomId3, roomId4]));
+    });
+});

--- a/test/utils/dm/findDMForUser-test.ts
+++ b/test/utils/dm/findDMForUser-test.ts
@@ -38,6 +38,7 @@ describe("findDMForUser", () => {
     let room4: Room;
     let room5: Room;
     let room6: Room;
+    const room7Id = "!room7:example.com";
     let dmRoomMap: DMRoomMap;
     let mockClient: MatrixClient;
 
@@ -89,29 +90,37 @@ describe("findDMForUser", () => {
         ]);
 
         mocked(mockClient.getRoom).mockImplementation((roomId: string) => {
-            return {
-                [room1.roomId]: room1,
-                [room2.roomId]: room2,
-                [room3.roomId]: room3,
-                [room4.roomId]: room4,
-                [room5.roomId]: room5,
-                [room6.roomId]: room6,
-            }[roomId];
+            return (
+                {
+                    [room1.roomId]: room1,
+                    [room2.roomId]: room2,
+                    [room3.roomId]: room3,
+                    [room4.roomId]: room4,
+                    [room5.roomId]: room5,
+                    [room6.roomId]: room6,
+                }[roomId] || null
+            );
         });
 
         dmRoomMap = {
             getDMRoomForIdentifiers: jest.fn(),
             getDMRoomsForUserId: jest.fn(),
-            getRoomIds: jest
-                .fn()
-                .mockReturnValue(
-                    new Set([room1.roomId, room2.roomId, room3.roomId, room4.roomId, room5.roomId, room6.roomId]),
-                ),
+            getRoomIds: jest.fn().mockReturnValue(
+                new Set([
+                    room1.roomId,
+                    room2.roomId,
+                    room3.roomId,
+                    room4.roomId,
+                    room5.roomId,
+                    room6.roomId,
+                    room7Id, // this room does not exist in client
+                ]),
+            ),
         } as unknown as DMRoomMap;
         jest.spyOn(DMRoomMap, "shared").mockReturnValue(dmRoomMap);
         mocked(dmRoomMap.getDMRoomsForUserId).mockImplementation((userId: string) => {
             if (userId === userId1) {
-                return [room1.roomId, room2.roomId, room3.roomId, room4.roomId, room5.roomId];
+                return [room1.roomId, room2.roomId, room3.roomId, room4.roomId, room5.roomId, room7Id];
             }
 
             return [];

--- a/test/utils/dm/findDMRoom-test.ts
+++ b/test/utils/dm/findDMRoom-test.ts
@@ -53,8 +53,8 @@ describe("findDMRoom", () => {
         expect(findDMRoom(mockClient, [member1])).toBe(room1);
     });
 
-    it("should return null for a single target without a room", () => {
-        mocked(findDMForUser).mockReturnValue(null);
+    it("should return undefined for a single target without a room", () => {
+        mocked(findDMForUser).mockReturnValue(undefined);
         expect(findDMRoom(mockClient, [member1])).toBeNull();
     });
 


### PR DESCRIPTION
Adds search in all known DM rooms for a 1:1 DM as a fallback, if no room can be found via user-Id.
This covers for instance the case of a 3rd party invite (e-mail).

More of a stop-gap solution until canonical DMs arrive ™.

closes https://github.com/vector-im/element-web/issues/23138

PSF-1901

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Prevent start another DM with a user if one already exists

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent start another DM with a user if one already exists ([\#10127](https://github.com/matrix-org/matrix-react-sdk/pull/10127)). Fixes vector-im/element-web#23138.<!-- CHANGELOG_PREVIEW_END -->