### PR TITLE
Tidy up `_RoomView.pcss`

### DIFF
--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -69,9 +69,8 @@ limitations under the License.
     background-size: 25px;
     background-repeat: no-repeat;
     position: relative;
-}
 
-.mx_RoomView_messagePanelSearchSpinner::before {
+&::before {
     background-color: $info-plinth-fg-color;
     mask: url("$(res)/img/feather-customised/search-input.svg");
     mask-repeat: no-repeat;
@@ -83,6 +82,7 @@ limitations under the License.
     left: 0;
     right: 0;
     height: 50px;
+}
 }
 
 .mx_RoomView_body {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -38,6 +38,12 @@ limitations under the License.
     .mx_MainSplit {
         flex: 1 1 0;
     }
+
+.mx_MessageComposer {
+    width: 100%;
+    flex: 0 0 auto;
+    margin-right: 2px;
+}
 }
 
 .mx_RoomView_auxPanel {
@@ -217,12 +223,6 @@ hr.mx_RoomView_myReadMarker {
     border-top: 2px hidden;
     padding-top: 1px;
 }
-}
-
-.mx_RoomView .mx_MessageComposer {
-    width: 100%;
-    flex: 0 0 auto;
-    margin-right: 2px;
 }
 
 .mx_MatrixChat_useCompactLayout {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -39,11 +39,11 @@ limitations under the License.
         flex: 1 1 0;
     }
 
-.mx_MessageComposer {
-    width: 100%;
-    flex: 0 0 auto;
-    margin-right: 2px;
-}
+    .mx_MessageComposer {
+        width: 100%;
+        flex: 0 0 auto;
+        margin-right: 2px;
+    }
 }
 
 .mx_RoomView_auxPanel {
@@ -76,19 +76,19 @@ limitations under the License.
     background-repeat: no-repeat;
     position: relative;
 
-&::before {
-    background-color: $info-plinth-fg-color;
-    mask: url("$(res)/img/feather-customised/search-input.svg");
-    mask-repeat: no-repeat;
-    mask-position: center;
-    mask-size: 50px;
-    content: "";
-    position: absolute;
-    top: 286px;
-    left: 0;
-    right: 0;
-    height: 50px;
-}
+    &::before {
+        background-color: $info-plinth-fg-color;
+        mask: url("$(res)/img/feather-customised/search-input.svg");
+        mask-repeat: no-repeat;
+        mask-position: center;
+        mask-size: 50px;
+        content: "";
+        position: absolute;
+        top: 286px;
+        left: 0;
+        right: 0;
+        height: 50px;
+    }
 }
 
 .mx_RoomView_body {
@@ -103,14 +103,14 @@ limitations under the License.
         order: 2;
     }
 
-.mx_RoomView_timeline {
-    /* offset parent for mx_RoomView_topUnreadMessagesBar  */
-    position: relative;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    margin-right: calc($container-gap-width / 2);
-}
+    .mx_RoomView_timeline {
+        /* offset parent for mx_RoomView_topUnreadMessagesBar  */
+        position: relative;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        margin-right: calc($container-gap-width / 2);
+    }
 }
 
 .mx_RoomView_statusArea {
@@ -178,9 +178,9 @@ limitations under the License.
     to prevent shrinking when WhoIsTypingTile is hidden */
     box-sizing: border-box;
 
-li {
-    clear: both;
-}
+    li {
+        clear: both;
+    }
 }
 
 .mx_RoomView--local .mx_ScrollPanel .mx_RoomView_MessageList {
@@ -213,16 +213,16 @@ hr.mx_RoomView_myReadMarker {
 }
 
 .mx_RoomView_inCall {
-.mx_RoomView_statusAreaBox_line {
-    margin-top: 2px;
-    border: none;
-    height: 0px;
-}
+    .mx_RoomView_statusAreaBox_line {
+        margin-top: 2px;
+        border: none;
+        height: 0px;
+    }
 
-.mx_MessageComposer_wrapper {
-    border-top: 2px hidden;
-    padding-top: 1px;
-}
+    .mx_MessageComposer_wrapper {
+        border-top: 2px hidden;
+        padding-top: 1px;
+    }
 }
 
 .mx_MatrixChat_useCompactLayout {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -96,15 +96,15 @@ limitations under the License.
     .mx_RoomView_messagePanelSearchSpinner {
         order: 2;
     }
-}
 
-.mx_RoomView_body .mx_RoomView_timeline {
+.mx_RoomView_timeline {
     /* offset parent for mx_RoomView_topUnreadMessagesBar  */
     position: relative;
     flex: 1;
     display: flex;
     flex-direction: column;
     margin-right: calc($container-gap-width / 2);
+}
 }
 
 .mx_RoomView_statusArea {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -171,14 +171,14 @@ limitations under the License.
     /* needed as min-height is set to clientHeight in ScrollPanel
     to prevent shrinking when WhoIsTypingTile is hidden */
     box-sizing: border-box;
+
+li {
+    clear: both;
+}
 }
 
 .mx_RoomView--local .mx_ScrollPanel .mx_RoomView_MessageList {
     justify-content: center;
-}
-
-.mx_RoomView_MessageList li {
-    clear: both;
 }
 
 li.mx_RoomView_myReadMarker_container {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -34,6 +34,10 @@ limitations under the License.
     flex-direction: column;
     flex: 1;
     position: relative;
+
+    .mx_MainSplit {
+        flex: 1 1 0;
+    }
 }
 
 .mx_RoomView_auxPanel {
@@ -49,10 +53,6 @@ limitations under the License.
     padding: 10px 26px;
     color: $alert;
     cursor: pointer;
-}
-
-.mx_RoomView .mx_MainSplit {
-    flex: 1 1 0;
 }
 
 .mx_RoomView_messagePanel {

--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -206,15 +206,17 @@ hr.mx_RoomView_myReadMarker {
     border: unset;
 }
 
-.mx_RoomView_inCall .mx_RoomView_statusAreaBox_line {
+.mx_RoomView_inCall {
+.mx_RoomView_statusAreaBox_line {
     margin-top: 2px;
     border: none;
     height: 0px;
 }
 
-.mx_RoomView_inCall .mx_MessageComposer_wrapper {
+.mx_MessageComposer_wrapper {
     border-top: 2px hidden;
     padding-top: 1px;
+}
 }
 
 .mx_RoomView .mx_MessageComposer {


### PR DESCRIPTION
After my archaeological investigation of `_RoomView.pcss` on https://github.com/matrix-org/matrix-react-sdk/pull/10733, I found a lot of the rules of that file could be organized *without changing their specificity*. This PR intends to tidy up the file to prevent those rules from becoming orphan, like the style rules which have been left for years that PR removed.

For reviewers: it is recommended to run Percy on the merge queue if you would like to ensure nothing regresses.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->