### PR TITLE
Fix big date separators when jump to date is enabled

### DIFF
--- a/res/css/views/messages/_DateSeparator.pcss
+++ b/res/css/views/messages/_DateSeparator.pcss
@@ -30,9 +30,13 @@ limitations under the License.
     border-bottom: 1px solid $menu-selected-color;
 }
 
-.mx_DateSeparator > h2 {
-    margin: 0 25px;
+.mx_DateSeparator_dateContent {
+    padding: 0 25px;
+}
+
+.mx_DateSeparator_dateHeading {
     flex: 0 0 auto;
+    margin: 0;
     font-size: inherit;
     font-weight: inherit;
     color: inherit;

--- a/src/components/views/messages/DateSeparator.tsx
+++ b/src/components/views/messages/DateSeparator.tsx
@@ -206,12 +206,14 @@ export default class DateSeparator extends React.Component<IProps, IState> {
 
         return (
             <ContextMenuTooltipButton
-                className="mx_DateSeparator_jumpToDateMenu"
+                className="mx_DateSeparator_jumpToDateMenu mx_DateSeparator_dateContent"
                 onClick={this.onContextMenuOpenClick}
                 isExpanded={!!this.state.contextMenuPosition}
                 title={_t("Jump to date")}
             >
-                <h2 aria-hidden="true">{this.getLabel()}</h2>
+                <h2 className="mx_DateSeparator_dateHeading" aria-hidden="true">
+                    {this.getLabel()}
+                </h2>
                 <div className="mx_DateSeparator_chevron" />
                 {contextMenu}
             </ContextMenuTooltipButton>
@@ -225,7 +227,13 @@ export default class DateSeparator extends React.Component<IProps, IState> {
         if (this.state.jumpToDateEnabled) {
             dateHeaderContent = this.renderJumpToDateMenu();
         } else {
-            dateHeaderContent = <h2 aria-hidden="true">{label}</h2>;
+            dateHeaderContent = (
+                <div className="mx_DateSeparator_dateContent">
+                    <h2 className="mx_DateSeparator_dateHeading" aria-hidden="true">
+                        {label}
+                    </h2>
+                </div>
+            );
         }
 
         // ARIA treats <hr/>s as separators, here we abuse them slightly so manually treat this entire thing as one


### PR DESCRIPTION
Fix big date separators when jump to date is enabled

Before | After
--- | ---
<img width="664" alt="Jump to date separator before with big text" src="https://user-images.githubusercontent.com/558581/226059817-be43543a-57df-4ad8-b3ba-60c1e37e6bf8.png"> | <img width="674" alt="Jump to date separator after with fixed font size" src="https://user-images.githubusercontent.com/558581/226059464-af625963-e636-4ff7-a99e-685a976b5a66.png">
<img width="676" alt="Regular date separator before" src="https://user-images.githubusercontent.com/558581/226059815-74cf3a26-ab6e-43bd-bb1c-f222d673bc4a.png"> | <img width="674" alt="Regular date separator (no change)" src="https://user-images.githubusercontent.com/558581/226059466-c53a0ae7-e337-4ea7-85e4-a22e4741d507.png">


## Testing strategy

 1. Enable `feature_jump_to_date` ("Jump to date (adds /jumptodate and jump to date headers)") in Labs
 1. View a date header
 1. Confirm the date separator text size is as expected (matches normal date separators)





<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
