### PR TITLE
Remove obsolete style blocks from `_RightPanel.pcss` 

### DIFF
--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -177,18 +177,6 @@ $pulse-color: $alert;
     }
 }
 
-.mx_RightPanel_headerButton_badge {
-    font-size: $font-8px;
-    border-radius: 8px;
-    color: $accent-fg-color;
-    background-color: $accent;
-    font-weight: bold;
-    position: absolute;
-    top: -4px;
-    left: 20px;
-    padding: 2px 4px;
-}
-
 .mx_RightPanel_collapsebutton {
     flex: 1;
     text-align: right;

--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -40,14 +40,6 @@ limitations under the License.
 
 /** Fixme - factor this out with the main header **/
 
-.mx_RightPanel_headerButtonGroup {
-    height: 100%;
-    display: flex;
-    background-color: $background;
-    padding: 0 9px;
-    align-items: center;
-}
-
 /* See: mx_RoomHeader_button, of which this is a copy.
  * TODO: factor out a common component to avoid this duplication.
  */

--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -32,12 +32,6 @@ limitations under the License.
     }
 }
 
-.mx_RightPanel_header {
-    order: 1;
-    border-bottom: 1px solid $primary-hairline-color;
-    flex: 0 0 52px;
-}
-
 /** Fixme - factor this out with the main header **/
 
 /* See: mx_RoomHeader_button, of which this is a copy.

--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -135,35 +135,6 @@ $pulse-color: $alert;
     }
 }
 
-@keyframes mx_RightPanel_indicator_pulse {
-    0% {
-        transform: scale(0.95);
-    }
-
-    70% {
-        transform: scale(1);
-    }
-
-    100% {
-        transform: scale(0.95);
-    }
-}
-
-@keyframes mx_RightPanel_indicator_pulse_shadow {
-    0% {
-        opacity: 0.7;
-    }
-
-    70% {
-        transform: scale(2.2);
-        opacity: 0;
-    }
-
-    100% {
-        opacity: 0;
-    }
-}
-
 .mx_RightPanel_headerButton_unread {
     &::before {
         background-color: $room-icon-unread-color !important;

--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -177,13 +177,6 @@ $pulse-color: $alert;
     }
 }
 
-.mx_RightPanel_collapsebutton {
-    flex: 1;
-    text-align: right;
-    height: 16px;
-    border: none;
-}
-
 .mx_RightPanel .mx_MemberList,
 .mx_RightPanel .mx_MemberInfo,
 .mx_RightPanel_blank {


### PR DESCRIPTION
Cherry-picked from https://github.com/matrix-org/matrix-react-sdk/pull/10495

This PR intends to remove obsolete style blocks from `_RightPanel.pcss`. They were deprecated by e80a1c5, 8c62ddd, and 694c39e.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->