### PR TITLE
Pin versions of third-party github actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
               )
             )
         steps:
-            - uses: tibdex/backport@v2
+            - uses: tibdex/backport@2e217641d82d02ba0603f46b1aeedefb258890ac # v2
               with:
                   labels_template: "<%= JSON.stringify([...labels, 'X-Release-Blocker']) %>"
                   # We can't use GITHUB_TOKEN here or CI won't run on the new PR

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -29,7 +29,7 @@ jobs:
         steps:
             # We create the status here and then update it to success/failure in the `report` stage
             # This provides an easy link to this workflow_run from the PR before Cypress is done.
-            - uses: Sibz/github-status-action@v1
+            - uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
                   state: pending
@@ -97,7 +97,7 @@ jobs:
             - uses: browser-actions/setup-chrome@latest
             - run: echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 
-            - uses: tecolicom/actions-use-apt-tools@v1
+            - uses: tecolicom/actions-use-apt-tools@ceaf289fdbc6169fd2406a0f0365a584ffba003b # v1
               with:
                   # Our test suite includes some screenshot tests with unusual diacritics, which are
                   # supposed to be covered by STIXGeneral.
@@ -115,7 +115,7 @@ jobs:
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
-              uses: dawidd6/action-download-artifact@v2
+              uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   run_id: ${{ github.event.workflow_run.id }}
                   name: previewbuild
@@ -205,7 +205,7 @@ jobs:
 
             - name: Skip Percy required check
               if: needs.prepare.outputs.percy_enable != '1'
-              uses: Sibz/github-status-action@v1
+              uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
                   state: success
@@ -214,7 +214,7 @@ jobs:
                   sha: ${{ github.event.workflow_run.head_sha }}
                   target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            - uses: Sibz/github-status-action@v1
+            - uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
                   state: ${{ needs.tests.result == 'success' && 'success' || 'failure' }}

--- a/.github/workflows/i18n_check.yml
+++ b/.github/workflows/i18n_check.yml
@@ -12,7 +12,7 @@ jobs:
             - name: "Get modified files"
               id: changed_files
               if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'RiotTranslateBot'
-              uses: tj-actions/changed-files@v35
+              uses: tj-actions/changed-files@84ed30e2f4daf616144de7e0c1db59d5b33025e3 # v35
               with:
                   files: |
                       src/i18n/strings/*

--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -13,7 +13,7 @@ jobs:
         environment: Netlify
         steps:
             - name: 📝 Create Deployment
-              uses: bobheadxi/deployments@v1
+              uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1
               id: deployment
               with:
                   step: start
@@ -33,7 +33,7 @@ jobs:
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
-              uses: dawidd6/action-download-artifact@v2
+              uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   run_id: ${{ github.event.workflow_run.id }}
                   name: previewbuild
@@ -41,7 +41,7 @@ jobs:
 
             - name: ☁️ Deploy to Netlify
               id: netlify
-              uses: nwtgck/actions-netlify@v2.0
+              uses: nwtgck/actions-netlify@5da65c9f74c7961c5501a3ba329b8d0912f39c03 # v2.0
               with:
                   publish-dir: webapp
                   deploy-message: "Deploy from GitHub Actions"
@@ -55,7 +55,7 @@ jobs:
               timeout-minutes: 1
 
             - name: 🚦 Update deployment status
-              uses: bobheadxi/deployments@v1
+              uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1
               if: always()
               with:
                   step: finish

--- a/.github/workflows/notify-element-web.yml
+++ b/.github/workflows/notify-element-web.yml
@@ -12,7 +12,7 @@ jobs:
         if: github.repository == 'matrix-org/matrix-react-sdk'
         steps:
             - name: Notify element-web repo that a new SDK build is on develop
-              uses: peter-evans/repository-dispatch@v2
+              uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # v2
               with:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
                   repository: vector-im/element-web

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -60,13 +60,13 @@ jobs:
 
             - name: Get diff lines
               id: diff
-              uses: Equip-Collaboration/diff-line-numbers@v1.0.0
+              uses: Equip-Collaboration/diff-line-numbers@df70b4b83e05105c15f20dc6cc61f1463411b2a6 # v1.0.0
               with:
                   include: '["\\.tsx?$"]'
 
             - name: Detecting files changed
               id: files
-              uses: futuratrepadeira/changed-files@v4.0.0
+              uses: futuratrepadeira/changed-files@96d5fd702a6479d573287ef07381ad59acc390ed # v4.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   pattern: '^.*\.tsx?$'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
             - name: Get number of CPU cores
               id: cpu-cores
-              uses: SimenB/github-actions-cpu-cores@v1
+              uses: SimenB/github-actions-cpu-cores@410541432439795d30db6501fb1d8178eb41e502 # v1
 
             - name: Load metrics reporter
               id: metrics


### PR DESCRIPTION
Type: Task
Related: https://github.com/matrix-org/matrix-js-sdk/pull/3208
Related: https://github.com/matrix-org/matrix-react-sdk/pull/10351
Related: https://github.com/vector-im/element-web/pull/24786

Previously, we used tags to version third-party actions. t3chguy suggested we should pin them to specific commit hashes by default.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->