### PR TITLE
Appease webpack

### DIFF
--- a/res/css/views/messages/_MPollBody.pcss
+++ b/res/css/views/messages/_MPollBody.pcss
@@ -50,7 +50,7 @@ limitations under the License.
     .mx_MPollBody_totalVotes {
         display: flex;
         flex-direction: inline;
-        justify-content: start;
+        justify-content: flex-start;
         color: $secondary-content;
         font-size: $font-12px;
 


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

This change stops webpack from issuing warnings related to `justify-content: start`. See: https://github.com/vector-im/element-web/issues/23595

type: task

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->