### PR TITLE
Remove a redundant snapshot - `'Manage integrations' on General settings tab`

### DIFF
--- a/cypress/e2e/settings/set-integration-manager.spec.ts
+++ b/cypress/e2e/settings/set-integration-manager.spec.ts
@@ -52,9 +52,5 @@ describe("Set integration manager", () => {
                 cy.get(".mx_SettingsTab_subheading").should("have.css", "margin-inline-end", "0px");
             });
         });
-
-        cy.get(".mx_SetIntegrationManager").percySnapshotElement("'Manage integrations' on General settings tab", {
-            widths: [692], // actual width of mx_SetIntegrationManager
-        });
     });
 });


### PR DESCRIPTION
This snapshot ([`'Manage integrations' on General settings tab`](https://percy.io/dfde73bd/matrix-react-sdk/builds/26815162/search/preview/1492764881?browser=safari&searchParam=manage&viewLayout=side-by-side&viewMode=new&width=692)) became redundant thanks to [a new one on `general-user-settings-tab.spec.ts`](https://github.com/matrix-org/matrix-react-sdk/blob/fdfe800b2c1a098c8264a1a7a9f2bced4d6e28bd/cypress/e2e/settings/general-user-settings-tab.spec.ts#L46-L48) ([`User settings tab - General`](https://percy.io/dfde73bd/matrix-react-sdk/builds/26815162/changed/1492765273?browser=firefox&browser_ids=36%2C38%2C39&subcategories=approved&viewLayout=overlay&viewMode=new&width=1024&widths=320%2C640%2C1024%2C1920)), and should be removed to reduce the usage of quota.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->