### PR TITLE
Add stable unstable version for jump to date before `v1.6` is fully supported on a homeserver

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -373,7 +373,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
             "feature_jump_to_date",
             defaultWatchManager,
             ["org.matrix.msc3030"],
-            undefined,
+            "v1.6",
             _td("Requires your server to support MSC3030"),
         ),
     },

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -230,7 +230,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         controller: new ServerSupportUnstableFeatureController(
             "feature_exploring_public_spaces",
             defaultWatchManager,
-            ["org.matrix.msc3827.stable"],
+            [["org.matrix.msc3827.stable"]],
             undefined,
             _td("Requires your server to support the stable version of MSC3827"),
         ),
@@ -372,7 +372,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         controller: new ServerSupportUnstableFeatureController(
             "feature_jump_to_date",
             defaultWatchManager,
-            ["org.matrix.msc3030", "org.matrix.msc3030.stable"],
+            [["org.matrix.msc3030"], ["org.matrix.msc3030.stable"]],
             "v1.6",
             _td("Requires your server to support MSC3030"),
         ),
@@ -388,7 +388,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         controller: new ServerSupportUnstableFeatureController(
             "sendReadReceipts",
             defaultWatchManager,
-            ["org.matrix.msc2285.stable"],
+            [["org.matrix.msc2285.stable"]],
             "v1.4",
             _td("Your server doesn't support disabling sending read receipts."),
             true,

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -372,7 +372,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         controller: new ServerSupportUnstableFeatureController(
             "feature_jump_to_date",
             defaultWatchManager,
-            ["org.matrix.msc3030"],
+            ["org.matrix.msc3030", "org.matrix.msc3030.stable"],
             "v1.6",
             _td("Requires your server to support MSC3030"),
         ),

--- a/src/settings/controllers/ServerSupportUnstableFeatureController.ts
+++ b/src/settings/controllers/ServerSupportUnstableFeatureController.ts
@@ -26,12 +26,21 @@ import SettingsStore from "../SettingsStore";
  * When a setting gets disabled or enabled from this controller it notifies the given WatchManager
  */
 export default class ServerSupportUnstableFeatureController extends MatrixClientBackedController {
+    // Starts off as `undefined` so when we first compare the `newDisabledValue`, it sees
+    // it as a change and updates the watchers.
     private enabled: boolean | undefined;
 
+    /**
+     * Construct a new ServerSupportUnstableFeatureController.
+     *
+     * @param unstableFeatureGroups - If any one of the feature groups is satisfied,
+     * then the setting is considered enabled. A feature group is satisfied if all of
+     * the features in the group are supported (all features in a group are required).
+     */
     public constructor(
         private readonly settingName: string,
         private readonly watchers: WatchManager,
-        private readonly unstableFeatures: string[],
+        private readonly unstableFeatureGroups: string[][],
         private readonly stableVersion?: string,
         private readonly disabledMessage?: string,
         private readonly forcedValue: any = false,
@@ -43,9 +52,9 @@ export default class ServerSupportUnstableFeatureController extends MatrixClient
         return !this.enabled;
     }
 
-    public set disabled(v: boolean) {
-        if (!v === this.enabled) return;
-        this.enabled = !v;
+    public set disabled(newDisabledValue: boolean) {
+        if (!newDisabledValue === this.enabled) return;
+        this.enabled = !newDisabledValue;
         const level = SettingsStore.firstSupportedLevel(this.settingName);
         if (!level) return;
         const settingValue = SettingsStore.getValue(this.settingName, null);
@@ -53,19 +62,33 @@ export default class ServerSupportUnstableFeatureController extends MatrixClient
     }
 
     protected async initMatrixClient(oldClient: MatrixClient, newClient: MatrixClient): Promise<void> {
-        this.disabled = true;
-        let supported = true;
-
+        // Check for stable version support first
         if (this.stableVersion && (await this.client.isVersionSupported(this.stableVersion))) {
             this.disabled = false;
             return;
         }
-        for (const feature of this.unstableFeatures) {
-            supported = await this.client.doesServerSupportUnstableFeature(feature);
-            if (!supported) break;
+
+        // Otherwise, only one of the unstable feature groups needs to be satisfied in
+        // order for this setting overall to be enabled
+        let isEnabled = false;
+        for (const featureGroup of this.unstableFeatureGroups) {
+            const featureSupportList = await Promise.all(
+                featureGroup.map(async (feature) => {
+                    const isFeatureSupported = await this.client.doesServerSupportUnstableFeature(feature);
+                    return isFeatureSupported;
+                }),
+            );
+
+            // Every feature in a feature group is required in order
+            // for this setting overall to be enabled.
+            const isFeatureGroupSatisfied = featureSupportList.every((isFeatureSupported) => isFeatureSupported);
+            if (isFeatureGroupSatisfied) {
+                isEnabled = true;
+                break;
+            }
         }
 
-        this.disabled = !supported;
+        this.disabled = !isEnabled;
     }
 
     public getValueOverride(


### PR DESCRIPTION
Add stable unstable version (`org.matrix.msc3030.stable`) for jump to date [before `v1.6` is fully supported on a homeserver](https://github.com/matrix-org/synapse/issues/15089). Discussion for whether we are okay with moving forward with this -> https://github.com/matrix-org/matrix-react-sdk/pull/10398#discussion_r1139847241

Related to https://github.com/vector-im/element-web/issues/24362 but does not solve immediately because Synapse does not supply `org.matrix.msc3030.stable` yet

Also refactored `ServerSupportUnstableFeatureController` to support multiple feature groups where any one of them will enable the setting. All features in a feature group are required. See discussion -> https://github.com/matrix-org/matrix-react-sdk/pull/10398#discussion_r1139850466




<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->