### PR TITLE
Convert remaining hook tests to RTL

### DIFF
--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -38,10 +38,10 @@ function simulateRequest(
 
 describe("renderhook tests", () => {
     it("should return a result", () => {
-        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const { result: hookResult } = renderHook(() => useLatestResult(mockSetter));
 
         const query = { id: "query1", delayInMs: 100, result: "result1" };
-        simulateRequest(result, query);
+        simulateRequest(hookResult, query);
 
         // check we have made no calls to the setter
         expect(mockSetter).not.toHaveBeenCalled();
@@ -53,13 +53,13 @@ describe("renderhook tests", () => {
     });
 
     it("should not let a slower response to an earlier query overwrite the result of a later query", () => {
-        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const { result: hookResult } = renderHook(() => useLatestResult(mockSetter));
 
         const slowQuery = { id: "slowQuery", delayInMs: 500, result: "slowResult" };
         const fastQuery = { id: "fastQuery", delayInMs: 100, result: "fastResult" };
 
-        simulateRequest(result, slowQuery);
-        simulateRequest(result, fastQuery);
+        simulateRequest(hookResult, slowQuery);
+        simulateRequest(hookResult, fastQuery);
 
         // advance to fastQuery response, check the setter call
         jest.advanceTimersToNextTimer();
@@ -74,7 +74,7 @@ describe("renderhook tests", () => {
     });
 
     it("should return expected results when all response times similar", () => {
-        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const { result: hookResult } = renderHook(() => useLatestResult(mockSetter));
 
         const commonDelayInMs = 180;
         const query1 = { id: "q1", delayInMs: commonDelayInMs, result: "r1" };
@@ -82,17 +82,17 @@ describe("renderhook tests", () => {
         const query3 = { id: "q3", delayInMs: commonDelayInMs, result: "r3" };
 
         // ELAPSED: 0ms, no queries sent
-        simulateRequest(result, query1);
+        simulateRequest(hookResult, query1);
         jest.advanceTimersByTime(100);
 
         // ELAPSED: 100ms, query1 sent, no responses
         expect(mockSetter).not.toHaveBeenCalled();
-        simulateRequest(result, query2);
+        simulateRequest(hookResult, query2);
         jest.advanceTimersByTime(70);
 
         // ELAPSED: 170ms, query1 and query2 sent, no responses
         expect(mockSetter).not.toHaveBeenCalled();
-        simulateRequest(result, query3);
+        simulateRequest(hookResult, query3);
         jest.advanceTimersByTime(70);
 
         // ELAPSED: 240ms, all queries sent, responses for query1 and query2
@@ -104,24 +104,24 @@ describe("renderhook tests", () => {
     });
 
     it("should prevent out of order results", () => {
-        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const { result: hookResult } = renderHook(() => useLatestResult(mockSetter));
 
         const query1 = { id: "q1", delayInMs: 0, result: "r1" };
         const query2 = { id: "q2", delayInMs: 50, result: "r2" };
         const query3 = { id: "q3", delayInMs: 1, result: "r3" };
 
         // ELAPSED: 0ms, no queries sent
-        simulateRequest(result, query1);
+        simulateRequest(hookResult, query1);
         jest.advanceTimersByTime(5);
 
         // ELAPSED: 5ms, query1 sent, response from query1
         expect(mockSetter).toHaveBeenCalledTimes(1);
         expect(mockSetter).toHaveBeenLastCalledWith(query1.result);
-        simulateRequest(result, query2);
+        simulateRequest(hookResult, query2);
         jest.advanceTimersByTime(5);
 
         // ELAPSED: 10ms, query1 and query2 sent, response from query1
-        simulateRequest(result, query3);
+        simulateRequest(hookResult, query3);
         jest.advanceTimersByTime(5);
 
         // ELAPSED: 15ms, all queries sent, responses from query1 and query3

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -41,8 +41,8 @@ describe("useLatestResult", () => {
             return query;
         };
         const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
-
         await act(() => sleep(100));
+
         expect(screen.getByText("0")).toBeInTheDocument();
 
         rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
@@ -53,6 +53,7 @@ describe("useLatestResult", () => {
         expect(screen.getByText("0")).toBeInTheDocument();
 
         await act(() => sleep(120));
+
         expect(screen.getByText("2")).toBeInTheDocument();
     });
 
@@ -62,8 +63,8 @@ describe("useLatestResult", () => {
             return query;
         };
         const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
-
         await act(() => sleep(5));
+
         expect(screen.getByText("0")).toBeInTheDocument();
 
         rerender(<LatestResultsComponent query={50} doRequest={doRequest} />);
@@ -74,6 +75,7 @@ describe("useLatestResult", () => {
         expect(screen.getByText("1")).toBeInTheDocument();
 
         await act(() => sleep(50));
+
         expect(screen.getByText("1")).toBeInTheDocument();
     });
 });

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -27,7 +27,10 @@ beforeEach(() => {
     mockSetter.mockClear();
 });
 
-function simulateRequest(hookResult, { id, delayInMs, result }: { id: string; delayInMs: number; result: string }) {
+function simulateRequest(
+    hookResult: any,
+    { id, delayInMs, result }: { id: string; delayInMs: number; result: string },
+) {
     const [setQuery, setResult] = hookResult.current;
 
     setQuery(id);

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -28,10 +28,7 @@ beforeEach(() => {
 });
 
 function simulateRequest(
-    hookResult: RenderHookResult<
-        () => {},
-        [(query: string) => void, (query: string, result: string) => void]
-    >["result"],
+    hookResult: RenderHookResult<typeof useLatestResult, ReturnType<typeof useLatestResult>>["result"],
     { id, delayInMs, result }: { id: string; delayInMs: number; result: string },
 ) {
     const [setQuery, setResult] = hookResult.current;

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -15,67 +15,145 @@ limitations under the License.
 */
 
 import { render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks/dom"; // add act
 import { sleep } from "matrix-js-sdk/src/utils";
 import React, { useEffect, useState } from "react";
 import { act } from "react-dom/test-utils";
 
 import { useLatestResult } from "../../src/hooks/useLatestResult";
 
-function LatestResultsComponent({ query, doRequest }: { query: number; doRequest(query: number): Promise<number> }) {
-    const [value, setValueInternal] = useState<number>(0);
-    const [updateQuery, updateResult] = useLatestResult(setValueInternal);
-    useEffect(() => {
-        updateQuery(query);
-        doRequest(query).then((it: number) => {
-            updateResult(query, it);
-        });
-    }, [doRequest, query, updateQuery, updateResult]);
+// function LatestResultsComponent({ query, doRequest }: { query: number; doRequest(query: number): Promise<number> }) {
+//     const [value, setValueInternal] = useState<number>(0);
+//     const [updateQuery, updateResult] = useLatestResult(setValueInternal);
+//     useEffect(() => {
+//         updateQuery(query);
+//         doRequest(query).then((it: number) => {
+//             updateResult(query, it);
+//         });
+//     }, [doRequest, query, updateQuery, updateResult]);
 
-    return <div>{value}</div>;
-}
+//     return <div>{value}</div>;
+// }
 
-describe("useLatestResult", () => {
-    it("should return results", async () => {
-        const doRequest = async (query: number) => {
-            await sleep(180);
-            return query;
-        };
-        const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
-        await act(() => sleep(100));
+// describe("useLatestResult", () => {
+//     it("should return results", async () => {
+//         const doRequest = async (query: number) => {
+//             await sleep(180);
+//             return query;
+//         };
+//         const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
+//         expect(screen.getByText("0")).toBeInTheDocument();
+//         await act(() => sleep(100));
 
-        expect(screen.getByText("0")).toBeInTheDocument();
+//         expect(screen.getByText("0")).toBeInTheDocument();
 
-        rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
-        await act(() => sleep(70));
-        rerender(<LatestResultsComponent query={2} doRequest={doRequest} />);
-        await act(() => sleep(70));
+//         rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
+//         await act(() => sleep(70));
+//         rerender(<LatestResultsComponent query={2} doRequest={doRequest} />);
+//         await act(() => sleep(70));
 
-        expect(screen.getByText("0")).toBeInTheDocument();
+//         expect(screen.getByText("0")).toBeInTheDocument();
 
-        await act(() => sleep(120));
+//         await act(() => sleep(120));
 
-        expect(screen.getByText("2")).toBeInTheDocument();
+//         expect(screen.getByText("2")).toBeInTheDocument();
+//     });
+
+//     it("should prevent out-of-order results", async () => {
+//         const doRequest = async (query: number) => {
+//             await sleep(query);
+//             return query;
+//         };
+//         const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
+//         await act(() => sleep(5));
+
+//         expect(screen.getByText("0")).toBeInTheDocument();
+
+//         rerender(<LatestResultsComponent query={50} doRequest={doRequest} />);
+//         await act(() => sleep(5));
+//         rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
+//         await act(() => sleep(5));
+
+//         expect(screen.getByText("1")).toBeInTheDocument();
+
+//         await act(() => sleep(50));
+
+//         expect(screen.getByText("1")).toBeInTheDocument();
+//     });
+// });
+
+jest.useFakeTimers();
+
+describe("renderhook tests", () => {
+    it("should return a result", async () => {
+        const mockSetter = jest.fn();
+        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const [setQuery, setResult] = result.current;
+
+        const query = { query: "query1", delayInMs: 100, result: "result1" };
+
+        // firstly set a query and a timeout for the result
+        setQuery(query.query);
+        setTimeout(() => setResult(query.query, query.result), query.delayInMs);
+
+        // now advance the timers, check the setter is called
+        jest.advanceTimersByTime(query.delayInMs);
+        expect(mockSetter).toHaveBeenLastCalledWith(query.result);
     });
 
-    it("should prevent out-of-order results", async () => {
-        const doRequest = async (query: number) => {
-            await sleep(query);
-            return query;
-        };
-        const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
-        await act(() => sleep(5));
+    it("should not let a slower response to an earlier query overwrie the result of a later query", () => {
+        const mockSetter = jest.fn();
+        const { result } = renderHook(() => useLatestResult(mockSetter));
+        const [setQuery, setResult] = result.current;
 
-        expect(screen.getByText("0")).toBeInTheDocument();
+        const slowQuery = { query: "slowQuery", delayInMs: 500, result: "slowResult" };
+        const fastQuery = { query: "fastQuery", delayInMs: 100, result: "fastResult" };
 
-        rerender(<LatestResultsComponent query={50} doRequest={doRequest} />);
-        await act(() => sleep(5));
-        rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
-        await act(() => sleep(5));
+        // firstly set a query and a timeout for the result
+        setQuery(slowQuery.query);
+        setTimeout(() => setResult(slowQuery.query, slowQuery.result), slowQuery.delayInMs);
 
-        expect(screen.getByText("1")).toBeInTheDocument();
+        setQuery(fastQuery.query);
+        setTimeout(() => setResult(fastQuery.query, fastQuery.result), fastQuery.delayInMs);
 
-        await act(() => sleep(50));
+        // check we have no calls
+        expect(mockSetter).not.toHaveBeenCalled();
 
-        expect(screen.getByText("1")).toBeInTheDocument();
+        // advance until fastQuery has responded, check the setter is called
+        // with the result
+        jest.advanceTimersToNextTimer();
+        expect(mockSetter).toHaveBeenCalledTimes(1);
+        expect(mockSetter).toHaveBeenLastCalledWith(fastQuery.result);
+
+        // advance time to after the slow query has returned, check the setter
+        // has not been recalled and the result is still from the fast query
+        jest.advanceTimersToNextTimer();
+        expect(mockSetter).toHaveBeenCalledTimes(1);
+        expect(mockSetter).toHaveBeenLastCalledWith(fastQuery.result);
+    });
+    it("should return results", async () => {
+        const mockSetter = jest.fn();
+        const { result } = renderHook(() => useLatestResult(mockSetter));
+        // now have [setQuery, setResult] = result.current;
+
+        const query = { query: "query1", delayInMs: 100, result: "result1" };
+
+        // firstly set a query and a timeout for the result
+        result.current[0](query.query);
+        setTimeout(() => result.current[1](query.query, query.result), query.delayInMs);
+
+        // now advance the timers, check the setter is called
+        jest.advanceTimersByTime(query.delayInMs);
+        expect(mockSetter).toHaveBeenLastCalledWith(query.result);
+
+        // fire two more queries with short delays
+        const quickQuery1 = { query: "qq1", delayInMs: 30, result: "qr1" };
+        const quickQuery2 = { query: "qq2", delayInMs: 30, result: "qr2" };
+
+        result.current[0](quickQuery1.query);
+        setTimeout(() => result.current[1](quickQuery1.query, quickQuery1.result), quickQuery1.delayInMs);
+        jest.advanceTimersByTime(quickQuery1.delayInMs);
+        expect(mockSetter).toHaveBeenLastCalledWith(query.result);
     });
 });

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -73,7 +73,7 @@ describe("renderhook tests", () => {
         expect(mockSetter).toHaveBeenLastCalledWith(fastQuery.result);
     });
 
-    it("should return expected results when all response times simiar", () => {
+    it("should return expected results when all response times similar", () => {
         const { result } = renderHook(() => useLatestResult(mockSetter));
 
         const commonDelayInMs = 180;

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -129,6 +129,7 @@ describe("renderhook tests", () => {
         expect(mockSetter).toHaveBeenLastCalledWith(query3.result);
 
         // ELAPSED: 65ms, all queries sent, all queries have responses
+        // so check that the result is still from query3, not query2
         jest.advanceTimersByTime(50);
         expect(mockSetter).toHaveBeenLastCalledWith(query3.result);
     });

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line deprecate/import
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { sleep } from "matrix-js-sdk/src/utils";
 import React, { useEffect, useState } from "react";
 import { act } from "react-dom/test-utils";
@@ -41,25 +40,20 @@ describe("useLatestResult", () => {
             await sleep(180);
             return query;
         };
+        const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
 
-        const wrapper = mount(<LatestResultsComponent query={0} doRequest={doRequest} />);
-        await act(async () => {
-            await sleep(100);
-        });
-        expect(wrapper.text()).toEqual("0");
-        wrapper.setProps({ doRequest, query: 1 });
-        await act(async () => {
-            await sleep(70);
-        });
-        wrapper.setProps({ doRequest, query: 2 });
-        await act(async () => {
-            await sleep(70);
-        });
-        expect(wrapper.text()).toEqual("0");
-        await act(async () => {
-            await sleep(120);
-        });
-        expect(wrapper.text()).toEqual("2");
+        await act(() => sleep(100));
+        expect(screen.getByText("0")).toBeInTheDocument();
+
+        rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
+        await act(() => sleep(70));
+        rerender(<LatestResultsComponent query={2} doRequest={doRequest} />);
+        await act(() => sleep(70));
+
+        expect(screen.getByText("0")).toBeInTheDocument();
+
+        await act(() => sleep(120));
+        expect(screen.getByText("2")).toBeInTheDocument();
     });
 
     it("should prevent out-of-order results", async () => {
@@ -67,24 +61,19 @@ describe("useLatestResult", () => {
             await sleep(query);
             return query;
         };
+        const { rerender } = render(<LatestResultsComponent query={0} doRequest={doRequest} />);
 
-        const wrapper = mount(<LatestResultsComponent query={0} doRequest={doRequest} />);
-        await act(async () => {
-            await sleep(5);
-        });
-        expect(wrapper.text()).toEqual("0");
-        wrapper.setProps({ doRequest, query: 50 });
-        await act(async () => {
-            await sleep(5);
-        });
-        wrapper.setProps({ doRequest, query: 1 });
-        await act(async () => {
-            await sleep(5);
-        });
-        expect(wrapper.text()).toEqual("1");
-        await act(async () => {
-            await sleep(50);
-        });
-        expect(wrapper.text()).toEqual("1");
+        await act(() => sleep(5));
+        expect(screen.getByText("0")).toBeInTheDocument();
+
+        rerender(<LatestResultsComponent query={50} doRequest={doRequest} />);
+        await act(() => sleep(5));
+        rerender(<LatestResultsComponent query={1} doRequest={doRequest} />);
+        await act(() => sleep(5));
+
+        expect(screen.getByText("1")).toBeInTheDocument();
+
+        await act(() => sleep(50));
+        expect(screen.getByText("1")).toBeInTheDocument();
     });
 });

--- a/test/hooks/useLatestResult-test.tsx
+++ b/test/hooks/useLatestResult-test.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { renderHook } from "@testing-library/react-hooks/dom";
+import { renderHook, RenderHookResult } from "@testing-library/react-hooks/dom";
 
 import { useLatestResult } from "../../src/hooks/useLatestResult";
 
@@ -28,11 +28,13 @@ beforeEach(() => {
 });
 
 function simulateRequest(
-    hookResult: any,
+    hookResult: RenderHookResult<
+        () => {},
+        [(query: string) => void, (query: string, result: string) => void]
+    >["result"],
     { id, delayInMs, result }: { id: string; delayInMs: number; result: string },
 ) {
     const [setQuery, setResult] = hookResult.current;
-
     setQuery(id);
     setTimeout(() => setResult(id, result), delayInMs);
 }

--- a/test/hooks/useProfileInfo-test.tsx
+++ b/test/hooks/useProfileInfo-test.tsx
@@ -102,7 +102,7 @@ describe("useProfileInfo", () => {
     });
 
     it("should be able to handle an empty result", async () => {
-        cli.getProfileInfo = () => Promise.resolve({});
+        cli.getProfileInfo = () => null as unknown as Promise<{}>;
         const query = "@user:home.server";
 
         const { result } = render();

--- a/test/hooks/useProfileInfo-test.tsx
+++ b/test/hooks/useProfileInfo-test.tsx
@@ -14,28 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line deprecate/import
-import { mount } from "enzyme";
-import { MatrixClient } from "matrix-js-sdk/src/matrix";
-import { sleep } from "matrix-js-sdk/src/utils";
-import React from "react";
-import { act } from "react-dom/test-utils";
+import { waitFor } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react-hooks/dom";
 
 import { useProfileInfo } from "../../src/hooks/useProfileInfo";
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
 import { stubClient } from "../test-utils/test-utils";
 
-function ProfileInfoComponent({ onClick }: { onClick(hook: ReturnType<typeof useProfileInfo>): void }) {
-    const profileInfo = useProfileInfo();
-
-    const { ready, loading, profile } = profileInfo;
-
-    return (
-        <div onClick={() => onClick(profileInfo)}>
-            {(!ready || loading) && `ready: ${ready}, loading: ${loading}`}
-            {profile && `Name: ${profile.display_name}`}
-        </div>
-    );
+function render() {
+    return renderHook(() => useProfileInfo());
 }
 
 describe("useProfileInfo", () => {
@@ -55,66 +42,44 @@ describe("useProfileInfo", () => {
     it("should display user profile when searching", async () => {
         const query = "@user:home.server";
 
-        const wrapper = mount(
-            <ProfileInfoComponent
-                onClick={(hook) => {
-                    hook.search({
-                        query,
-                    });
-                }}
-            />,
-        );
+        const { result } = render();
 
-        await act(async () => {
-            await sleep(1);
-            wrapper.simulate("click");
-            return act(() => sleep(1));
+        act(() => {
+            result.current.search({ query });
         });
 
-        expect(wrapper.text()).toContain(query);
+        await waitFor(() => expect(result.current.ready).toBe(true));
+
+        expect(result.current.profile?.display_name).toBe(query);
     });
 
     it("should work with empty queries", async () => {
-        const wrapper = mount(
-            <ProfileInfoComponent
-                onClick={(hook) => {
-                    hook.search({
-                        query: "",
-                    });
-                }}
-            />,
-        );
+        const query = "";
 
-        await act(async () => {
-            await sleep(1);
-            wrapper.simulate("click");
-            return act(() => sleep(1));
+        const { result } = render();
+
+        act(() => {
+            result.current.search({ query });
         });
 
-        expect(wrapper.text()).toBe("");
+        await waitFor(() => expect(result.current.ready).toBe(true));
+
+        expect(result.current.profile).toBeNull();
     });
 
     it("should treat invalid mxids as empty queries", async () => {
         const queries = ["@user", "user@home.server"];
 
         for (const query of queries) {
-            const wrapper = mount(
-                <ProfileInfoComponent
-                    onClick={(hook) => {
-                        hook.search({
-                            query,
-                        });
-                    }}
-                />,
-            );
+            const { result } = render();
 
-            await act(async () => {
-                await sleep(1);
-                wrapper.simulate("click");
-                return act(() => sleep(1));
+            act(() => {
+                result.current.search({ query });
             });
 
-            expect(wrapper.text()).toBe("");
+            await waitFor(() => expect(result.current.ready).toBe(true));
+
+            expect(result.current.profile).toBeNull();
         }
     });
 
@@ -124,43 +89,29 @@ describe("useProfileInfo", () => {
         };
         const query = "@user:home.server";
 
-        const wrapper = mount(
-            <ProfileInfoComponent
-                onClick={(hook) => {
-                    hook.search({
-                        query,
-                    });
-                }}
-            />,
-        );
-        await act(async () => {
-            await sleep(1);
-            wrapper.simulate("click");
-            return act(() => sleep(1));
+        const { result } = render();
+
+        act(() => {
+            result.current.search({ query });
         });
 
-        expect(wrapper.text()).toBe("");
+        await waitFor(() => expect(result.current.ready).toBe(true));
+
+        expect(result.current.profile).toBeNull();
     });
 
     it("should be able to handle an empty result", async () => {
         cli.getProfileInfo = () => null;
         const query = "@user:home.server";
 
-        const wrapper = mount(
-            <ProfileInfoComponent
-                onClick={(hook) => {
-                    hook.search({
-                        query,
-                    });
-                }}
-            />,
-        );
-        await act(async () => {
-            await sleep(1);
-            wrapper.simulate("click");
-            return act(() => sleep(1));
+        const { result } = render();
+
+        act(() => {
+            result.current.search({ query });
         });
 
-        expect(wrapper.text()).toBe("");
+        await waitFor(() => expect(result.current.ready).toBe(true));
+
+        expect(result.current.profile).toBeNull();
     });
 });

--- a/test/hooks/useProfileInfo-test.tsx
+++ b/test/hooks/useProfileInfo-test.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { waitFor } from "@testing-library/react";
 import { renderHook, act } from "@testing-library/react-hooks/dom";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { useProfileInfo } from "../../src/hooks/useProfileInfo";
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
@@ -101,7 +102,7 @@ describe("useProfileInfo", () => {
     });
 
     it("should be able to handle an empty result", async () => {
-        cli.getProfileInfo = () => null;
+        cli.getProfileInfo = () => Promise.resolve({});
         const query = "@user:home.server";
 
         const { result } = render();
@@ -112,6 +113,6 @@ describe("useProfileInfo", () => {
 
         await waitFor(() => expect(result.current.ready).toBe(true));
 
-        expect(result.current.profile).toBeNull();
+        expect(result.current.profile?.display_name).toBeUndefined();
     });
 });


### PR DESCRIPTION
PR to convert the final remaining hooks to RTL.

Both hooks are now tested using `renderHook` instead of mock testing components and the tests that previously used sleep now use mock timers.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->