### PR TITLE
Disable Percy snapshots that are flaky due to focus issues

### DIFF
--- a/cypress/e2e/room-directory/room-directory.spec.ts
+++ b/cypress/e2e/room-directory/room-directory.spec.ts
@@ -92,7 +92,8 @@ describe("Room Directory", () => {
 
         cy.get('.mx_SpotlightDialog [aria-label="Search"]').type("{selectAll}{backspace}test1234");
         cy.contains(".mx_SpotlightDialog .mx_SpotlightDialog_result_publicRoomName", name).should("exist");
-        cy.get(".mx_SpotlightDialog_wrapper").percySnapshotElement("Room Directory - filtered one result");
+        // Disabled because flaky - see https://github.com/vector-im/element-web/issues/24881
+        //cy.get(".mx_SpotlightDialog_wrapper").percySnapshotElement("Room Directory - filtered one result");
         cy.get(".mx_SpotlightDialog .mx_SpotlightDialog_option").find(".mx_AccessibleButton").contains("Join").click();
 
         cy.url().should("contain", `/#/room/#test1234:localhost`);

--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -770,9 +770,10 @@ describe("Timeline", () => {
             cy.get(".mx_EventTile_last[data-layout='irc'] .mx_ReplyChain").should("have.css", "margin", "0px");
 
             // Take a snapshot on IRC layout
-            cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on IRC layout", {
+            // Disabled because flaky - see https://github.com/vector-im/element-web/issues/24881
+            /*cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on IRC layout", {
                 percyCSS,
-            });
+            });*/
 
             // Check the margin value of ReplyChains of EventTile at the bottom on group/modern layout
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Group);
@@ -788,9 +789,10 @@ describe("Timeline", () => {
             cy.get(".mx_EventTile_last[data-layout='group'] .mx_ReplyChain").should("have.css", "margin-bottom", "4px");
 
             // Take a snapshot on compact modern layout
-            cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on compact modern layout", {
+            // Disabled because flaky - see https://github.com/vector-im/element-web/issues/24881
+            /*cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on compact modern layout", {
                 percyCSS,
-            });
+            });*/
 
             // Check the margin value of ReplyChains of EventTile at the bottom on bubble layout
             cy.setSettingValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);
@@ -801,9 +803,10 @@ describe("Timeline", () => {
             );
 
             // Take a snapshot on bubble layout
-            cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on bubble layout", {
+            // Disabled because flaky - see https://github.com/vector-im/element-web/issues/24881
+            /*cy.get(".mx_EventTile_last").percySnapshotElement("EventTile with reply chains on bubble layout", {
                 percyCSS,
-            });
+            });*/
         });
 
         it("should send, reply, and display long strings without overflowing", () => {


### PR DESCRIPTION
Disabling tests identified in https://github.com/vector-im/element-web/issues/24881

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->