### PR TITLE
Add a snapshot for `RoomHeaderButtons`

### DIFF
--- a/test/components/views/right_panel/RoomHeaderButtons-test.tsx
+++ b/test/components/views/right_panel/RoomHeaderButtons-test.tsx
@@ -54,6 +54,11 @@ describe("RoomHeaderButtons-test.tsx", function () {
         return container.querySelector(".mx_RightPanel_threadsButton .mx_Indicator")!.className.includes(type);
     }
 
+    it("should render", () => {
+        const { asFragment } = getComponent(room);
+        expect(asFragment()).toMatchSnapshot();
+    });
+
     it("shows the thread button", () => {
         const { container } = getComponent(room);
         expect(getThreadButton(container)).not.toBeNull();

--- a/test/components/views/right_panel/__snapshots__/RoomHeaderButtons-test.tsx.snap
+++ b/test/components/views/right_panel/__snapshots__/RoomHeaderButtons-test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RoomHeaderButtons-test.tsx should render 1`] = `
+<DocumentFragment>
+  <div
+    aria-current="false"
+    aria-label="Chat"
+    class="mx_AccessibleButton mx_RightPanel_headerButton mx_RightPanel_timelineCardButton"
+    role="button"
+    tabindex="0"
+  />
+  <div
+    aria-current="false"
+    aria-label="Threads"
+    class="mx_AccessibleButton mx_RightPanel_headerButton mx_RightPanel_threadsButton"
+    data-testid="threadsButton"
+    role="button"
+    tabindex="0"
+  />
+  <div
+    aria-current="false"
+    aria-label="Notifications"
+    class="mx_AccessibleButton mx_RightPanel_headerButton mx_RightPanel_notifsButton"
+    role="button"
+    tabindex="0"
+  />
+  <div
+    aria-current="false"
+    aria-label="Room info"
+    class="mx_AccessibleButton mx_RightPanel_headerButton mx_RightPanel_roomSummaryButton"
+    role="button"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/10495

This PR suggests to add a Jest snapshot of `RoomHeaderButtons` before factoring style rules of `_RightPanel.pcss` related to the buttons, making it easier to review https://github.com/matrix-org/matrix-react-sdk/pull/10495, which is expected to introduce a large change of the class names.

Ideally there should be a snapshot test which captures all of the buttons on `RoomHeader` including a call button for example, but since the main object of taking this snapshot is to save the pattern of the class names, to check whether they follow our naming policy, I think the snapshot of `RoomHeaderButtons` should be sufficient for now, and should be better than nothing.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->