### PR TITLE
Support dynamic room predecessors in BreadcrumbsStore

### DIFF
--- a/src/stores/BreadcrumbsStore.ts
+++ b/src/stores/BreadcrumbsStore.ts
@@ -74,7 +74,8 @@ export class BreadcrumbsStore extends AsyncStoreWithClient<IState> {
      */
     public get meetsRoomRequirement(): boolean {
         if (SettingsStore.getValue("feature_breadcrumbs_v2")) return true;
-        return this.matrixClient?.getVisibleRooms().length >= 20;
+        const msc3946ProcessDynamicPredecessor = SettingsStore.getValue("feature_dynamic_room_predecessors");
+        return this.matrixClient?.getVisibleRooms(msc3946ProcessDynamicPredecessor).length >= 20;
     }
 
     protected async onAction(payload: SettingUpdatedPayload | ViewRoomPayload | JoinRoomPayload): Promise<void> {
@@ -145,10 +146,11 @@ export class BreadcrumbsStore extends AsyncStoreWithClient<IState> {
     private async appendRoom(room: Room): Promise<void> {
         let updated = false;
         const rooms = (this.state.rooms || []).slice(); // cheap clone
+        const msc3946ProcessDynamicPredecessor = SettingsStore.getValue("feature_dynamic_room_predecessors");
 
         // If the room is upgraded, use that room instead. We'll also splice out
         // any children of the room.
-        const history = this.matrixClient.getRoomUpgradeHistory(room.roomId);
+        const history = this.matrixClient.getRoomUpgradeHistory(room.roomId, false, msc3946ProcessDynamicPredecessor);
         if (history.length > 1) {
             room = history[history.length - 1]; // Last room is most recent in history
 

--- a/src/stores/BreadcrumbsStore.ts
+++ b/src/stores/BreadcrumbsStore.ts
@@ -65,6 +65,13 @@ export class BreadcrumbsStore extends AsyncStoreWithClient<IState> {
         return !!this.state.enabled && this.meetsRoomRequirement;
     }
 
+    /**
+     * Do we have enough rooms to justify showing the breadcrumbs?
+     * (Or is the labs feature enabled?)
+     *
+     * @returns true if there are at least 20 visible rooms or
+     *          feature_breadcrumbs_v2 is enabled.
+     */
     public get meetsRoomRequirement(): boolean {
         if (SettingsStore.getValue("feature_breadcrumbs_v2")) return true;
         return this.matrixClient?.getVisibleRooms().length >= 20;

--- a/test/stores/BreadcrumbsStore-test.ts
+++ b/test/stores/BreadcrumbsStore-test.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { mocked } from "jest-mock";
+import { MatrixClient, Room } from "matrix-js-sdk/src/matrix";
+
+import { createTestClient, setupAsyncStoreWithClient } from "../test-utils";
+import SettingsStore from "../../src/settings/SettingsStore";
+import { BreadcrumbsStore } from "../../src/stores/BreadcrumbsStore";
+
+describe("BreadcrumbsStore", () => {
+    let store: BreadcrumbsStore;
+    const client: MatrixClient = createTestClient();
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        store = BreadcrumbsStore.instance;
+        setupAsyncStoreWithClient(store, client);
+    });
+
+    describe("If the feature_breadcrumbs_v2 feature is not enabled", () => {
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+        });
+
+        it("does not meet room requirements if there are not enough rooms", () => {
+            // We don't have enough rooms, so we don't meet requirements
+            mocked(client.getVisibleRooms).mockReturnValue(fakeRooms(2));
+            expect(store.meetsRoomRequirement).toBe(false);
+        });
+
+        it("meets room requirements if there are enough rooms", () => {
+            // We do have enough rooms to show breadcrumbs
+            mocked(client.getVisibleRooms).mockReturnValue(fakeRooms(25));
+            expect(store.meetsRoomRequirement).toBe(true);
+        });
+    });
+
+    describe("If the feature_breadcrumbs_v2 feature is enabled", () => {
+        beforeEach(() => {
+            // Turn on feature_breadcrumbs_v2 setting
+            jest.spyOn(SettingsStore, "getValue").mockImplementation(
+                (settingName) => settingName === "feature_breadcrumbs_v2",
+            );
+        });
+
+        it("always meets room requirements", () => {
+            // With enough rooms, we meet requirements
+            mocked(client.getVisibleRooms).mockReturnValue(fakeRooms(25));
+            expect(store.meetsRoomRequirement).toBe(true);
+
+            // And even with not enough we do, because the feature is enabled.
+            mocked(client.getVisibleRooms).mockReturnValue(fakeRooms(2));
+            expect(store.meetsRoomRequirement).toBe(true);
+        });
+    });
+
+    /**
+     * Create as many fake rooms in an array as you ask for.
+     */
+    function fakeRooms(howMany: number): Array<Room> {
+        const ret = [];
+        for (let i = 0; i < howMany; i++) {
+            ret.push(fakeRoom());
+        }
+        return ret;
+    }
+
+    let roomIdx = 0;
+
+    function fakeRoom(): Room {
+        roomIdx++;
+        return new Room(`room${roomIdx}`, client, "@user:example.com");
+    }
+});


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24417.

Towards [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

I recommend reviewing each commit individually.

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support dynamic room predecessors in BreadcrumbsStore ([\#10295](https://github.com/matrix-org/matrix-react-sdk/pull/10295)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->