### PR TITLE
Fix calls showing as 'connecting' after hangup

### DIFF
--- a/src/components/structures/LegacyCallEventGrouper.ts
+++ b/src/components/structures/LegacyCallEventGrouper.ts
@@ -35,7 +35,7 @@ const CONNECTING_STATES = [
     CallState.CreateAnswer,
 ];
 
-const SUPPORTED_STATES = [CallState.Connected, CallState.Ringing];
+const SUPPORTED_STATES = [CallState.Connected, CallState.Ringing, CallState.Ended];
 
 export enum CustomCallState {
     Missed = "missed",


### PR DESCRIPTION
If you hang up a call, the timeline would default to showing 'connecting' as the call's status because it races with the hangup event being sent. Adding `CallState.Ended` to the states that can be directly rendered by `LegacyCallEvent` allows `LegacyCallEventGrouper` to recognize the local echo of the call's state in this case.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix calls showing as 'connecting' after hangup ([\#10223](https://github.com/matrix-org/matrix-react-sdk/pull/10223)).<!-- CHANGELOG_PREVIEW_END -->