### PR TITLE
Fixes authentication when user is registered via module API

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -576,7 +576,7 @@ export async function hydrateSession(credentials: IMatrixClientCreds): Promise<M
  *
  * @returns {Promise} promise which resolves to the new MatrixClient once it has been started
  */
-async function doSetLoggedIn(credentials: IMatrixClientCreds, clearStorageEnabled: boolean): Promise<MatrixClient> {
+export async function doSetLoggedIn(credentials: IMatrixClientCreds, clearStorageEnabled: boolean): Promise<MatrixClient> {
     credentials.guest = Boolean(credentials.guest);
 
     const softLogout = isSoftLogout();

--- a/src/modules/ProxiedModuleApi.ts
+++ b/src/modules/ProxiedModuleApi.ts
@@ -35,7 +35,7 @@ import { parsePermalink } from "../utils/permalinks/Permalinks";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { getCachedRoomIDForAlias } from "../RoomAliasCache";
 import { Action } from "../dispatcher/actions";
-import { OverwriteLoginPayload } from "../dispatcher/payloads/OverwriteLoginPayload";
+import { doSetLoggedIn } from "../Lifecycle";
 
 /**
  * Glue between the `ModuleApi` interface and the react-sdk. Anticipates one instance
@@ -144,16 +144,13 @@ export class ProxiedModuleApi implements ModuleApi {
      * @override
      */
     public async overwriteAccountAuth(accountInfo: AccountAuthInfo): Promise<void> {
-        dispatcher.dispatch<OverwriteLoginPayload>(
+        await doSetLoggedIn(
             {
-                action: Action.OverwriteLogin,
-                credentials: {
-                    ...accountInfo,
-                    guest: false,
-                },
+                ...accountInfo,
+                guest: false,
             },
             true,
-        ); // require to be sync to match inherited interface behaviour
+        ).then(() => true);
     }
 
     /**


### PR DESCRIPTION
When user is registered via module API (using ILAG module for example) the following error is received:

```
Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.
    invariant invariant.js:40
    dispatch Dispatcher.js:179
    dispatch dispatcher.ts:45
    doSetLoggedIn Lifecycle.ts:604
    <anonymous> Lifecycle.ts:76
    _invokeCallback Dispatcher.js:214
    dispatch Dispatcher.js:189
    dispatch dispatcher.ts:45
    overwriteAccountAuth ProxiedModuleApi.ts:146
    _callee$ IlagModule.js:78
```

This PR provides a fix to resolve this problem.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
