### PR TITLE
Prep for matrix-js-sdk supporting intentional mentions

### DIFF
--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -176,6 +176,7 @@ export function createTestClient(): MatrixClient {
         isUserIgnored: jest.fn().mockReturnValue(false),
         getCapabilities: jest.fn().mockResolvedValue({}),
         supportsThreads: () => false,
+        supportsIntentionalMentions: () => false,
         getRoomUpgradeHistory: jest.fn().mockReturnValue([]),
         getOpenIdToken: jest.fn().mockResolvedValue(undefined),
         registerWithIdentityServer: jest.fn().mockResolvedValue({}),


### PR DESCRIPTION
matrix-org/matrix-js-sdk#3092 currently fails the upstream checks during merge because the matrix-react-sdk has within it an embedded fake `MatrixClient` object. Some matrix-react-sdk tests fail (on `develop`) if you merge that PR since the fake client would no longer be compatible with the real `MatrixClient`.

This gets around this issue by ripping part of #9983 into a separate PR which can be merged *first*, we can then merge matrix-org/matrix-js-sdk#3092; then we can merge #9983.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->