### PR TITLE
Add a test to check whether ReadReceiptGroup exists on ThreadView in the bubble layout

### DIFF
--- a/cypress/e2e/threads/threads.spec.ts
+++ b/cypress/e2e/threads/threads.spec.ts
@@ -18,6 +18,8 @@ limitations under the License.
 
 import { HomeserverInstance } from "../../plugins/utils/homeserver";
 import { MatrixClient } from "../../global";
+import { SettingLevel } from "../../../src/settings/SettingLevel";
+import { Layout } from "../../../src/settings/enums/Layout";
 
 describe("Threads", () => {
     let homeserver: HomeserverInstance;
@@ -54,6 +56,11 @@ describe("Threads", () => {
             cy.visit("/#/room/" + roomId);
         });
 
+        // Around 200 characters
+        const MessageLong =
+            "Hello there. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt " +
+            "ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi";
+
         // --MessageTimestamp-color = #acacac = rgb(172, 172, 172)
         // See: _MessageTimestamp.pcss
         const MessageTimestampColor = "rgb(172, 172, 172)";
@@ -76,7 +83,8 @@ describe("Threads", () => {
         // Bot starts thread
         cy.get<string>("@threadId").then((threadId) => {
             bot.sendMessage(roomId, threadId, {
-                body: "Hello there",
+                // Send a message long enough to be wrapped to check if avatars inside the ReadReceiptGroup are visible
+                body: MessageLong,
                 msgtype: "m.text",
             });
         });
@@ -86,11 +94,36 @@ describe("Threads", () => {
         cy.get(".mx_RoomView_body .mx_ThreadSummary .mx_ThreadSummary_content").should("contain", "Hello there");
         cy.get(".mx_RoomView_body .mx_ThreadSummary").click();
 
+        cy.get(".mx_ThreadView .mx_EventTile[data-layout='group'].mx_EventTile_last").within(() => {
+            // Wait until the messages are rendered
+            cy.get(".mx_EventTile_line .mx_MTextBody").should("have.text", MessageLong);
+
+            // Make sure the avatar inside ReadReceiptGroup is visible on the group layout
+            cy.get(".mx_ReadReceiptGroup .mx_BaseAvatar_image").should("be.visible");
+        });
+
+        // Enable the bubble layout
+        cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);
+
+        cy.get(".mx_ThreadView .mx_EventTile[data-layout='bubble'].mx_EventTile_last").within(() => {
+            // TODO: remove this after fixing the issue of ReadReceiptGroup being hidden on the bubble layout
+            // See: https://github.com/vector-im/element-web/issues/23569
+            cy.get(".mx_ReadReceiptGroup .mx_BaseAvatar_image").should("exist");
+
+            // Make sure the avatar inside ReadReceiptGroup is visible on bubble layout
+            // TODO: enable this after fixing the issue of ReadReceiptGroup being hidden on the bubble layout
+            // See: https://github.com/vector-im/element-web/issues/23569
+            // cy.get(".mx_ReadReceiptGroup .mx_BaseAvatar_image").should("be.visible");
+        });
+
+        // Re-enable the group layout
+        cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Group);
+
         // User responds in thread
         cy.get(".mx_ThreadView .mx_BasicMessageComposer_input").type("Test{enter}");
 
         // Check the colour of timestamp on EventTile in a thread (mx_ThreadView)
-        cy.get(".mx_ThreadView .mx_EventTile_last .mx_EventTile_line .mx_MessageTimestamp").should(
+        cy.get(".mx_ThreadView .mx_EventTile_last[data-layout='group'] .mx_EventTile_line .mx_MessageTimestamp").should(
             "have.css",
             "color",
             MessageTimestampColor,


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/23569 and https://github.com/vector-im/element-web/issues/23326
Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/9239#issue-1360269115:
> Once the read receipt code will land on synapse, I will write some e2ee tests on cypress to ensure that read receipts appear on threads, hence why there is not tests in this pull request

This PR adds a test which checks whether ReadReceiptGroup exists on `ThreadView` in the bubble layout.

After the issue that the read receipt group is hidden on ThreadView in the bubble layout (see: https://github.com/vector-im/element-web/issues/23569#issuecomment-1332157248) is fixed, it should be able to check whether the group is *visible*. Currently, checking it returns an error because the read receipt overflows the default visible area of `ThreadView` except on a large viewport.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->