### PR TITLE
Support dynamic room predecessors in SpaceHierarchy

### DIFF
--- a/src/components/structures/SpaceHierarchy.tsx
+++ b/src/components/structures/SpaceHierarchy.tsx
@@ -67,6 +67,7 @@ import { Alignment } from "../views/elements/Tooltip";
 import { getTopic } from "../../hooks/room/useTopic";
 import { SdkContextClass } from "../../contexts/SDKContext";
 import { getDisplayAliasForAliasSet } from "../../Rooms";
+import SettingsStore from "../../settings/SettingsStore";
 
 interface IProps {
     space: Room;
@@ -425,7 +426,11 @@ interface IHierarchyLevelProps {
 }
 
 export const toLocalRoom = (cli: MatrixClient, room: IHierarchyRoom, hierarchy: RoomHierarchy): IHierarchyRoom => {
-    const history = cli.getRoomUpgradeHistory(room.room_id, true);
+    const history = cli.getRoomUpgradeHistory(
+        room.room_id,
+        true,
+        SettingsStore.getValue("feature_dynamic_room_predecessors"),
+    );
 
     // Pick latest room that is actually part of the hierarchy
     let cliRoom = null;


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24417.

Towards [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support dynamic room predecessors in SpaceHierarchy ([\#10341](https://github.com/matrix-org/matrix-react-sdk/pull/10341)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->