### PR TITLE
Remove unused prop from `ResizeHandle` - reverse

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -265,7 +265,6 @@ class LoggedInView extends React.Component<IProps, IState> {
         resizer.setClassNames({
             handle: "mx_ResizeHandle",
             vertical: "mx_ResizeHandle_vertical",
-            reverse: "mx_ResizeHandle_reverse",
         });
         return resizer;
     }

--- a/src/components/views/elements/ResizeHandle.tsx
+++ b/src/components/views/elements/ResizeHandle.tsx
@@ -19,20 +19,16 @@ import React from "react"; // eslint-disable-line no-unused-vars
 //see src/resizer for the actual resizing code, this is just the DOM for the resize handle
 interface IResizeHandleProps {
     vertical?: boolean;
-    reverse?: boolean;
     id?: string;
     passRef?: React.RefObject<HTMLDivElement>;
 }
 
-const ResizeHandle: React.FC<IResizeHandleProps> = ({ vertical, reverse, id, passRef }) => {
+const ResizeHandle: React.FC<IResizeHandleProps> = ({ vertical, id, passRef }) => {
     const classNames = ["mx_ResizeHandle"];
     if (vertical) {
         classNames.push("mx_ResizeHandle_vertical");
     } else {
         classNames.push("mx_ResizeHandle_horizontal");
-    }
-    if (reverse) {
-        classNames.push("mx_ResizeHandle_reverse");
     }
     return (
         <div ref={passRef} className={classNames.join(" ")} data-id={id}>

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -110,7 +110,6 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
         const classNames = {
             handle: "mx_ResizeHandle",
             vertical: "mx_ResizeHandle_vertical",
-            reverse: "mx_ResizeHandle_reverse",
         };
         const collapseConfig = {
             onResizeStart: () => {
@@ -267,7 +266,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     if (i < 1) return app;
                     return (
                         <React.Fragment key={app.key}>
-                            <ResizeHandle reverse={i > apps.length / 2} />
+                            <ResizeHandle />
                             {app}
                         </React.Fragment>
                     );


### PR DESCRIPTION
This PR suggests to remove an unused prop from `ResizeHandle`. It was added by 928b6d47c8449b1b784e4ea04606085ab8dc446c and soon deprecated by e5d1b3328c509ff86c7c023aa10d12ec521de13b in the same PR.

type: task

|Before|After|
|---------|------|
|![1](https://user-images.githubusercontent.com/3362943/235755546-f61fb23f-f6f9-4ceb-995e-4a99cd56ad83.png)|![2](https://user-images.githubusercontent.com/3362943/235755565-4692cb0b-2a84-423a-a299-3c43ef77c936.png)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->