### PR TITLE
Support dynamic room predecessors in OwnBeaconStore

### DIFF
--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -123,7 +123,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
     /**
      * Ref returned from watchSetting for the MSC3946 labs flag
      */
-    private dynamicWatcherRef: string;
+    private dynamicWatcherRef: string | undefined;
 
     public constructor() {
         super(defaultDispatcher);
@@ -147,7 +147,7 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         this.matrixClient.removeListener(BeaconEvent.Update, this.onUpdateBeacon);
         this.matrixClient.removeListener(BeaconEvent.Destroy, this.onDestroyBeacon);
         this.matrixClient.removeListener(RoomStateEvent.Members, this.onRoomStateMembers);
-        SettingsStore.unwatchSetting(this.dynamicWatcherRef);
+        SettingsStore.unwatchSetting(this.dynamicWatcherRef ?? "");
 
         this.clearBeacons();
     }

--- a/src/stores/OwnBeaconStore.ts
+++ b/src/stores/OwnBeaconStore.ts
@@ -43,6 +43,7 @@ import {
 } from "../utils/beacon";
 import { getCurrentPosition } from "../utils/beacon";
 import { doMaybeLocalRoomAction } from "../utils/local-room";
+import SettingsStore from "../settings/SettingsStore";
 
 const isOwnBeacon = (beacon: Beacon, userId: string): boolean => beacon.beaconInfoOwner === userId;
 
@@ -119,6 +120,10 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
      * when the target is stationary
      */
     private lastPublishedPositionTimestamp?: number;
+    /**
+     * Ref returned from watchSetting for the MSC3946 labs flag
+     */
+    private dynamicWatcherRef: string;
 
     public constructor() {
         super(defaultDispatcher);
@@ -142,7 +147,12 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         this.matrixClient.removeListener(BeaconEvent.Update, this.onUpdateBeacon);
         this.matrixClient.removeListener(BeaconEvent.Destroy, this.onDestroyBeacon);
         this.matrixClient.removeListener(RoomStateEvent.Members, this.onRoomStateMembers);
+        SettingsStore.unwatchSetting(this.dynamicWatcherRef);
 
+        this.clearBeacons();
+    }
+
+    private clearBeacons(): void {
         this.beacons.forEach((beacon) => beacon.destroy());
 
         this.stopPollingLocation();
@@ -159,6 +169,11 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         this.matrixClient.on(BeaconEvent.Update, this.onUpdateBeacon);
         this.matrixClient.on(BeaconEvent.Destroy, this.onDestroyBeacon);
         this.matrixClient.on(RoomStateEvent.Members, this.onRoomStateMembers);
+        this.dynamicWatcherRef = SettingsStore.watchSetting(
+            "feature_dynamic_room_predecessors",
+            null,
+            this.reinitialiseBeaconState,
+        );
 
         this.initialiseBeaconState();
     }
@@ -308,9 +323,19 @@ export class OwnBeaconStore extends AsyncStoreWithClient<OwnBeaconStoreState> {
         );
     }
 
+    /**
+     * @internal public for test only
+     */
+    public reinitialiseBeaconState = (): void => {
+        this.clearBeacons();
+        this.initialiseBeaconState();
+    };
+
     private initialiseBeaconState = (): void => {
         const userId = this.matrixClient.getUserId()!;
-        const visibleRooms = this.matrixClient.getVisibleRooms();
+        const visibleRooms = this.matrixClient.getVisibleRooms(
+            SettingsStore.getValue("feature_dynamic_room_predecessors"),
+        );
 
         visibleRooms.forEach((room) => {
             const roomState = room.currentState;

--- a/test/components/views/beacon/RoomLiveShareWarning-test.tsx
+++ b/test/components/views/beacon/RoomLiveShareWarning-test.tsx
@@ -44,6 +44,7 @@ describe("<RoomLiveShareWarning />", () => {
         getUserId: jest.fn().mockReturnValue(aliceId),
         unstable_setLiveBeacon: jest.fn().mockResolvedValue({ event_id: "1" }),
         sendEvent: jest.fn(),
+        isGuest: jest.fn().mockReturnValue(false),
     });
 
     // 14.03.2022 16:15


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24417.

Towards [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support dynamic room predecessors in OwnBeaconStore ([\#10339](https://github.com/matrix-org/matrix-react-sdk/pull/10339)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->