### PR TITLE
Restore `createRoom.canEncryptToAllUsers` behaviour

### DIFF
--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -399,11 +399,9 @@ export async function canEncryptToAllUsers(client: MatrixClient, userIds: string
     try {
         const usersDeviceMap = await client.downloadKeys(userIds);
 
-        // There are no devices at all.
-        if (usersDeviceMap.size === 0) return false;
-
         for (const devices of usersDeviceMap.values()) {
             if (devices.size === 0) {
+                // This user does not have any encryption-capable devices.
                 return false;
             }
         }

--- a/test/createRoom-test.ts
+++ b/test/createRoom-test.ts
@@ -161,10 +161,16 @@ describe("canEncryptToAllUsers", () => {
         client = mocked(stubClient());
     });
 
-    it("should return false if download keys does not return any user", async () => {
+    it("should return true if userIds is empty", async () => {
+        client.downloadKeys.mockResolvedValue(new Map());
+        const result = await canEncryptToAllUsers(client, []);
+        expect(result).toBe(true);
+    });
+
+    it("should return true if download keys does not return any user", async () => {
         client.downloadKeys.mockResolvedValue(new Map());
         const result = await canEncryptToAllUsers(client, [user1Id, user2Id]);
-        expect(result).toBe(false);
+        expect(result).toBe(true);
     });
 
     it("should return false if none of the users has a device", async () => {


### PR DESCRIPTION
see https://github.com/matrix-org/matrix-react-sdk/pull/10487/files#r1154191516

fixes https://github.com/vector-im/element-web/issues/24998

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->