### PR TITLE
Add space between timestamp and the edge of event info tile on bubble layout

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -163,6 +163,24 @@ describe("Timeline", () => {
             cy.get(".mx_MainSplit").percySnapshotElement("Configured room on IRC layout");
         });
 
+        it("should create and configure a room on bubble layout", () => {
+            cy.visit("/#/room/" + roomId);
+            cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);
+            cy.contains(
+                ".mx_RoomView_body .mx_GenericEventListSummary[data-layout=bubble] " +
+                    ".mx_GenericEventListSummary_summary",
+                "created and configured the room.",
+            ).should("exist");
+
+            // Exclude timestamp and read marker from snapshot
+            const percyCSS = ".mx_MessageTimestamp, .mx_RoomView_myReadMarker { visibility: hidden !important; }";
+            cy.get(".mx_MainSplit").percySnapshotElement("Configured room on bubble layout", { percyCSS });
+
+            // Click "expand" link button
+            cy.get(".mx_GenericEventListSummary_toggle[aria-expanded=false]").click();
+        });
+
+
         it("should add inline start margin to an event line on IRC layout", () => {
             cy.visit("/#/room/" + roomId);
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.IRC);

--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -178,8 +178,14 @@ describe("Timeline", () => {
 
             // Click "expand" link button
             cy.get(".mx_GenericEventListSummary_toggle[aria-expanded=false]").click();
-        });
 
+            // Check the position of timestamp wrapper anchor of the info event line
+            cy.get(".mx_EventTile_info.mx_EventTile_last[data-layout=bubble] .mx_EventTile_line > a").should(
+                "have.css",
+                "inset-inline-start",
+                "-70px",
+            );
+        });
 
         it("should add inline start margin to an event line on IRC layout", () => {
             cy.visit("/#/room/" + roomId);

--- a/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/res/css/views/rooms/_EventBubbleTile.pcss
@@ -518,6 +518,19 @@ limitations under the License.
         }
     }
 
+    &.mx_EventTile_info {
+        .mx_EventTile_line {
+            /* timestamp wrapper anchor */
+            > a {
+                inset-inline-start: -70px; /* Add padding to the left side of timestamp wrapper anchor */
+            }
+
+            .mx_MessageActionBar + .mx_MessageTimestamp {
+                inset-inline-start: -77px; /* TODO: use a variable */
+            }
+        }
+    }
+
     .mx_MTextBody {
         max-width: 100%;
     }
@@ -570,19 +583,6 @@ limitations under the License.
         min-width: 100%;
         /* Preserve alignment with left edge of text in bubbles */
         margin: 0;
-    }
-}
-
-.mx_EventTile.mx_EventTile_info[data-layout="bubble"] {
-    .mx_EventTile_line {
-        /* timestamp wrapper anchor */
-        > a {
-            inset-inline-start: -70px; /* Add padding to the left side of timestamp wrapper anchor */
-        }
-
-        .mx_MessageActionBar + .mx_MessageTimestamp {
-            inset-inline-start: -77px; /* TODO: use a variable */
-        }
     }
 }
 

--- a/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/res/css/views/rooms/_EventBubbleTile.pcss
@@ -573,6 +573,30 @@ limitations under the License.
     }
 }
 
+.mx_EventTile.mx_EventTile_info[data-layout="bubble"] {
+    .mx_EventTile_line {
+        /* timestamp wrapper anchor */
+        > a {
+            inset-inline-start: -70px; /* Add padding to the left side of timestamp wrapper anchor */
+        }
+
+        .mx_MessageActionBar + .mx_MessageTimestamp {
+            inset-inline-start: -77px; /* TODO: use a variable */
+        }
+    }
+}
+
+.mx_EventTile.mx_EventTile_bubbleContainer[data-layout="bubble"],
+.mx_EventTile.mx_EventTile_leftAlignedBubble[data-layout="bubble"],
+.mx_GenericEventListSummary[data-layout="bubble"][data-expanded="false"] {
+    .mx_EventTile_line {
+        > a, /* timestamp wrapper anchor */
+        .mx_MessageActionBar + .mx_MessageTimestamp {
+            left: -77px;
+        }
+    }
+}
+
 .mx_EventTile.mx_EventTile_bubbleContainer[data-layout="bubble"],
 .mx_EventTile.mx_EventTile_leftAlignedBubble[data-layout="bubble"],
 .mx_EventTile.mx_EventTile_info[data-layout="bubble"],
@@ -595,7 +619,6 @@ limitations under the License.
         > a, /* timestamp wrapper anchor */
         .mx_MessageActionBar + .mx_MessageTimestamp {
             right: auto;
-            left: -77px;
             bottom: unset;
             align-self: center;
 


### PR DESCRIPTION
This PR adds space between the left edge of the hovered event info tile and the timestamp wrapper anchor on bubble layout. Since the change of this PR should be applied to event info tile only for now, I extracted the corresponding style rules to merge them with `mx_EventTile[data-layout="bubble"]`, instead of changing the value directly.

Fixes https://github.com/vector-im/element-web/issues/22922

|Before|After|
|---------|------|
|![Screenshot from 2023-03-03 01-33-51](https://user-images.githubusercontent.com/3362943/222492593-4d93b8f7-3020-464f-bbf5-b2bdc73236da.png)|![Screenshot from 2023-03-03 01-32-56](https://user-images.githubusercontent.com/3362943/222492576-9ec6d0ac-9800-4783-be23-310a1d71c5f8.png)|


type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add space between timestamp and the edge of event info tile on bubble layout ([\#10271](https://github.com/matrix-org/matrix-react-sdk/pull/10271)). Fixes vector-im/element-web#22922. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->