### PR TITLE
Fix space settings dialog having rogue title tooltip

### DIFF
--- a/src/components/views/dialogs/SpaceSettingsDialog.tsx
+++ b/src/components/views/dialogs/SpaceSettingsDialog.tsx
@@ -84,17 +84,13 @@ const SpaceSettingsDialog: React.FC<IProps> = ({ matrixClient: cli, space, onFin
 
     return (
         <BaseDialog
-            title={_t("Space settings")}
+            title={_t("Settings - %(spaceName)s", { spaceName: space.name || _t("Unnamed Space") })}
             className="mx_SpaceSettingsDialog"
             contentId="mx_SpaceSettingsDialog"
             onFinished={onFinished}
             fixedWidth={false}
         >
-            <div
-                className="mx_SpaceSettingsDialog_content"
-                id="mx_SpaceSettingsDialog"
-                title={_t("Settings - %(spaceName)s", { spaceName: space.name })}
-            >
+            <div className="mx_SpaceSettingsDialog_content" id="mx_SpaceSettingsDialog">
                 <TabbedView tabs={tabs} />
             </div>
         </BaseDialog>

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3012,7 +3012,6 @@
     "Proxy URL": "Proxy URL",
     "Sections to show": "Sections to show",
     "This groups your chats with members of this space. Turning this off will hide those chats from your view of %(spaceName)s.": "This groups your chats with members of this space. Turning this off will hide those chats from your view of %(spaceName)s.",
-    "Space settings": "Space settings",
     "Settings - %(spaceName)s": "Settings - %(spaceName)s",
     "To help us prevent this in future, please <a>send us logs</a>.": "To help us prevent this in future, please <a>send us logs</a>.",
     "Missing session data": "Missing session data",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24740
Caused by https://github.com/matrix-org/matrix-react-sdk/pull/6151
This PR matches original designs which my previous PR failed to match - https://www.figma.com/file/baCEQP0BvtuitBJUAtapoc/Spaces-Beta?node-id=4681%3A699

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix space settings dialog having rogue title tooltip ([\#10293](https://github.com/matrix-org/matrix-react-sdk/pull/10293)). Fixes vector-im/element-web#24740.<!-- CHANGELOG_PREVIEW_END -->