### PR TITLE
Update `user-view.spec.ts` - use Cypress Testing Library

### DIFF
--- a/cypress/e2e/user-view/user-view.spec.ts
+++ b/cypress/e2e/user-view/user-view.spec.ts
@@ -40,8 +40,14 @@ describe("UserView", () => {
             cy.visit(`/#/user/${bot.getUserId()}`);
         });
 
-        cy.get("#mx_RightPanel .mx_UserInfo_profile h2").should("contain", "Usman");
-        cy.get(".mx_RightPanel .mx_Spinner").should("not.exist"); // wait for spinners to finish
+        cy.get(".mx_RightPanel").within(() => {
+            cy.get("mx_UserInfo_profile h2").within(() => {
+                cy.findByText("Usman").should("exist");
+            });
+
+            cy.get(".mx_Spinner").should("not.exist"); // wait for spinners to finish
+        });
+
         cy.get(".mx_RightPanel").percySnapshotElement("User View", {
             // Hide the MXID field as it'll vary on each test
             percyCSS: ".mx_UserInfo_profile_mxid { visibility: hidden !important; }",

--- a/cypress/e2e/user-view/user-view.spec.ts
+++ b/cypress/e2e/user-view/user-view.spec.ts
@@ -40,12 +40,8 @@ describe("UserView", () => {
             cy.visit(`/#/user/${bot.getUserId()}`);
         });
 
-        cy.get(".mx_RightPanel").within(() => {
-            cy.get("mx_UserInfo_profile h2").within(() => {
-                cy.findByText("Usman").should("exist");
-            });
-
-            cy.get(".mx_Spinner").should("not.exist"); // wait for spinners to finish
+        cy.get(".mx_RightPanel .mx_UserInfo_profile h2").within(() => {
+            cy.findByText("Usman").should("exist");
         });
 
         cy.get(".mx_RightPanel").percySnapshotElement("User View", {


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25033

This PR intends to update `user-view.spec.ts` by using Cypress Testing Library. It also removes a command to wait until the spinner disappears as `percySnapshotElement` waits it by default.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->