### PR TITLE
Display "The sender has blocked you from receiving this message" error message instead of "Unable to decrypt message"

### DIFF
--- a/src/components/views/messages/DecryptionFailureBody.tsx
+++ b/src/components/views/messages/DecryptionFailureBody.tsx
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { ReactNode } from "react";
+import React from "react";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import { _t } from "../../../languageHandler";
 import { IBodyProps } from "./IBodyProps";
 
+function getErrorMessage(mxEvent?: MatrixEvent): string {
+    return mxEvent?.isEncryptedDisabledForUnverifiedDevices()
+        ? _t("The sender has blocked you from receiving this message")
+        : _t("Unable to decrypt message");
+}
+
 // A placeholder element for messages that could not be decrypted
-export default class DecryptionFailureBody extends React.Component<Partial<IBodyProps>> {
-    public render(): ReactNode {
-        return <div className="mx_DecryptionFailureBody mx_EventTile_content">{_t("Unable to decrypt message")}</div>;
-    }
+export function DecryptionFailureBody({ mxEvent }: Partial<IBodyProps>): JSX.Element {
+    return <div className="mx_DecryptionFailureBody mx_EventTile_content">{getErrorMessage(mxEvent)}</div>;
 }

--- a/src/components/views/messages/DecryptionFailureBody.tsx
+++ b/src/components/views/messages/DecryptionFailureBody.tsx
@@ -21,7 +21,7 @@ import { _t } from "../../../languageHandler";
 import { IBodyProps } from "./IBodyProps";
 
 function getErrorMessage(mxEvent?: MatrixEvent): string {
-    return mxEvent?.isEncryptedDisabledForUnverifiedDevices()
+    return mxEvent?.isEncryptedDisabledForUnverifiedDevices
         ? _t("The sender has blocked you from receiving this message")
         : _t("Unable to decrypt message");
 }

--- a/src/components/views/messages/MessageEvent.tsx
+++ b/src/components/views/messages/MessageEvent.tsx
@@ -41,7 +41,7 @@ import { MPollEndBody } from "./MPollEndBody";
 import MLocationBody from "./MLocationBody";
 import MjolnirBody from "./MjolnirBody";
 import MBeaconBody from "./MBeaconBody";
-import DecryptionFailureBody from "./DecryptionFailureBody";
+import { DecryptionFailureBody } from "./DecryptionFailureBody";
 import { GetRelationsForEvent, IEventTileOps } from "../rooms/EventTile";
 import { VoiceBroadcastBody, VoiceBroadcastInfoEventType, VoiceBroadcastInfoState } from "../../../voice-broadcast";
 

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -35,7 +35,7 @@ import { Layout } from "../../../settings/enums/Layout";
 import { formatTime } from "../../../DateUtils";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
-import DecryptionFailureBody from "../messages/DecryptionFailureBody";
+import { DecryptionFailureBody } from "../messages/DecryptionFailureBody";
 import { E2EState } from "./E2EIcon";
 import RoomAvatar from "../avatars/RoomAvatar";
 import MessageContextMenu from "../context_menus/MessageContextMenu";
@@ -1270,7 +1270,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                                 {this.props.mxEvent.isRedacted() ? (
                                     <RedactedBody mxEvent={this.props.mxEvent} />
                                 ) : this.props.mxEvent.isDecryptionFailure() ? (
-                                    <DecryptionFailureBody />
+                                    <DecryptionFailureBody mxEvent={this.props.mxEvent} />
                                 ) : (
                                     MessagePreviewStore.instance.generatePreviewForEvent(this.props.mxEvent)
                                 )}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2328,6 +2328,7 @@
     "Last month": "Last month",
     "The beginning of the room": "The beginning of the room",
     "Jump to date": "Jump to date",
+    "The sender has blocked you from receiving this message": "The sender has blocked you from receiving this message",
     "%(displayName)s (%(matrixId)s)": "%(displayName)s (%(matrixId)s)",
     "Downloading": "Downloading",
     "Decrypting": "Decrypting",

--- a/test/components/views/messages/DecryptionFailureBody-test.tsx
+++ b/test/components/views/messages/DecryptionFailureBody-test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+
+import { mkEvent } from "../../../test-utils";
+import { DecryptionFailureBody } from "../../../../src/components/views/messages/DecryptionFailureBody";
+
+describe("DecryptionFailureBody", () => {
+    function customRender(event: MatrixEvent) {
+        return render(<DecryptionFailureBody mxEvent={event} />);
+    }
+
+    it(`Should display "Unable to decrypt message"`, () => {
+        // When
+        const event = mkEvent({
+            type: "m.room.message",
+            room: "myfakeroom",
+            user: "myfakeuser",
+            content: {
+                msgtype: "m.bad.encrypted",
+            },
+            event: true,
+        });
+        const { container } = customRender(event);
+
+        // Then
+        expect(container).toMatchSnapshot();
+    });
+
+    it(`Should display "The sender has blocked you from receiving this message"`, () => {
+        // When
+        const event = mkEvent({
+            type: "m.room.message",
+            room: "myfakeroom",
+            user: "myfakeuser",
+            content: {
+                msgtype: "m.bad.encrypted",
+            },
+            event: true,
+        });
+        event.isEncryptedDisabledForUnverifiedDevices = jest.fn().mockReturnValue(true);
+        const { container } = customRender(event);
+
+        // Then
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/test/components/views/messages/DecryptionFailureBody-test.tsx
+++ b/test/components/views/messages/DecryptionFailureBody-test.tsx
@@ -54,7 +54,7 @@ describe("DecryptionFailureBody", () => {
             },
             event: true,
         });
-        event.isEncryptedDisabledForUnverifiedDevices = jest.fn().mockReturnValue(true);
+        jest.spyOn(event, "isEncryptedDisabledForUnverifiedDevices", "get").mockReturnValue(true);
         const { container } = customRender(event);
 
         // Then

--- a/test/components/views/messages/__snapshots__/DecryptionFailureBody-test.tsx.snap
+++ b/test/components/views/messages/__snapshots__/DecryptionFailureBody-test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DecryptionFailureBody Should display "The sender has blocked you from receiving this message" 1`] = `
+<div>
+  <div
+    class="mx_DecryptionFailureBody mx_EventTile_content"
+  >
+    The sender has blocked you from receiving this message
+  </div>
+</div>
+`;
+
+exports[`DecryptionFailureBody Should display "Unable to decrypt message" 1`] = `
+<div>
+  <div
+    class="mx_DecryptionFailureBody mx_EventTile_content"
+  >
+    Unable to decrypt message
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Depends of https://github.com/matrix-org/matrix-js-sdk/pull/3167

The purpose is to have a more specific and understandable error in the following use case: 

- Alice has an unverified device
- Bob has the `Never send encrypted messages to unverified sessions from this session` setting enabled (Security & Privacy settings)
- Bob send a message
- Alice can't decrypt Bob's message

**Before**

<img width="805" alt="Screenshot 2023-02-21 at 11 57 23" src="https://user-images.githubusercontent.com/2621378/220336056-a40400b2-4900-40d2-98b9-e8b81802651e.png">

**After**

<img width="805" alt="Screenshot 2023-02-21 at 11 56 05" src="https://user-images.githubusercontent.com/2621378/220336076-2b21d6c3-eea3-458e-bb3d-23060ef94553.png">

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Display "The sender has blocked you from receiving this message" error message instead of "Unable to decrypt message" ([\#10202](https://github.com/matrix-org/matrix-react-sdk/pull/10202)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->