### PR TITLE
Fix long display name overflowing reply tile on IRC layout

### DIFF
--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -185,6 +185,7 @@ $irc-line-height: $font-18px;
     .mx_ReplyChain {
         .mx_DisambiguatedProfile {
             order: unset;
+            flex-shrink: unset; /* Unset flex-shrink to prevent long display name blowout */
             width: unset;
             background: transparent;
         }

--- a/res/css/views/rooms/_IRCLayout.pcss
+++ b/res/css/views/rooms/_IRCLayout.pcss
@@ -184,10 +184,10 @@ $irc-line-height: $font-18px;
 
     .mx_ReplyChain {
         .mx_DisambiguatedProfile {
-            order: unset;
-            flex-shrink: unset; /* Unset flex-shrink to prevent long display name blowout */
             width: unset;
             background: transparent;
+            order: unset;
+            flex-shrink: unset; /* Unset flex-shrink to prevent long display name blowout */
         }
 
         .mx_EventTile_emote {


### PR DESCRIPTION
This PR fixes the issue that a long display name overflows `ReplyTile` on IRC layout.

It also adds a stress test to check that long strings do not overflow and are displayed with ellipsis where needed on each layout.

Fixes https://github.com/vector-im/element-web/issues/24738

|Before|After|
|---------|------|
|![Screenshot from 2023-03-05 04-26-39](https://user-images.githubusercontent.com/3362943/222925134-d945f3df-daf2-4499-a53c-f5273bcae331.png)|![Screenshot from 2023-03-05 04-26-50](https://user-images.githubusercontent.com/3362943/222925141-0bcab8e5-a309-47bf-befd-d786c0cabdb9.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

Retry of https://github.com/matrix-org/matrix-react-sdk/pull/10273 (the branch was mistakenly removed)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix long display name overflowing reply tile on IRC layout ([\#10343](https://github.com/matrix-org/matrix-react-sdk/pull/10343)). Fixes vector-im/element-web#24738. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->