### PR TITLE
Archaeological investigation - `_RoomView.pcss`

### DIFF
--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -237,20 +237,6 @@ hr.mx_RoomView_myReadMarker {
     margin-right: 2px;
 }
 
-.mx_RoomView_ongoingConfCallNotification {
-    width: 100%;
-    text-align: center;
-    background-color: $alert;
-    color: $accent-fg-color;
-    font-weight: bold;
-    padding: 6px 0;
-    cursor: pointer;
-}
-
-.mx_RoomView_ongoingConfCallNotification a {
-    color: $accent-fg-color !important;
-}
-
 .mx_MatrixChat_useCompactLayout {
     .mx_RoomView_MessageList {
         margin-bottom: 4px;

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -51,10 +51,6 @@ limitations under the License.
     cursor: pointer;
 }
 
-.mx_RoomView_auxPanel_apps {
-    max-width: 1920px !important;
-}
-
 .mx_RoomView .mx_MainSplit {
     flex: 1 1 0;
 }

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -237,17 +237,6 @@ hr.mx_RoomView_myReadMarker {
     right: 11px;
 }
 
-.mx_RoomView_voipButton {
-    float: right;
-    margin-right: 13px;
-    margin-top: 13px;
-    cursor: pointer;
-}
-
-.mx_RoomView_voipButton object {
-    pointer-events: none;
-}
-
 .mx_RoomView .mx_MessageComposer {
     width: 100%;
     flex: 0 0 auto;

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -231,12 +231,6 @@ hr.mx_RoomView_myReadMarker {
     padding-top: 1px;
 }
 
-.mx_RoomView_voipChevron {
-    position: absolute;
-    bottom: -11px;
-    right: 11px;
-}
-
 .mx_RoomView .mx_MessageComposer {
     width: 100%;
     flex: 0 0 auto;

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -44,16 +44,6 @@ limitations under the License.
     overflow: auto;
 }
 
-.mx_RoomView_auxPanel_fullHeight {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 3000;
-    background-color: $background;
-}
-
 .mx_RoomView_auxPanel_hiddenHighlights {
     border-bottom: 1px solid $primary-hairline-color;
     padding: 10px 26px;

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -220,15 +220,6 @@ hr.mx_RoomView_myReadMarker {
     border: unset;
 }
 
-.mx_RoomView_callStatusBar .mx_UploadBar_uploadProgressInner {
-    background-color: $background;
-}
-
-.mx_RoomView_callStatusBar .mx_UploadBar_uploadFilename {
-    color: $accent-fg-color;
-    opacity: 1;
-}
-
 .mx_RoomView_inCall .mx_RoomView_statusAreaBox_line {
     margin-top: 2px;
     border: none;


### PR DESCRIPTION
This PR suggests to remove CSS style rules which have been obsolete since several years from `_RoomView.pcss`. For reference, each commit message indicates which commit added the rules or related elements and which one made them irrelevant.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->