### PR TITLE
Pillify http and non-prefixed matrix.to links

### DIFF
--- a/src/utils/permalinks/MatrixToPermalinkConstructor.ts
+++ b/src/utils/permalinks/MatrixToPermalinkConstructor.ts
@@ -18,6 +18,7 @@ import PermalinkConstructor, { PermalinkParts } from "./PermalinkConstructor";
 
 export const host = "matrix.to";
 export const baseUrl = `https://${host}`;
+export const baseUrlPattern = `^(?:https?://)?${host.replace(".", "\\.")}/#/(.*)`;
 
 /**
  * Generates matrix.to permalinks
@@ -55,11 +56,17 @@ export default class MatrixToPermalinkConstructor extends PermalinkConstructor {
     // Heavily inspired by/borrowed from the matrix-bot-sdk (with permission):
     // https://github.com/turt2live/matrix-js-bot-sdk/blob/7c4665c9a25c2c8e0fe4e509f2616505b5b66a1c/src/Permalinks.ts#L33-L61
     public parsePermalink(fullUrl: string): PermalinkParts {
-        if (!fullUrl || !fullUrl.startsWith(baseUrl)) {
+        if (!fullUrl) {
             throw new Error("Does not appear to be a permalink");
         }
 
-        const parts = fullUrl.substring(`${baseUrl}/#/`.length).split("/");
+        const matches = [...fullUrl.matchAll(new RegExp(baseUrlPattern, "gi"))][0];
+
+        if (!matches || matches.length < 2) {
+            throw new Error("Does not appear to be a permalink");
+        }
+
+        const parts = matches[1].split("/");
 
         const entity = parts[0];
         if (entity[0] === "@") {

--- a/src/utils/permalinks/PermalinkConstructor.ts
+++ b/src/utils/permalinks/PermalinkConstructor.ts
@@ -48,10 +48,10 @@ export default class PermalinkConstructor {
 // https://github.com/turt2live/matrix-js-bot-sdk/blob/7c4665c9a25c2c8e0fe4e509f2616505b5b66a1c/src/Permalinks.ts#L1-L6
 export class PermalinkParts {
     public constructor(
-        public readonly roomIdOrAlias: string,
-        public readonly eventId: string,
-        public readonly userId: string,
-        public readonly viaServers: string[],
+        public readonly roomIdOrAlias: string | null,
+        public readonly eventId: string | null,
+        public readonly userId: string | null,
+        public readonly viaServers: string[] | null,
     ) {}
 
     public static forUser(userId: string): PermalinkParts {
@@ -66,11 +66,11 @@ export class PermalinkParts {
         return new PermalinkParts(roomId, eventId, null, viaServers);
     }
 
-    public get primaryEntityId(): string {
+    public get primaryEntityId(): string | null {
         return this.roomIdOrAlias || this.userId;
     }
 
     public get sigil(): string {
-        return this.primaryEntityId[0];
+        return this.primaryEntityId?.[0] || "?";
     }
 }

--- a/src/utils/permalinks/Permalinks.ts
+++ b/src/utils/permalinks/Permalinks.ts
@@ -22,7 +22,10 @@ import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
 import { EventType } from "matrix-js-sdk/src/@types/event";
 
 import { MatrixClientPeg } from "../../MatrixClientPeg";
-import MatrixToPermalinkConstructor, { baseUrl as matrixtoBaseUrl } from "./MatrixToPermalinkConstructor";
+import MatrixToPermalinkConstructor, {
+    baseUrl as matrixtoBaseUrl,
+    baseUrlPattern as matrixToBaseUrlPattern,
+} from "./MatrixToPermalinkConstructor";
 import PermalinkConstructor, { PermalinkParts } from "./PermalinkConstructor";
 import ElementPermalinkConstructor from "./ElementPermalinkConstructor";
 import SdkConfig from "../../SdkConfig";
@@ -420,8 +423,9 @@ function getPermalinkConstructor(): PermalinkConstructor {
 export function parsePermalink(fullUrl: string): PermalinkParts | null {
     try {
         const elementPrefix = SdkConfig.get("permalink_prefix");
-        if (decodeURIComponent(fullUrl).startsWith(matrixtoBaseUrl)) {
-            return new MatrixToPermalinkConstructor().parsePermalink(decodeURIComponent(fullUrl));
+        const decodedUrl = decodeURIComponent(fullUrl);
+        if (new RegExp(matrixToBaseUrlPattern, "i").test(decodedUrl)) {
+            return new MatrixToPermalinkConstructor().parsePermalink(decodedUrl);
         } else if (fullUrl.startsWith("matrix:")) {
             return new MatrixSchemePermalinkConstructor().parsePermalink(fullUrl);
         } else if (elementPrefix && fullUrl.startsWith(elementPrefix)) {

--- a/test/utils/permalinks/MatrixToPermalinkConstructor-test.ts
+++ b/test/utils/permalinks/MatrixToPermalinkConstructor-test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import MatrixToPermalinkConstructor from "../../../src/utils/permalinks/MatrixToPermalinkConstructor";
+import { PermalinkParts } from "../../../src/utils/permalinks/PermalinkConstructor";
+
+describe("MatrixToPermalinkConstructor", () => {
+    const peramlinkConstructor = new MatrixToPermalinkConstructor();
+
+    describe("parsePermalink", () => {
+        it.each([
+            ["empty URL", ""],
+            ["something that is not an URL", "hello"],
+            ["should raise an error for a non-matrix.to URL", "https://example.com/#/@user:example.com"],
+        ])("should raise an error for %s", (name: string, url: string) => {
+            expect(() => peramlinkConstructor.parsePermalink(url)).toThrow(
+                new Error("Does not appear to be a permalink"),
+            );
+        });
+
+        it.each([
+            ["(https)", "https://matrix.to/#/@user:example.com"],
+            ["(http)", "http://matrix.to/#/@user:example.com"],
+            ["without protocol", "matrix.to/#/@user:example.com"],
+        ])("should parse an MXID %s", (name: string, url: string) => {
+            expect(peramlinkConstructor.parsePermalink(url)).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
+    });
+});

--- a/test/utils/permalinks/Permalinks-test.ts
+++ b/test/utils/permalinks/Permalinks-test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import { Room, RoomMember, EventType, MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
+import { PermalinkParts } from "../../../src/utils/permalinks/PermalinkConstructor";
 import {
     makeRoomPermalink,
     makeUserPermalink,
@@ -367,24 +368,38 @@ describe("Permalinks", function () {
         expect(result).toBe("https://matrix.to/#/@someone:example.org");
     });
 
-    it("should correctly parse room permalinks with a via argument", () => {
-        const result = parsePermalink("https://matrix.to/#/!room_id:server?via=some.org");
-        expect(result?.roomIdOrAlias).toBe("!room_id:server");
-        expect(result?.viaServers).toEqual(["some.org"]);
-    });
+    describe("parsePermalink", () => {
+        it("should correctly parse room permalinks with a via argument", () => {
+            const result = parsePermalink("https://matrix.to/#/!room_id:server?via=some.org");
+            expect(result?.roomIdOrAlias).toBe("!room_id:server");
+            expect(result?.viaServers).toEqual(["some.org"]);
+        });
 
-    it("should correctly parse room permalink via arguments", () => {
-        const result = parsePermalink("https://matrix.to/#/!room_id:server?via=foo.bar&via=bar.foo");
-        expect(result?.roomIdOrAlias).toBe("!room_id:server");
-        expect(result?.viaServers).toEqual(["foo.bar", "bar.foo"]);
-    });
+        it("should correctly parse room permalink via arguments", () => {
+            const result = parsePermalink("https://matrix.to/#/!room_id:server?via=foo.bar&via=bar.foo");
+            expect(result?.roomIdOrAlias).toBe("!room_id:server");
+            expect(result?.viaServers).toEqual(["foo.bar", "bar.foo"]);
+        });
 
-    it("should correctly parse event permalink via arguments", () => {
-        const result = parsePermalink(
-            "https://matrix.to/#/!room_id:server/$event_id/some_thing_here/foobar" + "?via=m1.org&via=m2.org",
-        );
-        expect(result?.eventId).toBe("$event_id/some_thing_here/foobar");
-        expect(result?.roomIdOrAlias).toBe("!room_id:server");
-        expect(result?.viaServers).toEqual(["m1.org", "m2.org"]);
+        it("should correctly parse event permalink via arguments", () => {
+            const result = parsePermalink(
+                "https://matrix.to/#/!room_id:server/$event_id/some_thing_here/foobar" + "?via=m1.org&via=m2.org",
+            );
+            expect(result?.eventId).toBe("$event_id/some_thing_here/foobar");
+            expect(result?.roomIdOrAlias).toBe("!room_id:server");
+            expect(result?.viaServers).toEqual(["m1.org", "m2.org"]);
+        });
+
+        it("should correctly parse permalinks with http protocol", () => {
+            expect(parsePermalink("http://matrix.to/#/@user:example.com")).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
+
+        it("should correctly parse permalinks without protocol", () => {
+            expect(parsePermalink("matrix.to/#/@user:example.com")).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/vector-im/element-web/issues/20844

PSF-1926

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6216686/222463324-974a1c9b-65c2-403c-9003-dc6ace8cfd75.png) | ![image](https://user-images.githubusercontent.com/6216686/222463229-44d67f88-a870-4704-8b38-e8a667cb4234.png) |

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Pillify http and non-prefixed matrix.to links ([\#10277](https://github.com/matrix-org/matrix-react-sdk/pull/10277)). Fixes vector-im/element-web#20844.<!-- CHANGELOG_PREVIEW_END -->