### PR TITLE
Show search,dial,explore in filterContainer if "UIComponent.filterContainer" is enabled

### DIFF
--- a/res/css/structures/_LeftPanel.pcss
+++ b/res/css/structures/_LeftPanel.pcss
@@ -185,6 +185,10 @@ $roomListCollapsedWidth: 68px;
             }
         }
 
+        .mx_RoomListHeader:first-child {
+            margin-top: 12px;
+        }
+
         .mx_LeftPanel_roomListWrapper {
             /* Make the y-scrollbar more responsive */
             padding-right: 2px;

--- a/src/components/structures/LeftPanel.tsx
+++ b/src/components/structures/LeftPanel.tsx
@@ -393,7 +393,7 @@ export default class LeftPanel extends React.Component<IProps, IState> {
         return (
             <div className={containerClasses}>
                 <div className="mx_LeftPanel_roomListContainer">
-                    {this.renderSearchDialExplore()}
+                    {shouldShowComponent(UIComponent.FilterContainer) && this.renderSearchDialExplore()}
                     {this.renderBreadcrumbs()}
                     {!this.props.isMinimized && <RoomListHeader onVisibilityChange={this.refreshStickyHeaders} />}
                     <UserOnboardingButton

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -64,4 +64,9 @@ export enum UIComponent {
      * and integrations to the room, such as from the room information card.
      */
     AddIntegrations = "UIComponent.addIntegrations",
+
+    /**
+     * Component that lead to the user being able to search, dial, explore rooms
+     */
+    FilterContainer = "UIComponent.filterContainer",
 }

--- a/test/components/structures/LeftPanel-test.tsx
+++ b/test/components/structures/LeftPanel-test.tsx
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Mikhail Aheichyk
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { render, RenderResult, screen } from "@testing-library/react";
+import { mocked } from "jest-mock";
+
+import LeftPanel from "../../../src/components/structures/LeftPanel";
+import PageType from "../../../src/PageTypes";
+import ResizeNotifier from "../../../src/utils/ResizeNotifier";
+import { shouldShowComponent } from "../../../src/customisations/helpers/UIComponents";
+import { UIComponent } from "../../../src/settings/UIFeature";
+
+jest.mock("../../../src/customisations/helpers/UIComponents", () => ({
+    shouldShowComponent: jest.fn(),
+}));
+
+describe("LeftPanel", () => {
+    function renderComponent(): RenderResult {
+        return render(
+            <LeftPanel isMinimized={false} pageType={PageType.RoomView} resizeNotifier={new ResizeNotifier()} />,
+        );
+    }
+
+    it("does not show filter container when disabled by UIComponent customisations", () => {
+        mocked(shouldShowComponent).mockReturnValue(false);
+        renderComponent();
+        expect(shouldShowComponent).toHaveBeenCalledWith(UIComponent.FilterContainer);
+        expect(screen.queryByRole("button", { name: /search/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Explore rooms" })).not.toBeInTheDocument();
+    });
+
+    it("renders filter container when enabled by UIComponent customisations", () => {
+        mocked(shouldShowComponent).mockReturnValue(true);
+        renderComponent();
+        expect(shouldShowComponent).toHaveBeenCalledWith(UIComponent.FilterContainer);
+        expect(screen.getByRole("button", { name: /search/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Explore rooms" })).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Type: Enhancement

`"UIComponent.filterContainer"` is added as a new component that can be used by `shouldShowComponent` to customize rendering.

This PR suggests to enable/disable rendering of filter container that contains search, dial, explore components.

Some users may have very limited functionality. In this case it would be great to hide these components completely.  Please check the screenshots attached.

| search, explore rooms are enabled            | no search, explore rooms in top left |
| ------------- | ------------- |
| <img width="1029" alt="Screenshot 2023-03-15 at 09 51 55" src="https://user-images.githubusercontent.com/9369306/225233640-18ec7b3b-17a6-4c42-9e06-97d11f2d183b.png"> |  <img width="1024" alt="Screenshot 2023-03-15 at 10 01 19" src="https://user-images.githubusercontent.com/9369306/225233784-be68fd06-ae73-43b4-ba7b-71c182686c6b.png">|

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Show search,dial,explore in filterContainer if "UIComponent.filterContainer" is enabled ([\#10381](https://github.com/matrix-org/matrix-react-sdk/pull/10381)). Contributed by @maheichyk.<!-- CHANGELOG_PREVIEW_END -->