### PR TITLE
Fix wrong E2E icon in room header for unencrypted local room

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -301,7 +301,7 @@ function LocalRoomView(props: LocalRoomViewProps): ReactElement {
                     onSearchClick={null}
                     onInviteClick={null}
                     onForgetClick={null}
-                    e2eStatus={E2EStatus.Normal}
+                    e2eStatus={room.encrypted ? E2EStatus.Normal : undefined}
                     onAppsClick={null}
                     appsShown={false}
                     excludedRightPanelPhaseButtons={[]}
@@ -327,6 +327,7 @@ function LocalRoomView(props: LocalRoomViewProps): ReactElement {
 }
 
 interface ILocalRoomCreateLoaderProps {
+    localRoom: LocalRoom;
     names: string;
     resizeNotifier: ResizeNotifier;
 }
@@ -350,7 +351,7 @@ function LocalRoomCreateLoader(props: ILocalRoomCreateLoaderProps): ReactElement
                     onSearchClick={null}
                     onInviteClick={null}
                     onForgetClick={null}
-                    e2eStatus={E2EStatus.Normal}
+                    e2eStatus={props.localRoom.encrypted ? E2EStatus.Normal : undefined}
                     onAppsClick={null}
                     appsShown={false}
                     excludedRightPanelPhaseButtons={[]}
@@ -1918,11 +1919,11 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         return this.getPermalinkCreatorForRoom(this.state.room);
     }
 
-    private renderLocalRoomCreateLoader(): ReactElement {
+    private renderLocalRoomCreateLoader(localRoom: LocalRoom): ReactElement {
         const names = this.state.room.getDefaultRoomName(this.context.client.getUserId());
         return (
             <RoomContext.Provider value={this.state}>
-                <LocalRoomCreateLoader names={names} resizeNotifier={this.props.resizeNotifier} />
+                <LocalRoomCreateLoader localRoom={localRoom} names={names} resizeNotifier={this.props.resizeNotifier} />
             </RoomContext.Provider>
         );
     }
@@ -1956,7 +1957,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     public render(): React.ReactNode {
         if (this.state.room instanceof LocalRoom) {
             if (this.state.room.state === LocalRoomState.CREATING) {
-                return this.renderLocalRoomCreateLoader();
+                return this.renderLocalRoomCreateLoader(this.state.room);
             }
 
             return this.renderLocalRoomView(this.state.room);

--- a/test/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -40,9 +40,6 @@ exports[`RoomView for a local room in state CREATING should match the snapshot 1
           </div>
         </div>
         <div
-          class="mx_E2EIcon mx_E2EIcon_normal mx_RoomHeader_icon"
-        />
-        <div
           class="mx_RoomHeader_name mx_RoomHeader_name--textonly"
         >
           <div
@@ -136,9 +133,6 @@ exports[`RoomView for a local room in state ERROR should match the snapshot 1`] 
             </span>
           </div>
         </div>
-        <div
-          class="mx_E2EIcon mx_E2EIcon_normal mx_RoomHeader_icon"
-        />
         <div
           class="mx_RoomHeader_name mx_RoomHeader_name--textonly"
         >
@@ -329,9 +323,6 @@ exports[`RoomView for a local room in state NEW should match the snapshot 1`] = 
             </span>
           </div>
         </div>
-        <div
-          class="mx_E2EIcon mx_E2EIcon_normal mx_RoomHeader_icon"
-        />
         <div
           class="mx_RoomHeader_name mx_RoomHeader_name--textonly"
         >


### PR DESCRIPTION
`LocalRoom.encrypted`  was not checked in `LocalRoomView`.

closes https://github.com/vector-im/element-web/issues/24397

PSF-1958

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: When starting a DM, the end-to-end encryption status icon does now only appear if the DM can be encrypted

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * When starting a DM, the end-to-end encryption status icon does now only appear if the DM can be encrypted ([\#10394](https://github.com/matrix-org/matrix-react-sdk/pull/10394)). Fixes vector-im/element-web#24397.<!-- CHANGELOG_PREVIEW_END -->