### PR TITLE
Update `composer.spec.ts` to use `findBy*` type queries

### DIFF
--- a/cypress/e2e/composer/composer.spec.ts
+++ b/cypress/e2e/composer/composer.spec.ts
@@ -49,19 +49,25 @@ describe("Composer", () => {
             // Click send
             cy.findByRole("button", { name: "Send message" }).click();
             // It has been sent
-            cy.contains(".mx_EventTile_body", "my message 0");
+            cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                cy.findByText("my message 0").should("exist");
+            });
 
             // Type another and press Enter afterwards
             cy.findByRole("textbox", { name: "Send a message…" }).type("my message 1{enter}");
             // It was sent
-            cy.contains(".mx_EventTile_body", "my message 1");
+            cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                cy.findByText("my message 1").should("exist");
+            });
         });
 
         it("can write formatted text", () => {
             cy.findByRole("textbox", { name: "Send a message…" }).type("my bold{ctrl+b} message");
             cy.findByRole("button", { name: "Send message" }).click();
             // Note: both "bold" and "message" are bold, which is probably surprising
-            cy.contains(".mx_EventTile_body strong", "bold message");
+            cy.get(".mx_EventTile_body strong").within(() => {
+                cy.findByText("bold message").should("exist");
+            });
         });
 
         it("should allow user to input emoji via graphical picker", () => {
@@ -69,14 +75,16 @@ describe("Composer", () => {
                 cy.findByRole("button", { name: "Emoji" }).click();
             });
 
-            cy.get('[data-testid="mx_EmojiPicker"]').within(() => {
+            cy.findByTestId("mx_EmojiPicker").within(() => {
                 cy.contains(".mx_EmojiPicker_item", "😇").click();
             });
 
             cy.get(".mx_ContextualMenu_background").click(); // Close emoji picker
             cy.findByRole("textbox", { name: "Send a message…" }).type("{enter}"); // Send message
 
-            cy.contains(".mx_EventTile_body", "😇");
+            cy.get(".mx_EventTile_body").within(() => {
+                cy.findByText("😇");
+            });
         });
 
         describe("when Ctrl+Enter is required to send", () => {
@@ -93,7 +101,9 @@ describe("Composer", () => {
                 // Press Ctrl+Enter
                 cy.findByRole("textbox", { name: "Send a message…" }).type("{ctrl+enter}");
                 // It was sent
-                cy.contains(".mx_EventTile_body", "my message 3");
+                cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                    cy.findByText("my message 3").should("exist");
+                });
             });
         });
     });
@@ -116,14 +126,18 @@ describe("Composer", () => {
             // Click send
             cy.findByRole("button", { name: "Send message" }).click();
             // It has been sent
-            cy.contains(".mx_EventTile_body", "my message 0");
+            cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                cy.findByText("my message 0").should("exist");
+            });
 
             // Type another
             cy.get("div[contenteditable=true]").type("my message 1");
             // Send message
             cy.get("div[contenteditable=true]").type("{enter}");
             // It was sent
-            cy.contains(".mx_EventTile_body", "my message 1");
+            cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                cy.findByText("my message 1").should("exist");
+            });
         });
 
         it("sends only one message when you press Enter multiple times", () => {
@@ -137,14 +151,18 @@ describe("Composer", () => {
             cy.get("div[contenteditable=true]").type("{enter}");
             cy.get("div[contenteditable=true]").type("{enter}");
             // It has been sent
-            cy.contains(".mx_EventTile_body", "my message 0");
-            cy.get(".mx_EventTile_body").should("have.length", 1);
+            cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                cy.findByText("my message 0").should("exist");
+            });
+            cy.get(".mx_EventTile_last .mx_EventTile_body").should("have.length", 1);
         });
 
         it("can write formatted text", () => {
             cy.get("div[contenteditable=true]").type("my {ctrl+b}bold{ctrl+b} message");
             cy.findByRole("button", { name: "Send message" }).click();
-            cy.contains(".mx_EventTile_body strong", "bold");
+            cy.get(".mx_EventTile_body strong").within(() => {
+                cy.findByText("bold").should("exist");
+            });
         });
 
         describe("when Ctrl+Enter is required to send", () => {
@@ -162,7 +180,9 @@ describe("Composer", () => {
                 // Press Ctrl+Enter
                 cy.get("div[contenteditable=true]").type("{ctrl+enter}");
                 // It was sent
-                cy.contains(".mx_EventTile_body", "my message 3");
+                cy.get(".mx_EventTile_last .mx_EventTile_body").within(() => {
+                    cy.findByText("my message 3").should("exist");
+                });
             });
         });
 
@@ -181,7 +201,9 @@ describe("Composer", () => {
                 cy.findByRole("button", { name: "Send message" }).click();
 
                 // It was sent
-                cy.contains(".mx_EventTile_body a", "my message 0");
+                cy.get(".mx_EventTile_body a").within(() => {
+                    cy.findByText("my message 0").should("exist");
+                });
                 cy.get(".mx_EventTile_body a").should("have.attr", "href").and("include", "https://matrix.org/");
             });
         });

