### PR TITLE
Refactored mx_Dialog_cancelButton to replace ugly style rule

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -481,7 +481,7 @@ legend {
     height: unset;
 }
 
-.mx_Dialog_headerWithCancel div.mx_Dialog_cancelButton {
+div.mx_Dialog_cancelButton {
   width: 30px;
   height: 30px;
   transform: rotate(45deg);

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -481,6 +481,7 @@ legend {
     height: unset;
 }
 
+/* Begin of .mx_Dialog_cancelButton */
 div.mx_Dialog_cancelButton {
     cursor: pointer;
     width: 30px;
@@ -489,6 +490,7 @@ div.mx_Dialog_cancelButton {
     position: absolute;
     top: 10px;
     right: 0; 
+    border-radius: 20px;
     
     &:after {
         width: 26px;
@@ -502,8 +504,6 @@ div.mx_Dialog_cancelButton {
         top: 2px;
         left: 13px;
     }
-    border-radius: 2px;
-  
     &:after, &:before {
         content: '';
         position: absolute;
@@ -511,6 +511,7 @@ div.mx_Dialog_cancelButton {
         border-radius: 2px;
     }
 }
+/* End of .mx_Dialog_cancelButton */
 
 .mx_Dialog_content {
     margin: 24px 0 68px;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -488,10 +488,7 @@ legend {
   position: absolute;
   top: 10px;
   right: 0; 
-  
-  &.mx_Dialog_cancelButton {
-    width: 30px;
-    height: 30px;
+ 
     &:after {
       width: 26px;
       height: 4px;
@@ -504,7 +501,6 @@ legend {
       top: 2px;
       left: 13px;
     }
-  }
   border-radius: 2px;
   
   &:after, &:before {

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -482,7 +482,6 @@ legend {
 }
 
 .mx_Dialog_cancelButton {
-    @mixin customisedCancelButton;
     width: 18px;
     height: 18px;
     position: absolute;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -481,12 +481,43 @@ legend {
     height: unset;
 }
 
-.mx_Dialog_cancelButton {
-    width: 18px;
-    height: 18px;
+.mx_Dialog_headerWithCancel div.mx_Dialog_cancelButton {
+  width: 30px;
+  height: 30px;
+  transform: rotate(45deg);
+  position: absolute;
+  top: 10px;
+  right: 0; 
+  
+  &.mx_Dialog_cancelButton {
+    width: 30px;
+    height: 30px;
+    &:after {
+      width: 26px;
+      height: 4px;
+      left: 2px;
+      top: 13px;
+    }
+    &:before {
+      width: 4px;
+      height: 26px;
+      top: 2px;
+      left: 13px;
+    }
+  }
+  
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  
+  &:after, &:before {
+    content: '';
     position: absolute;
-    top: 10px;
-    right: 0;
+    background-color: #9fa9ba;
+    -webkit-border-radius: 2px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+  }
 }
 
 .mx_Dialog_content {

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -482,33 +482,34 @@ legend {
 }
 
 div.mx_Dialog_cancelButton {
-  width: 30px;
-  height: 30px;
-  transform: rotate(45deg);
-  position: absolute;
-  top: 10px;
-  right: 0; 
- 
+    cursor: pointer;
+    width: 30px;
+    height: 30px;
+    transform: rotate(45deg);
+    position: absolute;
+    top: 10px;
+    right: 0; 
+    
     &:after {
-      width: 26px;
-      height: 4px;
-      left: 2px;
-      top: 13px;
+        width: 26px;
+        height: 4px;
+        left: 2px;
+        top: 13px;
     }
     &:before {
-      width: 4px;
-      height: 26px;
-      top: 2px;
-      left: 13px;
+        width: 4px;
+        height: 26px;
+        top: 2px;
+        left: 13px;
     }
-  border-radius: 2px;
-  
-  &:after, &:before {
-    content: '';
-    position: absolute;
-    background-color: #9fa9ba;
     border-radius: 2px;
-  }
+  
+    &:after, &:before {
+        content: '';
+        position: absolute;
+        background-color: #9fa9ba;
+        border-radius: 2px;
+    }
 }
 
 .mx_Dialog_content {

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -505,17 +505,12 @@ legend {
       left: 13px;
     }
   }
-  
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
   border-radius: 2px;
   
   &:after, &:before {
     content: '';
     position: absolute;
     background-color: #9fa9ba;
-    -webkit-border-radius: 2px;
-    -moz-border-radius: 2px;
     border-radius: 2px;
   }
 }


### PR DESCRIPTION
I found this in styles:
```
.mx_Dialog_cancelButton {
    background-color: #9fa9ba;
    cursor: pointer;
    height:unset;height:18px;-webkit-mask:url(../../img/cancel.12c5c12.svg);
    mask:url(../../img/cancel.12c5c12.svg);
    -webkit-mask-position:center;mask-position:center;-webkit-mask-repeat:no-

repeat;mask-repeat:no-repeat;-webkit-mask-size:cover;mask-size:cover;position:unset;position:absolute;
    right:0;top:10px;
    width:unset;
    width:18px;
}
```
I did not find an element with with class. I hope it will be okay.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
type: enhancement
notes: better performance with new "Cancel" icon for dialog windows
Result: 
![image](https://user-images.githubusercontent.com/24779886/230899239-c5aba455-ba0c-4421-a1df-15a4794b9b90.png)
How it looks in my Element Web:
![image](https://user-images.githubusercontent.com/24779886/232569184-16f8e533-11ae-4b54-b9d9-de0c9523f64f.png)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * better performance with new "Cancel" icon for dialog windows ([\#10556](https://github.com/matrix-org/matrix-react-sdk/pull/10556)). Contributed by @JeanPaulLucien.<!-- CHANGELOG_PREVIEW_END -->