### PR TITLE
Update tests to ensure file size unit has been fixed

### DIFF
--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -211,6 +211,23 @@ describe("FilePanel", () => {
             });
         });
 
+        it("should render file size in kilobyte on a file tile", () => {
+            const size = "1.12 KB"; // actual file size in kilobyte (KB)
+
+            // Upload a file
+            uploadFile("cypress/fixtures/matrix-org-client-versions.json");
+
+            cy.get(".mx_FilePanel .mx_EventTile").within(() => {
+                // Assert that the file size is displayed in kilobyte, not kibibyte (kB)
+                // See: https://github.com/vector-im/element-web/issues/24866
+                cy.contains(".mx_MFileBody_info_filename", size).should("exist");
+                cy.get(".mx_MFileBody_download").within(() => {
+                    cy.contains("a", size).should("exist");
+                    cy.contains(".mx_MImageBody_size", size).should("exist");
+                });
+            });
+        });
+
         it("should not add inline padding to a tile when it is selected with right click", () => {
             // Upload a file
             uploadFile("cypress/fixtures/1sec.ogg");

--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -211,14 +211,14 @@ describe("FilePanel", () => {
             });
         });
 
-        it("should render file size in kilobyte on a file tile", () => {
-            const size = "1.12 KB"; // actual file size in kilobyte (KB)
+        it("should render file size in kibibytes on a file tile", () => {
+            const size = "1.12 KB"; // actual file size in kibibytes (1024 bytes)
 
             // Upload a file
             uploadFile("cypress/fixtures/matrix-org-client-versions.json");
 
             cy.get(".mx_FilePanel .mx_EventTile").within(() => {
-                // Assert that the file size is displayed in kilobyte, not kibibyte (kB)
+                // Assert that the file size is displayed in kibibytes, not kilobytes (1000 bytes)
                 // See: https://github.com/vector-im/element-web/issues/24866
                 cy.contains(".mx_MFileBody_info_filename", size).should("exist");
                 cy.get(".mx_MFileBody_download").within(() => {

--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -679,7 +679,7 @@ describe("Timeline", () => {
             cy.get(".mx_EventTile[data-layout=irc] .mx_ViewSourceEvent_expanded").should("be.visible");
         });
 
-        it("should render file size in kilobyte on a file tile", () => {
+        it("should render file size in kibibytes on a file tile", () => {
             cy.visit("/#/room/" + roomId);
             cy.get(".mx_GenericEventListSummary_summary").within(() => {
                 cy.findByText(OLD_NAME + " created and configured the room.").should("exist");
@@ -703,7 +703,7 @@ describe("Timeline", () => {
             // Assert that the file size is displayed in kibibytes (1024 bytes), not kilobytes (1000 bytes)
             // See: https://github.com/vector-im/element-web/issues/24866
             cy.get(".mx_EventTile_last").within(() => {
-                cy.contains(".mx_MFileBody_info_filename", "1.12 KB").should("exist"); // actual file size in kilobyte
+                cy.contains(".mx_MFileBody_info_filename", "1.12 KB").should("exist"); // actual file size in kibibytes
             });
         });
 

--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -679,6 +679,34 @@ describe("Timeline", () => {
             cy.get(".mx_EventTile[data-layout=irc] .mx_ViewSourceEvent_expanded").should("be.visible");
         });
 
+        it("should render file size in kilobyte on a file tile", () => {
+            cy.visit("/#/room/" + roomId);
+            cy.get(".mx_GenericEventListSummary_summary").within(() => {
+                cy.findByText(OLD_NAME + " created and configured the room.").should("exist");
+            });
+
+            // Upload a file from the message composer
+            cy.get(".mx_MessageComposer_actions input[type='file']").selectFile(
+                "cypress/fixtures/matrix-org-client-versions.json",
+                { force: true },
+            );
+
+            cy.get(".mx_Dialog").within(() => {
+                // Click "Upload" button
+                cy.findByRole("button", { name: "Upload" }).click();
+            });
+
+            // Wait until the file is sent
+            cy.get(".mx_RoomView_statusArea_expanded").should("not.exist");
+            cy.get(".mx_EventTile.mx_EventTile_last .mx_EventTile_receiptSent").should("exist");
+
+            // Assert that the file size is displayed in kilobyte, not kibibyte (kB)
+            // See: https://github.com/vector-im/element-web/issues/24866
+            cy.get(".mx_EventTile_last").within(() => {
+                cy.contains(".mx_MFileBody_info_filename", "1.12 KB").should("exist"); // actual file size in kilobyte
+            });
+        });
+
         it("should highlight search result words regardless of formatting", () => {
             sendEvent(roomId);
             sendEvent(roomId, true);

--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -700,7 +700,7 @@ describe("Timeline", () => {
             cy.get(".mx_RoomView_statusArea_expanded").should("not.exist");
             cy.get(".mx_EventTile.mx_EventTile_last .mx_EventTile_receiptSent").should("exist");
 
-            // Assert that the file size is displayed in kilobyte, not kibibyte (kB)
+            // Assert that the file size is displayed in kibibytes (1024 bytes), not kilobytes (1000 bytes)
             // See: https://github.com/vector-im/element-web/issues/24866
             cy.get(".mx_EventTile_last").within(() => {
                 cy.contains(".mx_MFileBody_info_filename", "1.12 KB").should("exist"); // actual file size in kilobyte


### PR DESCRIPTION
This PR is a follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/10561 in order to ensure that file size unit used on a file tile or audio player is kibibytes (1024 bytes), not kilobytes (1000 bytes).

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->