### PR TITLE
Introduce CSS custom properties to `_TopUnreadMessagesBar.pcss` 

### DIFF
--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -45,6 +45,9 @@ limitations under the License.
         border: var(--border);
         border-radius: var(--borderRadius);
 
+        --background: $background;
+        --border: 1.3px solid $muted-fg-color;
+
         &::before {
             content: "";
             position: absolute;
@@ -55,20 +58,19 @@ limitations under the License.
             mask-position: center;
             mask-image: var(--maskImage);
             mask-size: var(--maskSize);
+
+            --background: $muted-fg-color;
         }
     }
 
     .mx_TopUnreadMessagesBar_scrollUp {
-        --background: $background;
         --height: 38px;
-        --border: 1.3px solid $muted-fg-color;
         --borderRadius: 19px;
 
         box-sizing: border-box;
         cursor: pointer;
 
         &::before {
-            --background: $muted-fg-color;
             --width: 36px;
             --height: 36px;
             --maskImage: url("$(res)/img/element-icons/message/chevron-up.svg");
@@ -77,17 +79,14 @@ limitations under the License.
     }
 
     .mx_TopUnreadMessagesBar_markAsRead {
-        --background: $background;
         --width: 18px;
         --height: 18px;
-        --border: 1.3px solid $muted-fg-color;
         --borderRadius: 10px;
 
         display: block;
         margin: 5px auto;
 
         &::before {
-            --background: $muted-fg-color;
             --maskImage: url("$(res)/img/cancel.svg");
             --maskSize: 10px;
         }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -16,6 +16,20 @@ limitations under the License.
 
 @charset "utf-8";
 
+.mx_TopUnreadMessagesBar_scrollUp,
+.mx_TopUnreadMessagesBar_markAsRead {
+    border: 1.3px solid $muted-fg-color;
+    background: $background;
+
+    &::before {
+        content: "";
+        position: absolute;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        background: $muted-fg-color;
+    }
+}
+
 .mx_TopUnreadMessagesBar {
     z-index: 1000;
     position: absolute;
@@ -41,20 +55,13 @@ limitations under the License.
     height: 38px;
     border-radius: 19px;
     box-sizing: border-box;
-    background: $background;
-    border: 1.3px solid $muted-fg-color;
     cursor: pointer;
 
     &::before {
-        content: "";
-        position: absolute;
         width: 36px;
         height: 36px;
         mask-image: url("$(res)/img/element-icons/message/chevron-up.svg");
-        mask-repeat: no-repeat;
         mask-size: 20px;
-        mask-position: center;
-        background: $muted-fg-color;
     }
 }
 
@@ -62,20 +69,13 @@ limitations under the License.
     display: block;
     width: 18px;
     height: 18px;
-    background: $background;
-    border: 1.3px solid $muted-fg-color;
     border-radius: 10px;
     margin: 5px auto;
 
     &::before {
-        content: "";
-        position: absolute;
         width: 18px;
         height: 18px;
         mask-image: url("$(res)/img/cancel.svg");
-        mask-repeat: no-repeat;
         mask-size: 10px;
-        mask-position: 4px 4px;
-        background: $muted-fg-color;
     }
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -22,9 +22,8 @@ limitations under the License.
     top: 24px;
     right: 24px;
     width: 38px;
-}
 
-.mx_TopUnreadMessagesBar::after {
+&::after {
     content: "";
     position: absolute;
     top: -8px;
@@ -36,6 +35,7 @@ limitations under the License.
     border: 6px solid $accent;
     pointer-events: none;
 }
+}
 
 .mx_TopUnreadMessagesBar_scrollUp {
     height: 38px;
@@ -44,9 +44,8 @@ limitations under the License.
     background: $background;
     border: 1.3px solid $muted-fg-color;
     cursor: pointer;
-}
 
-.mx_TopUnreadMessagesBar_scrollUp::before {
+&::before {
     content: "";
     position: absolute;
     width: 36px;
@@ -57,6 +56,7 @@ limitations under the License.
     mask-position: center;
     background: $muted-fg-color;
 }
+}
 
 .mx_TopUnreadMessagesBar_markAsRead {
     display: block;
@@ -66,9 +66,8 @@ limitations under the License.
     border: 1.3px solid $muted-fg-color;
     border-radius: 10px;
     margin: 5px auto;
-}
 
-.mx_TopUnreadMessagesBar_markAsRead::before {
+&::before {
     content: "";
     position: absolute;
     width: 18px;
@@ -78,4 +77,5 @@ limitations under the License.
     mask-size: 10px;
     mask-position: 4px 4px;
     background: $muted-fg-color;
+}
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -88,7 +88,6 @@ limitations under the License.
         &::before {
             --background: $muted-fg-color;
             --width: 18px;
-            --height: 18px;
             --maskImage: url("$(res)/img/cancel.svg");
             --maskSize: 10px;
         }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -36,61 +36,61 @@ limitations under the License.
         pointer-events: none;
     }
 
-/* Define common declarations. Their values are specified below. */
-.mx_TopUnreadMessagesBar_scrollUp,
-.mx_TopUnreadMessagesBar_markAsRead {
-    background: var(--background);
-    height: var(--height);
-    border: var(--border);
-    border-radius: var(--borderRadius);
-
-    &::before {
-        content: "";
-        position: absolute;
+    /* Define common declarations. Their values are specified below. */
+    .mx_TopUnreadMessagesBar_scrollUp,
+    .mx_TopUnreadMessagesBar_markAsRead {
         background: var(--background);
-        width: var(--width);
         height: var(--height);
-        mask-repeat: no-repeat;
-        mask-position: center;
-        mask-image: var(--maskImage);
-        mask-size: var(--maskSize);
+        border: var(--border);
+        border-radius: var(--borderRadius);
+
+        &::before {
+            content: "";
+            position: absolute;
+            background: var(--background);
+            width: var(--width);
+            height: var(--height);
+            mask-repeat: no-repeat;
+            mask-position: center;
+            mask-image: var(--maskImage);
+            mask-size: var(--maskSize);
+        }
     }
-}
 
-.mx_TopUnreadMessagesBar_scrollUp {
-    --background: $background;
-    --height: 38px;
-    --border: 1.3px solid $muted-fg-color;
-    --borderRadius: 19px;
+    .mx_TopUnreadMessagesBar_scrollUp {
+        --background: $background;
+        --height: 38px;
+        --border: 1.3px solid $muted-fg-color;
+        --borderRadius: 19px;
 
-    box-sizing: border-box;
-    cursor: pointer;
+        box-sizing: border-box;
+        cursor: pointer;
 
-    &::before {
-        --background: $muted-fg-color;
-        --width: 36px;
-        --height: 36px;
-        --maskImage: url("$(res)/img/element-icons/message/chevron-up.svg");
-        --maskSize: 20px;
+        &::before {
+            --background: $muted-fg-color;
+            --width: 36px;
+            --height: 36px;
+            --maskImage: url("$(res)/img/element-icons/message/chevron-up.svg");
+            --maskSize: 20px;
+        }
     }
-}
 
-.mx_TopUnreadMessagesBar_markAsRead {
-    --background: $background;
-    --height: 18px;
-    --border: 1.3px solid $muted-fg-color;
-    --borderRadius: 10px;
-
-    display: block;
-    width: 18px;
-    margin: 5px auto;
-
-    &::before {
-        --background: $muted-fg-color;
-        --width: 18px;
+    .mx_TopUnreadMessagesBar_markAsRead {
+        --background: $background;
         --height: 18px;
-        --maskImage: url("$(res)/img/cancel.svg");
-        --maskSize: 10px;
+        --border: 1.3px solid $muted-fg-color;
+        --borderRadius: 10px;
+
+        display: block;
+        width: 18px;
+        margin: 5px auto;
+
+        &::before {
+            --background: $muted-fg-color;
+            --width: 18px;
+            --height: 18px;
+            --maskImage: url("$(res)/img/cancel.svg");
+            --maskSize: 10px;
+        }
     }
-}
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -40,6 +40,7 @@ limitations under the License.
     .mx_TopUnreadMessagesBar_scrollUp,
     .mx_TopUnreadMessagesBar_markAsRead {
         background: var(--background);
+        width: var(--width);
         height: var(--height);
         border: var(--border);
         border-radius: var(--borderRadius);
@@ -77,17 +78,16 @@ limitations under the License.
 
     .mx_TopUnreadMessagesBar_markAsRead {
         --background: $background;
+        --width: 18px;
         --height: 18px;
         --border: 1.3px solid $muted-fg-color;
         --borderRadius: 10px;
 
         display: block;
-        width: 18px;
         margin: 5px auto;
 
         &::before {
             --background: $muted-fg-color;
-            --width: 18px;
             --maskImage: url("$(res)/img/cancel.svg");
             --maskSize: 10px;
         }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -16,27 +16,6 @@ limitations under the License.
 
 @charset "utf-8";
 
-/* Define common declarations. Their values are specified below. */
-.mx_TopUnreadMessagesBar_scrollUp,
-.mx_TopUnreadMessagesBar_markAsRead {
-    background: var(--background);
-    height: var(--height);
-    border: var(--border);
-    border-radius: var(--borderRadius);
-
-    &::before {
-        content: "";
-        position: absolute;
-        background: var(--background);
-        width: var(--width);
-        height: var(--height);
-        mask-repeat: no-repeat;
-        mask-position: center;
-        mask-image: var(--maskImage);
-        mask-size: var(--maskSize);
-    }
-}
-
 .mx_TopUnreadMessagesBar {
     z-index: 1000;
     position: absolute;
@@ -55,6 +34,26 @@ limitations under the License.
         background-color: $secondary-accent-color;
         border: 6px solid $accent;
         pointer-events: none;
+    }
+
+/* Define common declarations. Their values are specified below. */
+.mx_TopUnreadMessagesBar_scrollUp,
+.mx_TopUnreadMessagesBar_markAsRead {
+    background: var(--background);
+    height: var(--height);
+    border: var(--border);
+    border-radius: var(--borderRadius);
+
+    &::before {
+        content: "";
+        position: absolute;
+        background: var(--background);
+        width: var(--width);
+        height: var(--height);
+        mask-repeat: no-repeat;
+        mask-position: center;
+        mask-image: var(--maskImage);
+        mask-size: var(--maskSize);
     }
 }
 
@@ -93,4 +92,5 @@ limitations under the License.
         --maskImage: url("$(res)/img/cancel.svg");
         --maskSize: 10px;
     }
+}
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -16,17 +16,24 @@ limitations under the License.
 
 @charset "utf-8";
 
+/* Define common declarations. Their values are specified below. */
 .mx_TopUnreadMessagesBar_scrollUp,
 .mx_TopUnreadMessagesBar_markAsRead {
-    border: 1.3px solid $muted-fg-color;
-    background: $background;
+    background: var(--background);
+    height: var(--height);
+    border: var(--border);
+    border-radius: var(--borderRadius);
 
     &::before {
         content: "";
         position: absolute;
+        background: var(--background);
+        width: var(--width);
+        height: var(--height);
         mask-repeat: no-repeat;
         mask-position: center;
-        background: $muted-fg-color;
+        mask-image: var(--maskImage);
+        mask-size: var(--maskSize);
     }
 }
 
@@ -52,30 +59,38 @@ limitations under the License.
 }
 
 .mx_TopUnreadMessagesBar_scrollUp {
-    height: 38px;
-    border-radius: 19px;
+    --background: $background;
+    --height: 38px;
+    --border: 1.3px solid $muted-fg-color;
+    --borderRadius: 19px;
+
     box-sizing: border-box;
     cursor: pointer;
 
     &::before {
-        width: 36px;
-        height: 36px;
-        mask-image: url("$(res)/img/element-icons/message/chevron-up.svg");
-        mask-size: 20px;
+        --background: $muted-fg-color;
+        --width: 36px;
+        --height: 36px;
+        --maskImage: url("$(res)/img/element-icons/message/chevron-up.svg");
+        --maskSize: 20px;
     }
 }
 
 .mx_TopUnreadMessagesBar_markAsRead {
+    --background: $background;
+    --height: 18px;
+    --border: 1.3px solid $muted-fg-color;
+    --borderRadius: 10px;
+
     display: block;
     width: 18px;
-    height: 18px;
-    border-radius: 10px;
     margin: 5px auto;
 
     &::before {
-        width: 18px;
-        height: 18px;
-        mask-image: url("$(res)/img/cancel.svg");
-        mask-size: 10px;
+        --background: $muted-fg-color;
+        --width: 18px;
+        --height: 18px;
+        --maskImage: url("$(res)/img/cancel.svg");
+        --maskSize: 10px;
     }
 }

--- a/res/css/views/rooms/_TopUnreadMessagesBar.pcss
+++ b/res/css/views/rooms/_TopUnreadMessagesBar.pcss
@@ -23,18 +23,18 @@ limitations under the License.
     right: 24px;
     width: 38px;
 
-&::after {
-    content: "";
-    position: absolute;
-    top: -8px;
-    left: 10.5px;
-    width: 4px;
-    height: 4px;
-    border-radius: 16px;
-    background-color: $secondary-accent-color;
-    border: 6px solid $accent;
-    pointer-events: none;
-}
+    &::after {
+        content: "";
+        position: absolute;
+        top: -8px;
+        left: 10.5px;
+        width: 4px;
+        height: 4px;
+        border-radius: 16px;
+        background-color: $secondary-accent-color;
+        border: 6px solid $accent;
+        pointer-events: none;
+    }
 }
 
 .mx_TopUnreadMessagesBar_scrollUp {
@@ -45,17 +45,17 @@ limitations under the License.
     border: 1.3px solid $muted-fg-color;
     cursor: pointer;
 
-&::before {
-    content: "";
-    position: absolute;
-    width: 36px;
-    height: 36px;
-    mask-image: url("$(res)/img/element-icons/message/chevron-up.svg");
-    mask-repeat: no-repeat;
-    mask-size: 20px;
-    mask-position: center;
-    background: $muted-fg-color;
-}
+    &::before {
+        content: "";
+        position: absolute;
+        width: 36px;
+        height: 36px;
+        mask-image: url("$(res)/img/element-icons/message/chevron-up.svg");
+        mask-repeat: no-repeat;
+        mask-size: 20px;
+        mask-position: center;
+        background: $muted-fg-color;
+    }
 }
 
 .mx_TopUnreadMessagesBar_markAsRead {
@@ -67,15 +67,15 @@ limitations under the License.
     border-radius: 10px;
     margin: 5px auto;
 
-&::before {
-    content: "";
-    position: absolute;
-    width: 18px;
-    height: 18px;
-    mask-image: url("$(res)/img/cancel.svg");
-    mask-repeat: no-repeat;
-    mask-size: 10px;
-    mask-position: 4px 4px;
-    background: $muted-fg-color;
-}
+    &::before {
+        content: "";
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        mask-image: url("$(res)/img/cancel.svg");
+        mask-repeat: no-repeat;
+        mask-size: 10px;
+        mask-position: 4px 4px;
+        background: $muted-fg-color;
+    }
 }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25282

This PR suggests to update `_TopUnreadMessagesBar.pcss` by introducing CSS custom properties, splitting structural definitions from their values. This way it will become possible to access and manipulate those values via TypeScript to change, for example, the border color and size, maintaining the style structure.

type: task

| |Image|
|-|---|
|TopUnreadMessageBar|![2_2](https://user-images.githubusercontent.com/3362943/236598850-27f6b3d4-0e99-47f2-a3fe-df6820e7d486.png)|
|`mx_TopUnreadMessagesBar_scrollUp`<br />cascading|![2](https://user-images.githubusercontent.com/3362943/236598839-cad0f9c6-e3b5-471d-b3bf-be8e6e684c93.png)|
|`mx_TopUnreadMessagesBar_markAsRead`<br />cascading|![2_1](https://user-images.githubusercontent.com/3362943/236598848-55f4c0f0-1797-4df3-a540-4cb73029e204.png)|



Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->