### PR TITLE
Fix accidentally inverted condition for room ordering

### DIFF
--- a/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
+++ b/src/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm.ts
@@ -104,7 +104,6 @@ export class ImportanceAlgorithm extends OrderingAlgorithm {
             // Every other sorting type affects the categories, not the whole tag.
             const categorized = this.categorizeRooms(rooms);
             for (const category of Object.keys(categorized)) {
-                if (!isNaN(Number(category))) continue;
                 const notificationColor = category as unknown as NotificationColor;
                 const roomsToOrder = categorized[notificationColor];
                 categorized[notificationColor] = sortRoomsWithAlgorithm(


### PR DESCRIPTION
Type: Defect
Fixes: https://github.com/vector-im/element-web/issues/24527

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix accidentally inverted condition for room ordering ([\#10178](https://github.com/matrix-org/matrix-react-sdk/pull/10178)). Fixes vector-im/element-web#24527. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->