### PR TITLE
Fix avatar text issue in rte

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
@@ -95,7 +95,9 @@ export function getMentionDisplayText(completion: ICompletion, client: MatrixCli
 export function getMentionAttributes(completion: ICompletion, client: MatrixClient, room: Room): Attributes {
     // to ensure that we always have something set in the --avatar-letter CSS variable
     // as otherwise alignment varies depending on whether the content is empty or not
-    const defaultLetterContent = "-";
+
+    // use a zero width space so that it counts as content, but does not display anything
+    const defaultLetterContent = "\u200b";
 
     if (completion.type === "user") {
         // logic as used in UserPillPart.setAvatar in parts.ts

--- a/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
@@ -96,7 +96,7 @@ export function getMentionAttributes(completion: ICompletion, client: MatrixClie
     // To ensure that we always have something set in the --avatar-letter CSS variable
     // as otherwise alignment varies depending on whether the content is empty or not.
 
-    // Wse a zero width space so that it counts as content, but does not display anything.
+    // Use a zero width space so that it counts as content, but does not display anything.
     const defaultLetterContent = "\u200b";
 
     if (completion.type === "user") {

--- a/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
@@ -90,13 +90,13 @@ export function getMentionDisplayText(completion: ICompletion, client: MatrixCli
  *
  * @param completion - the item selected from the autocomplete
  * @param client - the MatrixClient is required for us to look up the correct room mention text
- * @returns an object of attributes containing HTMLAnchor attributes or data-* attri
+ * @returns an object of attributes containing HTMLAnchor attributes or data-* attributes
  */
 export function getMentionAttributes(completion: ICompletion, client: MatrixClient, room: Room): Attributes {
-    // to ensure that we always have something set in the --avatar-letter CSS variable
-    // as otherwise alignment varies depending on whether the content is empty or not
+    // To ensure that we always have something set in the --avatar-letter CSS variable
+    // as otherwise alignment varies depending on whether the content is empty or not.
 
-    // use a zero width space so that it counts as content, but does not display anything
+    // Wse a zero width space so that it counts as content, but does not display anything.
     const defaultLetterContent = "\u200b";
 
     if (completion.type === "user") {

--- a/test/components/views/rooms/wysiwyg_composer/utils/autocomplete-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/autocomplete-test.ts
@@ -176,7 +176,7 @@ describe("getMentionAttributes", () => {
 
             expect(result).toEqual({
                 "data-mention-type": "user",
-                "style": `--avatar-background: url(${testAvatarUrlForMember}); --avatar-letter: '-'`,
+                "style": `--avatar-background: url(${testAvatarUrlForMember}); --avatar-letter: '\u200b'`,
             });
         });
 
@@ -203,7 +203,7 @@ describe("getMentionAttributes", () => {
 
             expect(result).toEqual({
                 "data-mention-type": "room",
-                "style": `--avatar-background: url(${testAvatarUrlForRoom}); --avatar-letter: '-'`,
+                "style": `--avatar-background: url(${testAvatarUrlForRoom}); --avatar-letter: '\u200b'`,
             });
         });
 


### PR DESCRIPTION
When testing the implementation of avatars in RTE, unfortunately the avatars I was testing with had a lot of white in them. As a result, I missed the fact that we were rendering a character on top of the avatar.

This PR fixes that issue by using a character that counts as content, but does not display anything when we have a user avatar present in the pill.

Before vs after:
<img width="665" alt="Element__1____Alun_Turner" src="https://user-images.githubusercontent.com/56027671/230899021-a553190a-1bab-4e47-8318-ccdadbc31cbf.png">
<img width="770" alt="Element__1____Alun_Turner" src="https://user-images.githubusercontent.com/56027671/230899225-8b105d98-60a8-4f1b-a5f7-e24c8defea2c.png">

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix avatar text issue in rte ([\#10559](https://github.com/matrix-org/matrix-react-sdk/pull/10559)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->