### PR TITLE
Check kiwi_enable value for '1'-ness, not presence

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -232,7 +232,7 @@ jobs:
             - tests
         environment: Kiwi
         runs-on: ubuntu-latest
-        if: ${{ needs.prepare.outputs.kiwi_enable }}
+        if: ${{ needs.prepare.outputs.kiwi_enable == '1' }}
         steps:
             - name: Download all zip files
               uses: actions/download-artifact@v3


### PR DESCRIPTION
Change from string-y checking for true ('0' is true) to comparison against the string '1', which is only true if exactly equal to '1'.

This has been submitting more test results to Kiwi than we want/need.

Compare [line 203](https://github.com/matrix-org/matrix-react-sdk/pull/10482/files#diff-51db9e43a2bd398477ba2c88d9a38051ab300bfc1fcb91da98c6d34a9e449c46L203) of this file for how the Percy check tests for true-ness - this changes to match that.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [X] Tests written for new code (and old code if feasible) - NA: gha change
-   [x] Linter and other CI checks pass
-   [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->

No changelog entry required:

Notes: none
element-web notes: none

Signed-Off-By: Michael Kaye <michaelk@ele ment.io>

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->