### PR TITLE
Secondary

### DIFF
--- a/res/css/views/elements/_CopyableText.pcss
+++ b/res/css/views/elements/_CopyableText.pcss
@@ -23,11 +23,12 @@ limitations under the License.
     max-width: 100%;
 
     &.mx_CopyableText_border {
+        overflow: auto;
         border-radius: 5px;
         border: solid 1px $light-fg-color;
         margin-bottom: 10px;
         margin-top: 10px;
-        padding: 10px;
+        padding: 10px 0 10px 10px;
     }
 
     .mx_CopyableText_copyButton {
@@ -36,7 +37,8 @@ limitations under the License.
         width: 1em;
         height: 1em;
         cursor: pointer;
-        margin-left: 20px;
+        padding-left: 12px;
+        padding-right: 10px;
         display: block;
         /* If the copy button is used within a scrollable div, make it stick to the right while scrolling */
         position: sticky;

--- a/res/css/views/settings/tabs/user/_HelpUserSettingsTab.pcss
+++ b/res/css/views/settings/tabs/user/_HelpUserSettingsTab.pcss
@@ -28,9 +28,4 @@ limitations under the License.
             margin-bottom: $spacing-16;
         }
     }
-
-    /* prevent the access token from overflowing the text box */
-    div .mx_CopyableText {
-        overflow: scroll;
-    }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

On element-web, although [Pull Request](https://github.com/matrix-org/matrix-react-sdk/pull/10069#issue-1569642190) solves the overflowing issue for the specific access token section, it fails when screen size is around 12 inches. In order to make the solution less of a fix for this specific case, I modified the main CSS classes that these copy button and the text div were using. This resulted changes on multiple section of the app ( room sharing link, room message sharing link, access token , room information ) which works perfectly fine in all of those cases while solving the overlapping problem in the access token section. 

Before :
![overlapping copy button](https://user-images.githubusercontent.com/75557670/220824999-6a0bb091-5c1a-46e3-8209-0835a13325cd.png)

After : 

1. Room information (Room settings -> Advanced ) 
![room advance](https://user-images.githubusercontent.com/75557670/220825106-bf0de723-ebed-4f3e-adc1-bbba7c9008d5.png)

2. Share room message 
![Share room message)](https://user-images.githubusercontent.com/75557670/220825357-e8efe107-beaf-4205-bb70-5cc6463d73f7.png)

3. Share room
![share room](https://user-images.githubusercontent.com/75557670/220825496-6adbebe9-4d1a-49c2-ac4d-ec445d114037.png)

4. Access Token
![Access token](https://user-images.githubusercontent.com/75557670/220825553-743cb1b9-987b-4eb5-99f4-2bc54527c1a8.png)

Notes: Fix a bug that was generated while solving the issue (https://github.com/vector-im/element-web/issues/24023) .
<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Stop access token overlapping the text created by ([\#10069](https://github.com/matrix-org/matrix-react-sdk/pull/10069)). Fixes vector-im/element-web#24023 ultimately. Contributed by @Adesh--Pandey.<!-- CHANGELOG_PREVIEW_END -->
 * 
Signed-off-by: Adesh Pandey adeshpandey836@gmail.com