### PR TITLE
Remove some obsolete button styles from `_common.pcss`

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -657,11 +657,6 @@ legend {
     margin: auto;
 }
 
-.mx_linkButton {
-    cursor: pointer;
-    color: $accent;
-}
-
 .mx_TextInputDialog_label {
     text-align: left;
     padding-bottom: 12px;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -671,16 +671,6 @@ legend {
     background-color: $background;
 }
 
-@define-mixin mx_DialogButton_small {
-    @mixin mx_DialogButton;
-    font-size: $font-15px;
-    padding: 0px 1.5em 0px 1.5em;
-}
-
-.mx_textButton {
-    @mixin mx_DialogButton_small;
-}
-
 .mx_button_row {
     margin-top: 69px;
 }


### PR DESCRIPTION
This PR intends to remove obsolete styles for buttons from `_common.pcss`: `mx_linkButton` and `mx_textButton`. For buttons for links and texts, `AccessibleButton` is expected to be used.

Since the buttons class name is too general, I could not detect since which commit those classes have not been used.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->