### PR TITLE
Fix use of logger that assumes it interpolates strings

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1504,7 +1504,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             if (state === SyncState.Syncing && prevState === SyncState.Syncing) {
                 return;
             }
-            logger.info("MatrixClient sync state => %s", state);
+            logger.info(`MatrixClient sync state => ${state}`);
             if (state !== SyncState.Prepared) {
                 return;
             }
@@ -1863,7 +1863,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 subAction: params?.action,
             });
         } else {
-            logger.info("Ignoring showScreen for '%s'", screen);
+            logger.info(`Ignoring showScreen for '${screen}'`);
         }
     }
 

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -842,7 +842,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         // making it impossible to indicate a newly joined room.
         if (!joining && roomId) {
             if (!room && shouldPeek) {
-                logger.info("Attempting to peek into room %s", roomId);
+                logger.info(`Attempting to peek into room ${roomId}`);
                 this.setState({
                     peekLoading: true,
                     isPeeking: true, // this will change to false if peeking fails
@@ -1671,7 +1671,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 });
             },
             (error) => {
-                logger.error("Failed to reject invite: %s", error);
+                logger.error(`Failed to reject invite: ${error}`);
 
                 const msg = error.message ? error.message : JSON.stringify(error);
                 Modal.createDialog(ErrorDialog, {
@@ -1705,7 +1705,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 rejecting: false,
             });
         } catch (error) {
-            logger.error("Failed to reject invite: %s", error);
+            logger.error(`Failed to reject invite: ${error}`);
 
             const msg = error.message ? error.message : JSON.stringify(error);
             Modal.createDialog(ErrorDialog, {

--- a/src/components/views/auth/CaptchaForm.tsx
+++ b/src/components/views/auth/CaptchaForm.tsx
@@ -94,7 +94,7 @@ export default class CaptchaForm extends React.Component<ICaptchaFormProps, ICap
             throw new Error("This server has not supplied enough information for Recaptcha authentication");
         }
 
-        logger.info("Rendering to %s", divId);
+        logger.info(`Rendering to ${divId}`);
         this.captchaWidgetId = global.grecaptcha?.render(divId, {
             sitekey: publicKey,
             callback: this.props.onCaptchaResponse,

--- a/src/editor/commands.tsx
+++ b/src/editor/commands.tsx
@@ -78,7 +78,7 @@ export async function runSlashCommand(
         }
     }
     if (error) {
-        logger.error("Command failure: %s", error);
+        logger.error(`Command failure: ${error}`);
         // assume the error is a server error when the command is async
         const isServerError = !!result.promise;
         const title = isServerError ? _td("Server error") : _td("Command error");


### PR DESCRIPTION
I found a few log lines in rageshakes that include `%s`. This was why.

Replaced with use of backticks interpolation. None of the places look performance-critical, so this probably has negligible effect on our performance.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->