### PR TITLE
Handle /me in rte

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -63,6 +63,14 @@ interface CreateMessageContentParams {
     editedEvent?: MatrixEvent;
 }
 
+function isMatrixEvent(e: MatrixEvent | undefined): e is MatrixEvent {
+    return Boolean(e);
+}
+
+function isMatrixEventAndReply(areWeEditing: boolean, e: MatrixEvent | undefined): e is MatrixEvent {
+    return areWeEditing ? Boolean(e?.replyEventId) : Boolean(e);
+}
+
 export async function createMessageContent(
     messageProp: string,
     isHTML: boolean,
@@ -74,8 +82,8 @@ export async function createMessageContent(
         editedEvent,
     }: CreateMessageContentParams,
 ): Promise<IContent> {
-    const isEditing = Boolean(editedEvent);
-    const isReply = isEditing ? Boolean(editedEvent?.replyEventId) : Boolean(replyToEvent);
+    const isEditing = isMatrixEvent(editedEvent);
+    const isReply = isMatrixEventAndReply(isEditing, isEditing ? editedEvent : replyToEvent);
     const isReplyAndEditing = isEditing && isReply;
 
     let message = messageProp;

--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -66,7 +66,7 @@ interface CreateMessageContentParams {
 const isMatrixEvent = (e: MatrixEvent | undefined): e is MatrixEvent => e instanceof MatrixEvent;
 
 export async function createMessageContent(
-    messageProp: string,
+    message: string,
     isHTML: boolean,
     {
         relation,
@@ -79,8 +79,6 @@ export async function createMessageContent(
     const isEditing = isMatrixEvent(editedEvent);
     const isReply = isEditing ? Boolean(editedEvent.replyEventId) : isMatrixEvent(replyToEvent);
     const isReplyAndEditing = isEditing && isReply;
-
-    let message = messageProp;
 
     const isEmote = message.startsWith(EMOTE_PREFIX);
     if (isEmote) {

--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -63,13 +63,7 @@ interface CreateMessageContentParams {
     editedEvent?: MatrixEvent;
 }
 
-function isMatrixEvent(e: MatrixEvent | undefined): e is MatrixEvent {
-    return Boolean(e);
-}
-
-function isMatrixEventAndReply(areWeEditing: boolean, e: MatrixEvent | undefined): e is MatrixEvent {
-    return areWeEditing ? Boolean(e?.replyEventId) : Boolean(e);
-}
+const isMatrixEvent = (e: MatrixEvent | undefined): e is MatrixEvent => e instanceof MatrixEvent;
 
 export async function createMessageContent(
     messageProp: string,
@@ -83,7 +77,7 @@ export async function createMessageContent(
     }: CreateMessageContentParams,
 ): Promise<IContent> {
     const isEditing = isMatrixEvent(editedEvent);
-    const isReply = isMatrixEventAndReply(isEditing, isEditing ? editedEvent : replyToEvent);
+    const isReply = isEditing ? Boolean(editedEvent.replyEventId) : isMatrixEvent(replyToEvent);
     const isReplyAndEditing = isEditing && isReply;
 
     let message = messageProp;

--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -84,13 +84,13 @@ export async function createMessageContent(
 
     const isEmote = message.startsWith(EMOTE_PREFIX);
     if (isEmote) {
-        // if an emote, remove the emote prefix - nb assuming here it's plain
-        // text as wrapping /me in a <p> tag won't hit here
+        // if we are dealing with an emote we want to remove the prefix so that `/me` does not
+        // appear after the `* <userName>` text in the timeline
         message = message.slice(EMOTE_PREFIX.length);
     }
     if (message.startsWith("//")) {
         // if user wants to enter a single slash at the start of a message, this
-        // is how they have to do it (due to it clashing with commands), so we
+        // is how they have to do it (due to it clashing with commands), so here we
         // remove the first character to make sure //word displays as /word
         message = message.slice(1);
     }

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -31,7 +31,7 @@ import dis from "../../../../../dispatcher/dispatcher";
 import { createRedactEventDialog } from "../../../dialogs/ConfirmRedactDialog";
 import { endEditing, cancelPreviousPendingEdit } from "./editing";
 import EditorStateTransfer from "../../../../../utils/EditorStateTransfer";
-import { createMessageContent } from "./createMessageContent";
+import { createMessageContent, EMOTE_PREFIX } from "./createMessageContent";
 import { isContentModified } from "./isContentModified";
 import { CommandCategories, getCommand } from "../../../../../SlashCommands";
 import { runSlashCommand, shouldSendAnyway } from "../../../../../editor/commands";
@@ -78,8 +78,9 @@ export async function sendMessage(
 
     let content: IContent | null = null;
 
-    // Functionality here approximates what can be found in SendMessageComposer.sendMessage()
-    if (message.startsWith("/") && !message.startsWith("//")) {
+    // Slash command handling here approximates what can be found in SendMessageComposer.sendMessage()
+    // but note that the /me and // special cases are handled by the call to createMessageContent
+    if (message.startsWith("/") && !message.startsWith("//") && !message.startsWith(EMOTE_PREFIX)) {
         const { cmd, args } = getCommand(message);
         if (cmd) {
             // TODO handle /me special case separately, see end of SlashCommands.Commands

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -83,7 +83,6 @@ export async function sendMessage(
     if (message.startsWith("/") && !message.startsWith("//") && !message.startsWith(EMOTE_PREFIX)) {
         const { cmd, args } = getCommand(message);
         if (cmd) {
-            // TODO handle /me special case separately, see end of SlashCommands.Commands
             const threadId = relation?.rel_type === THREAD_RELATION_TYPE.name ? relation?.event_id : null;
             let commandSuccessful: boolean;
             [content, commandSuccessful] = await runSlashCommand(cmd, args, roomId, threadId ?? null);

--- a/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -13,10 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { MsgType } from "matrix-js-sdk/src/matrix";
 
 import { mkEvent } from "../../../../../test-utils";
 import { RoomPermalinkCreator } from "../../../../../../src/utils/permalinks/Permalinks";
-import { createMessageContent } from "../../../../../../src/components/views/rooms/wysiwyg_composer/utils/createMessageContent";
+import {
+    createMessageContent,
+    EMOTE_PREFIX,
+} from "../../../../../../src/components/views/rooms/wysiwyg_composer/utils/createMessageContent";
 
 describe("createMessageContent", () => {
     const permalinkCreator = {
@@ -129,5 +133,25 @@ describe("createMessageContent", () => {
                 rel_type: "m.replace",
             },
         });
+    });
+
+    it("Should strip the /me prefix from a message", async () => {
+        const textBody = "some body text";
+        const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+
+        expect(content).toMatchObject({ body: textBody, formatted_body: textBody });
+    });
+
+    it("Should strip single / from message prefixed with //", async () => {
+        const content = await createMessageContent("//twoSlashes", true, { permalinkCreator });
+
+        expect(content).toMatchObject({ body: "/twoSlashes", formatted_body: "/twoSlashes" });
+    });
+
+    it("Should set the content type to MsgType.Emote when /me prefix is used", async () => {
+        const textBody = "some body text";
+        const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+
+        expect(content).toMatchObject({ msgtype: MsgType.Emote });
     });
 });


### PR DESCRIPTION
The `/me` command is a special case in the slash commands. This PR:

- reads the implementation across from the current composer into the rich text editor
- also handles the case where a user wants to start a regular message with a single slash (ie they have to type `// message` to get `/message` to show in the timeline, as per the current composer behaviour)
- adds tests

Before vs after behaviour can be seen in the following videos.

**Attempting to use `/me` from rte currently:**

https://user-images.githubusercontent.com/56027671/230909238-596376a2-32ff-482f-823d-c3dec726ce4a.mov


**After changes have been applied:**

https://user-images.githubusercontent.com/56027671/230909397-b9865de4-f5f1-46a8-a16a-92d6d39e038f.mov



<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Handle /me in rte ([\#10558](https://github.com/matrix-org/matrix-react-sdk/pull/10558)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->