### PR TITLE
Remove mixin `mx_Tooltip_dark` and rename class `mx_Tooltip_dark`

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -695,15 +695,6 @@ legend {
     color: $username-variant8-color;
 }
 
-@define-mixin mx_Tooltip_dark {
-    box-shadow: none;
-    background-color: $tooltip-timeline-bg-color;
-    color: $tooltip-timeline-fg-color;
-    border: none;
-    border-radius: 3px;
-    padding: 6px 8px;
-}
-
 /* This is a workaround for our mixins not supporting child selectors */
 .mx_Tooltip_dark {
     .mx_Tooltip_chevron::after {

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -695,13 +695,6 @@ legend {
     color: $username-variant8-color;
 }
 
-/* This is a workaround for our mixins not supporting child selectors */
-.mx_Tooltip_dark {
-    .mx_Tooltip_chevron::after {
-        border-right-color: $tooltip-timeline-bg-color;
-    }
-}
-
 @define-mixin ProgressBarColour $colour {
     color: $colour;
     &::-moz-progress-bar {

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -359,7 +359,12 @@ $MinWidth: 240px;
 }
 
 .mx_AppPermissionWarning_tooltip {
-    @mixin mx_Tooltip_dark;
+    box-shadow: none;
+    background-color: $tooltip-timeline-bg-color;
+    color: $tooltip-timeline-fg-color;
+    border: none;
+    border-radius: 3px;
+    padding: 6px 8px;
 
     ul {
         list-style-position: inside;

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -366,6 +366,12 @@ $MinWidth: 240px;
     border-radius: 3px;
     padding: 6px 8px;
 
+    &.mx_AppPermissionWarning_tooltip--dark {
+        .mx_Tooltip_chevron::after {
+            border-right-color: $tooltip-timeline-bg-color;
+        }
+    }
+
     ul {
         list-style-position: inside;
         padding-left: 2px;

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -115,7 +115,7 @@ export default class AppPermission extends React.Component<IProps, IState> {
         const warningTooltip = (
             <TextWithTooltip
                 tooltip={warningTooltipText}
-                tooltipClass="mx_AppPermissionWarning_tooltip mx_Tooltip_dark"
+                tooltipClass="mx_AppPermissionWarning_tooltip mx_AppPermissionWarning_tooltip--dark"
             >
                 <span className="mx_AppPermissionWarning_helpIcon" />
             </TextWithTooltip>


### PR DESCRIPTION
This PR intends to:

- Remove mixin `mx_Tooltip_dark` from `_common.pcss` for vanilla CSS
- Rename class `mx_Tooltip_dark` to `mx_AppPermissionWarning_tooltip--dark` on `AppPermission.tsx`

Both have been used for `mx_AppPermissionWarning_tooltip` only, so should be coded so.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->