### PR TITLE
Fix `[object Object]` in feedback metadata

### DIFF
--- a/src/components/views/dialogs/GenericFeatureFeedbackDialog.tsx
+++ b/src/components/views/dialogs/GenericFeatureFeedbackDialog.tsx
@@ -29,7 +29,7 @@ interface IProps {
     title: string;
     subheading: string;
     rageshakeLabel: string;
-    rageshakeData?: Record<string, string>;
+    rageshakeData?: Record<string, any>;
     children?: ReactNode;
     onFinished(sendFeedback?: boolean): void;
 }

--- a/src/components/views/spaces/SpaceCreateMenu.tsx
+++ b/src/components/views/spaces/SpaceCreateMenu.tsx
@@ -140,7 +140,7 @@ export const SpaceFeedbackPrompt: React.FC<{
                         rageshakeData: Object.fromEntries(
                             ["Spaces.allRoomsInHome", "Spaces.enabledMetaSpaces"].map((k) => [
                                 k,
-                                String(SettingsStore.getValue(k)),
+                                SettingsStore.getValue(k),
                             ]),
                         ),
                     });

--- a/src/rageshake/submit-rageshake.ts
+++ b/src/rageshake/submit-rageshake.ts
@@ -288,7 +288,7 @@ export async function submitFeedback(
     label: string,
     comment: string,
     canContact = false,
-    extraData: Record<string, string> = {},
+    extraData: Record<string, any> = {},
 ): Promise<void> {
     let version: string | undefined;
     try {


### PR DESCRIPTION
E.g. https://github.com/matrix-org/element-web-rageshakes/issues/20633

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix `[object Object]` in feedback metadata ([\#10390](https://github.com/matrix-org/matrix-react-sdk/pull/10390)).<!-- CHANGELOG_PREVIEW_END -->