### PR TITLE
Support dynamic room predecessors in AddExistingToSpaceDialog

### DIFF
--- a/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
+++ b/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
@@ -39,6 +39,7 @@ import ProgressBar from "../elements/ProgressBar";
 import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar";
 import QueryMatcher from "../../../autocomplete/QueryMatcher";
 import LazyRenderList from "../elements/LazyRenderList";
+import { useSettingValue } from "../../../hooks/useSettings";
 
 // These values match CSS
 const ROW_HEIGHT = 32 + 12;
@@ -135,7 +136,11 @@ export const AddExistingToSpace: React.FC<IAddExistingToSpaceProps> = ({
     onFinished,
 }) => {
     const cli = useContext(MatrixClientContext);
-    const visibleRooms = useMemo(() => cli.getVisibleRooms().filter((r) => r.getMyMembership() === "join"), [cli]);
+    const msc3946ProcessDynamicPredecessor = useSettingValue<boolean>("feature_dynamic_room_predecessors");
+    const visibleRooms = useMemo(
+        () => cli.getVisibleRooms(msc3946ProcessDynamicPredecessor).filter((r) => r.getMyMembership() === "join"),
+        [cli, msc3946ProcessDynamicPredecessor],
+    );
 
     const scrollRef = useRef<AutoHideScrollbar<"div">>();
     const [scrollState, setScrollState] = useState<IScrollState>({

--- a/test/components/views/spaces/AddExistingToSpaceDialog-test.tsx
+++ b/test/components/views/spaces/AddExistingToSpaceDialog-test.tsx
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { render } from "@testing-library/react";
+import { mocked } from "jest-mock";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
+import React from "react";
+
+import AddExistingToSpaceDialog from "../../../../src/components/views/dialogs/AddExistingToSpaceDialog";
+import SettingsStore from "../../../../src/settings/SettingsStore";
+import DMRoomMap from "../../../../src/utils/DMRoomMap";
+import { mkSpace, stubClient } from "../../../test-utils";
+
+describe("<AddExistingToSpaceDialog />", () => {
+    it("looks as expected", () => {
+        const client = stubClient();
+        const dialog = renderAddExistingToSpaceDialog(client);
+        expect(dialog.asFragment()).toMatchSnapshot();
+    });
+
+    describe("If the feature_dynamic_room_predecessors is not enabled", () => {
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+        });
+
+        it("Passes through the dynamic predecessor setting", async () => {
+            const client = stubClient();
+            mocked(client.getVisibleRooms).mockClear();
+            renderAddExistingToSpaceDialog(client);
+            expect(client.getVisibleRooms).toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("If the feature_dynamic_room_predecessors is enabled", () => {
+        beforeEach(() => {
+            // Turn on feature_dynamic_room_predecessors setting
+            jest.spyOn(SettingsStore, "getValue").mockImplementation(
+                (settingName) => settingName === "feature_dynamic_room_predecessors",
+            );
+        });
+
+        it("Passes through the dynamic predecessor setting", async () => {
+            const client = stubClient();
+            mocked(client.getVisibleRooms).mockClear();
+            renderAddExistingToSpaceDialog(client);
+            expect(client.getVisibleRooms).toHaveBeenCalledWith(true);
+        });
+    });
+});
+
+function renderAddExistingToSpaceDialog(client: MatrixClient) {
+    const dmRoomMap = new DMRoomMap(client);
+    jest.spyOn(DMRoomMap, "shared").mockReturnValue(dmRoomMap);
+    const space = mkSpace(client, "!spaceid:example.com");
+    const dialog = render(
+        <AddExistingToSpaceDialog
+            space={space}
+            onCreateRoomClick={jest.fn()}
+            onAddSubspaceClick={jest.fn()}
+            onFinished={jest.fn()}
+        />,
+    );
+    return dialog;
+}

--- a/test/components/views/spaces/__snapshots__/AddExistingToSpaceDialog-test.tsx.snap
+++ b/test/components/views/spaces/__snapshots__/AddExistingToSpaceDialog-test.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AddExistingToSpaceDialog /> looks as expected 1`] = `
+<DocumentFragment>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-describedby="mx_AddExistingToSpace"
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_AddExistingToSpaceDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header mx_Dialog_headerWithCancel"
+    >
+      <h2
+        class="mx_Heading_h2 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        <div
+          class="mx_SubspaceSelector"
+        >
+          <img
+            alt=""
+            class="mx_BaseAvatar mx_BaseAvatar_image mx_RoomAvatar_isSpaceRoom"
+            data-testid="avatar-img"
+            src="http://this.is.a.url/avatar.url/room.png"
+            style="width: 40px; height: 40px;"
+          />
+          <div>
+            <h1>
+              Add existing rooms
+            </h1>
+            <div
+              class="mx_SubspaceSelector_onlySpace"
+            >
+              !spaceid:example.com
+            </div>
+          </div>
+        </div>
+      </h2>
+      <div
+        aria-label="Close dialog"
+        class="mx_AccessibleButton mx_Dialog_cancelButton"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <div
+      class="mx_AddExistingToSpace"
+    >
+      <div
+        class="mx_SearchBox mx_textinput"
+      >
+        <input
+          autocomplete="off"
+          class="mx_textinput_icon mx_textinput_search mx_textinput_icon mx_textinput_search"
+          data-testid="searchbox-input"
+          placeholder="Search for rooms"
+          type="text"
+          value=""
+        />
+        <div
+          class="mx_AccessibleButton mx_SearchBox_closeButton"
+          role="button"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="mx_AutoHideScrollbar mx_AddExistingToSpace_content"
+        tabindex="-1"
+      >
+        <span
+          class="mx_AddExistingToSpace_noResults"
+        >
+          No results
+        </span>
+      </div>
+      <div
+        class="mx_AddExistingToSpace_footer"
+      >
+        <span>
+          <div>
+            Want to add a new room instead?
+          </div>
+          <div
+            class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_link"
+            role="button"
+            tabindex="0"
+          >
+            Create a new room
+          </div>
+        </span>
+        <div
+          aria-disabled="true"
+          class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary mx_AccessibleButton_disabled"
+          disabled=""
+          role="button"
+          tabindex="0"
+        >
+          Add
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24417.

Towards [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support dynamic room predecessors in AddExistingToSpaceDialog ([\#10342](https://github.com/matrix-org/matrix-react-sdk/pull/10342)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->