### PR TITLE
Remove mixin `mx_Dialog_link`

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -861,8 +861,3 @@ legend {
         }
     }
 }
-
-@define-mixin mx_Dialog_link {
-    color: $accent;
-    text-decoration: none;
-}

--- a/res/css/views/auth/_AuthBody.pcss
+++ b/res/css/views/auth/_AuthBody.pcss
@@ -53,7 +53,8 @@ limitations under the License.
     a:link,
     a:hover,
     a:visited {
-        @mixin mx_Dialog_link;
+        color: $accent;
+        text-decoration: none;
     }
 
     fieldset {

--- a/res/css/views/auth/_CompleteSecurityBody.pcss
+++ b/res/css/views/auth/_CompleteSecurityBody.pcss
@@ -37,6 +37,7 @@ limitations under the License.
     a:link,
     a:hover,
     a:visited {
-        @mixin mx_Dialog_link;
+        color: $accent;
+        text-decoration: none;
     }
 }


### PR DESCRIPTION
Based on https://github.com/vector-im/element-web/issues/25240

This PR intends to remove a mixin `mx_Dialog_link` on the ground that:

- There is not a component named (or whose class name is) `mx_Dialog_link`
- Removing a mixin is always good for pushing our style codebase toward vanilla CSS

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->