### PR TITLE
Extract avatars from permalink hook

### DIFF
--- a/src/components/views/elements/Pill.tsx
+++ b/src/components/views/elements/Pill.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState } from "react";
+import React, { ReactElement, useState } from "react";
 import classNames from "classnames";
 import { Room } from "matrix-js-sdk/src/models/room";
 
@@ -22,6 +22,8 @@ import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import Tooltip, { Alignment } from "../elements/Tooltip";
 import { usePermalink } from "../../../hooks/usePermalink";
+import RoomAvatar from "../avatars/RoomAvatar";
+import MemberAvatar from "../avatars/MemberAvatar";
 
 export enum PillType {
     UserMention = "TYPE_USER_MENTION",
@@ -52,7 +54,7 @@ export interface PillProps {
 
 export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room, shouldShowPillAvatar }) => {
     const [hover, setHover] = useState(false);
-    const { avatar, onClick, resourceId, text, type } = usePermalink({
+    const { member, onClick, resourceId, targetRoom, text, type } = usePermalink({
         room,
         type: propType,
         url,
@@ -79,6 +81,37 @@ export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room
     };
 
     const tip = hover && resourceId ? <Tooltip label={resourceId} alignment={Alignment.Right} /> : null;
+    let content: ReactElement | null = null;
+
+    switch (type) {
+        case PillType.AtRoomMention:
+        case PillType.RoomMention:
+            {
+                const avatar = <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" />;
+                content = (
+                    <>
+                        {shouldShowPillAvatar && avatar}
+                        <span className="mx_Pill_linkText">{text}</span>
+                    </>
+                );
+            }
+            break;
+        case PillType.UserMention:
+            {
+                const avatar = <MemberAvatar member={member} width={16} height={16} aria-hidden="true" hideTitle />;
+                content = (
+                    <>
+                        {shouldShowPillAvatar && avatar}
+                        <span className="mx_Pill_linkText">{text}</span>
+                    </>
+                );
+            }
+            break;
+    }
+
+    if (!content) {
+        return null;
+    }
 
     return (
         <bdi>
@@ -91,14 +124,12 @@ export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room
                         onMouseOver={onMouseOver}
                         onMouseLeave={onMouseLeave}
                     >
-                        {shouldShowPillAvatar && avatar}
-                        <span className="mx_Pill_linkText">{text}</span>
+                        {content}
                         {tip}
                     </a>
                 ) : (
                     <span className={classes} onMouseOver={onMouseOver} onMouseLeave={onMouseLeave}>
-                        {shouldShowPillAvatar && avatar}
-                        <span className="mx_Pill_linkText">{text}</span>
+                        {content}
                         {tip}
                     </span>
                 )}

--- a/src/components/views/elements/Pill.tsx
+++ b/src/components/views/elements/Pill.tsx
@@ -87,7 +87,9 @@ export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room
         case PillType.AtRoomMention:
         case PillType.RoomMention:
             {
-                const avatar = <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" />;
+                const avatar = targetRoom ? (
+                    <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" />
+                ) : null;
                 content = (
                     <>
                         {shouldShowPillAvatar && avatar}

--- a/src/components/views/elements/Pill.tsx
+++ b/src/components/views/elements/Pill.tsx
@@ -60,7 +60,7 @@ export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room
         url,
     });
 
-    if (!type) {
+    if (!type || !text) {
         return null;
     }
 
@@ -81,39 +81,27 @@ export const Pill: React.FC<PillProps> = ({ type: propType, url, inMessage, room
     };
 
     const tip = hover && resourceId ? <Tooltip label={resourceId} alignment={Alignment.Right} /> : null;
-    let content: ReactElement | null = null;
+    let avatar: ReactElement | null = null;
 
     switch (type) {
         case PillType.AtRoomMention:
         case PillType.RoomMention:
-            {
-                const avatar = targetRoom ? (
-                    <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" />
-                ) : null;
-                content = (
-                    <>
-                        {shouldShowPillAvatar && avatar}
-                        <span className="mx_Pill_linkText">{text}</span>
-                    </>
-                );
-            }
+        case "space":
+            avatar = targetRoom ? <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" /> : null;
             break;
         case PillType.UserMention:
-            {
-                const avatar = <MemberAvatar member={member} width={16} height={16} aria-hidden="true" hideTitle />;
-                content = (
-                    <>
-                        {shouldShowPillAvatar && avatar}
-                        <span className="mx_Pill_linkText">{text}</span>
-                    </>
-                );
-            }
+            avatar = <MemberAvatar member={member} width={16} height={16} aria-hidden="true" hideTitle />;
             break;
+        default:
+            return null;
     }
 
-    if (!content) {
-        return null;
-    }
+    const content = (
+        <>
+            {shouldShowPillAvatar && avatar}
+            <span className="mx_Pill_linkText">{text}</span>
+        </>
+    );
 
     return (
         <bdi>

--- a/src/hooks/usePermalink.ts
+++ b/src/hooks/usePermalink.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
-import React, { ReactElement, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { ButtonEvent } from "../components/views/elements/AccessibleButton";
 import { PillType } from "../components/views/elements/Pill";
@@ -24,8 +24,6 @@ import { MatrixClientPeg } from "../MatrixClientPeg";
 import { parsePermalink } from "../utils/permalinks/Permalinks";
 import dis from "../dispatcher/dispatcher";
 import { Action } from "../dispatcher/actions";
-import RoomAvatar from "../components/views/avatars/RoomAvatar";
-import MemberAvatar from "../components/views/avatars/MemberAvatar";
 
 interface Args {
     /** Room in which the permalink should be displayed. */
@@ -37,13 +35,15 @@ interface Args {
 }
 
 interface HookResult {
-    /** Avatar of the permalinked resource. */
-    avatar: ReactElement | null;
+    /** Room member of a user mention permalink */
+    member: RoomMember | null;
     /** Displayable text of the permalink resource. Can for instance be a user or room name. */
     text: string | null;
     onClick: ((e: ButtonEvent) => void) | null;
     /** This can be for instance a user or room Id. */
     resourceId: string | null;
+    /** Room of the target of this permalink (room or event room). */
+    targetRoom: Room | null;
     type: PillType | "space" | null;
 }
 
@@ -139,15 +139,12 @@ export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, 
     }, [doProfileLookup, type, resourceId, room]);
 
     let onClick: ((e: ButtonEvent) => void) | null = null;
-    let avatar: ReactElement | null = null;
     let text = resourceId;
 
     if (type === PillType.AtRoomMention && room) {
         text = "@room";
-        avatar = <RoomAvatar room={room} width={16} height={16} aria-hidden="true" />;
     } else if (type === PillType.UserMention && member) {
         text = member.name || resourceId;
-        avatar = <MemberAvatar member={member} width={16} height={16} aria-hidden="true" hideTitle />;
         onClick = (e: ButtonEvent): void => {
             e.preventDefault();
             dis.dispatch({
@@ -158,15 +155,15 @@ export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, 
     } else if (type === PillType.RoomMention) {
         if (targetRoom) {
             text = targetRoom.name || resourceId;
-            avatar = <RoomAvatar room={targetRoom} width={16} height={16} aria-hidden="true" />;
         }
     }
 
     return {
-        avatar,
-        text,
+        member,
         onClick,
         resourceId,
+        targetRoom,
+        text,
         type,
     };
 };

--- a/src/hooks/usePermalink.ts
+++ b/src/hooks/usePermalink.ts
@@ -43,7 +43,7 @@ interface HookResult {
     member: RoomMember | null;
     /**
      * Displayable text of the permalink resource. Can for instance be a user or room name.
-     * null here means that there is nothing to display. Most likely if the URL was no permalink.
+     * null here means that there is nothing to display. Most likely if the URL was not a permalink.
      */
     text: string | null;
     /**
@@ -53,19 +53,19 @@ interface HookResult {
     onClick: (e: ButtonEvent) => void;
     /**
      * This can be for instance a user or room Id.
-     * null here means that the resource cannot be detected. Most likely if the URL was no permalink.
+     * null here means that the resource cannot be detected. Most likely if the URL was not a permalink.
      */
     resourceId: string | null;
     /**
      * Target room of the permalink:
-     * For an @room, this is the room where the permalink should be displayed.
+     * For an @room mention, this is the room where the permalink should be displayed.
      * For a room permalink, it is the room from the permalink.
      * null for other links or if the room cannot be found.
      */
     targetRoom: Room | null;
     /**
      * Type of the pill plus "space" for spaces.
-     * null here means that the type cannot be detected. Most likely if the URL was no permalink.
+     * null here means that the type cannot be detected. Most likely if the URL was not a permalink.
      */
     type: PillType | "space" | null;
 }

--- a/src/hooks/usePermalink.ts
+++ b/src/hooks/usePermalink.ts
@@ -76,7 +76,7 @@ interface HookResult {
 export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, url }): HookResult => {
     const [member, setMember] = useState<RoomMember | null>(null);
     // room of the entity this pill points to
-    const [targetRoom, setTargetRoom] = useState<Room | null>(room || null);
+    const [targetRoom, setTargetRoom] = useState<Room | null>(room ?? null);
 
     let resourceId: string | null = null;
 

--- a/src/hooks/usePermalink.ts
+++ b/src/hooks/usePermalink.ts
@@ -35,15 +35,38 @@ interface Args {
 }
 
 interface HookResult {
-    /** Room member of a user mention permalink */
+    /**
+     * Room member of a user mention permalink.
+     * null for other links, if the profile was not found or not yet loaded.
+     * This can change, for instance, from null to a RoomMember after the profile lookup completed.
+     */
     member: RoomMember | null;
-    /** Displayable text of the permalink resource. Can for instance be a user or room name. */
+    /**
+     * Displayable text of the permalink resource. Can for instance be a user or room name.
+     * null here means that there is nothing to display. Most likely if the URL was no permalink.
+     */
     text: string | null;
+    /**
+     * Should be used for click actions on the permalink.
+     * In case of a user permalink, a view profile action is dispatched.
+     */
     onClick: (e: ButtonEvent) => void;
-    /** This can be for instance a user or room Id. */
+    /**
+     * This can be for instance a user or room Id.
+     * null here means that the resource cannot be detected. Most likely if the URL was no permalink.
+     */
     resourceId: string | null;
-    /** Room of the target of this permalink (room or event room). */
+    /**
+     * Target room of the permalink:
+     * For an @room, this is the room where the permalink should be displayed.
+     * For a room permalink, it is the room from the permalink.
+     * null for other links or if the room cannot be found.
+     */
     targetRoom: Room | null;
+    /**
+     * Type of the pill plus "space" for spaces.
+     * null here means that the type cannot be detected. Most likely if the URL was no permalink.
+     */
     type: PillType | "space" | null;
 }
 

--- a/src/hooks/usePermalink.ts
+++ b/src/hooks/usePermalink.ts
@@ -39,7 +39,7 @@ interface HookResult {
     member: RoomMember | null;
     /** Displayable text of the permalink resource. Can for instance be a user or room name. */
     text: string | null;
-    onClick: ((e: ButtonEvent) => void) | null;
+    onClick: (e: ButtonEvent) => void;
     /** This can be for instance a user or room Id. */
     resourceId: string | null;
     /** Room of the target of this permalink (room or event room). */
@@ -53,7 +53,7 @@ interface HookResult {
 export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, url }): HookResult => {
     const [member, setMember] = useState<RoomMember | null>(null);
     // room of the entity this pill points to
-    const [targetRoom, setTargetRoom] = useState<Room | undefined | null>(room);
+    const [targetRoom, setTargetRoom] = useState<Room | null>(room || null);
 
     let resourceId: string | null = null;
 
@@ -101,9 +101,6 @@ export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, 
 
     useMemo(() => {
         switch (type) {
-            case PillType.AtRoomMention:
-                setTargetRoom(room);
-                break;
             case PillType.UserMention:
                 {
                     if (resourceId) {
@@ -131,14 +128,14 @@ export const usePermalink: (args: Args) => HookResult = ({ room, type: argType, 
                                           );
                                       })
                                 : MatrixClientPeg.get().getRoom(resourceId);
-                        setTargetRoom(newRoom);
+                        setTargetRoom(newRoom || null);
                     }
                 }
                 break;
         }
     }, [doProfileLookup, type, resourceId, room]);
 
-    let onClick: ((e: ButtonEvent) => void) | null = null;
+    let onClick: (e: ButtonEvent) => void = () => {};
     let text = resourceId;
 
     if (type === PillType.AtRoomMention && room) {

--- a/test/components/views/elements/Pill-test.tsx
+++ b/test/components/views/elements/Pill-test.tsx
@@ -38,6 +38,8 @@ describe("<Pill>", () => {
     const room1Alias = "#room1:example.com";
     const room1Id = "!room1:example.com";
     let room1: Room;
+    const space1Id = "!space1:example.com";
+    let space1: Room;
     const user1Id = "@user1:example.com";
     const user2Id = "@user2:example.com";
     let renderResult: RenderResult;
@@ -70,9 +72,13 @@ describe("<Pill>", () => {
         ]);
         room1.getMember(user1Id)!.setMembershipEvent(user1JoinRoom1Event);
 
-        client.getRooms.mockReturnValue([room1]);
+        space1 = new Room(space1Id, client, client.getSafeUserId());
+        space1.name = "Space 1";
+
+        client.getRooms.mockReturnValue([room1, space1]);
         client.getRoom.mockImplementation((roomId: string) => {
             if (roomId === room1.roomId) return room1;
+            if (roomId === space1.roomId) return space1;
             return null;
         });
 
@@ -114,6 +120,20 @@ describe("<Pill>", () => {
                 });
             });
         });
+    });
+
+    it("should not render a non-permalinkk", () => {
+        renderPill({
+            url: "https://example.com/hello",
+        });
+        expect(renderResult.asFragment()).toMatchSnapshot();
+    });
+
+    it("should render the expected pill for a space", () => {
+        renderPill({
+            url: permalinkPrefix + space1Id,
+        });
+        expect(renderResult.asFragment()).toMatchSnapshot();
     });
 
     it("should render the expected pill for a room alias", () => {

--- a/test/components/views/elements/Pill-test.tsx
+++ b/test/components/views/elements/Pill-test.tsx
@@ -122,7 +122,7 @@ describe("<Pill>", () => {
         });
     });
 
-    it("should not render a non-permalinkk", () => {
+    it("should not render a non-permalink", () => {
         renderPill({
             url: "https://example.com/hello",
         });

--- a/test/components/views/elements/__snapshots__/Pill-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/Pill-test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Pill> should not render a non-permalinkk 1`] = `<DocumentFragment />`;
+exports[`<Pill> should not render a non-permalink 1`] = `<DocumentFragment />`;
 
 exports[`<Pill> should not render an avatar or link when called with inMessage = false and shouldShowPillAvatar = false 1`] = `
 <DocumentFragment>

--- a/test/components/views/elements/__snapshots__/Pill-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/Pill-test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Pill> should not render a non-permalinkk 1`] = `<DocumentFragment />`;
+
 exports[`<Pill> should not render an avatar or link when called with inMessage = false and shouldShowPillAvatar = false 1`] = `
 <DocumentFragment>
   <bdi>
@@ -85,6 +87,44 @@ exports[`<Pill> should render the expected pill for a room alias 1`] = `
         class="mx_Pill_linkText"
       >
         Room 1
+      </span>
+    </a>
+  </bdi>
+</DocumentFragment>
+`;
+
+exports[`<Pill> should render the expected pill for a space 1`] = `
+<DocumentFragment>
+  <bdi>
+    <a
+      class="mx_Pill mx_RoomPill"
+      href="https://matrix.to/#/!space1:example.com"
+    >
+      <span
+        aria-hidden="true"
+        class="mx_BaseAvatar"
+        role="presentation"
+      >
+        <span
+          aria-hidden="true"
+          class="mx_BaseAvatar_initial"
+          style="font-size: 10.4px; width: 16px; line-height: 16px;"
+        >
+          S
+        </span>
+        <img
+          alt=""
+          aria-hidden="true"
+          class="mx_BaseAvatar_image"
+          data-testid="avatar-img"
+          src="data:image/png;base64,00"
+          style="width: 16px; height: 16px;"
+        />
+      </span>
+      <span
+        class="mx_Pill_linkText"
+      >
+        Space 1
       </span>
     </a>
   </bdi>


### PR DESCRIPTION
Avatars and the content are part of the view and should go to the `Pill` component.
As preparation for further work.

Should not change anything visible:

Pills before

![image](https://user-images.githubusercontent.com/6216686/223757239-ddc134c8-da7a-435b-a034-51694561dabe.png)

Pills after

![image](https://user-images.githubusercontent.com/6216686/223755428-14f21b4e-1def-416c-9e9f-08bb3f032168.png)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->