### PR TITLE
Await start DM from user profile (right panel)

### DIFF
--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -131,7 +131,7 @@ async function openDmForUser(matrixClient: MatrixClient, user: Member): Promise<
         display_name: user.rawDisplayName,
         avatar_url: avatarUrl,
     });
-    startDmOnFirstMessage(matrixClient, [startDmUser]);
+    await startDmOnFirstMessage(matrixClient, [startDmUser]);
 }
 
 type SetUpdating = (updating: boolean) => void;


### PR DESCRIPTION
## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: Show spinner when starting a DM from the user profile (right panel)

PSF-1935

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Show spinner when starting a DM from the user profile (right panel) ([\#10290](https://github.com/matrix-org/matrix-react-sdk/pull/10290)).<!-- CHANGELOG_PREVIEW_END -->