### PR TITLE
Update rte autocomplete styling

### DIFF
--- a/res/css/views/rooms/wysiwyg_composer/_SendWysiwygComposer.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/_SendWysiwygComposer.pcss
@@ -84,10 +84,3 @@ limitations under the License.
         border-color: $quaternary-content;
     }
 }
-
-.mx_SendWysiwygComposer_AutoCompleteWrapper {
-    position: relative;
-    > .mx_Autocomplete {
-        min-width: 100%;
-    }
-}

--- a/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
@@ -149,7 +149,13 @@ limitations under the License.
 
 .mx_WysiwygComposer_AutoCompleteWrapper {
     position: relative;
+
+    /* Due to the fact that editing a message now has a larger amount of grey
+    colour above it (due to the rich text buttons above the composer), we need
+    to give the autocomplete a bit more visual separation by using a border.
+    */
     > .mx_Autocomplete {
-        min-width: 100%;
+        border: 1px solid $quinary-content;
+        border-radius: 8px;
     }
 }

--- a/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
+++ b/res/css/views/rooms/wysiwyg_composer/components/_Editor.pcss
@@ -146,3 +146,10 @@ limitations under the License.
         color: $tertiary-content;
     }
 }
+
+.mx_WysiwygComposer_AutoCompleteWrapper {
+    position: relative;
+    > .mx_Autocomplete {
+        min-width: 100%;
+    }
+}

--- a/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
@@ -119,7 +119,7 @@ const WysiwygAutocomplete = forwardRef(
         }
 
         return room ? (
-            <div className="mx_SendWysiwygComposer_AutoCompleteWrapper" data-testid="autocomplete-wrapper">
+            <div className="mx_WysiwygComposer_AutoCompleteWrapper" data-testid="autocomplete-wrapper">
                 <Autocomplete
                     ref={ref}
                     query={buildQuery(suggestion)}


### PR DESCRIPTION
Due to changes in design around the rich text editor, it is necessary to amend the styling of the autocomplete (when rendered by the rich text editor). This PR adds a border to increase the visual separation between the autocomplete and the composer in a way that works for the "main" composer (ie at the bottom of the viewport) and the "editing" composer (ie what you get when you are editing a message in the timeline.

Before vs After, "main" composer
<img width="1594" alt="Element_Nightly___aluntest0_and_Element__2____Alun_Turner_🔊" src="https://user-images.githubusercontent.com/56027671/229732145-9e9fd27d-f85e-4438-9d8d-eb2c03308566.png">

Before vs After, "editing" composer

<img width="718" alt="Element__1____Alun_Turner" src="https://user-images.githubusercontent.com/56027671/229734203-8c75fd7e-7c27-4416-a39d-4c0e15906ccf.png">


<img width="655" alt="Element__1____Alun_Turner" src="https://user-images.githubusercontent.com/56027671/229733531-bda1f226-1d7a-43cd-a2db-9e853f4cecb9.png">

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Update rte autocomplete styling ([\#10503](https://github.com/matrix-org/matrix-react-sdk/pull/10503)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->