### PR TITLE
Use '_t' for caption to have strings localized

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -486,9 +486,9 @@ export const SETTINGS: { [setting: string]: ISetting } = {
             title: _td("New session manager"),
             caption: () => (
                 <>
-                    <p>{_td("Have greater visibility and control over all your sessions.")}</p>
+                    <p>{_t("Have greater visibility and control over all your sessions.")}</p>
                     <p>
-                        {_td(
+                        {_t(
                             "Our new sessions manager provides better visibility of all your sessions, " +
                                 "and greater control over them including the ability to remotely toggle push notifications.",
                         )}


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

`caption` inside `betaInfo` should use `_t` instead of `_td` so that localization of the strings should be applied. Please search `feature_threadenabled` in the file for an example.

Before:
![before](https://user-images.githubusercontent.com/3362943/218279031-7b7ad2e1-4cd8-4b8f-b944-6e2650880cfd.png)

After:
![after](https://user-images.githubusercontent.com/3362943/218279029-8800d992-db56-49e2-ac16-55a9a690ca45.png)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

type: defect
Notes: Fix the caption of new sessions manager on Labs settings page for localization

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the caption of new sessions manager on Labs settings page for localization ([\#10143](https://github.com/matrix-org/matrix-react-sdk/pull/10143)). Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->