### PR TITLE
Enable running cypress tests with dendrite & pinecone

### DIFF
--- a/cypress/plugins/dendritedocker/templates/default/dendrite.yaml
+++ b/cypress/plugins/dendritedocker/templates/default/dendrite.yaml
@@ -346,6 +346,10 @@ key_server:
     database:
         connection_string: file:dendrite-keyserverapi.db
 
+relay_api:
+    database:
+        connection_string: file:dendrite-relayapi.db
+
 # Configuration for Opentracing.
 # See https://github.com/matrix-org/dendrite/tree/master/docs/tracing for information on
 # how this works and how to set it up.


### PR DESCRIPTION
This extends the existing cypress homeserver configuration to be able to run the tests using dendrite with pinecone routing.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->