### PR TITLE
Remove obsolete class name and declarations on `General` user settings tab

### DIFF
--- a/res/css/views/settings/_EmailAddresses.pcss
+++ b/res/css/views/settings/_EmailAddresses.pcss
@@ -21,12 +21,6 @@ limitations under the License.
     margin-bottom: 5px;
 }
 
-.mx_ExistingEmailAddress_delete {
-    margin-right: 5px;
-    cursor: pointer;
-    vertical-align: middle;
-}
-
 .mx_ExistingEmailAddress_email,
 .mx_ExistingEmailAddress_promptText {
     flex: 1;

--- a/res/css/views/settings/_PhoneNumbers.pcss
+++ b/res/css/views/settings/_PhoneNumbers.pcss
@@ -21,12 +21,6 @@ limitations under the License.
     margin-bottom: 5px;
 }
 
-.mx_ExistingPhoneNumber_delete {
-    margin-right: 5px;
-    cursor: pointer;
-    vertical-align: middle;
-}
-
 .mx_ExistingPhoneNumber_address,
 .mx_ExistingPhoneNumber_promptText {
     flex: 1;

--- a/src/components/views/settings/account/EmailAddresses.tsx
+++ b/src/components/views/settings/account/EmailAddresses.tsx
@@ -276,7 +276,7 @@ export default class EmailAddresses extends React.Component<IProps, IState> {
         return (
             <div className="mx_EmailAddresses">
                 {existingEmailElements}
-                <form onSubmit={this.onAddClick} autoComplete="off" noValidate={true} className="mx_EmailAddresses_new">
+                <form onSubmit={this.onAddClick} autoComplete="off" noValidate={true}>
                     <Field
                         type="text"
                         label={_t("Email Address")}


### PR DESCRIPTION
This PR suggests to remove obsolete class name and declarations on `General` user settings tab. For reference, each commit notes which commit deprecated them.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
