### PR TITLE
Fix incorrect avatar background colour when using a custom theme

### DIFF
--- a/src/Avatar.ts
+++ b/src/Avatar.ts
@@ -96,7 +96,7 @@ export function defaultAvatarUrlForString(s: string): string {
     const colorIndex = total % defaultColors.length;
     // overwritten color value in custom themes
     const cssVariable = `--avatar-background-colors_${colorIndex}`;
-    const cssValue = document.body.style.getPropertyValue(cssVariable);
+    const cssValue = getComputedStyle(document.body).getPropertyValue(cssVariable);
     const color = cssValue || defaultColors[colorIndex];
     let dataUrl = colorToDataURLCache.get(color);
     if (!dataUrl) {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

"--avatar-background-colors_*" are not taken in account in some situation, by using "getComputedStyle" we ensure it's taken in account in all case.

## Problem Details

When you add variables at the body level like that for a custom theme :

https://github.com/tchapgouv/tchap-web-v4/blob/6f62e1536754468b7c03ff7542dcdfb352de512d/res/themes/tchap-light/css/_tchap_custom_vars.pcss#L36-L40
![image](https://user-images.githubusercontent.com/1238254/232023173-08a4258b-d599-4215-8135-2a7e0405dbc6.png)


We can see the variable here :
![image](https://user-images.githubusercontent.com/1238254/232021962-0de3cb5d-ccc8-41ba-aa0e-9e38caf3cfd9.png)

But as the style isn't computed, document.body.style.getPropertyValue("--avatar-background-colors_1"); don't return the value.
getComputedStyle(document.body) do the computation of the style and return the good answer :
![image](https://user-images.githubusercontent.com/1238254/232022416-2f636c62-54e1-4719-89ed-81a4ef7f8623.png)


## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))



<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->

Signed-off-by: Julien DAUPHANT [julien.dauphant@beta.gouv.fr](mailto:julien.dauphant@beta.gouv.fr)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect avatar background colour when using a custom theme ([\#10598](https://github.com/matrix-org/matrix-react-sdk/pull/10598)). Contributed by @jdauphant.<!-- CHANGELOG_PREVIEW_END -->