### PR TITLE
Fix double translation issue (#10240

### DIFF
--- a/cypress/e2e/crypto/decryption-failure.spec.ts
+++ b/cypress/e2e/crypto/decryption-failure.spec.ts
@@ -164,7 +164,7 @@ describe("Decryption Failure Bar", () => {
             cy.contains(".mx_DecryptionFailureBar_button", "Resend key requests").should("not.exist");
 
             cy.get(".mx_DecryptionFailureBar").percySnapshotElement(
-                "DecryptionFailureBar prompts user to open another device, " + "without Resend Key Requests button",
+                "DecryptionFailureBar prompts user to open another device, without Resend Key Requests button",
                 {
                     widths: [320, 640],
                 },

--- a/src/AddThreepid.ts
+++ b/src/AddThreepid.ts
@@ -213,8 +213,7 @@ export default class AddThreepid {
                             [SSOAuthEntry.PHASE_PREAUTH]: {
                                 title: _t("Use Single Sign On to continue"),
                                 body: _t(
-                                    "Confirm adding this email address by using " +
-                                        "Single Sign On to prove your identity.",
+                                    "Confirm adding this email address by using Single Sign On to prove your identity.",
                                 ),
                                 continueText: _t("Single Sign On"),
                                 continueKind: "primary",
@@ -333,7 +332,7 @@ export default class AddThreepid {
                         [SSOAuthEntry.PHASE_PREAUTH]: {
                             title: _t("Use Single Sign On to continue"),
                             body: _t(
-                                "Confirm adding this phone number by using " + "Single Sign On to prove your identity.",
+                                "Confirm adding this phone number by using Single Sign On to prove your identity.",
                             ),
                             continueText: _t("Single Sign On"),
                             continueKind: "primary",

--- a/src/LegacyCallHandler.tsx
+++ b/src/LegacyCallHandler.tsx
@@ -737,7 +737,7 @@ export default class LegacyCallHandler extends EventEmitter {
         );
         if (!stats) {
             logger.debug(
-                "Call statistics are undefined. The call has " + "probably failed before a peerConn was established",
+                "Call statistics are undefined. The call has probably failed before a peerConn was established",
             );
             return;
         }

--- a/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
+++ b/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
@@ -157,11 +157,9 @@ export default class ManageEventIndexDialog extends React.Component<IProps, ISta
 
         const eventIndexingSettings = (
             <div>
-                {_t(
-                    "%(brand)s is securely caching encrypted messages locally for them " +
-                        "to appear in search results:",
-                    { brand },
-                )}
+                {_t("%(brand)s is securely caching encrypted messages locally for them to appear in search results:", {
+                    brand,
+                })}
                 <div className="mx_SettingsTab_subsectionText">
                     {crawlerState}
                     <br />

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -1473,9 +1473,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
                         "do not have permission to view the message in question.",
                 );
             } else {
-                description = _t(
-                    "Tried to load a specific point in this room's timeline, but was " + "unable to find it.",
-                );
+                description = _t("Tried to load a specific point in this room's timeline, but was unable to find it.");
             }
 
             Modal.createDialog(ErrorDialog, {

--- a/src/components/structures/auth/Login.tsx
+++ b/src/components/structures/auth/Login.tsx
@@ -454,7 +454,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState> 
         }
 
         let errorText: ReactNode =
-            _t("There was a problem communicating with the homeserver, " + "please try again later.") +
+            _t("There was a problem communicating with the homeserver, please try again later.") +
             (errCode ? " (" + errCode + ")" : "");
 
         if (err instanceof ConnectionError) {

--- a/src/components/views/auth/CaptchaForm.tsx
+++ b/src/components/views/auth/CaptchaForm.tsx
@@ -91,7 +91,7 @@ export default class CaptchaForm extends React.Component<ICaptchaFormProps, ICap
         const publicKey = this.props.sitePublicKey;
         if (!publicKey) {
             logger.error("No public key for recaptcha!");
-            throw new Error("This server has not supplied enough information for Recaptcha " + "authentication");
+            throw new Error("This server has not supplied enough information for Recaptcha authentication");
         }
 
         logger.info("Rendering to %s", divId);

--- a/src/components/views/dialogs/StorageEvictedDialog.tsx
+++ b/src/components/views/dialogs/StorageEvictedDialog.tsx
@@ -70,7 +70,7 @@ export default class StorageEvictedDialog extends React.Component<IProps> {
                         )}
                     </p>
                     <p>
-                        {_t("Your browser likely removed this data when running low on " + "disk space.")} {logRequest}
+                        {_t("Your browser likely removed this data when running low on disk space.")} {logRequest}
                     </p>
                 </div>
                 <DialogButtons

--- a/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
+++ b/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
@@ -405,7 +405,7 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                 <div>
                     <p>
                         {_t(
-                            "<b>Warning</b>: you should only set up key backup " + "from a trusted computer.",
+                            "<b>Warning</b>: you should only set up key backup from a trusted computer.",
                             {},
                             { b: (sub) => <b>{sub}</b> },
                         )}
@@ -480,7 +480,7 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                 <div>
                     <p>
                         {_t(
-                            "<b>Warning</b>: you should only set up key backup " + "from a trusted computer.",
+                            "<b>Warning</b>: you should only set up key backup from a trusted computer.",
                             {},
                             { b: (sub) => <b>{sub}</b> },
                         )}

--- a/src/components/views/location/LocationPicker.tsx
+++ b/src/components/views/location/LocationPicker.tsx
@@ -93,7 +93,7 @@ class LocationPicker extends React.Component<ILocationPickerProps, IState> {
 
             this.map.on("error", (e) => {
                 logger.error(
-                    "Failed to load map: check map_style_url in config.json " + "has a valid URL and API key",
+                    "Failed to load map: check map_style_url in config.json has a valid URL and API key",
                     e.error,
                 );
                 this.setState({ error: LocationShareError.MapStyleUrlNotReachable });

--- a/src/components/views/rooms/NewRoomIntro.tsx
+++ b/src/components/views/rooms/NewRoomIntro.tsx
@@ -23,7 +23,7 @@ import { User } from "matrix-js-sdk/src/models/user";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import RoomContext from "../../../contexts/RoomContext";
 import DMRoomMap from "../../../utils/DMRoomMap";
-import { _t } from "../../../languageHandler";
+import { _t, _td } from "../../../languageHandler";
 import AccessibleButton, { ButtonEvent } from "../elements/AccessibleButton";
 import MiniAvatarUploader, { AVATAR_SIZE } from "../elements/MiniAvatarUploader";
 import RoomAvatar from "../avatars/RoomAvatar";
@@ -55,11 +55,11 @@ const NewRoomIntro: React.FC = () => {
 
     let body: JSX.Element;
     if (dmPartner) {
-        let introMessage = _t("This is the beginning of your direct message history with <displayName/>.");
+        let introMessage = _td("This is the beginning of your direct message history with <displayName/>.");
         let caption: string | undefined;
 
         if (isLocalRoom) {
-            introMessage = _t("Send your first message to invite <displayName/> to chat");
+            introMessage = _td("Send your first message to invite <displayName/> to chat");
         } else if (room.getJoinedMemberCount() + room.getInvitedMemberCount() === 2) {
             caption = _t("Only the two of you are in this conversation, unless either of you invites anyone to join.");
         }

--- a/src/components/views/rooms/RoomPreviewBar.tsx
+++ b/src/components/views/rooms/RoomPreviewBar.tsx
@@ -435,7 +435,7 @@ export default class RoomPreviewBar extends React.Component<IProps, IState> {
                 }
 
                 subTitle = _t(
-                    "Link this email with your account in Settings to receive invites " + "directly in %(brand)s.",
+                    "Link this email with your account in Settings to receive invites directly in %(brand)s.",
                     { brand },
                 );
                 primaryActionLabel = _t("Join the discussion");

--- a/src/components/views/settings/EventIndexPanel.tsx
+++ b/src/components/views/settings/EventIndexPanel.tsx
@@ -177,7 +177,7 @@ export default class EventIndexPanel extends React.Component<{}, IState> {
             eventIndexingSettings = (
                 <div>
                     <div className="mx_SettingsTab_subsectionText">
-                        {_t("Securely cache encrypted messages locally for them to " + "appear in search results.")}
+                        {_t("Securely cache encrypted messages locally for them to appear in search results.")}
                     </div>
                     <div>
                         <AccessibleButton kind="primary" disabled={this.state.enabling} onClick={this.onEnable}>

--- a/src/components/views/settings/SecureBackupPanel.tsx
+++ b/src/components/views/settings/SecureBackupPanel.tsx
@@ -183,7 +183,7 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
         Modal.createDialog(QuestionDialog, {
             title: _t("Delete Backup"),
             description: _t(
-                "Are you sure? You will lose your encrypted messages if your " + "keys are not backed up properly.",
+                "Are you sure? You will lose your encrypted messages if your keys are not backed up properly.",
             ),
             button: _t("Delete Backup"),
             danger: true,

--- a/src/components/views/settings/SetIdServer.tsx
+++ b/src/components/views/settings/SetIdServer.tsx
@@ -192,7 +192,7 @@ export default class SetIdServer extends React.Component<IProps, IState> {
                     const [confirmed] = await this.showServerChangeWarning({
                         title: _t("Change identity server"),
                         unboundMessage: _t(
-                            "Disconnect from the identity server <current /> and " + "connect to <new /> instead?",
+                            "Disconnect from the identity server <current /> and connect to <new /> instead?",
                             {},
                             {
                                 current: (sub) => <b>{abbreviateUrl(currentClientIdServer)}</b>,
@@ -330,7 +330,7 @@ export default class SetIdServer extends React.Component<IProps, IState> {
                 <div>
                     <p>
                         {_t(
-                            "You are still <b>sharing your personal data</b> on the identity " + "server <idserver />.",
+                            "You are still <b>sharing your personal data</b> on the identity server <idserver />.",
                             {},
                             messageElements,
                         )}

--- a/src/components/views/settings/account/EmailAddresses.tsx
+++ b/src/components/views/settings/account/EmailAddresses.tsx
@@ -223,7 +223,7 @@ export default class EmailAddresses extends React.Component<IProps, IState> {
                     Modal.createDialog(ErrorDialog, {
                         title: _t("Your email address hasn't been verified yet"),
                         description: _t(
-                            "Click the link in the email you received to verify " + "and then click continue again.",
+                            "Click the link in the email you received to verify and then click continue again.",
                         ),
                     });
                 } else {

--- a/src/components/views/settings/discovery/EmailAddresses.tsx
+++ b/src/components/views/settings/discovery/EmailAddresses.tsx
@@ -184,7 +184,7 @@ export class EmailAddress extends React.Component<IEmailAddressProps, IEmailAddr
                 Modal.createDialog(ErrorDialog, {
                     title: _t("Your email address hasn't been verified yet"),
                     description: _t(
-                        "Click the link in the email you received to verify " + "and then click continue again.",
+                        "Click the link in the email you received to verify and then click continue again.",
                     ),
                 });
             } else {

--- a/src/utils/leave-behaviour.ts
+++ b/src/utils/leave-behaviour.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { sleep } from "matrix-js-sdk/src/utils";
-import React from "react";
+import React, { ReactNode } from "react";
 import { EventStatus } from "matrix-js-sdk/src/models/event-status";
 import { MatrixEventEvent } from "matrix-js-sdk/src/models/event";
 import { Room } from "matrix-js-sdk/src/models/room";
@@ -110,7 +110,7 @@ export async function leaveRoomBehaviour(roomId: string, retry = true, spinner =
 
     const errors = Object.entries(results).filter((r) => !!r[1]);
     if (errors.length > 0) {
-        const messages = [];
+        const messages: ReactNode[] = [];
         for (const roomErr of errors) {
             const err = roomErr[1]; // [0] is the roomId
             let message = _t("Unexpected server error trying to leave the room");

--- a/src/utils/location/findMapStyleUrl.ts
+++ b/src/utils/location/findMapStyleUrl.ts
@@ -29,9 +29,7 @@ export function findMapStyleUrl(): string {
     const mapStyleUrl = getTileServerWellKnown()?.map_style_url ?? SdkConfig.get().map_style_url;
 
     if (!mapStyleUrl) {
-        logger.error(
-            "'map_style_url' missing from homeserver .well-known area, and " + "missing from from config.json.",
-        );
+        logger.error("'map_style_url' missing from homeserver .well-known area, and missing from from config.json.");
         throw new Error(LocationShareError.MapStyleUrlNotConfigured);
     }
 

--- a/src/utils/location/map.ts
+++ b/src/utils/location/map.ts
@@ -50,10 +50,7 @@ export const createMap = (interactive: boolean, bodyId: string, onError?: (error
         map.addControl(new maplibregl.AttributionControl(), "top-right");
 
         map.on("error", (e) => {
-            logger.error(
-                "Failed to load map: check map_style_url in config.json has a " + "valid URL and API key",
-                e.error,
-            );
+            logger.error("Failed to load map: check map_style_url in config.json has a valid URL and API key", e.error);
             onError?.(new Error(LocationShareError.MapStyleUrlNotReachable));
         });
 

--- a/test/components/views/elements/EventListSummary-test.tsx
+++ b/test/components/views/elements/EventListSummary-test.tsx
@@ -567,9 +567,7 @@ describe("EventListSummary", function () {
         const summary = wrapper.find(".mx_GenericEventListSummary_summary");
         const summaryText = summary.text();
 
-        expect(summaryText).toBe(
-            "user_1 and one other rejected their invitations and " + "had their invitations withdrawn",
-        );
+        expect(summaryText).toBe("user_1 and one other rejected their invitations and had their invitations withdrawn");
     });
 
     it("handles invitation plurals correctly when there are multiple invites", function () {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/element-web-rageshakes/issues/20269

I tried to protect against this in Typescript with 2 approaches

1. only allow string literals and `_td()` results to be passed to `_t`
2. only allow keys of the en_EN json file to be used as the key for translation

both of these failed due to Typescript treating a string literal concatenated with another string literal as the opaque type `string` preventing a `keyof` working with it and preventing you discerning it from a non-literal string.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix double translation issue ([\#10240](https://github.com/matrix-org/matrix-react-sdk/pull/10240)). Fixes matrix-org/element-web-rageshakes#20269.<!-- CHANGELOG_PREVIEW_END -->