### PR TITLE
Update `InviteDialog.pcss` - for `mx_InviteDialog_content`

### DIFF
--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -64,7 +64,7 @@ describe("Invite dialog", function () {
             });
 
             // Assert that the bar is rendered
-            cy.get(".mx_InviteDialog_addressBar").should("exist");
+            cy.get(".mx_InviteDialog_content_addressBar").should("exist");
         });
 
         // TODO: unhide userId
@@ -124,7 +124,7 @@ describe("Invite dialog", function () {
             });
 
             // Assert that the bar is rendered
-            cy.get(".mx_InviteDialog_addressBar").should("exist");
+            cy.get(".mx_InviteDialog_content_addressBar").should("exist");
         });
 
         // TODO: unhide userId and invite link

--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -57,7 +57,7 @@ describe("Invite dialog", function () {
             cy.findByRole("button", { name: /Invite to this room/ }).click();
         });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             cy.get(".mx_Dialog_header .mx_Dialog_title").within(() => {
                 // Assert that the header is rendered
                 cy.findByText("Invite to Test Room").should("exist");
@@ -73,7 +73,7 @@ describe("Invite dialog", function () {
         // Take a snapshot of the invite dialog including its wrapper
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Room (without a user)", { percyCSS });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             cy.get(".mx_InviteDialog_identityServer").should("not.exist");
 
             cy.findByTestId("invite-dialog-input").type(bot.getUserId());
@@ -100,13 +100,13 @@ describe("Invite dialog", function () {
         // Take a snapshot of the invite dialog with a user pill
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Room (with a user pill)", { percyCSS });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             // Invite the bot
             cy.findByRole("button", { name: "Invite" }).click();
         });
 
         // Assert that the invite dialog disappears
-        cy.get(".mx_InviteDialog_other").should("not.exist");
+        cy.get(".mx_InviteDialog--other").should("not.exist");
 
         // Assert that they were invited and joined
         cy.findByText(`${botName} joined the room`).should("exist");
@@ -117,7 +117,7 @@ describe("Invite dialog", function () {
             cy.findByRole("button", { name: "Start chat" }).click();
         });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             cy.get(".mx_Dialog_header .mx_Dialog_title").within(() => {
                 // Assert that the header is rendered
                 cy.findByText("Direct Messages").should("exist");
@@ -136,7 +136,7 @@ describe("Invite dialog", function () {
             percyCSS,
         });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             cy.findByTestId("invite-dialog-input").type(bot.getUserId());
 
             cy.get(".mx_InviteDialog_tile_nameStack").within(() => {
@@ -154,13 +154,13 @@ describe("Invite dialog", function () {
             percyCSS,
         });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             // Open a direct message UI
             cy.findByRole("button", { name: "Go" }).click();
         });
 
         // Assert that the invite dialog disappears
-        cy.get(".mx_InviteDialog_other").should("not.exist");
+        cy.get(".mx_InviteDialog--other").should("not.exist");
 
         // Send a message to invite the bots
         cy.getComposer().type("Hello{enter}");

--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -74,12 +74,12 @@ describe("Invite dialog", function () {
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Room (without a user)", { percyCSS });
 
         cy.get(".mx_InviteDialog--other").within(() => {
-            cy.get(".mx_InviteDialog_identityServer").should("not.exist");
+            cy.get(".mx_InviteDialog_content_identityServer").should("not.exist");
 
             cy.findByTestId("invite-dialog-input").type(bot.getUserId());
 
             // Assert that notification about identity servers appears after typing userId
-            cy.get(".mx_InviteDialog_identityServer").should("exist");
+            cy.get(".mx_InviteDialog_content_identityServer").should("exist");
 
             cy.get(".mx_InviteDialog_tile_nameStack").within(() => {
                 cy.get(".mx_InviteDialog_tile_nameStack_userId").within(() => {

--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -129,7 +129,8 @@ describe("Invite dialog", function () {
 
         // TODO: unhide userId and invite link
         const percyCSS =
-            ".mx_InviteDialog_footer_link, .mx_InviteDialog_content_helpText_userId { visibility: hidden !important; }";
+            ".mx_InviteDialog_content_footer_link, " +
+            ".mx_InviteDialog_content_helpText_userId { visibility: hidden !important; }";
 
         // Take a snapshot of the invite dialog including its wrapper
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Direct Messages (without a user)", {

--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -68,7 +68,7 @@ describe("Invite dialog", function () {
         });
 
         // TODO: unhide userId
-        const percyCSS = ".mx_InviteDialog_helpText_userId { visibility: hidden !important; }";
+        const percyCSS = ".mx_InviteDialog_content_helpText_userId { visibility: hidden !important; }";
 
         // Take a snapshot of the invite dialog including its wrapper
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Room (without a user)", { percyCSS });
@@ -129,7 +129,7 @@ describe("Invite dialog", function () {
 
         // TODO: unhide userId and invite link
         const percyCSS =
-            ".mx_InviteDialog_footer_link, .mx_InviteDialog_helpText_userId { visibility: hidden !important; }";
+            ".mx_InviteDialog_footer_link, .mx_InviteDialog_content_helpText_userId { visibility: hidden !important; }";
 
         // Take a snapshot of the invite dialog including its wrapper
         cy.get(".mx_Dialog_wrapper").percySnapshotElement("Invite Dialog - Direct Messages (without a user)", {

--- a/cypress/e2e/spaces/spaces.spec.ts
+++ b/cypress/e2e/spaces/spaces.spec.ts
@@ -217,12 +217,12 @@ describe("Spaces", () => {
             cy.findByRole("button", { name: /Invite people/ }).click();
         });
 
-        cy.get(".mx_InviteDialog_other").within(() => {
+        cy.get(".mx_InviteDialog--other").within(() => {
             cy.findByRole("textbox").type(bot.getUserId());
             cy.findByRole("button", { name: "Invite" }).click();
         });
 
-        cy.get(".mx_InviteDialog_other").should("not.exist");
+        cy.get(".mx_InviteDialog--other").should("not.exist");
     });
 
     it("should show space invites at the top of the space panel", () => {

--- a/cypress/e2e/user-onboarding/user-onboarding-new.spec.ts
+++ b/cypress/e2e/user-onboarding/user-onboarding-new.spec.ts
@@ -75,7 +75,7 @@ describe("User Onboarding (new user)", () => {
                 const findPeopleAction = cy.findByRole("button", { name: "Find friends" });
                 expect(findPeopleAction).to.exist;
                 findPeopleAction.click();
-                cy.get(".mx_InviteDialog_editor").findByRole("textbox").type(bot1.getUserId());
+                cy.get(".mx_InviteDialog_content_addressBar_editor").findByRole("textbox").type(bot1.getUserId());
                 cy.findByRole("button", { name: "Go" }).click();
                 cy.get(".mx_InviteDialog_buttonAndSpinner").should("not.exist");
                 const message = "Hi!";

--- a/cypress/e2e/user-onboarding/user-onboarding-new.spec.ts
+++ b/cypress/e2e/user-onboarding/user-onboarding-new.spec.ts
@@ -77,7 +77,7 @@ describe("User Onboarding (new user)", () => {
                 findPeopleAction.click();
                 cy.get(".mx_InviteDialog_content_addressBar_editor").findByRole("textbox").type(bot1.getUserId());
                 cy.findByRole("button", { name: "Go" }).click();
-                cy.get(".mx_InviteDialog_buttonAndSpinner").should("not.exist");
+                cy.get(".mx_InviteDialog_content_addressBar_buttonAndSpinner").should("not.exist");
                 const message = "Hi!";
                 cy.findByRole("textbox", { name: "Send a message…" }).type(`${message}{enter}`);
                 cy.get(".mx_MTextBody.mx_EventTile_content").findByText(message);

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -255,7 +255,7 @@ limitations under the License.
     padding: 0 45px $spacing-4 0; /* TODO: Use a spacing variable */
 }
 
-.mx_InviteDialog_helpText {
+.mx_InviteDialog_content_helpText {
     margin: 0;
 }
 

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -23,7 +23,7 @@ limitations under the License.
     padding-bottom: $spacing-16;
 }
 
-.mx_InviteDialog_addressBar {
+.mx_InviteDialog_content_addressBar {
     display: flex;
     flex-direction: row;
     /* Right margin for the design. We could apply this to the whole dialog, but then the scrollbar */
@@ -192,7 +192,7 @@ limitations under the License.
     height: 600px;
     overflow: hidden;
 
-    .mx_InviteDialog_addressBar {
+    .mx_InviteDialog_content_addressBar {
         margin-inline-end: 0;
     }
 
@@ -240,7 +240,7 @@ limitations under the License.
         }
     }
 
-    .mx_InviteDialog_addressBar {
+    .mx_InviteDialog_content_addressBar {
         margin-top: $spacing-8;
     }
 

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -453,7 +453,7 @@ limitations under the License.
     margin-top: 1em; /* TODO: Use a spacing variable */
 }
 
-.mx_InviteDialog_oneThreepid {
+.mx_InviteDialog_content_oneThreepid {
     font-size: $font-12px;
     margin: $spacing-8 0;
 }

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -449,7 +449,7 @@ limitations under the License.
     }
 }
 
-.mx_InviteDialog_identityServer {
+.mx_InviteDialog_content_identityServer {
     margin-top: 1em; /* TODO: Use a spacing variable */
 }
 

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -30,7 +30,7 @@ limitations under the License.
     /* for the user section gets weird. */
     margin: $spacing-8 45px 0 0; /* TODO: Use a spacing variable */
 
-    .mx_InviteDialog_editor {
+    .mx_InviteDialog_content_addressBar_editor {
         flex: 1;
         width: 100%; /* Needed to make the Field inside grow */
         background-color: $header-panel-bg-color;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -212,6 +212,19 @@ limitations under the License.
     flex-direction: column;
     flex-grow: 1;
     overflow: hidden;
+
+    .mx_InviteDialog_content_helpText {
+        margin: 0;
+    }
+
+    .mx_InviteDialog_content_identityServer {
+        margin-top: 1em; /* TODO: Use a spacing variable */
+    }
+
+    .mx_InviteDialog_content_oneThreepid {
+        font-size: $font-12px;
+        margin: $spacing-8 0;
+    }
 }
 
 .mx_InviteDialog--transfer {
@@ -253,10 +266,6 @@ limitations under the License.
     margin-top: $spacing-4;
     overflow-y: auto;
     padding: 0 45px $spacing-4 0; /* TODO: Use a spacing variable */
-}
-
-.mx_InviteDialog_content_helpText {
-    margin: 0;
 }
 
 .mx_InviteDialog_dialPad {
@@ -447,13 +456,4 @@ limitations under the License.
         color: $secondary-content;
         font-weight: normal;
     }
-}
-
-.mx_InviteDialog_content_identityServer {
-    margin-top: 1em; /* TODO: Use a spacing variable */
-}
-
-.mx_InviteDialog_content_oneThreepid {
-    font-size: $font-12px;
-    margin: $spacing-8 0;
 }

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -122,7 +122,7 @@ limitations under the License.
     }
 }
 
-.mx_InviteDialog_footer {
+.mx_InviteDialog_content_footer {
     border-top: 1px solid $input-border-color;
 
     > h3 {

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -65,8 +65,8 @@ limitations under the License.
         }
     }
 
-    .mx_InviteDialog_buttonAndSpinner {
-        .mx_InviteDialog_buttonAndSpinner_goButton {
+    .mx_InviteDialog_content_addressBar_buttonAndSpinner {
+        .mx_InviteDialog_content_addressBar_buttonAndSpinner_goButton {
             min-width: 48px;
             margin-inline-start: 10px; /* TODO: Use a spacing variable */
             height: 25px;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -65,14 +65,14 @@ limitations under the License.
         }
     }
 
-    .mx_InviteDialog_goButton {
-        min-width: 48px;
-        margin-inline-start: 10px; /* TODO: Use a spacing variable */
-        height: 25px;
-        line-height: $font-25px;
-    }
-
     .mx_InviteDialog_buttonAndSpinner {
+        .mx_InviteDialog_buttonAndSpinner_goButton {
+            min-width: 48px;
+            margin-inline-start: 10px; /* TODO: Use a spacing variable */
+            height: 25px;
+            line-height: $font-25px;
+        }
+
         .mx_Spinner {
             /* Width and height are required to trick the layout engine. */
             width: 20px;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -306,10 +306,10 @@ limitations under the License.
     display: flex;
     flex-direction: row;
     align-items: center;
-}
 
-.mx_InviteDialog_content_transfer_pushRight {
-    margin-inline-start: auto;
+    .mx_InviteDialog_content_transfer_pushRight {
+        margin-inline-start: auto;
+    }
 }
 
 .mx_InviteDialog_userDirectoryIcon::before {

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -185,7 +185,7 @@ limitations under the License.
     }
 }
 
-.mx_InviteDialog_other {
+.mx_InviteDialog--other {
     /* Prevent the dialog from jumping around randomly when elements change. */
     display: flex;
     flex-direction: column;
@@ -214,7 +214,7 @@ limitations under the License.
     overflow: hidden;
 }
 
-.mx_InviteDialog_transfer {
+.mx_InviteDialog--transfer {
     width: auto;
 
     .mx_InviteDialog_content {

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -294,7 +294,7 @@ limitations under the License.
     }
 }
 
-.mx_InviteDialog_transferConsultConnect {
+.mx_InviteDialog_content_transfer {
     padding-top: $spacing-16;
     /* This wants a drop shadow the full width of the dialog, so use negative margin to make it full width,
      * then compensate with padding
@@ -308,7 +308,7 @@ limitations under the License.
     align-items: center;
 }
 
-.mx_InviteDialog_transferConsultConnect_pushRight {
+.mx_InviteDialog_content_transfer_pushRight {
     margin-inline-start: auto;
 }
 

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1386,7 +1386,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 {
                     userId: () => (
                         <a
-                            className="mx_InviteDialog_helpText_userId"
+                            className="mx_InviteDialog_content_helpText_userId"
                             href={makeUserPermalink(userId)}
                             rel="noreferrer noopener"
                             target="_blank"

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1141,7 +1141,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         const defaultIdentityServerUrl = getDefaultIdentityServerUrl();
         if (defaultIdentityServerUrl) {
             return (
-                <div className="mx_InviteDialog_identityServer">
+                <div className="mx_InviteDialog_content_identityServer">
                     {_t(
                         "Use an identity server to invite by email. " +
                             "<default>Use the default (%(defaultIdentityServerName)s)</default> " +
@@ -1166,7 +1166,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             );
         } else {
             return (
-                <div className="mx_InviteDialog_identityServer">
+                <div className="mx_InviteDialog_content_identityServer">
                     {_t(
                         "Use an identity server to invite by email. " + "Manage in <settings>Settings</settings>.",
                         {},

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1451,7 +1451,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 <AccessibleButton
                     kind="primary"
                     onClick={goButtonFn}
-                    className="mx_InviteDialog_goButton"
+                    className="mx_InviteDialog_buttonAndSpinner_goButton"
                     disabled={this.state.busy || !hasSelection}
                 >
                     {buttonText}

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1412,7 +1412,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                     visibilityEvent && visibilityEvent.getContent() && visibilityEvent.getContent().history_visibility;
                 if (visibility === "world_readable" || visibility === "shared") {
                     keySharingWarning = (
-                        <p className="mx_InviteDialog_helpText">
+                        <p className="mx_InviteDialog_content_helpText">
                             <InfoIcon height={14} width={14} />
                             {" " + _t("Invited people will be able to read old messages.")}
                         </p>
@@ -1480,7 +1480,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
         const usersSection = (
             <React.Fragment>
-                <p className="mx_InviteDialog_helpText">{helpText}</p>
+                <p className="mx_InviteDialog_content_helpText">{helpText}</p>
                 <div className="mx_InviteDialog_addressBar">
                     {this.renderEditor()}
                     <div className="mx_InviteDialog_buttonAndSpinner">

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1562,9 +1562,10 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         return (
             <BaseDialog
                 className={classNames({
-                    mx_InviteDialog_transfer: this.props.kind === InviteKind.CallTransfer,
-                    mx_InviteDialog_other: this.props.kind !== InviteKind.CallTransfer,
-                    mx_InviteDialog_hasFooter: !!footer,
+                    "mx_InviteDialog": true,
+                    "mx_InviteDialog--transfer": this.props.kind === InviteKind.CallTransfer,
+                    "mx_InviteDialog--other": this.props.kind !== InviteKind.CallTransfer,
+                    "mx_InviteDialog--hasFooter": !!footer,
                 })}
                 hasCancel={true}
                 onFinished={this.props.onFinished}

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1451,7 +1451,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 <AccessibleButton
                     kind="primary"
                     onClick={goButtonFn}
-                    className="mx_InviteDialog_buttonAndSpinner_goButton"
+                    className="mx_InviteDialog_content_addressBar_buttonAndSpinner_goButton"
                     disabled={this.state.busy || !hasSelection}
                 >
                     {buttonText}
@@ -1483,7 +1483,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 <p className="mx_InviteDialog_content_helpText">{helpText}</p>
                 <div className="mx_InviteDialog_content_addressBar">
                     {this.renderEditor()}
-                    <div className="mx_InviteDialog_buttonAndSpinner">
+                    <div className="mx_InviteDialog_content_addressBar_buttonAndSpinner">
                         {goButton}
                         {spinner}
                     </div>

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1423,7 +1423,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             title = _t("Transfer");
 
             consultConnectSection = (
-                <div className="mx_InviteDialog_transferConsultConnect">
+                <div className="mx_InviteDialog_content_transfer">
                     <label>
                         <input type="checkbox" checked={this.state.consultFirst} onChange={this.onConsultFirstChange} />
                         {_t("Consult first")}
@@ -1431,7 +1431,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                     <AccessibleButton
                         kind="secondary"
                         onClick={this.onCancel}
-                        className="mx_InviteDialog_transferConsultConnect_pushRight"
+                        className="mx_InviteDialog_content_transfer_pushRight"
                     >
                         {_t("Cancel")}
                     </AccessibleButton>

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1122,7 +1122,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             />
         );
         return (
-            <div className="mx_InviteDialog_editor" onClick={this.onClickInputArea}>
+            <div className="mx_InviteDialog_content_addressBar_editor" onClick={this.onClickInputArea}>
                 {targets}
                 {input}
             </div>

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1334,7 +1334,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             );
             const link = makeUserPermalink(MatrixClientPeg.get().getUserId()!);
             footer = (
-                <div className="mx_InviteDialog_footer">
+                <div className="mx_InviteDialog_content_footer">
                     <h3>{_t("Or send invite link")}</h3>
                     <CopyableText getTextToCopy={() => makeUserPermalink(MatrixClientPeg.get().getUserId()!)}>
                         <a className="mx_InviteDialog_footer_link" href={link} onClick={this.onLinkClick}>

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1337,7 +1337,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 <div className="mx_InviteDialog_content_footer">
                     <h3>{_t("Or send invite link")}</h3>
                     <CopyableText getTextToCopy={() => makeUserPermalink(MatrixClientPeg.get().getUserId()!)}>
-                        <a className="mx_InviteDialog_footer_link" href={link} onClick={this.onLinkClick}>
+                        <a className="mx_InviteDialog_content_footer_link" href={link} onClick={this.onLinkClick}>
                             {link}
                         </a>
                     </CopyableText>

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1481,7 +1481,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         const usersSection = (
             <React.Fragment>
                 <p className="mx_InviteDialog_content_helpText">{helpText}</p>
-                <div className="mx_InviteDialog_addressBar">
+                <div className="mx_InviteDialog_content_addressBar">
                     {this.renderEditor()}
                     <div className="mx_InviteDialog_buttonAndSpinner">
                         {goButton}

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -1464,7 +1464,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         if (!this.canInviteMore() || (this.hasFilterAtLeastOneEmail() && !this.canInviteThirdParty())) {
             // We are in DM case here, because of the checks in canInviteMore() / canInviteThirdParty().
             onlyOneThreepidNote = (
-                <div className="mx_InviteDialog_oneThreepid">
+                <div className="mx_InviteDialog_content_oneThreepid">
                     {_t("Invites by email can only be sent one at a time")}
                 </div>
             );


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/10693 for Cypress snapshots
Requires https://github.com/matrix-org/matrix-react-sdk/pull/10791 for Jest snapshots

For https://github.com/vector-im/element-web/issues/25176

This PR is one of the PRs which intend to conform `InviteDialog.pcss` to the naming policy on our style guide.

### What to change

#### `mx_InviteDialog` class name

At first, this PR introduces distinction to class names of the top level of the dialog, `mx_InviteDialog`.

Up to now there are three classes to distinguish three types of the invite dialog: `mx_InviteDialog_transfer`, `mx_InviteDialog_other`, and `mx_InviteDialog_hasFooter`. However, because those three are variants of the invite dialog, they should have been specified with the flag (`--`). Therefore, this PR suggest them to be changed as below:

````
"mx_InviteDialog": true,
"mx_InviteDialog--transfer": this.props.kind === InviteKind.CallTransfer,
"mx_InviteDialog--other": this.props.kind !== InviteKind.CallTransfer,
"mx_InviteDialog--hasFooter": !!footer,
````

The style rules which are common among every invite dialog are going to be included in `mx_InviteDialog` later.

#### Class name of elements defined by `mx_InviteDialog_content`

const `usersSection` is defined by `dialogContent`.

Because `dialogContent` has the class name `mx_InviteDialog_content`, the class names of elements in `usersSection` should be `mx_InviteDialog_content_*`. 

Here are some of those elements: {this.renderEditor()},  {goButton}, {spinner}, {keySharingWarning}, {this.renderIdentityServerWarning()}, {onlyOneThreepidNote}, {results}, and {footer}.

type: task

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->