### PR TITLE
Handle group call redaction

### DIFF
--- a/src/components/views/messages/CallEvent.tsx
+++ b/src/components/views/messages/CallEvent.tsx
@@ -168,7 +168,7 @@ export const CallEvent = forwardRef<any, CallEventProps>(({ mxEvent }, ref) => {
         .getRoom(mxEvent.getRoomId())!
         .currentState.getStateEvents(mxEvent.getType(), mxEvent.getStateKey()!)!;
 
-    if ("m.terminated" in latestEvent.getContent()) {
+    if ("m.terminated" in latestEvent.getContent() || latestEvent.isRedacted()) {
         // The call is terminated
         return (
             <div className="mx_CallEvent_wrapper" ref={ref}>

--- a/src/toasts/IncomingCallToast.tsx
+++ b/src/toasts/IncomingCallToast.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { useCallback, useEffect } from "react";
-import { MatrixEvent } from "matrix-js-sdk/src/models/event";
+import { MatrixEvent, MatrixEventEvent } from "matrix-js-sdk/src/models/event";
 
 import { _t } from "../languageHandler";
 import RoomAvatar from "../components/views/avatars/RoomAvatar";
@@ -36,6 +36,7 @@ import { ButtonEvent } from "../components/views/elements/AccessibleButton";
 import { useDispatcher } from "../hooks/useDispatcher";
 import { ActionPayload } from "../dispatcher/payloads";
 import { Call } from "../models/Call";
+import { useTypedEventEmitter } from "../hooks/useEventEmitter";
 
 export const getIncomingCallToastKey = (stateKey: string): string => `call_${stateKey}`;
 
@@ -88,6 +89,8 @@ export function IncomingCallToast({ callEvent }: Props): JSX.Element {
             dismissToast();
         }
     }, [latestEvent, dismissToast]);
+
+    useTypedEventEmitter(latestEvent, MatrixEventEvent.BeforeRedaction, dismissToast);
 
     useDispatcher(
         defaultDispatcher,

--- a/test/components/views/messages/CallEvent-test.tsx
+++ b/test/components/views/messages/CallEvent-test.tsx
@@ -114,6 +114,14 @@ describe("CallEvent", () => {
         screen.getByText("1m 30s");
     });
 
+    it("shows a message if the call was redacted", () => {
+        const event = room.currentState.getStateEvents(MockedCall.EVENT_TYPE, "1")!;
+        jest.spyOn(event, "isRedacted").mockReturnValue(true);
+        renderEvent();
+
+        screen.getByText("Video call ended");
+    });
+
     it("shows placeholder info if the call isn't loaded yet", () => {
         jest.spyOn(CallStore.instance, "getCall").mockReturnValue(null);
         jest.advanceTimersByTime(90000);

--- a/test/toasts/IncomingCallToast-test.tsx
+++ b/test/toasts/IncomingCallToast-test.tsx
@@ -21,6 +21,7 @@ import { Room } from "matrix-js-sdk/src/models/room";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 import { RoomStateEvent } from "matrix-js-sdk/src/models/room-state";
 import { ClientWidgetApi, Widget } from "matrix-widget-api";
+import { MatrixEvent, MatrixEventEvent } from "matrix-js-sdk/src/models/event";
 
 import type { RoomMember } from "matrix-js-sdk/src/models/room-member";
 import {
@@ -171,6 +172,17 @@ describe("IncomingCallEvent", () => {
             room_id: room.roomId,
             view_call: true,
         });
+
+        await waitFor(() =>
+            expect(toastStore.dismissToast).toHaveBeenCalledWith(getIncomingCallToastKey(call.event.getStateKey()!)),
+        );
+    });
+
+    it("closes toast when the call event is redacted", async () => {
+        renderToast();
+
+        const event = room.currentState.getStateEvents(MockedCall.EVENT_TYPE, "1")!;
+        event.emit(MatrixEventEvent.BeforeRedaction, event, {} as unknown as MatrixEvent);
 
         await waitFor(() =>
             expect(toastStore.dismissToast).toHaveBeenCalledWith(getIncomingCallToastKey(call.event.getStateKey()!)),


### PR DESCRIPTION
Redacted group call events should be interpreted as terminated calls.

For https://github.com/vector-im/voip-internal/issues/128

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Handle group call redaction ([\#10465](https://github.com/matrix-org/matrix-react-sdk/pull/10465)).<!-- CHANGELOG_PREVIEW_END -->