### PR TITLE
Fix lack of screen reader indication when triggering auto complete

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -798,7 +798,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         };
 
         const { completionIndex } = this.state;
-        const hasAutocomplete = Boolean(this.state.autoComplete);
+        const hasAutocomplete = !!this.state.autoComplete;
         let activeDescendant: string | undefined;
         if (hasAutocomplete && completionIndex! >= 0) {
             activeDescendant = generateCompletionDomId(completionIndex!);
@@ -828,7 +828,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                     aria-multiline="true"
                     aria-autocomplete="list"
                     aria-haspopup="listbox"
-                    aria-expanded={hasAutocomplete ? true : undefined}
+                    aria-expanded={hasAutocomplete ? !this.autocompleteRef.current?.state.hide : undefined}
                     aria-owns={hasAutocomplete ? "mx_Autocomplete" : undefined}
                     aria-activedescendant={activeDescendant}
                     dir="auto"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/11011

https://user-images.githubusercontent.com/2403652/233106563-64e02726-1ff6-4f86-9ddb-e83afb63b299.mov



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix lack of screen reader indication when triggering auto complete ([\#10664](https://github.com/matrix-org/matrix-react-sdk/pull/10664)). Fixes vector-im/element-web#11011.<!-- CHANGELOG_PREVIEW_END -->