### PR TITLE
Remove obsolete `mx_InviteDialog_transferButton` class

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1433,7 +1433,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                     <AccessibleButton
                         kind="primary"
                         onClick={this.transferCall}
-                        className="mx_InviteDialog_transferButton"
                         disabled={!hasSelection && this.state.dialPadValue === ""}
                     >
                         {_t("Transfer")}


### PR DESCRIPTION
The class has been introduced by https://github.com/matrix-org/matrix-react-sdk/pull/6217/commits/2cc6bcec29be908ac45bf181272e2542aadd73f9 ("Much theming & visual of transfer window dial pad"), and removed by https://github.com/matrix-org/matrix-react-sdk/pull/6217/commits/c829cb948031f83d1422867ff54af9ebc2047ba9 ("Use flexbox to layout buttons") from _InviteDialog.scss on the same PR (https://github.com/matrix-org/matrix-react-sdk/pull/6217). The class has not used anywhere else since then.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->