### PR TITLE
Remove unreadable alt attribute from the room status bar warning icon (nonsense to screenreaders)

### DIFF
--- a/src/components/structures/RoomStatusBar.tsx
+++ b/src/components/structures/RoomStatusBar.tsx
@@ -282,8 +282,7 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
                                 src={require("../../../res/img/feather-customised/warning-triangle.svg").default}
                                 width="24"
                                 height="24"
-                                title="/!\ "
-                                alt="/!\ "
+                                alt=""
                             />
                             <div>
                                 <div className="mx_RoomStatusBar_connectionLostBar_title">


### PR DESCRIPTION
Remove unreadable alt attribute from the room status bar warning icon (nonsense to screenreaders). And the other content like the title already describe what's going on sufficiently.

Split out from https://github.com/matrix-org/matrix-react-sdk/pull/8354

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove unreadable alt attribute from the room status bar warning icon (nonsense to screenreaders) ([\#10402](https://github.com/matrix-org/matrix-react-sdk/pull/10402)). Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->