### PR TITLE
Fix block/inline Element descendants error noise in `NewRoomIntro.tsx`

### DIFF
--- a/src/components/views/rooms/NewRoomIntro.tsx
+++ b/src/components/views/rooms/NewRoomIntro.tsx
@@ -141,7 +141,7 @@ const NewRoomIntro: React.FC = () => {
                 { topic },
                 {
                     a: (sub) => (
-                        <AccessibleButton kind="link_inline" onClick={onTopicClick}>
+                        <AccessibleButton element="a" kind="link_inline" onClick={onTopicClick}>
                             {sub}
                         </AccessibleButton>
                     ),
@@ -155,7 +155,7 @@ const NewRoomIntro: React.FC = () => {
                 {},
                 {
                     a: (sub) => (
-                        <AccessibleButton kind="link_inline" onClick={onTopicClick}>
+                        <AccessibleButton element="a" kind="link_inline" onClick={onTopicClick}>
                             {sub}
                         </AccessibleButton>
                     ),


### PR DESCRIPTION
Fix block/inline Element descendants error noise in `NewRoomIntro.tsx`

Error before:
```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    at div
    at AccessibleButton (webpack-internal:///470:43:7)
    at span
    at p
    at li
    at NewRoomIntro (webpack-internal:///2063:77:71)
    at ol
    at div
    at div
    at AutoHideScrollbar (webpack-internal:///1020:37:5)
    at ScrollPanel (webpack-internal:///1106:69:5)
    at ErrorBoundary (webpack-internal:///2070:47:5)
    at MessagePanel (webpack-internal:///2060:169:5)
    at TimelinePanel (webpack-internal:///2095:113:5)
    at div
    at div
    at div
    at MainSplit (webpack-internal:///2019:31:5)
    at ErrorBoundary (webpack-internal:///2070:47:5)
    at main
    at RoomView (webpack-internal:///2018:330:5)
    at div
    at div
    at div
    at LoggedInView (webpack-internal:///1907:130:5)
    at ErrorBoundary (webpack-internal:///2070:47:5)
    at MatrixChat (webpack-internal:///1900:234:5)
```

`NewRoomIntro.tsx` component example in UI:
<img width="652" alt="" src="https://user-images.githubusercontent.com/558581/226541320-3b1f7d50-8d27-464f-88bb-02efacf92389.png">


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix block/inline Element descendants error noise in `NewRoomIntro.tsx` ([\#10412](https://github.com/matrix-org/matrix-react-sdk/pull/10412)). Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->