### PR TITLE
Remove one of the tsc strict check CIs

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -49,12 +49,6 @@ jobs:
         permissions:
             pull-requests: read
             checks: write
-        strategy:
-            fail-fast: false
-            matrix:
-                args:
-                    - "--strict --noImplicitAny"
-                    - "--noImplicitAny"
         steps:
             - uses: actions/checkout@v3
               with:
@@ -82,7 +76,7 @@ jobs:
                   use-check: false
                   check-fail-mode: added
                   output-behaviour: annotate
-                  ts-extra-args: ${{ matrix.args }}
+                  ts-extra-args: "--strict --noImplicitAny"
                   files-changed: ${{ steps.files.outputs.files_updated }}
                   files-added: ${{ steps.files.outputs.files_created }}
                   files-deleted: ${{ steps.files.outputs.files_deleted }}


### PR DESCRIPTION
Given we no longer gate the branch protection on it, no point duplicating a subset of the errors. One X is plenty.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->