### PR TITLE
Manually finalize Percy builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,4 +23,4 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 [*.{yml,yaml}]
-indent_size = 2
+indent_size = 4

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -162,8 +162,9 @@ jobs:
                   PERCY_BRANCH: ${{ github.event.workflow_run.head_branch }}
                   PERCY_COMMIT: ${{ github.event.workflow_run.head_sha }}
                   PERCY_PULL_REQUEST: ${{ needs.prepare.outputs.pr_id }}
-                  PERCY_PARALLEL_TOTAL: ${{ strategy.job-total }}
                   PERCY_PARALLEL_NONCE: ${{ needs.prepare.outputs.uuid }}
+                  # We manually finalize the build in the report stage
+                  PERCY_PARALLEL_TOTAL: -1
 
             - name: Upload Artifact
               if: failure()
@@ -181,14 +182,23 @@ jobs:
               with:
                   name: cypress-junit
                   path: cypress/results
+
     report:
         name: Report results
-        needs: tests
+        needs:
+            - prepare
+            - tests
         runs-on: ubuntu-latest
         if: always()
         permissions:
             statuses: write
         steps:
+            - name: Finalize Percy
+              if: needs.prepare.outputs.percy_enable == '1'
+              run: npx -p @percy/cli percy build:finalize
+              env:
+                  PERCY_PARALLEL_NONCE: ${{ needs.prepare.outputs.uuid }}
+
             - uses: Sibz/github-status-action@v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
@@ -196,6 +206,7 @@ jobs:
                   context: ${{ github.workflow }} / cypress (${{ github.event.workflow_run.event }} => ${{ github.event_name }})
                   sha: ${{ github.event.workflow_run.head_sha }}
                   target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     testrail:
         name: Report results to testrail
         needs:


### PR DESCRIPTION
To prevent Percy from choking when one of our parallel runners doesn't have any percy work to upload

Fixes https://github.com/vector-im/element-web/issues/24613

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->