### PR TITLE
Fix default content in devtools event sender

### DIFF
--- a/src/components/views/dialogs/devtools/Event.tsx
+++ b/src/components/views/dialogs/devtools/Event.tsx
@@ -182,7 +182,7 @@ export const TimelineEventEditor: React.FC<IEditorProps> = ({ mxEvent, onBack })
         return cli.sendEvent(context.room.roomId, eventType, content || {});
     };
 
-    let defaultContent = "";
+    let defaultContent: string | undefined;
 
     if (mxEvent) {
         const originalContent = mxEvent.getContent();


### PR DESCRIPTION
It regressed from `{\n\n}` to an empty string in #10391

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix default content in devtools event sender ([\#10699](https://github.com/matrix-org/matrix-react-sdk/pull/10699)). Contributed by @tulir.<!-- CHANGELOG_PREVIEW_END -->