### PR TITLE
Fix view source from edit history dialog always showing latest event

### DIFF
--- a/src/components/structures/ViewSource.tsx
+++ b/src/components/structures/ViewSource.tsx
@@ -31,6 +31,7 @@ import CopyableText from "../views/elements/CopyableText";
 
 interface IProps {
     mxEvent: MatrixEvent; // the MatrixEvent associated with the context menu
+    ignoreEdits?: boolean;
     onFinished(): void;
 }
 
@@ -58,7 +59,11 @@ export default class ViewSource extends React.Component<IProps, IState> {
 
     // returns the dialog body for viewing the event source
     private viewSourceContent(): JSX.Element {
-        const mxEvent = this.props.mxEvent.replacingEvent() || this.props.mxEvent; // show the replacing event, not the original, if it is an edit
+        let mxEvent = this.props.mxEvent.replacingEvent() || this.props.mxEvent; // show the replacing event, not the original, if it is an edit
+        if (this.props.ignoreEdits) {
+            mxEvent = this.props.mxEvent;
+        }
+
         const isEncrypted = mxEvent.isEncrypted();
         // @ts-ignore
         const decryptedEventSource = mxEvent.clearEvent; // FIXME: clearEvent is private

--- a/src/components/views/messages/EditHistoryMessage.tsx
+++ b/src/components/views/messages/EditHistoryMessage.tsx
@@ -91,6 +91,7 @@ export default class EditHistoryMessage extends React.PureComponent<IProps, ISta
             ViewSource,
             {
                 mxEvent: this.props.mxEvent,
+                ignoreEdits: true,
             },
             "mx_Dialog_viewsource",
         );


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21859

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix view source from edit history dialog always showing latest event ([\#10626](https://github.com/matrix-org/matrix-react-sdk/pull/10626)). Fixes vector-im/element-web#21859.<!-- CHANGELOG_PREVIEW_END -->