### PR TITLE
Update `create-room.spec.ts` - deprecate custom commands

### DIFF
--- a/cypress/e2e/create-room/create-room.spec.ts
+++ b/cypress/e2e/create-room/create-room.spec.ts
@@ -20,8 +20,8 @@ import { HomeserverInstance } from "../../plugins/utils/homeserver";
 import Chainable = Cypress.Chainable;
 
 function openCreateRoomDialog(): Chainable<JQuery<HTMLElement>> {
-    cy.findButton("Add room").click();
-    cy.findMenuitem("New room").click();
+    cy.findByRole("button", { name: "Add room" }).click();
+    cy.findByRole("menuitem", { name: "New room" }).click();
     return cy.get(".mx_CreateRoomDialog");
 }
 
@@ -46,15 +46,15 @@ describe("Create Room", () => {
 
         openCreateRoomDialog().within(() => {
             // Fill name & topic
-            cy.findTextbox("Name").type(name);
-            cy.findTextbox("Topic (optional)").type(topic);
+            cy.findByRole("textbox", { name: "Name" }).type(name);
+            cy.findByRole("textbox", { name: "Topic (optional)" }).type(topic);
             // Change room to public
-            cy.findButton("Room visibility").click();
-            cy.findOption("Public room").click();
+            cy.findByRole("button", { name: "Room visibility" }).click();
+            cy.findByRole("option", { name: "Public room" }).click();
             // Fill room address
-            cy.findTextbox("Room address").type("test-room-1");
+            cy.findByRole("textbox", { name: "Room address" }).type("test-room-1");
             // Submit
-            cy.findButton("Create room").click();
+            cy.findByRole("button", { name: "Create room" }).click();
         });
 
         cy.url().should("contain", "/#/room/#test-room-1:localhost");


### PR DESCRIPTION
This PR intends to replace custom commands on `create-room.spec.ts`.

For https://github.com/vector-im/element-web/issues/25058

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->