### PR TITLE
Reduce height of toggle on expanded view source event

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -351,6 +351,9 @@ describe("Timeline", () => {
             // 1. clickability of top left of view source event toggle
             // 2. clickability of view source toggle on IRC layout
 
+            // Exclude timestamp from snapshot
+            const percyCSS = ".mx_MessageTimestamp { visibility: hidden !important; }";
+
             sendEvent(roomId);
             cy.visit("/#/room/" + roomId);
             cy.setSettingValue("showHiddenEventsInTimeline", null, SettingLevel.DEVICE, true);
@@ -376,25 +379,28 @@ describe("Timeline", () => {
                     cy.get(".mx_ViewSourceEvent_toggle").click("topLeft", { force: false });
                 });
 
-            // Make sure the expand toggle worked
-            cy.get(".mx_EventTile .mx_ViewSourceEvent_expanded").should("be.visible");
-
-            // Click again to collapse the source
-            cy.get(".mx_EventTile_last[data-layout=group] .mx_ViewSourceEvent")
-                .should("exist")
+            // Make sure the expand toggle works
+            cy.get(".mx_EventTile_last[data-layout=group] .mx_ViewSourceEvent_expanded")
+                .should("be.visible")
                 .realHover()
                 .within(() => {
-                    cy.get(".mx_ViewSourceEvent_toggle").click("topLeft", { force: false });
+                    cy.get(".mx_ViewSourceEvent_toggle")
+                        // Check size and position of toggle on expanded view source event
+                        // See: _ViewSourceEvent.pcss
+                        .should("have.css", "height", "12px") // --ViewSourceEvent_toggle-size
+                        .should("have.css", "align-self", "flex-end")
+
+                        // Click again to collapse the source
+                        .click("topLeft", { force: false });
                 });
-            cy.get(".mx_EventTile .mx_ViewSourceEvent_expanded").should("not.exist");
+
+            // Make sure the collapse toggle works
+            cy.get(".mx_EventTile_last[data-layout=group] .mx_ViewSourceEvent_expanded").should("not.exist");
 
             // 2. clickability of view source toggle on IRC layout
 
             // Enable IRC layout
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.IRC);
-
-            // Exclude timestamp from snapshot
-            const percyCSS = ".mx_MessageTimestamp { visibility: hidden !important; }";
 
             // Hover the view source toggle on IRC layout
             cy.get(".mx_GenericEventListSummary[data-layout=irc] .mx_EventTile .mx_ViewSourceEvent")

--- a/res/css/views/messages/_ViewSourceEvent.pcss
+++ b/res/css/views/messages/_ViewSourceEvent.pcss
@@ -29,32 +29,34 @@ limitations under the License.
 
     pre {
         line-height: 1.2;
-        margin: 3.5px 0;
+        margin: 3.5px 0; /* TODO: use a variable */
     }
 
     .mx_ViewSourceEvent_toggle {
+        --ViewSourceEvent_toggle-size: 12px;
+
         visibility: hidden;
         /* override styles from AccessibleButton */
         border-radius: 0;
         /* icon */
         mask-repeat: no-repeat;
         mask-position: 0 center;
-        mask-size: auto 12px;
-        width: 12px;
-        min-width: 12px;
+        mask-size: auto var(--ViewSourceEvent_toggle-size);
+        width: var(--ViewSourceEvent_toggle-size);
+        min-width: var(--ViewSourceEvent_toggle-size);
         background-color: $accent;
         mask-image: url("$(res)/img/element-icons/maximise-expand.svg");
+
+        .mx_EventTile:hover & {
+            visibility: visible;
+        }
     }
 
     &.mx_ViewSourceEvent_expanded .mx_ViewSourceEvent_toggle {
+        align-self: flex-end;
+        height: var(--ViewSourceEvent_toggle-size);
         mask-position: 0 bottom;
-        margin-bottom: 5px;
+        margin-bottom: 5px; /* TODO: use a variable */
         mask-image: url("$(res)/img/element-icons/minimise-collapse.svg");
-    }
-}
-
-.mx_EventTile:hover {
-    .mx_ViewSourceEvent_toggle {
-        visibility: visible;
     }
 }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22873

This PR fixes the issue related to the height of clickable toggle area on expanded view source event, adding a test to check it.

|Before|After|
|---------|------|
|![before](https://user-images.githubusercontent.com/3362943/179398583-6fe2e415-3549-4191-867b-32aa1fc8631d.png)|![after](https://user-images.githubusercontent.com/3362943/179398580-a65b4d09-10d7-4ca2-979f-5de281580b55.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Reduce height of toggle on expanded view source event ([\#10283](https://github.com/matrix-org/matrix-react-sdk/pull/10283)). Fixes vector-im/element-web#22873. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->