### PR TITLE
Do not prompt for a password when doing a „reset all“ after login

### DIFF
--- a/src/contexts/SDKContext.ts
+++ b/src/contexts/SDKContext.ts
@@ -21,6 +21,7 @@ import defaultDispatcher from "../dispatcher/dispatcher";
 import LegacyCallHandler from "../LegacyCallHandler";
 import { PosthogAnalytics } from "../PosthogAnalytics";
 import { SlidingSyncManager } from "../SlidingSyncManager";
+import { AccountPasswordStore } from "../stores/AccountPasswordStore";
 import { MemberListStore } from "../stores/MemberListStore";
 import { RoomNotificationStateStore } from "../stores/notifications/RoomNotificationStateStore";
 import RightPanelStore from "../stores/right-panel/RightPanelStore";
@@ -73,6 +74,7 @@ export class SdkContextClass {
     protected _VoiceBroadcastRecordingsStore?: VoiceBroadcastRecordingsStore;
     protected _VoiceBroadcastPreRecordingStore?: VoiceBroadcastPreRecordingStore;
     protected _VoiceBroadcastPlaybacksStore?: VoiceBroadcastPlaybacksStore;
+    protected _AccountPasswordStore?: AccountPasswordStore;
 
     /**
      * Automatically construct stores which need to be created eagerly so they can register with
@@ -175,5 +177,12 @@ export class SdkContextClass {
             this._VoiceBroadcastPlaybacksStore = new VoiceBroadcastPlaybacksStore(this.voiceBroadcastRecordingsStore);
         }
         return this._VoiceBroadcastPlaybacksStore;
+    }
+
+    public get accountPasswordStore(): AccountPasswordStore {
+        if (!this._AccountPasswordStore) {
+            this._AccountPasswordStore = new AccountPasswordStore();
+        }
+        return this._AccountPasswordStore;
     }
 }

--- a/src/stores/AccountPasswordStore.ts
+++ b/src/stores/AccountPasswordStore.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const PASSWORD_TIMEOUT = 5 * 60 * 1000; // five minutes
+
+/**
+ * Store for the account password.
+ * This password can be used for a short time after login
+ * to avoid requestin the password all the time for instance during e2ee setup.
+ */
+export class AccountPasswordStore {
+    private password: string = null;
+    private passwordTimeoutId: number = null;
+
+    public setPassword(password: string): void {
+        this.password = password;
+        clearTimeout(this.passwordTimeoutId);
+        this.passwordTimeoutId = setTimeout(this.clearPassword, PASSWORD_TIMEOUT);
+    }
+
+    public getPassword(): string | null {
+        return this.password;
+    }
+
+    public clearPassword = (): void => {
+        clearTimeout(this.passwordTimeoutId);
+        this.passwordTimeoutId = null;
+        this.password = null;
+    };
+}

--- a/src/stores/AccountPasswordStore.ts
+++ b/src/stores/AccountPasswordStore.ts
@@ -22,8 +22,8 @@ const PASSWORD_TIMEOUT = 5 * 60 * 1000; // five minutes
  * to avoid requestin the password all the time for instance during e2ee setup.
  */
 export class AccountPasswordStore {
-    private password: string = null;
-    private passwordTimeoutId: number = null;
+    private password?: string;
+    private passwordTimeoutId?: ReturnType<typeof setTimeout>;
 
     public setPassword(password: string): void {
         this.password = password;
@@ -31,13 +31,13 @@ export class AccountPasswordStore {
         this.passwordTimeoutId = setTimeout(this.clearPassword, PASSWORD_TIMEOUT);
     }
 
-    public getPassword(): string | null {
+    public getPassword(): string | undefined {
         return this.password;
     }
 
     public clearPassword = (): void => {
         clearTimeout(this.passwordTimeoutId);
-        this.passwordTimeoutId = null;
-        this.password = null;
+        this.passwordTimeoutId = undefined;
+        this.password = undefined;
     };
 }

--- a/test/stores/AccountPasswordStore-test.ts
+++ b/test/stores/AccountPasswordStore-test.ts
@@ -26,7 +26,7 @@ describe("AccountPasswordStore", () => {
     });
 
     it("should not have a password by default", () => {
-        expect(accountPasswordStore.getPassword()).toBeNull();
+        expect(accountPasswordStore.getPassword()).toBeUndefined();
     });
 
     describe("when setting a password", () => {
@@ -44,7 +44,7 @@ describe("AccountPasswordStore", () => {
             });
 
             it("should clear the password", () => {
-                expect(accountPasswordStore.getPassword()).toBeNull();
+                expect(accountPasswordStore.getPassword()).toBeUndefined();
             });
         });
 

--- a/test/stores/AccountPasswordStore-test.ts
+++ b/test/stores/AccountPasswordStore-test.ts
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AccountPasswordStore } from "../../src/stores/AccountPasswordStore";
+
+jest.useFakeTimers();
+
+describe("AccountPasswordStore", () => {
+    let accountPasswordStore: AccountPasswordStore;
+
+    beforeEach(() => {
+        accountPasswordStore = new AccountPasswordStore();
+    });
+
+    it("should not have a password by default", () => {
+        expect(accountPasswordStore.getPassword()).toBeNull();
+    });
+
+    describe("when setting a password", () => {
+        beforeEach(() => {
+            accountPasswordStore.setPassword("pass1");
+        });
+
+        it("should return the password", () => {
+            expect(accountPasswordStore.getPassword()).toBe("pass1");
+        });
+
+        describe("and the password timeout exceed", () => {
+            beforeEach(() => {
+                jest.advanceTimersToNextTimer();
+            });
+
+            it("should clear the password", () => {
+                expect(accountPasswordStore.getPassword()).toBeNull();
+            });
+        });
+
+        describe("and setting another password", () => {
+            beforeEach(() => {
+                accountPasswordStore.setPassword("pass2");
+            });
+
+            it("should return the other password", () => {
+                expect(accountPasswordStore.getPassword()).toBe("pass2");
+            });
+        });
+    });
+});

--- a/test/stores/SetupEncryptionStore-test.ts
+++ b/test/stores/SetupEncryptionStore-test.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { mocked, Mocked } from "jest-mock";
+import { IBootstrapCrossSigningOpts } from "matrix-js-sdk/src/crypto";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
+
+import { SdkContextClass } from "../../src/contexts/SDKContext";
+import { accessSecretStorage } from "../../src/SecurityManager";
+import { SetupEncryptionStore } from "../../src/stores/SetupEncryptionStore";
+import { stubClient } from "../test-utils";
+
+jest.mock("../../src/SecurityManager", () => ({
+    accessSecretStorage: jest.fn(),
+}));
+
+describe("SetupEncryptionStore", () => {
+    const cachedPassword = "p4assword";
+    let client: Mocked<MatrixClient>;
+    let setupEncryptionStore: SetupEncryptionStore;
+
+    beforeEach(() => {
+        client = mocked(stubClient());
+        setupEncryptionStore = new SetupEncryptionStore();
+        SdkContextClass.instance.accountPasswordStore.setPassword(cachedPassword);
+    });
+
+    afterEach(() => {
+        SdkContextClass.instance.accountPasswordStore.clearPassword();
+    });
+
+    it("resetConfirm should work with a cached account password", async () => {
+        const makeRequest = jest.fn();
+        client.hasSecretStorageKey.mockResolvedValue(true);
+        client.bootstrapCrossSigning.mockImplementation(async (opts: IBootstrapCrossSigningOpts) => {
+            await opts.authUploadDeviceSigningKeys(makeRequest);
+        });
+        mocked(accessSecretStorage).mockImplementation(async (func) => {
+            await func();
+        });
+
+        await setupEncryptionStore.resetConfirm();
+
+        expect(mocked(accessSecretStorage)).toHaveBeenCalledWith(expect.any(Function), true);
+        expect(makeRequest).toHaveBeenCalledWith({
+            identifier: {
+                type: "m.id.user",
+                user: "@userId:matrix.org",
+            },
+            password: cachedPassword,
+            type: "m.login.password",
+            user: "@userId:matrix.org",
+        });
+    });
+});

--- a/test/stores/SetupEncryptionStore-test.ts
+++ b/test/stores/SetupEncryptionStore-test.ts
@@ -46,9 +46,9 @@ describe("SetupEncryptionStore", () => {
         const makeRequest = jest.fn();
         client.hasSecretStorageKey.mockResolvedValue(true);
         client.bootstrapCrossSigning.mockImplementation(async (opts: IBootstrapCrossSigningOpts) => {
-            await opts.authUploadDeviceSigningKeys(makeRequest);
+            await opts?.authUploadDeviceSigningKeys(makeRequest);
         });
-        mocked(accessSecretStorage).mockImplementation(async (func) => {
+        mocked(accessSecretStorage).mockImplementation(async (func: () => Promise<void>) => {
             await func();
         });
 

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -102,6 +102,8 @@ export function createTestClient(): MatrixClient {
         getDevices: jest.fn().mockResolvedValue({ devices: [{ device_id: "ABCDEFGHI" }] }),
         getSessionId: jest.fn().mockReturnValue("iaszphgvfku"),
         credentials: { userId: "@userId:matrix.org" },
+        bootstrapCrossSigning: jest.fn(),
+        hasSecretStorageKey: jest.fn(),
 
         store: {
             getPendingEvents: jest.fn().mockResolvedValue([]),


### PR DESCRIPTION
- Factor out `AccountPasswordStore`
- Use the cached password for a „reset all“ after login

relates to https://github.com/vector-im/element-web/issues/24516

PSB-168

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Do not prompt for a password when doing a „reset all“ after login ([\#10208](https://github.com/matrix-org/matrix-react-sdk/pull/10208)).<!-- CHANGELOG_PREVIEW_END -->