### PR TITLE
Support dynamic room predecessors for RoomProvider

### DIFF
--- a/src/autocomplete/RoomProvider.tsx
+++ b/src/autocomplete/RoomProvider.tsx
@@ -1,7 +1,7 @@
 /*
 Copyright 2016 Aviral Dasgupta
 Copyright 2018 Michael Telatynski <7t3chguy@gmail.com>
-Copyright 2017, 2018, 2021 The Matrix.org Foundation C.I.C.
+Copyright 2017-2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import { makeRoomPermalink } from "../utils/permalinks/Permalinks";
 import { ICompletion, ISelectionRange } from "./Autocompleter";
 import RoomAvatar from "../components/views/avatars/RoomAvatar";
 import { TimelineRenderingType } from "../contexts/RoomContext";
+import SettingsStore from "../settings/SettingsStore";
 
 const ROOM_REGEX = /\B#\S*/g;
 
@@ -67,7 +68,9 @@ export default class RoomProvider extends AutocompleteProvider {
         const cli = MatrixClientPeg.get();
 
         // filter out spaces here as they get their own autocomplete provider
-        return cli.getVisibleRooms().filter((r) => !r.isSpaceRoom());
+        return cli
+            .getVisibleRooms(SettingsStore.getValue("feature_dynamic_room_predecessors"))
+            .filter((r) => !r.isSpaceRoom());
     }
 
     public async getCompletions(

--- a/test/autocomplete/RoomProvider-test.ts
+++ b/test/autocomplete/RoomProvider-test.ts
@@ -1,0 +1,128 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { mocked } from "jest-mock";
+import { MatrixClient, Room } from "matrix-js-sdk/src/matrix";
+
+import RoomProvider from "../../src/autocomplete/RoomProvider";
+import SettingsStore from "../../src/settings/SettingsStore";
+import { mkRoom, stubClient } from "../test-utils";
+
+describe("RoomProvider", () => {
+    it("suggests a room whose alias matches a prefix", async () => {
+        // Given a room
+        const client = stubClient();
+        const room = makeRoom(client, "room:e.com");
+        mocked(client.getVisibleRooms).mockReturnValue([room]);
+
+        // When we search for rooms starting with its prefix
+        const roomProvider = new RoomProvider(room);
+        const completions = await roomProvider.getCompletions("#ro", { beginning: true, start: 0, end: 3 });
+
+        // Then we find it
+        expect(completions).toStrictEqual([
+            {
+                type: "room",
+                completion: room.getCanonicalAlias(),
+                completionId: room.roomId,
+                component: expect.anything(),
+                href: "https://matrix.to/#/#room:e.com",
+                range: { start: 0, end: 3 },
+                suffix: " ",
+            },
+        ]);
+    });
+
+    it("suggests only rooms matching a prefix", async () => {
+        // Given some rooms with different names
+        const client = stubClient();
+        const room1 = makeRoom(client, "room1:e.com");
+        const room2 = makeRoom(client, "room2:e.com");
+        const other = makeRoom(client, "other:e.com");
+        mocked(client.getVisibleRooms).mockReturnValue([room1, room2, other]);
+
+        // When we search for rooms starting with a prefix
+        const roomProvider = new RoomProvider(room1);
+        const completions = await roomProvider.getCompletions("#ro", { beginning: true, start: 0, end: 3 });
+
+        // Then we find the two rooms with that prefix, but not the other one
+        expect(completions).toStrictEqual([
+            {
+                type: "room",
+                completion: room1.getCanonicalAlias(),
+                completionId: room1.roomId,
+                component: expect.anything(),
+                href: "https://matrix.to/#/#room1:e.com",
+                range: { start: 0, end: 3 },
+                suffix: " ",
+            },
+            {
+                type: "room",
+                completion: room2.getCanonicalAlias(),
+                completionId: room2.roomId,
+                component: expect.anything(),
+                href: "https://matrix.to/#/#room2:e.com",
+                range: { start: 0, end: 3 },
+                suffix: " ",
+            },
+        ]);
+    });
+
+    describe("If the feature_dynamic_room_predecessors is not enabled", () => {
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+        });
+
+        it("Passes through the dynamic predecessor setting", async () => {
+            const client = stubClient();
+            const room = makeRoom(client, "room:e.com");
+            mocked(client.getVisibleRooms).mockReturnValue([room]);
+            mocked(client.getVisibleRooms).mockClear();
+
+            const roomProvider = new RoomProvider(room);
+            await roomProvider.getCompletions("#ro", { beginning: true, start: 0, end: 3 });
+
+            expect(client.getVisibleRooms).toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("If the feature_dynamic_room_predecessors is enabled", () => {
+        beforeEach(() => {
+            // Turn on feature_dynamic_room_predecessors setting
+            jest.spyOn(SettingsStore, "getValue").mockImplementation(
+                (settingName) => settingName === "feature_dynamic_room_predecessors",
+            );
+        });
+
+        it("Passes through the dynamic predecessor setting", async () => {
+            const client = stubClient();
+            const room = makeRoom(client, "room:e.com");
+            mocked(client.getVisibleRooms).mockReturnValue([room]);
+            mocked(client.getVisibleRooms).mockClear();
+
+            const roomProvider = new RoomProvider(room);
+            await roomProvider.getCompletions("#ro", { beginning: true, start: 0, end: 3 });
+
+            expect(client.getVisibleRooms).toHaveBeenCalledWith(true);
+        });
+    });
+});
+
+function makeRoom(client: MatrixClient, name: string): Room {
+    const room = mkRoom(client, `!${name}`);
+    room.getCanonicalAlias.mockReturnValue(`#${name}`);
+    return room;
+}


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24417.

Towards [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support dynamic room predecessors for RoomProvider ([\#10346](https://github.com/matrix-org/matrix-react-sdk/pull/10346)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->