### PR TITLE
Tweak Percy cron trigger to not run on weekends (#10519

### DIFF
--- a/.github/workflows/element-web.yaml
+++ b/.github/workflows/element-web.yaml
@@ -4,7 +4,7 @@
 name: Element Web - Build
 on:
     schedule:
-        - cron: "17 4 * * *" # every day at 04:17 UTC
+        - cron: "17 4 * * 1-5" # every weekday at 04:17 UTC
     pull_request: {}
     push:
         branches: [develop, master]


### PR DESCRIPTION
`Runs at 04:17, Monday through Friday.`

Closes https://github.com/orgs/vector-im/projects/67/views/12?pane=issue&itemId=24894033


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->