### PR TITLE
Memoize field validation results

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "matrix-events-sdk": "0.0.1",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
         "matrix-widget-api": "^1.3.1",
+        "memoize-one": "^5.1.1",
         "minimist": "^1.2.5",
         "opus-recorder": "^8.0.3",
         "pako": "^2.0.3",

--- a/src/components/views/auth/PassphraseField.tsx
+++ b/src/components/views/auth/PassphraseField.tsx
@@ -92,6 +92,7 @@ class PassphraseField extends PureComponent<IProps> {
                 },
             },
         ],
+        memoize: true,
     });
 
     public onValidate = async (fieldState: IFieldState): Promise<IValidationResult> => {

--- a/src/components/views/directory/NetworkDropdown.tsx
+++ b/src/components/views/directory/NetworkDropdown.tsx
@@ -68,6 +68,7 @@ const validServer = withValidation<undefined, { error?: MatrixError }>({
                     : _t("Can't find this server or its room list"),
         },
     ],
+    memoize: true,
 });
 
 function useSettingsValueWithSetter<T>(

--- a/src/components/views/elements/Field.tsx
+++ b/src/components/views/elements/Field.tsx
@@ -17,7 +17,6 @@ limitations under the License.
 import React, { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes, RefObject } from "react";
 import classNames from "classnames";
 import { debounce } from "lodash";
-import memoizeOne from "memoize-one";
 
 import { IFieldState, IValidationResult } from "./Validation";
 import Tooltip from "./Tooltip";
@@ -196,18 +195,12 @@ export default class Field extends React.PureComponent<PropShapes, IState> {
         this.props.onBlur?.(ev);
     };
 
-    // Memoize latest result as some validation functions can be costly, e.g. API hits
-    private onValidate = memoizeOne(
-        (fieldState: IFieldState): Promise<IValidationResult> => this.props.onValidate!(fieldState),
-        ([a], [b]) => a.value === b.value && a.focused === b.focused && a.allowEmpty === b.allowEmpty,
-    );
-
     public async validate({ focused, allowEmpty = true }: IValidateOpts): Promise<boolean | undefined> {
         if (!this.props.onValidate) {
             return;
         }
         const value = this.inputRef.current?.value ?? null;
-        const { valid, feedback } = await this.onValidate({
+        const { valid, feedback } = await this.props.onValidate({
             value,
             focused: !!focused,
             allowEmpty,


### PR DESCRIPTION
https://github.com/vector-im/element-web/issues/12778

Re-uses an existing transitive dependency

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Memoize field validation results ([\#10714](https://github.com/matrix-org/matrix-react-sdk/pull/10714)).<!-- CHANGELOG_PREVIEW_END -->