### PR TITLE
Fix the repository that we check out from for the cypress tests

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -128,8 +128,9 @@ jobs:
               with:
                   # XXX: We're checking out untrusted code in a secure context
                   # We need to be careful to not trust anything this code outputs/may do
-                  # We need to check this out to access the cypress tests which are on the head branch
-                  repository: ${{ github.event.workflow_run.head_repository.full_name }}
+                  #
+                  # Note that we check out from the default repository, which is (for this workflow) the
+                  # *target* repository for the pull request.
                   ref: ${{ steps.sha.outputs.sha }}
                   persist-credentials: false
                   path: matrix-react-sdk


### PR DESCRIPTION
Followup to #10688, and hopefully fixes https://github.com/vector-im/element-web/issues/25234.

Since we're checking out the simulated merge sha, we need to check out from the repository that is the *target* of the PR, not the source.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->