### PR TITLE
Fix --name-width value on _IRCLayout.pcss

### DIFF
--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -17,7 +17,7 @@ limitations under the License.
 $irc-line-height: $font-18px;
 
 .mx_IRCLayout {
-    --name-width: 70px;
+    --name-width: 80px; // cf. ircDisplayNameWidth on Settings.tsx
     --icon-width: 14px;
     --right-padding: 5px;
 


### PR DESCRIPTION
This PR fixes the `--name-width` on _IRCLayout.pcss.

The name width `--name-width` was set to 70px on [this line](https://github.com/matrix-org/matrix-react-sdk/pull/4531/commits/5029c3f1434b33fe8b4aae825f5f3e03d4425dc0#diff-29c6a3cc88dee2f8be7fa065c46d7d64f66ba006cd8ba9f3f16f301f41d67444R23) of #4531, while at the same time the default value was set to *80px* on [this line](https://github.com/matrix-org/matrix-react-sdk/pull/4531/commits/5029c3f1434b33fe8b4aae825f5f3e03d4425dc0#diff-3f8872f1070a7169ba9e9ffbeab55fe752a26aaebf42e748f4a59db8eb101eadR539) of the same PR. The value is still available [here](https://github.com/matrix-org/matrix-react-sdk/blob/ad8d27d2b2bc534c0a5f9fd862d9975768ad40a4/src/settings/Settings.tsx#L958).

The reason is not clear (it might be related to the profile resizer), but since the latter value has been respected on the UI anyway, I think the former should be able to be changed to 80px.

![Screenshot from 2023-03-07 22-18-44](https://user-images.githubusercontent.com/3362943/223434468-e7057f90-b77e-4ba7-8272-f9d856780baa.png)

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

This is a partial retry of https://github.com/matrix-org/matrix-react-sdk/pull/9064, which initially tried to implement a test.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->