### PR TITLE
Fix failing develop with mis-matched snapshots

### DIFF
--- a/test/components/structures/__snapshots__/MessagePanel-test.tsx.snap
+++ b/test/components/structures/__snapshots__/MessagePanel-test.tsx.snap
@@ -47,11 +47,16 @@ exports[`MessagePanel should handle lots of membership events quickly 1`] = `
             <hr
               role="none"
             />
-            <h2
-              aria-hidden="true"
+            <div
+              class="mx_DateSeparator_dateContent"
             >
-              Thu, Jan 1 1970
-            </h2>
+              <h2
+                aria-hidden="true"
+                class="mx_DateSeparator_dateHeading"
+              >
+                Thu, Jan 1 1970
+              </h2>
+            </div>
             <hr
               role="none"
             />


### PR DESCRIPTION
Fix failing develop with mis-matched snapshots

 - `develop` failure: https://github.com/matrix-org/matrix-react-sdk/actions/runs/4470319896/jobs/7853678384
 - What happened?
    - Date separator markup updated in https://github.com/matrix-org/matrix-react-sdk/pull/10404
    - While some new snapshot tests added and merged in https://github.com/matrix-org/matrix-react-sdk/pull/10353
 - Merge trains could have helped


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->