### PR TITLE
Replace uses of `checkDeviceTrust` with `getDeviceVerificationStatus`

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -310,7 +310,11 @@ export default class DeviceListener {
         const newUnverifiedDeviceIds = new Set<string>();
 
         const isCurrentDeviceTrusted =
-            crossSigningReady && (await cli.checkDeviceTrust(cli.getUserId()!, cli.deviceId!).isCrossSigningVerified());
+            crossSigningReady &&
+            Boolean(
+                (await cli.getCrypto()?.getDeviceVerificationStatus(cli.getUserId()!, cli.deviceId!))
+                    ?.crossSigningVerified,
+            );
 
         // as long as cross-signing isn't ready,
         // you can't see or dismiss any device toasts
@@ -319,8 +323,10 @@ export default class DeviceListener {
             for (const device of devices) {
                 if (device.deviceId === cli.deviceId) continue;
 
-                const deviceTrust = await cli.checkDeviceTrust(cli.getUserId()!, device.deviceId!);
-                if (!deviceTrust.isCrossSigningVerified() && !this.dismissed.has(device.deviceId)) {
+                const deviceTrust = await cli
+                    .getCrypto()
+                    ?.getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
+                if (!deviceTrust?.crossSigningVerified && !this.dismissed.has(device.deviceId)) {
                     if (this.ourDeviceIdsAtStart?.has(device.deviceId)) {
                         oldUnverifiedDeviceIds.add(device.deviceId);
                     } else {

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -325,7 +325,7 @@ export default class DeviceListener {
 
                 const deviceTrust = await cli
                     .getCrypto()
-                    ?.getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
+                    !.getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
                 if (!deviceTrust?.crossSigningVerified && !this.dismissed.has(device.deviceId)) {
                     if (this.ourDeviceIdsAtStart?.has(device.deviceId)) {
                         oldUnverifiedDeviceIds.add(device.deviceId);

--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -324,8 +324,8 @@ export default class DeviceListener {
                 if (device.deviceId === cli.deviceId) continue;
 
                 const deviceTrust = await cli
-                    .getCrypto()
-                    !.getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
+                    .getCrypto()!
+                    .getDeviceVerificationStatus(cli.getUserId()!, device.deviceId!);
                 if (!deviceTrust?.crossSigningVerified && !this.dismissed.has(device.deviceId)) {
                     if (this.ourDeviceIdsAtStart?.has(device.deviceId)) {
                         oldUnverifiedDeviceIds.add(device.deviceId);

--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -1073,9 +1073,9 @@ export const Commands = [
                                     },
                                 );
                             }
-                            const deviceTrust = await cli.checkDeviceTrust(userId, deviceId);
+                            const deviceTrust = await cli.getCrypto()?.getDeviceVerificationStatus(userId, deviceId);
 
-                            if (deviceTrust.isVerified()) {
+                            if (deviceTrust?.isVerified()) {
                                 if (device.getFingerprint() === fingerprint) {
                                     throw new UserFriendlyError("Session already verified!");
                                 } else {

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -79,6 +79,7 @@ import PosthogTrackers from "../../../PosthogTrackers";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import { DirectoryMember, startDmOnFirstMessage } from "../../../utils/direct-messages";
 import { SdkContextClass } from "../../../contexts/SDKContext";
+import { asyncSome } from "../../../utils/arrays";
 
 export interface IDevice extends DeviceInfo {
     ambiguous?: boolean;
@@ -101,22 +102,22 @@ export const disambiguateDevices = (devices: IDevice[]): void => {
     }
 };
 
-export const getE2EStatus = (cli: MatrixClient, userId: string, devices: IDevice[]): E2EStatus => {
+export const getE2EStatus = async (cli: MatrixClient, userId: string, devices: IDevice[]): Promise<E2EStatus> => {
     const isMe = userId === cli.getUserId();
     const userTrust = cli.checkUserTrust(userId);
     if (!userTrust.isCrossSigningVerified()) {
         return userTrust.wasCrossSigningVerified() ? E2EStatus.Warning : E2EStatus.Normal;
     }
 
-    const anyDeviceUnverified = devices.some((device) => {
+    const anyDeviceUnverified = await asyncSome(devices, async (device) => {
         const { deviceId } = device;
         // For your own devices, we use the stricter check of cross-signing
         // verification to encourage everyone to trust their own devices via
         // cross-signing so that other users can then safely trust you.
         // For other people's devices, the more general verified check that
         // includes locally verified devices can be used.
-        const deviceTrust = cli.checkDeviceTrust(userId, deviceId);
-        return isMe ? !deviceTrust.isCrossSigningVerified() : !deviceTrust.isVerified();
+        const deviceTrust = await cli.getCrypto()?.getDeviceVerificationStatus(userId, deviceId);
+        return isMe ? !deviceTrust?.crossSigningVerified : !deviceTrust?.isVerified();
     });
     return anyDeviceUnverified ? E2EStatus.Warning : E2EStatus.Verified;
 };
@@ -1611,10 +1612,13 @@ const UserInfo: React.FC<IProps> = ({ user, room, onClose, phase = RightPanelPha
     const isRoomEncrypted = useIsEncrypted(cli, room);
     const devices = useDevices(user.userId) ?? [];
 
-    let e2eStatus: E2EStatus | undefined;
-    if (isRoomEncrypted && devices) {
-        e2eStatus = getE2EStatus(cli, user.userId, devices);
-    }
+    const e2eStatus = useAsyncMemo(async () => {
+        if (!isRoomEncrypted || !devices) {
+            return undefined;
+        } else {
+            return await getE2EStatus(cli, user.userId, devices);
+        }
+    }, [cli, isRoomEncrypted, user.userId, devices]);
 
     const classes = ["mx_UserInfo"];
 

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1626,9 +1626,8 @@ const UserInfo: React.FC<IProps> = ({ user, room, onClose, phase = RightPanelPha
     const e2eStatus = useAsyncMemo(async () => {
         if (!isRoomEncrypted || !devices) {
             return undefined;
-        } else {
-            return await getE2EStatus(cli, user.userId, devices);
         }
+        return await getE2EStatus(cli, user.userId, devices);
     }, [cli, isRoomEncrypted, user.userId, devices]);
 
     const classes = ["mx_UserInfo"];

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -242,15 +242,17 @@ function DevicesSection({
 
     const [isExpanded, setExpanded] = useState(false);
 
-    if (loading) {
+    const deviceTrusts = useAsyncMemo(() => {
+        const cryptoApi = cli.getCrypto();
+        if (!cryptoApi) return Promise.resolve(undefined);
+        return Promise.all(devices.map((d) => cryptoApi.getDeviceVerificationStatus(userId, d.deviceId)));
+    }, [cli, userId, devices]);
+
+    if (loading || deviceTrusts === undefined) {
         // still loading
         return <Spinner />;
     }
-    if (devices === null) {
-        return <p>{_t("Unable to load session list")}</p>;
-    }
     const isMe = userId === cli.getUserId();
-    const deviceTrusts = devices.map((d) => cli.checkDeviceTrust(userId, d.deviceId));
 
     let expandSectionDevices: IDevice[] = [];
     const unverifiedDevices: IDevice[] = [];
@@ -268,7 +270,7 @@ function DevicesSection({
             // cross-signing so that other users can then safely trust you.
             // For other people's devices, the more general verified check that
             // includes locally verified devices can be used.
-            const isVerified = isMe ? deviceTrust.isCrossSigningVerified() : deviceTrust.isVerified();
+            const isVerified = deviceTrust && (isMe ? deviceTrust.crossSigningVerified : deviceTrust.isVerified());
 
             if (isVerified) {
                 expandSectionDevices.push(device);

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -265,6 +265,8 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     public static contextType = RoomContext;
     public context!: React.ContextType<typeof RoomContext>;
 
+    private unmounted = false;
+
     public constructor(props: EventTileProps, context: React.ContextType<typeof MatrixClientContext>) {
         super(props, context);
 
@@ -420,6 +422,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             this.props.mxEvent.removeListener(MatrixEventEvent.RelationsCreated, this.onReactionsCreated);
         }
         this.props.mxEvent.off(ThreadEvent.Update, this.updateThread);
+        this.unmounted = false;
     }
 
     public componentDidUpdate(prevProps: Readonly<EventTileProps>, prevState: Readonly<IState>): void {
@@ -561,7 +564,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         this.verifyEvent();
     };
 
-    private verifyEvent(): void {
+    private async verifyEvent(): Promise<void> {
         // if the event was edited, show the verification info for the edit, not
         // the original
         const mxEvent = this.props.mxEvent.replacingEvent() ?? this.props.mxEvent;
@@ -590,7 +593,14 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         }
 
         const eventSenderTrust =
-            encryptionInfo.sender && MatrixClientPeg.get().checkDeviceTrust(senderId, encryptionInfo.sender.deviceId);
+            senderId &&
+            encryptionInfo.sender &&
+            (await MatrixClientPeg.get()
+                .getCrypto()
+                ?.getDeviceVerificationStatus(senderId, encryptionInfo.sender.deviceId));
+
+        if (this.unmounted) return;
+
         if (!eventSenderTrust) {
             this.setState({ verified: E2EState.Unknown });
             return;

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -59,19 +59,15 @@ const parseDeviceExtendedInformation = (matrixClient: MatrixClient, device: IMyD
 export async function fetchExtendedDeviceInformation(matrixClient: MatrixClient): Promise<DevicesDictionary> {
     const { devices } = await matrixClient.getDevices();
 
-    const devicesDict = devices.reduce(
-        (acc, device: IMyDevice) => ({
-            ...acc,
-            [device.device_id]: {
-                ...device,
-                isVerified: isDeviceVerified(matrixClient, device.device_id),
-                ...parseDeviceExtendedInformation(matrixClient, device),
-                ...parseUserAgent(device[UNSTABLE_MSC3852_LAST_SEEN_UA.name]),
-            },
-        }),
-        {},
-    );
-
+    const devicesDict: DevicesDictionary = {};
+    for (const device of devices) {
+        devicesDict[device.device_id] = {
+            ...device,
+            isVerified: await isDeviceVerified(matrixClient, device.device_id),
+            ...parseDeviceExtendedInformation(matrixClient, device),
+            ...parseUserAgent(device[UNSTABLE_MSC3852_LAST_SEEN_UA.name]),
+        };
+    }
     return devicesDict;
 }
 

--- a/src/components/views/settings/devices/useOwnDevices.ts
+++ b/src/components/views/settings/devices/useOwnDevices.ts
@@ -50,7 +50,13 @@ const parseDeviceExtendedInformation = (matrixClient: MatrixClient, device: IMyD
     };
 };
 
-const fetchDevicesWithVerification = async (matrixClient: MatrixClient): Promise<DevicesState["devices"]> => {
+/**
+ * Fetch extended details of the user's own devices
+ *
+ * @param matrixClient - Matrix Client
+ * @returns A dictionary mapping from device ID to ExtendedDevice
+ */
+export async function fetchExtendedDeviceInformation(matrixClient: MatrixClient): Promise<DevicesDictionary> {
     const { devices } = await matrixClient.getDevices();
 
     const devicesDict = devices.reduce(
@@ -67,7 +73,7 @@ const fetchDevicesWithVerification = async (matrixClient: MatrixClient): Promise
     );
 
     return devicesDict;
-};
+}
 
 export enum OwnDevicesError {
     Unsupported = "Unsupported",
@@ -112,7 +118,7 @@ export const useOwnDevices = (): DevicesState => {
     const refreshDevices = useCallback(async (): Promise<void> => {
         setIsLoadingDeviceList(true);
         try {
-            const devices = await fetchDevicesWithVerification(matrixClient);
+            const devices = await fetchExtendedDeviceInformation(matrixClient);
             setDevices(devices);
 
             const { pushers } = await matrixClient.getPushers();

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2252,7 +2252,6 @@
     "Room settings": "Room settings",
     "Trusted": "Trusted",
     "Not trusted": "Not trusted",
-    "Unable to load session list": "Unable to load session list",
     "%(count)s verified sessions|other": "%(count)s verified sessions",
     "%(count)s verified sessions|one": "1 verified session",
     "Hide verified sessions": "Hide verified sessions",

--- a/src/toasts/UnverifiedSessionToast.tsx
+++ b/src/toasts/UnverifiedSessionToast.tsx
@@ -48,7 +48,7 @@ export const showToast = async (deviceId: string): Promise<void> => {
     const device = await cli.getDevice(deviceId);
     const extendedDevice = {
         ...device,
-        isVerified: isDeviceVerified(cli, deviceId),
+        isVerified: await isDeviceVerified(cli, deviceId),
         deviceType: DeviceType.Unknown,
     };
 

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -324,6 +324,16 @@ export async function asyncEvery<T>(values: T[], predicate: (value: T) => Promis
     return true;
 }
 
+/**
+ * Async version of Array.some.
+ */
+export async function asyncSome<T>(values: T[], predicate: (value: T) => Promise<boolean>): Promise<boolean> {
+    for (const value of values) {
+        if (await predicate(value)) return true;
+    }
+    return false;
+}
+
 export function filterBoolean<T>(values: Array<T | null | undefined>): T[] {
     return values.filter(Boolean) as T[];
 }

--- a/src/utils/device/isDeviceVerified.ts
+++ b/src/utils/device/isDeviceVerified.ts
@@ -25,10 +25,10 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
  * @returns `true` if the device has been correctly cross-signed. `false` if the device is unknown or not correctly
  *    cross-signed. `null` if there was an error fetching the device info.
  */
-export const isDeviceVerified = (client: MatrixClient, deviceId: string): boolean | null => {
+export const isDeviceVerified = async (client: MatrixClient, deviceId: string): Promise<boolean | null> => {
     try {
-        const trustLevel = client.checkDeviceTrust(client.getSafeUserId(), deviceId);
-        return trustLevel.isCrossSigningVerified();
+        const trustLevel = await client.getCrypto()?.getDeviceVerificationStatus(client.getSafeUserId(), deviceId);
+        return trustLevel?.crossSigningVerified ?? false;
     } catch (e) {
         console.error("Error getting device cross-signing info", e);
         return null;

--- a/test/components/views/right_panel/UserInfo-test.tsx
+++ b/test/components/views/right_panel/UserInfo-test.tsx
@@ -29,7 +29,7 @@ import {
     DeviceVerificationStatus,
 } from "matrix-js-sdk/src/matrix";
 import { Phase, VerificationRequest } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
-import { DeviceTrustLevel, UserTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
+import { UserTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
 import { defer } from "matrix-js-sdk/src/utils";
 
@@ -148,7 +148,6 @@ beforeEach(() => {
         currentState: {
             on: jest.fn(),
         },
-        checkDeviceTrust: jest.fn(),
         checkUserTrust: jest.fn(),
         getRoom: jest.fn(),
         credentials: {},
@@ -266,7 +265,6 @@ describe("<UserInfo />", () => {
         beforeEach(() => {
             mockClient.isCryptoEnabled.mockReturnValue(true);
             mockClient.checkUserTrust.mockReturnValue(new UserTrustLevel(false, false, false));
-            mockClient.checkDeviceTrust.mockReturnValue(new DeviceTrustLevel(false, false, false, false));
 
             const device1 = DeviceInfo.fromStorage(
                 {

--- a/test/components/views/right_panel/UserInfo-test.tsx
+++ b/test/components/views/right_panel/UserInfo-test.tsx
@@ -18,7 +18,16 @@ import React from "react";
 import { fireEvent, render, screen, waitFor, cleanup, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Mocked, mocked } from "jest-mock";
-import { Room, User, MatrixClient, RoomMember, MatrixEvent, EventType } from "matrix-js-sdk/src/matrix";
+import {
+    Room,
+    User,
+    MatrixClient,
+    RoomMember,
+    MatrixEvent,
+    EventType,
+    CryptoApi,
+    DeviceVerificationStatus,
+} from "matrix-js-sdk/src/matrix";
 import { Phase, VerificationRequest } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
 import { DeviceTrustLevel, UserTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
@@ -79,6 +88,7 @@ const defaultUser = new User(defaultUserId);
 let mockRoom: Mocked<Room>;
 let mockSpace: Mocked<Room>;
 let mockClient: Mocked<MatrixClient>;
+let mockCrypto: Mocked<CryptoApi>;
 
 beforeEach(() => {
     mockRoom = mocked({
@@ -115,6 +125,10 @@ beforeEach(() => {
         getEventReadUpTo: jest.fn(),
     } as unknown as Room);
 
+    mockCrypto = mocked({
+        getDeviceVerificationStatus: jest.fn(),
+    } as unknown as CryptoApi);
+
     mockClient = mocked({
         getUser: jest.fn(),
         isGuest: jest.fn().mockReturnValue(false),
@@ -141,6 +155,7 @@ beforeEach(() => {
         setPowerLevel: jest.fn(),
         downloadKeys: jest.fn(),
         getStoredDevicesForUser: jest.fn(),
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
     } as unknown as MatrixClient);
 
     jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
@@ -370,10 +385,10 @@ describe("<DeviceItem />", () => {
         mockClient.checkUserTrust.mockReturnValue({ isVerified: () => isVerified } as UserTrustLevel);
     };
     const setMockDeviceTrust = (isVerified = false, isCrossSigningVerified = false) => {
-        mockClient.checkDeviceTrust.mockReturnValue({
+        mockCrypto.getDeviceVerificationStatus.mockResolvedValue({
             isVerified: () => isVerified,
-            isCrossSigningVerified: () => isCrossSigningVerified,
-        } as DeviceTrustLevel);
+            crossSigningVerified: isCrossSigningVerified,
+        } as DeviceVerificationStatus);
     };
 
     const mockVerifyDevice = jest.spyOn(mockVerification, "verifyDevice");
@@ -384,7 +399,7 @@ describe("<DeviceItem />", () => {
     });
 
     afterEach(() => {
-        mockClient.checkDeviceTrust.mockReset();
+        mockCrypto.getDeviceVerificationStatus.mockReset();
         mockClient.checkUserTrust.mockReset();
         mockVerifyDevice.mockClear();
     });
@@ -393,32 +408,36 @@ describe("<DeviceItem />", () => {
         mockVerifyDevice.mockRestore();
     });
 
-    it("with unverified user and device, displays button without a label", () => {
+    it("with unverified user and device, displays button without a label", async () => {
         renderComponent();
+        await act(flushPromises);
 
         expect(screen.getByRole("button", { name: device.getDisplayName()! })).toBeInTheDocument;
         expect(screen.queryByText(/trusted/i)).not.toBeInTheDocument();
     });
 
-    it("with verified user only, displays button with a 'Not trusted' label", () => {
+    it("with verified user only, displays button with a 'Not trusted' label", async () => {
         setMockUserTrust(true);
         renderComponent();
+        await act(flushPromises);
 
         expect(screen.getByRole("button", { name: `${device.getDisplayName()} Not trusted` })).toBeInTheDocument;
     });
 
-    it("with verified device only, displays no button without a label", () => {
+    it("with verified device only, displays no button without a label", async () => {
         setMockDeviceTrust(true);
         renderComponent();
+        await act(flushPromises);
 
         expect(screen.getByText(device.getDisplayName()!)).toBeInTheDocument();
         expect(screen.queryByText(/trusted/)).not.toBeInTheDocument();
     });
 
-    it("when userId is the same as userId from client, uses isCrossSigningVerified to determine if button is shown", () => {
+    it("when userId is the same as userId from client, uses isCrossSigningVerified to determine if button is shown", async () => {
         mockClient.getSafeUserId.mockReturnValueOnce(defaultUserId);
         mockClient.getUserId.mockReturnValueOnce(defaultUserId);
         renderComponent();
+        await act(flushPromises);
 
         // set trust to be false for isVerified, true for isCrossSigningVerified
         setMockDeviceTrust(false, true);
@@ -428,10 +447,11 @@ describe("<DeviceItem />", () => {
         expect(screen.getByText(device.getDisplayName()!)).toBeInTheDocument();
     });
 
-    it("with verified user and device, displays no button and a 'Trusted' label", () => {
+    it("with verified user and device, displays no button and a 'Trusted' label", async () => {
         setMockUserTrust(true);
         setMockDeviceTrust(true);
         renderComponent();
+        await act(flushPromises);
 
         expect(screen.queryByRole("button")).not.toBeInTheDocument;
         expect(screen.getByText(device.getDisplayName()!)).toBeInTheDocument();
@@ -441,6 +461,7 @@ describe("<DeviceItem />", () => {
     it("does not call verifyDevice if client.getUser returns null", async () => {
         mockClient.getUser.mockReturnValueOnce(null);
         renderComponent();
+        await act(flushPromises);
 
         const button = screen.getByRole("button", { name: device.getDisplayName()! });
         expect(button).toBeInTheDocument;
@@ -455,6 +476,7 @@ describe("<DeviceItem />", () => {
         // even more mocking
         mockClient.isGuest.mockReturnValueOnce(true);
         renderComponent();
+        await act(flushPromises);
 
         const button = screen.getByRole("button", { name: device.getDisplayName()! });
         expect(button).toBeInTheDocument;

--- a/test/components/views/settings/DevicesPanel-test.tsx
+++ b/test/components/views/settings/DevicesPanel-test.tsx
@@ -18,7 +18,6 @@ import { act, fireEvent, render } from "@testing-library/react";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { PUSHER_DEVICE_ID, PUSHER_ENABLED } from "matrix-js-sdk/src/@types/event";
-import { DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 
 import DevicesPanel from "../../../../src/components/views/settings/DevicesPanel";
 import { flushPromises, getMockClientWithEventEmitter, mkPusher, mockClientMethodsUser } from "../../../test-utils";
@@ -29,16 +28,21 @@ describe("<DevicesPanel />", () => {
     const device1 = { device_id: "device_1" };
     const device2 = { device_id: "device_2" };
     const device3 = { device_id: "device_3" };
+    const mockCrypto = {
+        getDeviceVerificationStatus: jest.fn().mockResolvedValue({
+            crossSigningVerified: false,
+        }),
+    };
     const mockClient = getMockClientWithEventEmitter({
         ...mockClientMethodsUser(userId),
         getDevices: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue(device1.device_id),
         deleteMultipleDevices: jest.fn(),
-        checkDeviceTrust: jest.fn().mockReturnValue(new DeviceTrustLevel(false, false, false, false)),
         getStoredDevice: jest.fn().mockReturnValue(new DeviceInfo("id")),
         generateClientSecret: jest.fn(),
         getPushers: jest.fn(),
         setPusher: jest.fn(),
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
     });
 
     const getComponent = () => (

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -18,7 +18,6 @@ import React from "react";
 import { act, fireEvent, render, RenderResult } from "@testing-library/react";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
 import { logger } from "matrix-js-sdk/src/logger";
-import { DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 import { VerificationRequest } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
 import { defer, sleep } from "matrix-js-sdk/src/utils";
 import {
@@ -30,7 +29,10 @@ import {
     PUSHER_ENABLED,
     IAuthData,
     UNSTABLE_MSC3882_CAPABILITY,
+    CryptoApi,
+    DeviceVerificationStatus,
 } from "matrix-js-sdk/src/matrix";
+import { mocked } from "jest-mock";
 
 import { clearAllModals } from "../../../../../test-utils";
 import SessionManagerTab from "../../../../../../src/components/views/settings/tabs/user/SessionManagerTab";
@@ -78,9 +80,14 @@ describe("<SessionManagerTab />", () => {
         cancel: jest.fn(),
         on: jest.fn(),
     } as unknown as VerificationRequest;
+
+    const mockCrypto = mocked({
+        getDeviceVerificationStatus: jest.fn(),
+    } as unknown as CryptoApi);
+
     const mockClient = getMockClientWithEventEmitter({
         ...mockClientMethodsUser(aliceId),
-        checkDeviceTrust: jest.fn(),
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
         getDevices: jest.fn(),
         getStoredDevice: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue(deviceId),
@@ -171,7 +178,7 @@ describe("<SessionManagerTab />", () => {
             const device = [alicesDevice, alicesMobileDevice].find((device) => device.device_id === id);
             return device ? new DeviceInfo(device.device_id) : null;
         });
-        mockClient.checkDeviceTrust.mockReset().mockReturnValue(new DeviceTrustLevel(false, false, false, false));
+        mockCrypto.getDeviceVerificationStatus.mockReset().mockResolvedValue(new DeviceVerificationStatus({}));
 
         mockClient.getDevices.mockReset().mockResolvedValue({ devices: [alicesDevice, alicesMobileDevice] });
 
@@ -221,13 +228,13 @@ describe("<SessionManagerTab />", () => {
     });
 
     it("does not fail when checking device verification fails", async () => {
-        const logSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const logSpy = jest.spyOn(console, "error").mockImplementation((e) => {});
         mockClient.getDevices.mockResolvedValue({
             devices: [alicesDevice, alicesMobileDevice],
         });
-        const noCryptoError = new Error("End-to-end encryption disabled");
-        mockClient.checkDeviceTrust.mockImplementation(() => {
-            throw noCryptoError;
+        const failError = new Error("non-specific failure");
+        mockCrypto.getDeviceVerificationStatus.mockImplementation(() => {
+            throw failError;
         });
         render(getComponent());
 
@@ -236,9 +243,9 @@ describe("<SessionManagerTab />", () => {
         });
 
         // called for each device despite error
-        expect(mockClient.checkDeviceTrust).toHaveBeenCalledWith(aliceId, alicesDevice.device_id);
-        expect(mockClient.checkDeviceTrust).toHaveBeenCalledWith(aliceId, alicesMobileDevice.device_id);
-        expect(logSpy).toHaveBeenCalledWith("Error getting device cross-signing info", noCryptoError);
+        expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalledWith(aliceId, alicesDevice.device_id);
+        expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalledWith(aliceId, alicesMobileDevice.device_id);
+        expect(logSpy).toHaveBeenCalledWith("Error getting device cross-signing info", failError);
     });
 
     it("sets device verification status correctly", async () => {
@@ -246,14 +253,14 @@ describe("<SessionManagerTab />", () => {
             devices: [alicesDevice, alicesMobileDevice, alicesOlderMobileDevice],
         });
         mockClient.getStoredDevice.mockImplementation((_userId, deviceId) => new DeviceInfo(deviceId));
-        mockClient.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+        mockCrypto.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
             // alices device is trusted
             if (deviceId === alicesDevice.device_id) {
-                return new DeviceTrustLevel(true, true, false, false);
+                return new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true });
             }
             // alices mobile device is not
             if (deviceId === alicesMobileDevice.device_id) {
-                return new DeviceTrustLevel(false, false, false, false);
+                return new DeviceVerificationStatus({});
             }
             // alicesOlderMobileDevice does not support encryption
             throw new Error("encryption not supported");
@@ -265,7 +272,7 @@ describe("<SessionManagerTab />", () => {
             await flushPromises();
         });
 
-        expect(mockClient.checkDeviceTrust).toHaveBeenCalledTimes(3);
+        expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalledTimes(3);
         expect(
             getByTestId(`device-tile-${alicesDevice.device_id}`).querySelector('[aria-label="Verified"]'),
         ).toBeTruthy();
@@ -418,7 +425,9 @@ describe("<SessionManagerTab />", () => {
                 devices: [alicesDevice, alicesMobileDevice],
             });
             mockClient.getStoredDevice.mockImplementation(() => new DeviceInfo(alicesDevice.device_id));
-            mockClient.checkDeviceTrust.mockReturnValue(new DeviceTrustLevel(true, true, false, false));
+            mockCrypto.getDeviceVerificationStatus.mockResolvedValue(
+                new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true }),
+            );
 
             const { getByTestId } = render(getComponent());
 
@@ -520,11 +529,11 @@ describe("<SessionManagerTab />", () => {
                 devices: [alicesDevice, alicesMobileDevice],
             });
             mockClient.getStoredDevice.mockImplementation((_userId, deviceId) => new DeviceInfo(deviceId));
-            mockClient.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+            mockCrypto.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                 if (deviceId === alicesDevice.device_id) {
-                    return new DeviceTrustLevel(true, true, false, false);
+                    return new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true });
                 }
-                return new DeviceTrustLevel(false, false, false, false);
+                return new DeviceVerificationStatus({});
             });
 
             const { getByTestId } = render(getComponent());
@@ -547,12 +556,13 @@ describe("<SessionManagerTab />", () => {
                 devices: [alicesDevice, alicesMobileDevice],
             });
             mockClient.getStoredDevice.mockImplementation((_userId, deviceId) => new DeviceInfo(deviceId));
-            mockClient.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+            mockCrypto.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                 // current session verified = able to verify other sessions
                 if (deviceId === alicesDevice.device_id) {
-                    return new DeviceTrustLevel(true, true, false, false);
+                    return new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true });
                 }
                 // but alicesMobileDevice doesn't support encryption
+                // XXX this is not what happens if a device doesn't support encryption.
                 throw new Error("encryption not supported");
             });
 
@@ -581,11 +591,11 @@ describe("<SessionManagerTab />", () => {
                 devices: [alicesDevice, alicesMobileDevice],
             });
             mockClient.getStoredDevice.mockImplementation((_userId, deviceId) => new DeviceInfo(deviceId));
-            mockClient.checkDeviceTrust.mockImplementation((_userId, deviceId) => {
+            mockCrypto.getDeviceVerificationStatus.mockImplementation(async (_userId, deviceId) => {
                 if (deviceId === alicesDevice.device_id) {
-                    return new DeviceTrustLevel(true, true, false, false);
+                    return new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true });
                 }
-                return new DeviceTrustLevel(false, false, false, false);
+                return new DeviceVerificationStatus({});
             });
 
             const { getByTestId } = render(getComponent());

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -234,6 +234,7 @@ export function createTestClient(): MatrixClient {
         }),
 
         searchUserDirectory: jest.fn().mockResolvedValue({ limited: false, results: [] }),
+        getCrypto: jest.fn(),
     } as unknown as MatrixClient;
 
     client.reEmitter = new ReEmitter(client);

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -99,7 +99,6 @@ export function createTestClient(): MatrixClient {
         getDevice: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue("ABCDEFGHI"),
         getStoredCrossSigningForUser: jest.fn(),
-        checkDeviceTrust: jest.fn(),
         getStoredDevice: jest.fn(),
         requestVerification: jest.fn(),
         deviceId: "ABCDEFGHI",

--- a/test/toasts/UnverifiedSessionToast-test.tsx
+++ b/test/toasts/UnverifiedSessionToast-test.tsx
@@ -18,9 +18,8 @@ import React from "react";
 import { render, RenderResult, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mocked, Mocked } from "jest-mock";
-import { IMyDevice, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { CryptoApi, DeviceVerificationStatus, IMyDevice, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { DeviceInfo } from "matrix-js-sdk/src/crypto/deviceinfo";
-import { DeviceTrustLevel } from "matrix-js-sdk/src/crypto/CrossSigning";
 
 import dis from "../../src/dispatcher/dispatcher";
 import { showToast } from "../../src/toasts/UnverifiedSessionToast";
@@ -55,7 +54,11 @@ describe("UnverifiedSessionToast", () => {
 
             return null;
         });
-        client.checkDeviceTrust.mockReturnValue(new DeviceTrustLevel(true, false, false, false));
+        client.getCrypto.mockReturnValue({
+            getDeviceVerificationStatus: jest
+                .fn()
+                .mockResolvedValue(new DeviceVerificationStatus({ crossSigningVerified: true })),
+        } as unknown as CryptoApi);
         jest.spyOn(dis, "dispatch");
         jest.spyOn(DeviceListener.sharedInstance(), "dismissUnverifiedSessions");
     });

--- a/test/utils/arrays-test.ts
+++ b/test/utils/arrays-test.ts
@@ -30,6 +30,7 @@ import {
     GroupedArray,
     concat,
     asyncEvery,
+    asyncSome,
 } from "../../src/utils/arrays";
 
 type TestParams = { input: number[]; output: number[] };
@@ -439,6 +440,29 @@ describe("arrays", () => {
         it("when called with some items and the predicate resolves to false for one of them, it should return false", async () => {
             const predicate = jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
             expect(await asyncEvery([1, 2, 3], predicate)).toBe(false);
+            expect(predicate).toHaveBeenCalledTimes(2);
+            expect(predicate).toHaveBeenCalledWith(1);
+            expect(predicate).toHaveBeenCalledWith(2);
+        });
+    });
+
+    describe("asyncSome", () => {
+        it("when called with an empty array, it should return false", async () => {
+            expect(await asyncSome([], jest.fn().mockResolvedValue(true))).toBe(false);
+        });
+
+        it("when called with some items and the predicate resolves to false for all of them, it should return false", async () => {
+            const predicate = jest.fn().mockResolvedValue(false);
+            expect(await asyncSome([1, 2, 3], predicate)).toBe(false);
+            expect(predicate).toHaveBeenCalledTimes(3);
+            expect(predicate).toHaveBeenCalledWith(1);
+            expect(predicate).toHaveBeenCalledWith(2);
+            expect(predicate).toHaveBeenCalledWith(3);
+        });
+
+        it("when called with some items and the predicate resolves to true, it should short-circuit and return true", async () => {
+            const predicate = jest.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+            expect(await asyncSome([1, 2, 3], predicate)).toBe(true);
             expect(predicate).toHaveBeenCalledTimes(2);
             expect(predicate).toHaveBeenCalledWith(1);
             expect(predicate).toHaveBeenCalledWith(2);


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3287 and https://github.com/matrix-org/matrix-js-sdk/pull/3303 added  a new API called `getDeviceVerificationStatus`. Let's use it.

Hopefully this makes sense to review commit-by-commit.

The quality gate isn't quite met but there are cypress tests covering the places where coverage is lacking.

Fixes https://github.com/vector-im/element-web/issues/25092 and https://github.com/vector-im/element-web/issues/25093

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->