### PR TITLE
Add E2E test for labs user settings tab

### DIFF
--- a/cypress/e2e/settings/labs-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/labs-user-settings-tab.spec.ts
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+const USER_NAME = "Alice";
+
+describe("Labs user settings tab", () => {
+    let homeserver: HomeserverInstance;
+
+    beforeEach(() => {
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+            cy.initTestUser(homeserver, USER_NAME);
+        });
+    });
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should render labs user settings tab", () => {
+        const checkBetaCards = (titles, captions) => {
+            const items = titles.length; // assuming there is not a BetaCard without a title
+
+            // Ensure other beta cards than specified are not rendered
+            cy.get(".mx_BetaCard").should("have.length", items);
+
+            titles.forEach((title) => {
+                cy.contains(".mx_BetaCard_title", title);
+            });
+
+            captions.forEach((caption) => {
+                cy.contains(".mx_BetaCard_caption", caption);
+            });
+
+            // Buttons area for each BetaCard
+            cy.get(".mx_BetaCard_buttons").should("have.length", items);
+        };
+
+        const checkLabsGroup = (group, subheading, labels) => {
+            const items = labels.length;
+
+            cy.get(`[data-testid='labs-group-${group}']`).within(() => {
+                cy.contains(".mx_SettingsTab_subheading", subheading);
+
+                // Ensure other labels and their toggles than specified are not rendered
+                cy.get(".mx_SettingsFlag_labelText").should("have.length", items);
+                cy.get(".mx_ToggleSwitch").should("have.length", items);
+
+                labels.forEach((label) => {
+                    cy.contains(".mx_SettingsFlag_labelText", label);
+                    cy.get(`.mx_ToggleSwitch[aria-label='${label}']`).should("exist");
+                });
+            });
+        };
+
+        // Show labs settings
+        cy.tweakConfig({ show_labs_settings: "true" });
+
+        cy.openUserSettings("Labs");
+
+        cy.get(".mx_SettingsTab.mx_LabsUserSettingsTab").within(() => {
+            // Ensure the top heading is rendered
+            cy.get("[data-testid='heading']").should("have.text", "Upcoming features");
+
+            // Ensure the text under the heading is rendered
+            cy.contains("[data-testid='heading-text']", "What's next for");
+
+            // Beta section
+            cy.get("[data-testid='labs-beta-section']").within(() => {
+                checkBetaCards(
+                    ["Video rooms", "New session manager"],
+                    [
+                        "A new way to chat over voice and video in Element.",
+                        "Have greater visibility and control over all your sessions.",
+                    ],
+                );
+            });
+
+            // Ensure "Early preview" is rendered
+            cy.get("[data-testid='heading-labs']").should("have.text", "Early previews");
+
+            // Ensure the text under the heading is rendered
+            cy.contains("[data-testid='heading-labs-text']", "Feeling experimental?");
+
+            // "Messaging" subsection
+            checkLabsGroup(0, "Messaging", [
+                "Render LaTeX maths in messages",
+                "Message Pinning",
+                "Rich text editor",
+                "Live Location Sharing",
+                "Favourite Messages",
+                "Voice broadcast",
+            ]);
+
+            // "Spaces" subsection
+            checkLabsGroup(2, "Spaces", ["Explore public spaces in the new search dialog"]);
+
+            // "Rooms" subsection
+            checkLabsGroup(4, "Rooms", [
+                "Render simple counters in room header",
+                "Show HTML representation of room topics",
+                "Show info about bridges in room settings",
+                "Use new room breadcrumbs",
+                "Right panel stays open",
+                "Polls history",
+                "Dynamic room predecessors",
+                "Hide notification dot (only display counters badges)",
+            ]);
+
+            // "Voice & Video" subsection
+            checkLabsGroup(5, "Voice & Video", ["Element Call video rooms", "New group call experience"]);
+
+            // "Moderation" subsection
+            checkLabsGroup(6, "Moderation", [
+                "Let moderators hide messages pending moderation.",
+                "Report to moderators",
+                "New ways to ignore people",
+            ]);
+
+            // "Analytics" subsection
+            checkLabsGroup(7, "Analytics", [
+                "Automatically send debug logs on any error",
+                "Automatically send debug logs on decryption errors",
+            ]);
+
+            // "Message Previews" subsection
+            checkLabsGroup(8, "Message Previews", [
+                "Show message previews for reactions in DMs",
+                "Show message previews for reactions in all rooms",
+            ]);
+
+            // "Themes" subsection
+            checkLabsGroup(9, "Themes", ["Support adding custom themes"]);
+
+            // "Encryption" subsection
+            checkLabsGroup(10, "Encryption", ["Offline encrypted messaging using dehydrated devices"]);
+
+            // "Experimental" subsection
+            checkLabsGroup(11, "Experimental", ["Low bandwidth mode"]);
+
+            // "Developer" subsection
+            checkLabsGroup(12, "Developer", ["Sliding Sync mode"]);
+        });
+
+        cy.get(".mx_SettingsTab.mx_LabsUserSettingsTab").percySnapshotElement("Labs user settings tab");
+    });
+});

--- a/cypress/e2e/settings/labs-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/labs-user-settings-tab.spec.ts
@@ -156,7 +156,7 @@ describe("Labs user settings tab", () => {
             checkLabsGroup(11, "Experimental", ["Low bandwidth mode"]);
 
             // "Developer" subsection
-            checkLabsGroup(12, "Developer", ["Sliding Sync mode"]);
+            checkLabsGroup(12, "Developer", ["Sliding Sync mode", "Rust cryptography implementation"]);
         });
 
         cy.get(".mx_SettingsTab.mx_LabsUserSettingsTab").percySnapshotElement("Labs user settings tab");

--- a/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
@@ -125,8 +125,10 @@ export default class LabsUserSettingsTab extends React.Component<{}, State> {
 
         return (
             <div className="mx_SettingsTab mx_LabsUserSettingsTab">
-                <div className="mx_SettingsTab_heading">{_t("Upcoming features")}</div>
-                <div className="mx_SettingsTab_subsectionText">
+                <div className="mx_SettingsTab_heading" data-testid="heading">
+                    {_t("Upcoming features")}
+                </div>
+                <div className="mx_SettingsTab_subsectionText" data-testid="heading-text">
                     {_t(
                         "What's next for %(brand)s? " +
                             "Labs are the best way to get things early, " +
@@ -137,8 +139,10 @@ export default class LabsUserSettingsTab extends React.Component<{}, State> {
                 {betaSection}
                 {labsSections && (
                     <>
-                        <div className="mx_SettingsTab_heading">{_t("Early previews")}</div>
-                        <div className="mx_SettingsTab_subsectionText">
+                        <div className="mx_SettingsTab_heading" data-testid="heading-labs">
+                            {_t("Early previews")}
+                        </div>
+                        <div className="mx_SettingsTab_subsectionText" data-testid="heading-labs-text">
                             {_t(
                                 "Feeling experimental? " +
                                     "Try out our latest ideas in development. " +


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/24813

This PR intends to add a basic E2E test for labs user settings tab, checking whether beta cards and labs groups are actually rendered as expected.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->