### PR TITLE
Emulate TabbedView's actual min and max widths on user settings tabs

### DIFF
--- a/cypress/e2e/settings/general-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/general-user-settings-tab.spec.ts
@@ -45,6 +45,10 @@ describe("General user settings tab", () => {
 
         cy.get(".mx_SettingsTab.mx_GeneralUserSettingsTab").percySnapshotElement("User settings tab - General", {
             percyCSS,
+            // Emulate TabbedView's actual min and max widths
+            // 580: '.mx_UserSettingsDialog .mx_TabbedView' min-width
+            // 796: 1036 (mx_TabbedView_tabsOnLeft actual width) - 240 (mx_TabbedView_tabPanel margin-right)
+            widths: [580, 796],
         });
 
         cy.get(".mx_SettingsTab.mx_GeneralUserSettingsTab").within(() => {

--- a/cypress/e2e/settings/preferences-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/preferences-user-settings-tab.spec.ts
@@ -40,6 +40,14 @@ describe("Preferences user settings tab", () => {
             cy.findByTestId("preferences").should("have.text", "Preferences").should("be.visible");
         });
 
-        cy.get(".mx_SettingsTab.mx_PreferencesUserSettingsTab").percySnapshotElement("User settings tab - Preferences");
+        cy.get(".mx_SettingsTab.mx_PreferencesUserSettingsTab").percySnapshotElement(
+            "User settings tab - Preferences",
+            {
+                // Emulate TabbedView's actual min and max widths
+                // 580: '.mx_UserSettingsDialog .mx_TabbedView' min-width
+                // 796: 1036 (mx_TabbedView_tabsOnLeft actual width) - 240 (mx_TabbedView_tabPanel margin-right)
+                widths: [580, 796],
+            },
+        );
     });
 });


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25229

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->