### PR TITLE
Remove dependency on `org.matrix.e2e_cross_signing` unstable feature

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -251,7 +251,8 @@ export default class DeviceListener {
         if (!this.running) return; // we have been stopped
         const cli = MatrixClientPeg.get();
 
-        if (!(await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing"))) return;
+        // cross-signing support was added to Matrix in MSC1756, which landed in spec v1.1
+        if (!(await cli.isVersionSupported("v1.1"))) return;
 
         if (!cli.isCryptoEnabled()) return;
         // don't recheck until the initial sync is complete: lots of account data events will fire

--- a/src/rageshake/submit-rageshake.ts
+++ b/src/rageshake/submit-rageshake.ts
@@ -95,10 +95,6 @@ async function collectBugReport(opts: IOpts = {}, gzipLogs = true): Promise<Form
             const secretStorage = client.crypto.secretStorage;
 
             body.append("cross_signing_ready", String(await client.isCrossSigningReady()));
-            body.append(
-                "cross_signing_supported_by_hs",
-                String(await client.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")),
-            );
             body.append("cross_signing_key", crossSigning.getId() ?? "n/a");
             body.append(
                 "cross_signing_privkey_in_secret_storage",

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -132,9 +132,6 @@ async function getCryptoContext(client: MatrixClient): Promise<CryptoContext> {
     return {
         device_keys: keys.join(", "),
         cross_signing_ready: String(await client.isCrossSigningReady()),
-        cross_signing_supported_by_hs: String(
-            await client.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing"),
-        ),
         cross_signing_key: crossSigning.getId()!,
         cross_signing_privkey_in_secret_storage: String(!!(await crossSigning.isStoredInSecretStorage(secretStorage))),
         cross_signing_master_privkey_cached: String(!!(pkCache && (await pkCache.getCrossSigningKeyCache?.("master")))),

--- a/test/DeviceListener-test.ts
+++ b/test/DeviceListener-test.ts
@@ -80,7 +80,7 @@ describe("DeviceListener", () => {
             getUserId: jest.fn().mockReturnValue(userId),
             getKeyBackupVersion: jest.fn().mockResolvedValue(undefined),
             getRooms: jest.fn().mockReturnValue([]),
-            doesServerSupportUnstableFeature: jest.fn().mockResolvedValue(true),
+            isVersionSupported: jest.fn().mockResolvedValue(true),
             isCrossSigningReady: jest.fn().mockResolvedValue(true),
             isSecretStorageReady: jest.fn().mockResolvedValue(true),
             isCryptoEnabled: jest.fn().mockReturnValue(true),
@@ -234,9 +234,10 @@ describe("DeviceListener", () => {
 
     describe("recheck", () => {
         it("does nothing when cross signing feature is not supported", async () => {
-            mockClient!.doesServerSupportUnstableFeature.mockResolvedValue(false);
+            mockClient!.isVersionSupported.mockResolvedValue(false);
             await createAndStart();
 
+            expect(mockClient!.isVersionSupported).toHaveBeenCalledWith("v1.1");
             expect(mockClient!.isCrossSigningReady).not.toHaveBeenCalled();
         });
         it("does nothing when crypto is not enabled", async () => {


### PR DESCRIPTION
Currently, we have some code that relies on the server declaring support for an
`unstable_feature` called `org.matrix.e2e_cross_signing`. There is nothing in
the spec that requires this, so this would make us incompatible with some
server implementations.

The features in question were added in spec v1.1, so we can test for that
instead.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove dependency on `org.matrix.e2e_cross_signing` unstable feature ([\#10593](https://github.com/matrix-org/matrix-react-sdk/pull/10593)).<!-- CHANGELOG_PREVIEW_END -->