### PR TITLE
Implement updated open dialog method using module API

### DIFF
--- a/src/components/views/dialogs/ModuleUiDialog.tsx
+++ b/src/components/views/dialogs/ModuleUiDialog.tsx
@@ -23,8 +23,11 @@ import { _t } from "../../../languageHandler";
 
 interface IProps<C extends React.Component = React.Component> {
     contentFactory: (props: DialogProps, ref: React.Ref<C>) => React.ReactNode;
-    contentProps: DialogProps;
+    contentProps: Omit<DialogProps, "setCanSubmit">;
+    canSubmit?: boolean;
     title: string;
+    cancelLabel?: string;
+    actionLabel?: string;
     onFinished(ok?: boolean, model?: Awaited<ReturnType<DialogContent["trySubmit"]>>): void;
 }
 
@@ -39,9 +42,10 @@ export class ModuleUiDialog extends ScrollableBaseModal<IProps, IState> {
         super(props);
 
         this.state = {
+            canSubmit: this.props.canSubmit ?? true,
             title: this.props.title,
-            canSubmit: true,
-            actionLabel: _t("OK"),
+            cancelLabel: this.props.cancelLabel,
+            actionLabel: this.props.actionLabel ?? _t("OK"),
         };
     }
 
@@ -59,10 +63,10 @@ export class ModuleUiDialog extends ScrollableBaseModal<IProps, IState> {
     }
 
     protected renderContent(): React.ReactNode {
-        return (
-            <div className="mx_ModuleUiDialog">
-                {this.props.contentFactory(this.props.contentProps, this.contentRef)}
-            </div>
-        );
+        const dialogProps: DialogProps = {
+            ...this.props.contentProps,
+            setCanSubmit: (canSubmit: boolean) => this.setState({ canSubmit }),
+        };
+        return <div className="mx_ModuleUiDialog">{this.props.contentFactory(dialogProps, this.contentRef)}</div>;
     }
 }

--- a/src/components/views/dialogs/ScrollableBaseModal.tsx
+++ b/src/components/views/dialogs/ScrollableBaseModal.tsx
@@ -28,6 +28,7 @@ import { getKeyBindingsManager } from "../../../KeyBindingsManager";
 export interface IScrollableBaseState {
     canSubmit: boolean;
     title: string;
+    cancelLabel?: string;
     actionLabel: string;
 }
 
@@ -99,7 +100,7 @@ export default abstract class ScrollableBaseModal<
                         <div className="mx_CompoundDialog_content">{this.renderContent()}</div>
                         <div className="mx_CompoundDialog_footer">
                             <AccessibleButton onClick={this.onCancel} kind="primary_outline">
-                                {_t("Cancel")}
+                                {this.state.cancelLabel ?? _t("Cancel")}
                             </AccessibleButton>
                             <AccessibleButton
                                 onClick={this.onSubmit}

--- a/src/modules/ProxiedModuleApi.ts
+++ b/src/modules/ProxiedModuleApi.ts
@@ -20,6 +20,7 @@ import { Optional } from "matrix-events-sdk";
 import { DialogProps } from "@matrix-org/react-sdk-module-api/lib/components/DialogContent";
 import React from "react";
 import { AccountAuthInfo } from "@matrix-org/react-sdk-module-api/lib/types/AccountAuthInfo";
+import { ModuleUiDialogProps } from "@matrix-org/react-sdk-module-api/lib/types/ModuleUiDialogProps";
 import { PlainSubstitution } from "@matrix-org/react-sdk-module-api/lib/types/translations";
 import * as Matrix from "matrix-js-sdk/src/matrix";
 import { IRegisterRequestParams } from "matrix-js-sdk/src/matrix";
@@ -86,16 +87,17 @@ export class ProxiedModuleApi implements ModuleApi {
         P extends DialogProps = DialogProps,
         C extends React.Component = React.Component,
     >(
-        title: string,
+        moduleUiDialogProps: ModuleUiDialogProps,
         body: (props: P, ref: React.RefObject<C>) => React.ReactNode,
+        pr,
     ): Promise<{ didOkOrSubmit: boolean; model: M }> {
         return new Promise<{ didOkOrSubmit: boolean; model: M }>((resolve) => {
             Modal.createDialog(
                 ModuleUiDialog,
                 {
-                    title: title,
+                    ...moduleUiDialogProps,
                     contentFactory: body,
-                    contentProps: <DialogProps>{
+                    contentProps: <Omit<DialogProps, "setCanSubmit">>{
                         moduleApi: this,
                     },
                 },


### PR DESCRIPTION
Type: Enhancement
Related: https://github.com/matrix-org/matrix-react-sdk-module-api/pull/14

This PR suggests implementation to the updated open dialog method from the module API. It would allow users to control labels for the dialog buttons and enable/disable module submission button.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement updated open dialog method using module API ([\#10536](https://github.com/matrix-org/matrix-react-sdk/pull/10536)). Contributed by @maheichyk.<!-- CHANGELOG_PREVIEW_END -->