### PR TITLE
Fix flaky Percy test: hidden event line with zero padding on IRC layout

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -223,6 +223,9 @@ describe("Timeline", () => {
                 "0px",
             );
 
+            // Select the event line to highlight it
+            cy.get(".mx_EventTile[data-layout=irc].mx_EventTile_info .mx_MessageTimestamp").click();
+
             cy.get(".mx_MainSplit").percySnapshotElement("Hidden event line with zero padding on IRC layout", {
                 percyCSS,
             });


### PR DESCRIPTION
This PR intends to fix the [flaky Percy test](https://percy.io/dfde73bd/matrix-react-sdk/builds/25580736/changed/1426171459?browser=edge&browser_ids=18%2C33%2C34%2C35&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=original&width=1920&widths=1024%2C1920) `Hidden event line with zero padding on IRC layout` by having the event line selected before taking snapshots.

Fixes https://github.com/vector-im/element-web/issues/24718

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->