### PR TITLE
Fix autocomplete not resetting properly on message send

### DIFF
--- a/src/editor/model.ts
+++ b/src/editor/model.ts
@@ -99,10 +99,10 @@ export default class EditorModel {
 
     private insertPart(index: number, part: Part): void {
         this._parts.splice(index, 0, part);
-        if (this.activePartIdx && this.activePartIdx >= index) {
+        if (this.activePartIdx !== null && this.activePartIdx >= index) {
             ++this.activePartIdx;
         }
-        if (this.autoCompletePartIdx && this.autoCompletePartIdx >= index) {
+        if (this.autoCompletePartIdx !== null && this.autoCompletePartIdx >= index) {
             ++this.autoCompletePartIdx;
         }
     }
@@ -111,12 +111,12 @@ export default class EditorModel {
         this._parts.splice(index, 1);
         if (index === this.activePartIdx) {
             this.activePartIdx = null;
-        } else if (this.activePartIdx && this.activePartIdx > index) {
+        } else if (this.activePartIdx !== null && this.activePartIdx > index) {
             --this.activePartIdx;
         }
         if (index === this.autoCompletePartIdx) {
             this.autoCompletePartIdx = null;
-        } else if (this.autoCompletePartIdx && this.autoCompletePartIdx > index) {
+        } else if (this.autoCompletePartIdx !== null && this.autoCompletePartIdx > index) {
             --this.autoCompletePartIdx;
         }
     }

--- a/test/editor/mock.ts
+++ b/test/editor/mock.ts
@@ -21,7 +21,7 @@ import { Caret } from "../../src/editor/caret";
 import { PillPart, Part, PartCreator } from "../../src/editor/parts";
 import DocumentPosition from "../../src/editor/position";
 
-class MockAutoComplete {
+export class MockAutoComplete {
     public _updateCallback;
     public _partCreator;
     public _completions;
@@ -44,7 +44,7 @@ class MockAutoComplete {
         });
         if (matches.length === 1 && this._part && this._part.text.length > 1) {
             const match = matches[0];
-            let pill;
+            let pill: PillPart;
             if (match.resourceId[0] === "@") {
                 pill = this._partCreator.userPill(match.text, match.resourceId);
             } else {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25170
Regressed by https://github.com/matrix-org/matrix-react-sdk/commit/e4dfb21e56de9d469ff4b73387316034f8aa3721

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix autocomplete not resetting properly on message send ([\#10741](https://github.com/matrix-org/matrix-react-sdk/pull/10741)). Fixes vector-im/element-web#25170.<!-- CHANGELOG_PREVIEW_END -->