### PR TITLE
Remove css causing list and paragraph issues

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -642,12 +642,6 @@ $left-gutter: 64px;
         ul {
             list-style-type: disc;
         }
-
-        /* Remove top and bottom margin for better display in rich text editor output */
-        :is(blockquote > p, ol, ul) {
-            margin-top: 0;
-            margin-bottom: 0;
-        }
     }
 }
 


### PR DESCRIPTION
Over the course of rich text editor work, regressions in the timeline display have been reported. Namely:
- https://github.com/vector-im/element-web/issues/24419
- https://github.com/vector-im/element-web/issues/24602

This work removes the CSS that was amended in the first issue above, that is causing part of the complaint in the second issue. To ensure this change does we're aiming at, here are before vs after comparisons.

| Issue | Before vs after|
| ----- | --- |
| 24419, spacing around block quotes |      |
| 24602, spacing around lists |     |

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
