### PR TITLE
Replace uses of `checkDeviceTrust` with `getDeviceVerificationStatus`

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -310,7 +310,11 @@ export default class DeviceListener {
         const newUnverifiedDeviceIds = new Set<string>();
 
         const isCurrentDeviceTrusted =
-            crossSigningReady && (await cli.checkDeviceTrust(cli.getUserId()!, cli.deviceId!).isCrossSigningVerified());
+            crossSigningReady &&
+            Boolean(
+                (await cli.getCrypto()?.getDeviceVerificationStatus(cli.getUserId()!, cli.deviceId!))
+                    ?.crossSigningVerified,
+            );
 
         // as long as cross-signing isn't ready,
         // you can't see or dismiss any device toasts
@@ -319,8 +323,10 @@ export default class DeviceListener {
             for (const device of devices) {
                 if (device.deviceId === cli.deviceId) continue;
 
-                const deviceTrust = await cli.checkDeviceTrust(cli.getUserId()!, device.deviceId!);
-                if (!deviceTrust.isCrossSigningVerified() && !this.dismissed.has(device.deviceId)) {
+                const deviceTrust = await cli
+                    .getCrypto()
+                    ?.getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
+                if (!deviceTrust?.crossSigningVerified && !this.dismissed.has(device.deviceId)) {
                     if (this.ourDeviceIdsAtStart?.has(device.deviceId)) {
                         oldUnverifiedDeviceIds.add(device.deviceId);
                     } else {

--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -1073,9 +1073,9 @@ export const Commands = [
                                     },
                                 );
                             }
-                            const deviceTrust = await cli.checkDeviceTrust(userId, deviceId);
+                            const deviceTrust = await cli.getCrypto()?.getDeviceVerificationStatus(userId, deviceId);
 
-                            if (deviceTrust.isVerified()) {
+                            if (deviceTrust?.isVerified()) {
                                 if (device.getFingerprint() === fingerprint) {
                                     throw new UserFriendlyError("Session already verified!");
                                 } else {

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -79,6 +79,7 @@ import PosthogTrackers from "../../../PosthogTrackers";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { DirectoryMember, startDmOnFirstMessage } from "../../../utils/direct-messages";
 import { SdkContextClass } from "../../../contexts/SDKContext";
+import { asyncSome } from "../../../utils/arrays";
 
 export interface IDevice extends DeviceInfo {
     ambiguous?: boolean;
@@ -101,22 +102,22 @@ export const disambiguateDevices = (devices: IDevice[]): void => {
     }
 };
 
-export const getE2EStatus = (cli: MatrixClient, userId: string, devices: IDevice[]): E2EStatus => {
+export const getE2EStatus = async (cli: MatrixClient, userId: string, devices: IDevice[]): Promise<E2EStatus> => {
     const isMe = userId === cli.getUserId();
     const userTrust = cli.checkUserTrust(userId);
     if (!userTrust.isCrossSigningVerified()) {
         return userTrust.wasCrossSigningVerified() ? E2EStatus.Warning : E2EStatus.Normal;
     }
 
-    const anyDeviceUnverified = devices.some((device) => {
+    const anyDeviceUnverified = await asyncSome(devices, async (device) => {
         const { deviceId } = device;
         // For your own devices, we use the stricter check of cross-signing
         // verification to encourage everyone to trust their own devices via
         // cross-signing so that other users can then safely trust you.
         // For other people's devices, the more general verified check that
         // includes locally verified devices can be used.
-        const deviceTrust = cli.checkDeviceTrust(userId, deviceId);
-        return isMe ? !deviceTrust.isCrossSigningVerified() : !deviceTrust.isVerified();
+        const deviceTrust = await cli.getCrypto()?.getDeviceVerificationStatus(userId, deviceId);
+        return isMe ? !deviceTrust?.crossSigningVerified : !deviceTrust?.isVerified();
     });
     return anyDeviceUnverified ? E2EStatus.Warning : E2EStatus.Verified;
 };
@@ -1611,10 +1612,13 @@ const UserInfo: React.FC<IProps> = ({ user, room, onClose, phase = RightPanelPha
     const isRoomEncrypted = useIsEncrypted(cli, room);
     const devices = useDevices(user.userId) ?? [];
 
-    let e2eStatus: E2EStatus | undefined;
-    if (isRoomEncrypted && devices) {
-        e2eStatus = getE2EStatus(cli, user.userId, devices);
-    }
+    const e2eStatus = useAsyncMemo(async () => {
+        if (!isRoomEncrypted || !devices) {
+            return undefined;
+        } else {
+            return await getE2EStatus(cli, user.userId, devices);
+        }
+    }, [cli, isRoomEncrypted, user.userId, devices]);
 
     const classes = ["mx_UserInfo"];
 

--- a/src/components/views/settings/DevicesPanel.tsx
+++ b/src/components/views/settings/DevicesPanel.tsx
@@ -26,14 +26,15 @@ import Spinner from "../elements/Spinner";
 import AccessibleButton from "../elements/AccessibleButton";
 import { deleteDevicesWithInteractiveAuth } from "./devices/deleteDevices";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
-import { isDeviceVerified } from "../../../utils/device/isDeviceVerified";
+import { fetchExtendedDeviceInformation } from "./devices/useOwnDevices";
+import { DevicesDictionary, ExtendedDevice } from "./devices/types";
 
 interface IProps {
     className?: string;
 }
 
 interface IState {
-    devices: IMyDevice[];
+    devices?: DevicesDictionary;
     deviceLoadError?: string;
     selectedDevices: string[];
     deleting?: boolean;
@@ -47,7 +48,6 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
     public constructor(props: IProps) {
         super(props);
         this.state = {
-            devices: [],
             selectedDevices: [],
         };
         this.loadDevices = this.loadDevices.bind(this);
@@ -70,18 +70,16 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
 
     private loadDevices(): void {
         const cli = this.context;
-        cli.getDevices().then(
-            (resp) => {
+        fetchExtendedDeviceInformation(cli).then(
+            (devices) => {
                 if (this.unmounted) {
                     return;
                 }
 
                 this.setState((state, props) => {
-                    const deviceIds = resp.devices.map((device) => device.device_id);
-                    const selectedDevices = state.selectedDevices.filter((deviceId) => deviceIds.includes(deviceId));
                     return {
-                        devices: resp.devices || [],
-                        selectedDevices,
+                        devices: devices,
+                        selectedDevices: state.selectedDevices.filter((deviceId) => devices.hasOwnProperty(deviceId)),
                     };
                 });
             },
@@ -117,10 +115,6 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
         const idA = a.device_id;
         const idB = b.device_id;
         return idA < idB ? -1 : idA > idB ? 1 : 0;
-    }
-
-    private isDeviceVerified(device: IMyDevice): boolean | null {
-        return isDeviceVerified(this.context, device.device_id);
     }
 
     private onDeviceSelectionToggled = (device: IMyDevice): void => {
@@ -205,15 +199,15 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
         }
     };
 
-    private renderDevice = (device: IMyDevice): JSX.Element => {
-        const myDeviceId = this.context.getDeviceId();
-        const myDevice = this.state.devices.find((device) => device.device_id === myDeviceId);
+    private renderDevice = (device: ExtendedDevice): JSX.Element => {
+        const myDeviceId = this.context.getDeviceId()!;
+        const myDevice = this.state.devices[myDeviceId]!;
 
         const isOwnDevice = device.device_id === myDeviceId;
 
         // If our own device is unverified, it can't verify other
         // devices, it can only request verification for itself
-        const canBeVerified = (myDevice && this.isDeviceVerified(myDevice)) || isOwnDevice;
+        const canBeVerified = (myDevice && myDevice.isVerified) || isOwnDevice;
 
         return (
             <DevicesPanelEntry
@@ -221,7 +215,7 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
                 device={device}
                 selected={this.state.selectedDevices.includes(device.device_id)}
                 isOwnDevice={isOwnDevice}
-                verified={this.isDeviceVerified(device)}
+                verified={device.isVerified}
                 canBeVerified={canBeVerified}
                 onDeviceChange={this.loadDevices}
                 onDeviceToggled={this.onDeviceSelectionToggled}
@@ -242,21 +236,21 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
             return <Spinner />;
         }
 
-        const myDeviceId = this.context.getDeviceId();
-        const myDevice = devices.find((device) => device.device_id === myDeviceId);
+        const myDeviceId = this.context.getDeviceId()!;
+        const myDevice = devices[myDeviceId];
 
         if (!myDevice) {
             return loadError;
         }
 
-        const otherDevices = devices.filter((device) => device.device_id !== myDeviceId);
+        const otherDevices = Object.values(devices).filter((device) => device.device_id !== myDeviceId);
         otherDevices.sort(this.deviceCompare);
 
-        const verifiedDevices: IMyDevice[] = [];
-        const unverifiedDevices: IMyDevice[] = [];
-        const nonCryptoDevices: IMyDevice[] = [];
+        const verifiedDevices: ExtendedDevice[] = [];
+        const unverifiedDevices: ExtendedDevice[] = [];
+        const nonCryptoDevices: ExtendedDevice[] = [];
         for (const device of otherDevices) {
-            const verified = this.isDeviceVerified(device);
+            const verified = device.isVerified;
             if (verified === true) {
                 verifiedDevices.push(device);
             } else if (verified === false) {
@@ -266,7 +260,7 @@ export default class DevicesPanel extends React.Component<IProps, IState> {
             }
         }
 
-        const section = (trustIcon: JSX.Element, title: string, deviceList: IMyDevice[]): JSX.Element => {
+        const section = (trustIcon: JSX.Element, title: string, deviceList: ExtendedDevice[]): JSX.Element => {
             if (deviceList.length === 0) {
                 return <React.Fragment />;
             }

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -59,19 +59,15 @@ const parseDeviceExtendedInformation = (matrixClient: MatrixClient, device: IMyD
 export async function fetchExtendedDeviceInformation(matrixClient: MatrixClient): Promise<DevicesDictionary> {
     const { devices } = await matrixClient.getDevices();
 
-    const devicesDict = devices.reduce(
-        (acc, device: IMyDevice) => ({
-            ...acc,
-            [device.device_id]: {
-                ...device,
-                isVerified: isDeviceVerified(matrixClient, device.device_id),
-                ...parseDeviceExtendedInformation(matrixClient, device),
-                ...parseUserAgent(device[UNSTABLE_MSC3852_LAST_SEEN_UA.name]),
-            },
-        }),
-        {},
-    );
-
+    const devicesDict: DevicesDictionary = {};
+    for (const device of devices) {
+        devicesDict[device.device_id] = {
+            ...device,
+            isVerified: await isDeviceVerified(matrixClient, device.device_id),
+            ...parseDeviceExtendedInformation(matrixClient, device),
+            ...parseUserAgent(device[UNSTABLE_MSC3852_LAST_SEEN_UA.name]),
+        };
+    }
     return devicesDict;
 }
 

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -50,7 +50,13 @@ const parseDeviceExtendedInformation = (matrixClient: MatrixClient, device: IMyD
     };
 };
 
-const fetchDevicesWithVerification = async (matrixClient: MatrixClient): Promise<DevicesState["devices"]> => {
+/**
+ * Fetch extended details of the user's own devices
+ *
+ * @param matrixClient - Matrix Client
+ * @returns A dictionary mapping from device ID to ExtendedDevice
+ */
+export async function fetchExtendedDeviceInformation(matrixClient: MatrixClient): Promise<DevicesDictionary> {
     const { devices } = await matrixClient.getDevices();
 
     const devicesDict = devices.reduce(
@@ -67,7 +73,7 @@ const fetchDevicesWithVerification = async (matrixClient: MatrixClient): Promise
     );
 
     return devicesDict;
-};
+}
 
 export enum OwnDevicesError {
     Unsupported = "Unsupported",
@@ -112,7 +118,7 @@ export const useOwnDevices = (): DevicesState => {
     const refreshDevices = useCallback(async (): Promise<void> => {
         setIsLoadingDeviceList(true);
         try {
-            const devices = await fetchDevicesWithVerification(matrixClient);
+            const devices = await fetchExtendedDeviceInformation(matrixClient);
             setDevices(devices);
 
             const { pushers } = await matrixClient.getPushers();

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2247,7 +2247,6 @@
     "Room settings": "Room settings",
     "Trusted": "Trusted",
     "Not trusted": "Not trusted",
-    "Unable to load session list": "Unable to load session list",
     "%(count)s verified sessions|other": "%(count)s verified sessions",
     "%(count)s verified sessions|one": "1 verified session",
     "Hide verified sessions": "Hide verified sessions",

--- a/src/stores/SetupEncryptionStore.ts
+++ b/src/stores/SetupEncryptionStore.ts
@@ -109,14 +109,20 @@ export class SetupEncryptionStore extends EventEmitter {
         const dehydratedDevice = await cli.getDehydratedDevice();
         const ownUserId = cli.getUserId()!;
         const crossSigningInfo = cli.getStoredCrossSigningForUser(ownUserId);
-        this.hasDevicesToVerifyAgainst = cli
-            .getStoredDevicesForUser(ownUserId)
-            .some(
-                (device) =>
-                    device.getIdentityKey() &&
-                    (!dehydratedDevice || device.deviceId != dehydratedDevice.device_id) &&
-                    crossSigningInfo?.checkDeviceTrust(crossSigningInfo, device, false, true).isCrossSigningVerified(),
-            );
+        this.hasDevicesToVerifyAgainst = cli.getStoredDevicesForUser(ownUserId).some((device) => {
+            if (!device.getIdentityKey() || (dehydratedDevice && device.deviceId == dehydratedDevice?.device_id)) {
+                return false;
+            }
+            // check if the device is signed by the cross-signing key stored for our user. Note that this is
+            // *different* to calling `cryptoApi.getDeviceVerificationStatus`, because even if we have stored
+            // a cross-signing key for our user, we don't necessarily trust it yet (In legacy Crypto, we have not
+            // yet imported it into `Crypto.crossSigningInfo`, which for maximal confusion is a different object to
+            // `Crypto.getStoredCrossSigningForUser(ownUserId)`).
+            //
+            // TODO: figure out wtf to to here for rust-crypto
+            const verificationStatus = crossSigningInfo?.checkDeviceTrust(crossSigningInfo, device, false, true);
+            return verificationStatus.isCrossSigningVerified();
+        });
 
         this.phase = Phase.Intro;
         this.emit("update");

--- a/src/toasts/UnverifiedSessionToast.tsx
+++ b/src/toasts/UnverifiedSessionToast.tsx
@@ -48,7 +48,7 @@ export const showToast = async (deviceId: string): Promise<void> => {
     const device = await cli.getDevice(deviceId);
     const extendedDevice = {
         ...device,
-        isVerified: isDeviceVerified(cli, deviceId),
+        isVerified: await isDeviceVerified(cli, deviceId),
         deviceType: DeviceType.Unknown,
     };
 

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -324,6 +324,16 @@ export async function asyncEvery<T>(values: T[], predicate: (value: T) => Promis
     return true;
 }
 
+/**
+ * Async version of Array.some.
+ */
+export async function asyncSome<T>(values: T[], predicate: (value: T) => Promise<boolean>): Promise<boolean> {
+    for (const value of values) {
+        if (await predicate(value)) return true;
+    }
+    return false;
+}
+
 export function filterBoolean<T>(values: Array<T | null | undefined>): T[] {
     return values.filter(Boolean) as T[];
 }

--- a/src/utils/device/isDeviceVerified.ts
+++ b/src/utils/device/isDeviceVerified.ts
@@ -25,10 +25,10 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
  * @returns `true` if the device has been correctly cross-signed. `false` if the device is unknown or not correctly
  *    cross-signed. `null` if there was an error fetching the device info.
  */
-export const isDeviceVerified = (client: MatrixClient, deviceId: string): boolean | null => {
+export const isDeviceVerified = async (client: MatrixClient, deviceId: string): Promise<boolean | null> => {
     try {
-        const trustLevel = client.checkDeviceTrust(client.getSafeUserId(), deviceId);
-        return trustLevel.isCrossSigningVerified();
+        const trustLevel = await client.getCrypto()?.getDeviceVerificationStatus(client.getSafeUserId(), deviceId);
+        return trustLevel?.crossSigningVerified ?? false;
     } catch (e) {
         console.error("Error getting device cross-signing info", e);
         return null;

--- a/test/DeviceListener-test.ts
+++ b/test/DeviceListener-test.ts
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 import { Mocked, mocked } from "jest-mock";
-import { MatrixEvent, Room, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { MatrixEvent, Room, MatrixClient, DeviceVerificationStatus, CryptoApi } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
-import { CrossSigningInfo, DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
+import { CrossSigningInfo } from "matrix-js-sdk/src/crypto/CrossSigning";
 import { CryptoEvent } from "matrix-js-sdk/src/crypto";
 import { IKeyBackupInfo } from "matrix-js-sdk/src/crypto/keybackup";
 
@@ -60,6 +60,7 @@ const flushPromises = async () => await new Promise(process.nextTick);
 
 describe("DeviceListener", () => {
     let mockClient: Mocked<MatrixClient> | undefined;
+    let mockCrypto: Mocked<CryptoApi> | undefined;
 
     // spy on various toasts' hide and show functions
     // easier than mocking
@@ -75,6 +76,11 @@ describe("DeviceListener", () => {
         mockPlatformPeg({
             getAppVersion: jest.fn().mockResolvedValue("1.2.3"),
         });
+        mockCrypto = {
+            getDeviceVerificationStatus: jest.fn().mockResolvedValue({
+                crossSigningVerified: false,
+            }),
+        } as unknown as Mocked<CryptoApi>;
         mockClient = getMockClientWithEventEmitter({
             isGuest: jest.fn(),
             getUserId: jest.fn().mockReturnValue(userId),
@@ -97,7 +103,7 @@ describe("DeviceListener", () => {
             setAccountData: jest.fn(),
             getAccountData: jest.fn(),
             deleteAccountData: jest.fn(),
-            checkDeviceTrust: jest.fn().mockReturnValue(new DeviceTrustLevel(false, false, false, false)),
+            getCrypto: jest.fn().mockReturnValue(mockCrypto),
         });
         jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
         jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
@@ -391,14 +397,14 @@ describe("DeviceListener", () => {
             const device2 = new DeviceInfo("d2");
             const device3 = new DeviceInfo("d3");
 
-            const deviceTrustVerified = new DeviceTrustLevel(true, false, false, false);
-            const deviceTrustUnverified = new DeviceTrustLevel(false, false, false, false);
+            const deviceTrustVerified = new DeviceVerificationStatus(true, false, false, false);
+            const deviceTrustUnverified = new DeviceVerificationStatus(false, false, false, false);
 
             beforeEach(() => {
                 mockClient!.isCrossSigningReady.mockResolvedValue(true);
                 mockClient!.getStoredDevicesForUser.mockReturnValue([currentDevice, device2, device3]);
                 // all devices verified by default
-                mockClient!.checkDeviceTrust.mockReturnValue(deviceTrustVerified);
+                mockCrypto!.getDeviceVerificationStatus.mockResolvedValue(deviceTrustVerified);
                 mockClient!.deviceId = currentDevice.deviceId;
                 jest.spyOn(SettingsStore, "getValue").mockImplementation(
                     (settingName) => settingName === UIFeature.BulkUnverifiedSessionsReminder,
@@ -423,7 +429,7 @@ describe("DeviceListener", () => {
                     jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
                     // currentDevice, device2 are verified, device3 is unverified
                     // ie if reminder was enabled it should be shown
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case currentDevice.deviceId:
                             case device2.deviceId:
@@ -438,7 +444,7 @@ describe("DeviceListener", () => {
 
                 it("hides toast when current device is unverified", async () => {
                     // device2 verified, current and device3 unverified
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case device2.deviceId:
                                 return deviceTrustVerified;
@@ -454,7 +460,7 @@ describe("DeviceListener", () => {
                 it("hides toast when reminder is snoozed", async () => {
                     mocked(isBulkUnverifiedDeviceReminderSnoozed).mockReturnValue(true);
                     // currentDevice, device2 are verified, device3 is unverified
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case currentDevice.deviceId:
                             case device2.deviceId:
@@ -470,7 +476,7 @@ describe("DeviceListener", () => {
 
                 it("shows toast with unverified devices at app start", async () => {
                     // currentDevice, device2 are verified, device3 is unverified
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case currentDevice.deviceId:
                             case device2.deviceId:
@@ -488,7 +494,7 @@ describe("DeviceListener", () => {
 
                 it("hides toast when unverified sessions at app start have been dismissed", async () => {
                     // currentDevice, device2 are verified, device3 is unverified
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case currentDevice.deviceId:
                             case device2.deviceId:
@@ -510,7 +516,7 @@ describe("DeviceListener", () => {
 
                 it("hides toast when unverified sessions are added after app start", async () => {
                     // currentDevice, device2 are verified, device3 is unverified
-                    mockClient!.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+                    mockCrypto!.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                         switch (deviceId) {
                             case currentDevice.deviceId:
                             case device2.deviceId:

--- a/test/components/views/settings/DevicesPanel-test.tsx
+++ b/test/components/views/settings/DevicesPanel-test.tsx
@@ -18,7 +18,6 @@ import { act, fireEvent, render } from "@testing-library/react";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { PUSHER_DEVICE_ID, PUSHER_ENABLED } from "matrix-js-sdk/src/@types/event";
-import { DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 
 import DevicesPanel from "../../../../src/components/views/settings/DevicesPanel";
 import { flushPromises, getMockClientWithEventEmitter, mkPusher, mockClientMethodsUser } from "../../../test-utils";
@@ -29,16 +28,21 @@ describe("<DevicesPanel />", () => {
     const device1 = { device_id: "device_1" };
     const device2 = { device_id: "device_2" };
     const device3 = { device_id: "device_3" };
+    const mockCrypto = {
+        getDeviceVerificationStatus: jest.fn().mockResolvedValue({
+            crossSigningVerified: false,
+        }),
+    };
     const mockClient = getMockClientWithEventEmitter({
         ...mockClientMethodsUser(userId),
         getDevices: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue(device1.device_id),
         deleteMultipleDevices: jest.fn(),
-        checkDeviceTrust: jest.fn().mockReturnValue(new DeviceTrustLevel(false, false, false, false)),
         getStoredDevice: jest.fn().mockReturnValue(new DeviceInfo("id")),
         generateClientSecret: jest.fn(),
         getPushers: jest.fn(),
         setPusher: jest.fn(),
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
     });
 
     const getComponent = () => (

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -234,6 +234,7 @@ export function createTestClient(): MatrixClient {
         }),
 
         searchUserDirectory: jest.fn().mockResolvedValue({ limited: false, results: [] }),
+        getCrypto: jest.fn(),
     } as unknown as MatrixClient;
 
     client.reEmitter = new ReEmitter(client);

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -99,7 +99,6 @@ export function createTestClient(): MatrixClient {
         getDevice: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue("ABCDEFGHI"),
         getStoredCrossSigningForUser: jest.fn(),
-        checkDeviceTrust: jest.fn(),
         getStoredDevice: jest.fn(),
         requestVerification: jest.fn(),
         deviceId: "ABCDEFGHI",

--- a/test/test-utils/utilities.ts
+++ b/test/test-utils/utilities.ts
@@ -127,7 +127,7 @@ export function untilEmission(
     });
 }
 
-export const flushPromises = async () => await new Promise((resolve) => window.setTimeout(resolve));
+export const flushPromises = async () => await new Promise<void>((resolve) => window.setTimeout(resolve));
 
 // with jest's modern fake timers process.nextTick is also mocked,
 // flushing promises in the normal way then waits for some advancement

--- a/test/toasts/UnverifiedSessionToast-test.tsx
+++ b/test/toasts/UnverifiedSessionToast-test.tsx
@@ -18,9 +18,8 @@ import React from "react";
 import { render, RenderResult, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mocked, Mocked } from "jest-mock";
-import { IMyDevice, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { CryptoApi, DeviceVerificationStatus, IMyDevice, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
-import { DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 
 import dis from "../../src/dispatcher/dispatcher";
 import { showToast } from "../../src/toasts/UnverifiedSessionToast";
@@ -55,7 +54,11 @@ describe("UnverifiedSessionToast", () => {
 
             return null;
         });
-        client.checkDeviceTrust.mockReturnValue(new DeviceTrustLevel(true, false, false, false));
+        client.getCrypto.mockReturnValue({
+            getDeviceVerificationStatus: jest
+                .fn()
+                .mockResolvedValue(new DeviceVerificationStatus(true, false, false, false)),
+        } as unknown as CryptoApi);
         jest.spyOn(dis, "dispatch");
         jest.spyOn(DeviceListener.sharedInstance(), "dismissUnverifiedSessions");
     });

--- a/test/utils/ShieldUtils-test.ts
+++ b/test/utils/ShieldUtils-test.ts
@@ -22,21 +22,25 @@ import DMRoomMap from "../../src/utils/DMRoomMap";
 function mkClient(selfTrust = false) {
     return {
         getUserId: () => "@self:localhost",
+        getCrypto: () => ({
+            getDeviceVerificationStatus: (userId: string, deviceId: string) =>
+                Promise.resolve({
+                    isVerified: () => (userId === "@self:localhost" ? selfTrust : userId[2] == "T"),
+                }),
+        }),
         checkUserTrust: (userId: string) => ({
             isCrossSigningVerified: () => userId[1] == "T",
             wasCrossSigningVerified: () => userId[1] == "T" || userId[1] == "W",
-        }),
-        checkDeviceTrust: (userId: string, deviceId: string) => ({
-            isVerified: () => (userId === "@self:localhost" ? selfTrust : userId[2] == "T"),
         }),
         getStoredDevicesForUser: (userId: string) => ["DEVICE"],
     } as unknown as MatrixClient;
 }
 
 describe("mkClient self-test", function () {
-    test.each([true, false])("behaves well for self-trust=%s", (v) => {
+    test.each([true, false])("behaves well for self-trust=%s", async (v) => {
         const client = mkClient(v);
-        expect(client.checkDeviceTrust("@self:localhost", "DEVICE").isVerified()).toBe(v);
+        const status = await client.getCrypto().getDeviceVerificationStatus("@self:localhost", "DEVICE");
+        expect(status.isVerified()).toBe(v);
     });
 
     test.each([
@@ -53,8 +57,9 @@ describe("mkClient self-test", function () {
         ["@TF:h", false],
         ["@FT:h", true],
         ["@FF:h", false],
-    ])("behaves well for device trust %s", (userId, trust) => {
-        expect(mkClient().checkDeviceTrust(userId, "device").isVerified()).toBe(trust);
+    ])("behaves well for device trust %s", async (userId, trust) => {
+        const status = await mkClient().getCrypto().getDeviceVerificationStatus(userId, "device");
+        expect(status.isVerified()).toBe(trust);
     });
 });
 

--- a/test/utils/arrays-test.ts
+++ b/test/utils/arrays-test.ts
@@ -30,6 +30,7 @@ import {
     GroupedArray,
     concat,
     asyncEvery,
+    asyncSome,
 } from "../../src/utils/arrays";
 
 type TestParams = { input: number[]; output: number[] };
@@ -439,6 +440,29 @@ describe("arrays", () => {
         it("when called with some items and the predicate resolves to false for one of them, it should return false", async () => {
             const predicate = jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
             expect(await asyncEvery([1, 2, 3], predicate)).toBe(false);
+            expect(predicate).toHaveBeenCalledTimes(2);
+            expect(predicate).toHaveBeenCalledWith(1);
+            expect(predicate).toHaveBeenCalledWith(2);
+        });
+    });
+
+    describe("asyncSome", () => {
+        it("when called with an empty array, it should return false", async () => {
+            expect(await asyncSome([], jest.fn().mockResolvedValue(true))).toBe(false);
+        });
+
+        it("when called with some items and the predicate resolves to false for all of them, it should return false", async () => {
+            const predicate = jest.fn().mockResolvedValue(false);
+            expect(await asyncSome([1, 2, 3], predicate)).toBe(false);
+            expect(predicate).toHaveBeenCalledTimes(3);
+            expect(predicate).toHaveBeenCalledWith(1);
+            expect(predicate).toHaveBeenCalledWith(2);
+            expect(predicate).toHaveBeenCalledWith(3);
+        });
+
+        it("when called with some items and the predicate resolves to true, it should short-circuit and return true", async () => {
+            const predicate = jest.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+            expect(await asyncSome([1, 2, 3], predicate)).toBe(true);
             expect(predicate).toHaveBeenCalledTimes(2);
             expect(predicate).toHaveBeenCalledWith(1);
             expect(predicate).toHaveBeenCalledWith(2);


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3287 creates a new API called `getDeviceVerificationStatus`. Let's use it.

Hopefully this makes sense to review commit-by-commit.

Fixes https://github.com/vector-im/element-web/issues/25092

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->