### PR TITLE
New toast design

### DIFF
--- a/res/css/structures/_ToastContainer.pcss
+++ b/res/css/structures/_ToastContainer.pcss
@@ -16,10 +16,9 @@ limitations under the License.
 
 .mx_ToastContainer {
     position: absolute;
-    top: 0;
+    top: $spacing-4;
     left: 70px;
     z-index: 101;
-    padding: 4px;
     display: grid;
     grid-template-rows: 1fr 14px 6px;
 
@@ -45,7 +44,7 @@ limitations under the License.
         grid-template-columns: 22px 1fr;
         column-gap: 8px;
         row-gap: 4px;
-        padding: 8px;
+        padding: $spacing-16;
 
         &.mx_Toast_hasIcon {
             &::before,
@@ -60,6 +59,8 @@ limitations under the License.
                 mask-repeat: no-repeat;
                 background-size: 100%;
                 background-repeat: no-repeat;
+                position: relative;
+                top: 1px;
             }
 
             &.mx_Toast_icon_verification::after {
@@ -104,21 +105,17 @@ limitations under the License.
             }
         }
 
-        .mx_Toast_title,
-        .mx_Toast_description {
-            padding-right: 8px;
-        }
-
         .mx_Toast_title {
             display: flex;
             align-items: center;
             column-gap: 8px;
             width: 100%;
             box-sizing: border-box;
+            margin-bottom: $spacing-16;
 
             h2 {
                 margin: 0;
-                font-size: $font-15px;
+                font-size: $font-18px;
                 font-weight: 600;
                 display: inline;
                 width: auto;
@@ -140,7 +137,8 @@ limitations under the License.
         .mx_Toast_buttons {
             display: flex;
             justify-content: flex-end;
-            column-gap: 5px;
+            column-gap: $spacing-8;
+            margin-top: $spacing-32;
 
             .mx_AccessibleButton {
                 min-width: 96px;
@@ -152,8 +150,9 @@ limitations under the License.
             max-width: 272px;
             overflow: hidden;
             text-overflow: ellipsis;
-            margin: 4px 0 11px 0;
-            font-size: $font-12px;
+            margin: 0;
+            font-size: $font-15px;
+            font-weight: 600;
 
             a {
                 text-decoration: none;
@@ -162,6 +161,9 @@ limitations under the License.
 
         .mx_Toast_detail {
             color: $secondary-content;
+            font-size: $font-12px;
+            font-weight: 400;
+            max-width: 272px;
         }
 
         .mx_Toast_deviceID {

--- a/src/components/views/toasts/GenericToast.tsx
+++ b/src/components/views/toasts/GenericToast.tsx
@@ -44,10 +44,8 @@ const GenericToast: React.FC<XOR<IPropsExtended, IProps>> = ({
 
     return (
         <div>
-            <div className="mx_Toast_description">
-                {description}
-                {detailContent}
-            </div>
+            <div className="mx_Toast_description">{description}</div>
+            {detailContent}
             <div className="mx_Toast_buttons" aria-live="off">
                 {onReject && rejectLabel && (
                     <AccessibleButton kind="danger_outline" onClick={onReject}>

--- a/test/toasts/__snapshots__/UnverifiedSessionToast-test.tsx.snap
+++ b/test/toasts/__snapshots__/UnverifiedSessionToast-test.tsx.snap
@@ -26,22 +26,21 @@ exports[`UnverifiedSessionToast when rendering the toast should render as expect
           <div>
             <div
               class="mx_Toast_description"
+            />
+            <div
+              class="mx_Toast_detail"
             >
-              <div
-                class="mx_Toast_detail"
+              <span
+                data-testid="device-metadata-isVerified"
               >
-                <span
-                  data-testid="device-metadata-isVerified"
-                >
-                  Verified
-                </span>
-                 · 
-                <span
-                  data-testid="device-metadata-deviceId"
-                >
-                  ABC123
-                </span>
-              </div>
+                Verified
+              </span>
+               · 
+              <span
+                data-testid="device-metadata-deviceId"
+              >
+                ABC123
+              </span>
             </div>
             <div
               aria-live="off"


### PR DESCRIPTION
closes https://github.com/vector-im/element-web/issues/24490

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6216686/221863765-9bd61ed9-f855-4b7a-906d-4eb72c17a774.png) | ![image](https://user-images.githubusercontent.com/6216686/221863371-9bb29c94-67bb-4465-a215-0ea85dd28c1b.png) |

Designs: https://github.com/vector-im/element-web/issues/24490#issuecomment-1428182188

:information_source: in design the toast is more on the left side.
I did not do this, because many of our Cypress tests would explode, because they currently don't care about the toasts.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * New toast design ([\#10258](https://github.com/matrix-org/matrix-react-sdk/pull/10258)). Fixes vector-im/element-web#24490.<!-- CHANGELOG_PREVIEW_END -->