### PR TITLE
Add space for vertical stroke on message edit composer on Rich Text Editor mode

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -45,6 +45,7 @@ $timeline-image-border-radius: 8px;
     --MessageTimestamp-width: $MessageTimestamp_width;
     --buttons-dialog-gap-row: $spacing-8;
     --buttons-dialog-gap-column: $spacing-8;
+    --EditComposer-padding-inline: 3px;
 }
 
 @media only percy {

--- a/res/css/views/rooms/_EditMessageComposer.pcss
+++ b/res/css/views/rooms/_EditMessageComposer.pcss
@@ -16,14 +16,12 @@ limitations under the License.
 */
 
 .mx_EditMessageComposer {
-    --EditMessageComposer-padding-inline: 3px;
-
     display: flex;
     flex-direction: column;
     max-width: 100%; /* disable overflow */
     width: auto;
     gap: 5px;
-    padding: 3px var(--EditMessageComposer-padding-inline);
+    padding: 3px var(--EditComposer-padding-inline);
 
     .mx_BasicMessageComposer_input {
         border-radius: 4px;

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -315,9 +315,9 @@ $left-gutter: 64px;
         }
 
         &.mx_EventTile_isEditing > .mx_EventTile_line {
-            .mx_EditMessageComposer {
+            .mx_EditComposer {
                 /* add space for the stroke on box-shadow */
-                padding-inline-start: calc($selected-message-border-width + var(--EditMessageComposer-padding-inline));
+                padding-inline-start: calc($selected-message-border-width + var(--EditComposer-padding-inline));
             }
         }
 

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -462,7 +462,10 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
         if (!room) return null;
 
         return (
-            <div className={classNames("mx_EditMessageComposer", this.props.className)} onKeyDown={this.onKeyDown}>
+            <div
+                className={classNames("mx_EditComposer mx_EditMessageComposer", this.props.className)}
+                onKeyDown={this.onKeyDown}
+            >
                 <BasicMessageComposer
                     ref={this.editorRef}
                     model={this.model}

--- a/src/components/views/rooms/wysiwyg_composer/EditWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/EditWysiwygComposer.tsx
@@ -65,7 +65,7 @@ export default function EditWysiwygComposer({
     return (
         <ComposerContext.Provider value={defaultContextValue.current}>
             <WysiwygComposer
-                className={classNames("mx_EditWysiwygComposer", className)}
+                className={classNames("mx_EditComposer mx_EditWysiwygComposer", className)}
                 initialContent={initialContent}
                 onChange={onChange}
                 onSend={editMessage}


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25237

This PR intends to add space for vertical stroke on message edit composer of Rich Text Editor. It also suggests to add E2E tests for edit composers on both CIDER and RTE, with two new Percy screenshots: `EditComposer on EventTile - CIDER` and `EditComposer on EventTile - Rich Text Editor`.

Here are cropped screenshots of message edit composer on RTE mode:

|Before|After|
|---------|------|
|![Screenshot from 2023-05-01 00-01-04](https://user-images.githubusercontent.com/3362943/235361712-84f16fab-a265-4345-80ee-716651b63a1c.png)|![Screenshot from 2023-05-01 00-03-39](https://user-images.githubusercontent.com/3362943/235361719-c511678b-7548-4669-8870-67519bae3f37.png)|

Please note that this PR intentionally suggests to create two `EditComposer` categories for CIDER and RTE, so that they will be added with other tests for each mode. 

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add space for vertical stroke on message edit composer on Rich Text Editor mode ([\#10749](https://github.com/matrix-org/matrix-react-sdk/pull/10749)). Fixes vector-im/element-web#25237. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->