--- a/cypress/e2e/composer/composer.spec.ts
+++ b/cypress/e2e/composer/composer.spec.ts
@@ -42,31 +42,31 @@ describe("Composer", () => {
 
         it("sends a message when you click send or press Enter", () => {
             // Type a message
-            cy.findTextbox("Send a message…").type("my message 0");
+            cy.findByRole("textbox", { name: "Send a message…" }).type("my message 0");
             // It has not been sent yet
             cy.contains(".mx_EventTile_body", "my message 0").should("not.exist");
 
             // Click send
-            cy.findButton("Send message").click();
+            cy.findByRole("button", { name: "Send message" }).click();
             // It has been sent
             cy.contains(".mx_EventTile_body", "my message 0");
 
             // Type another and press Enter afterwards
-            cy.findTextbox("Send a message…").type("my message 1{enter}");
+            cy.findByRole("textbox", { name: "Send a message…" }).type("my message 1{enter}");
             // It was sent
             cy.contains(".mx_EventTile_body", "my message 1");
         });
 
         it("can write formatted text", () => {
-            cy.findTextbox("Send a message…").type("my bold{ctrl+b} message");
-            cy.findButton("Send message").click();
+            cy.findByRole("textbox", { name: "Send a message…" }).type("my bold{ctrl+b} message");
+            cy.findByRole("button", { name: "Send message" }).click();
             // Note: both "bold" and "message" are bold, which is probably surprising
             cy.contains(".mx_EventTile_body strong", "bold message");
         });
 
         it("should allow user to input emoji via graphical picker", () => {
             cy.getComposer(false).within(() => {
-                cy.findButton("Emoji").click();
+                cy.findByRole("button", { name: "Emoji" }).click();
             });
 
             cy.get('[data-testid="mx_EmojiPicker"]').within(() => {
@@ -74,7 +74,7 @@ describe("Composer", () => {
             });
 
             cy.get(".mx_ContextualMenu_background").click(); // Close emoji picker
-            cy.findTextbox("Send a message…").type("{enter}"); // Send message
+            cy.findByRole("textbox", { name: "Send a message…" }).type("{enter}"); // Send message
 
             cy.contains(".mx_EventTile_body", "😇");
         });
@@ -86,12 +86,12 @@ describe("Composer", () => {
 
             it("only sends when you press Ctrl+Enter", () => {
                 // Type a message and press Enter
-                cy.findTextbox("Send a message…").type("my message 3{enter}");
+                cy.findByRole("textbox", { name: "Send a message…" }).type("my message 3{enter}");
                 // It has not been sent yet
                 cy.contains(".mx_EventTile_body", "my message 3").should("not.exist");
 
                 // Press Ctrl+Enter
-                cy.findTextbox("Send a message…").type("{ctrl+enter}");
+                cy.findByRole("textbox", { name: "Send a message…" }).type("{ctrl+enter}");
                 // It was sent
                 cy.contains(".mx_EventTile_body", "my message 3");
             });
@@ -114,7 +114,7 @@ describe("Composer", () => {
             cy.contains(".mx_EventTile_body", "my message 0").should("not.exist");
 
             // Click send
-            cy.findButton("Send message").click();
+            cy.findByRole("button", { name: "Send message" }).click();
             // It has been sent
             cy.contains(".mx_EventTile_body", "my message 0");
 
@@ -143,7 +143,7 @@ describe("Composer", () => {
 
         it("can write formatted text", () => {
             cy.get("div[contenteditable=true]").type("my {ctrl+b}bold{ctrl+b} message");
-            cy.findButton("Send message").click();
+            cy.findByRole("button", { name: "Send message" }).click();
             cy.contains(".mx_EventTile_body strong", "bold");
         });
 
@@ -172,13 +172,13 @@ describe("Composer", () => {
                 cy.get("div[contenteditable=true]").type("my message 0{selectAll}");
 
                 // Open link modal
-                cy.findButton("Link").click();
+                cy.findByRole("button", { name: "Link" }).click();
                 // Fill the link field
-                cy.findTextbox("Link").type("https://matrix.org/");
+                cy.findByRole("textbox", { name: "Link" }).type("https://matrix.org/");
                 // Click on save
-                cy.findButton("Save").click();
+                cy.findByRole("button", { name: "Save" }).click();
                 // Send the message
-                cy.findButton("Send message").click();
+                cy.findByRole("button", { name: "Send message" }).click();
 
                 // It was sent
                 cy.contains(".mx_EventTile_body a", "my message 0");


### PR DESCRIPTION
This PR intends to update `composer.spec.ts` by replacing the custom commands of`find.ts` and using `findBy*` type queries like `findByText`.

For https://github.com/vector-im/element-web/issues/25058 and https://github.com/vector-im/element-web/issues/25033

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->