### PR TITLE
Hide seek bar of audio player to fix a flaky Percy test temporarily

### DIFF
--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -134,7 +134,9 @@ describe("FilePanel", () => {
                 });
 
                 // Exclude timestamps and read markers from snapshot
-                const percyCSS = ".mx_MessageTimestamp, .mx_RoomView_myReadMarker { visibility: hidden !important; }";
+                // FIXME: hide mx_SeekBar because flaky - see https://github.com/vector-im/element-web/issues/24897
+                const percyCSS =
+                    ".mx_MessageTimestamp, .mx_RoomView_myReadMarker, .mx_SeekBar { visibility: hidden !important; }";
                 cy.get(".mx_RoomView_MessageList").percySnapshotElement("File tiles on FilePanel", { percyCSS });
             });
         });

--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -135,6 +135,7 @@ describe("FilePanel", () => {
 
                 // Exclude timestamps and read markers from snapshot
                 // FIXME: hide mx_SeekBar because flaky - see https://github.com/vector-im/element-web/issues/24897
+                //   Remove this once https://github.com/vector-im/element-web/issues/24898 is fixed.
                 const percyCSS =
                     ".mx_MessageTimestamp, .mx_RoomView_myReadMarker, .mx_SeekBar { visibility: hidden !important; }";
                 cy.get(".mx_RoomView_MessageList").percySnapshotElement("File tiles on FilePanel", { percyCSS });


### PR DESCRIPTION
This PR should temporarily fix a flaky Percy test of audio player on `FilePanel` by hiding the seek bar whose indicator is not consistently rendered.

Closes https://github.com/vector-im/element-web/issues/24897

Here is an example of the flaky test: https://percy.io/dfde73bd/matrix-react-sdk/builds/26097295/changed/1454569038?browser=chrome&browser_ids=33%2C34%2C35%2C36&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1920&widths=1024%2C1920

Here is a cropped screenshot of the test. The indicator is rendered on a different position on the seek bar.

![Screenshot from 2023-03-23 04-16-21](https://user-images.githubusercontent.com/3362943/227013014-da6401aa-f776-48bb-9c4f-203462db5e23.png)

The issue of the indicator was logged here too: https://github.com/vector-im/element-web/issues/24898

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->