### PR TITLE
Improve performance of rendering a room with many hidden events

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -564,35 +564,26 @@ export default class MessagePanel extends React.Component<IProps, IState> {
     /**
      * Find the next event in the list, and the next visible event in the list.
      *
-     * @param arr        - the list of events to look in
-     * @param shouldShow - which of these events should be shown (a cache of
-     *                     calling this.shouldShowEvent(e) for each e in arr)
+     * @param event      - the list of events to look in and whether they are shown
      * @param i          - where in the list we are now
      *
      * @returns { nextEvent, nextTile }
      *
-     * nextEvent is the last event in the supplied array.
+     * nextEvent is the event after i in the supplied array.
      *
-     * nextTile is the last event in the array that we will show a tile for. It
-     * is used to to determine the 'last successful' flag when rendering the
-     * tile.
+     * nextTile is the first event in the array after i that we will show a tile
+     * for. It is used to to determine the 'last successful' flag when rendering
+     * the tile.
      */
     private getNextEventInfo(
-        arr: MatrixEvent[],
-        shouldShow: boolean[],
+        events: EventAndShouldShow[],
         i: number,
-    ): { nextEvent: MatrixEvent; nextTile: MatrixEvent } {
+    ): { nextEvent: MatrixEvent | null; nextTile: MatrixEvent | null } {
         // WARNING: this method is on a hot path.
 
-        const nextEvent = i < arr.length - 1 ? arr[i + 1] : null;
+        const nextEvent = i < events.length - 1 ? events[i + 1].event : null;
 
-        let nextTile = null;
-        for (let n = i + 1; n < arr.length; n++) {
-            if (shouldShow[n]) {
-                nextTile = arr[n];
-                break;
-            }
-        }
+        const nextTile = findFirstShownAfter(i, events);
 
         return { nextEvent, nextTile };
     }
@@ -618,14 +609,16 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         // we also need to figure out which is the last event we show which isn't
         // a local echo, to manage the read-marker.
         let lastShownEvent: MatrixEvent | undefined;
-        const shouldShow = this.props.events.map((e) => this.shouldShowEvent(e));
+        const events: EventAndShouldShow[] = this.props.events.map((event) => {
+            return { event, shouldShow: this.shouldShowEvent(event) };
+        });
 
         let lastShownNonLocalEchoIndex = -1;
-        for (let i = this.props.events.length - 1; i >= 0; i--) {
-            if (!shouldShow[i]) {
+        for (let i = events.length - 1; i >= 0; i--) {
+            const { event: mxEv, shouldShow } = events[i];
+            if (!shouldShow) {
                 continue;
             }
-            const mxEv = this.props.events[i];
 
             if (lastShownEvent === undefined) {
                 lastShownEvent = mxEv;
@@ -654,12 +647,11 @@ export default class MessagePanel extends React.Component<IProps, IState> {
 
         let grouper: BaseGrouper = null;
 
-        for (let i = 0; i < this.props.events.length; i++) {
-            const mxEv = this.props.events[i];
-            const shouldShowEv = shouldShow[i];
+        for (let i = 0; i < events.length; i++) {
+            const { event: mxEv, shouldShow } = events[i];
             const eventId = mxEv.getId();
             const last = mxEv === lastShownEvent;
-            const { nextEvent, nextTile } = this.getNextEventInfo(this.props.events, shouldShow, i);
+            const { nextEvent, nextTile } = this.getNextEventInfo(events, i);
 
             if (grouper) {
                 if (grouper.shouldGroup(mxEv)) {
@@ -682,7 +674,7 @@ export default class MessagePanel extends React.Component<IProps, IState> {
             }
 
             if (!grouper) {
-                if (shouldShowEv) {
+                if (shouldShow) {
                     // make sure we unpack the array returned by getTilesForEvent,
                     // otherwise React will auto-generate keys, and we will end up
                     // replacing all the DOM elements every time we paginate.
@@ -1064,6 +1056,15 @@ export default class MessagePanel extends React.Component<IProps, IState> {
     }
 }
 
+/**
+ * Holds on to an event, caching the information about whether it should be
+ * shown. Avoids calling shouldShowEvent more times than we need to.
+ */
+interface EventAndShouldShow {
+    event: MatrixEvent;
+    shouldShow: boolean;
+}
+
 abstract class BaseGrouper {
     public static canStartGroup = (panel: MessagePanel, ev: MatrixEvent): boolean => true;
 
@@ -1393,3 +1394,17 @@ class MainGrouper extends BaseGrouper {
 
 // all the grouper classes that we use, ordered by priority
 const groupers = [CreationGrouper, MainGrouper];
+
+/**
+ * Look through the supplied list of EventAndShouldShow, and return the first
+ * event that is >start items through the list, and is shown.
+ */
+function findFirstShownAfter(start: number, events: EventAndShouldShow[]): MatrixEvent | null {
+    for (let n = start + 1; n < events.length; n++) {
+        const { event, shouldShow } = events[n];
+        if (shouldShow) {
+            return event;
+        }
+    }
+    return null;
+}

--- a/test/components/structures/MessagePanel-test.tsx
+++ b/test/components/structures/MessagePanel-test.tsx
@@ -669,6 +669,27 @@ describe("MessagePanel", function () {
         expect(els.length).toEqual(1);
         expect(els[0].getAttribute("data-scroll-tokens")?.split(",")).toHaveLength(3);
     });
+
+    it("should handle large numbers of hidden events quickly", () => {
+        // Increase the length of the loop here to test performance issues with
+        // rendering
+
+        const events = [];
+        for (let i = 0; i < 100; i++) {
+            events.push(
+                TestUtilsMatrix.mkEvent({
+                    event: true,
+                    type: "unknown.event.type",
+                    content: { key: "value" },
+                    room: "!room:id",
+                    user: "@user:id",
+                    ts: 1000000 + i,
+                }),
+            );
+        }
+        const { asFragment } = render(getComponent({ events }, { showHiddenEvents: false }));
+        expect(asFragment()).toMatchSnapshot();
+    });
 });
 
 describe("shouldFormContinuation", () => {

--- a/test/components/structures/__snapshots__/MessagePanel-test.tsx.snap
+++ b/test/components/structures/__snapshots__/MessagePanel-test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MessagePanel should handle large numbers of hidden events quickly 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_AutoHideScrollbar mx_ScrollPanel cls"
+    tabindex="-1"
+  >
+    <div
+      class="mx_RoomView_messageListWrapper"
+    >
+      <ol
+        aria-live="polite"
+        class="mx_RoomView_MessageList"
+        style="height: 400px;"
+      />
+    </div>
+  </div>
+  );
+</DocumentFragment>
+`;


### PR DESCRIPTION
A small part of https://github.com/vector-im/element-web/issues/24480 and found while investigating https://github.com/vector-im/element-web/issues/24420

We were calling `shouldShowEvent` in `MessagePanel` a lot of times, and it was very slow when a room had many hidden events. This changes caches the result of calling it in the hottest path. There is definitely more work needed in this area.

Benchmark (ish):
If I modify the test to run 1000 times, running it used to take 1459ms and now it takes 85ms.

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Improve performance of rendering a room with many hidden events ([\#10131](https://github.com/matrix-org/matrix-react-sdk/pull/10131)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->