### PR TITLE
Posthog properly handle Analytics ID changing from under us

### DIFF
--- a/src/PosthogAnalytics.ts
+++ b/src/PosthogAnalytics.ts
@@ -312,6 +312,14 @@ export class PosthogAnalytics {
                         Object.assign({ id: analyticsID }, accountData),
                     );
                 }
+                if (this.posthog.get_distinct_id() === analyticsID) {
+                    // No point identifying again
+                    return;
+                }
+                if (this.posthog.persistence.get_user_state() === "identified") {
+                    // Analytics ID has changed, reset as Posthog will refuse to merge in this case
+                    this.posthog.reset();
+                }
                 this.posthog.identify(analyticsID);
             } catch (e) {
                 // The above could fail due to network requests, but not essential to starting the application,

--- a/test/PosthogAnalytics-test.ts
+++ b/test/PosthogAnalytics-test.ts
@@ -33,6 +33,10 @@ const getFakePosthog = (): PostHog =>
         identify: jest.fn(),
         reset: jest.fn(),
         register: jest.fn(),
+        get_distinct_id: jest.fn(),
+        persistence: {
+            get_user_state: jest.fn(),
+        },
     } as unknown as PostHog);
 
 interface ITestEvent extends IPosthogEvent {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25187

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Posthog properly handle Analytics ID changing from under us ([\#10702](https://github.com/matrix-org/matrix-react-sdk/pull/10702)). Fixes vector-im/element-web#25187.<!-- CHANGELOG_PREVIEW_END -->