### PR TITLE
Fix long room address and name not being clipped on room info card and update `_RoomSummaryCard.pcss`

### DIFF
--- a/cypress/e2e/right-panel/right-panel.spec.ts
+++ b/cypress/e2e/right-panel/right-panel.spec.ts
@@ -20,8 +20,16 @@ import { HomeserverInstance } from "../../plugins/utils/homeserver";
 import Chainable = Cypress.Chainable;
 
 const ROOM_NAME = "Test room";
+const ROOM_NAME_LONG =
+    "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore " +
+    "et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut " +
+    "aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum " +
+    "dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui " +
+    "officia deserunt mollit anim id est laborum.";
 const SPACE_NAME = "Test space";
 const NAME = "Alice";
+const ROOM_ADDRESS_LONG =
+    "loremIpsumDolorSitAmetConsecteturAdipisicingElitSedDoEiusmodTemporIncididuntUtLaboreEtDoloreMagnaAliqua";
 
 const getMemberTileByName = (name: string): Chainable<JQuery<HTMLElement>> => {
     return cy.get(`.mx_EntityTile, [title="${name}"]`);
@@ -58,6 +66,31 @@ describe("RightPanel", () => {
     });
 
     describe("in rooms", () => {
+        it("should handle long room address and long room name", () => {
+            cy.createRoom({ name: ROOM_NAME_LONG });
+            viewRoomSummaryByName(ROOM_NAME_LONG);
+
+            cy.openRoomSettings();
+
+            // Set a local room address
+            cy.findByTestId("local-address-fieldset").within(() => {
+                cy.get(".mx_AliasSettings_localAddresses").click();
+                cy.findByLabelText("Room address").type(ROOM_ADDRESS_LONG);
+                cy.findByRole("button", { name: "Add" }).click();
+            });
+
+            cy.closeDialog();
+
+            // Close and reopen the right panel to render the room address
+            cy.findByRole("button", { name: "Room info" }).click();
+            cy.get(".mx_RightPanel").should("not.exist");
+            cy.findByRole("button", { name: "Room info" }).click();
+
+            cy.get(".mx_RightPanel").percySnapshotElement("RoomSummaryCard - with a room name and a local address", {
+                widths: [264], // Emulate the UI. The value is based on minWidth specified on MainSplit.tsx
+            });
+        });
+
         it("should handle clicking add widgets", () => {
             viewRoomSummaryByName(ROOM_NAME);
 

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -27,7 +27,6 @@ limitations under the License.
         .mx_RoomSummaryCard_alias {
             font-size: $font-13px;
             color: $secondary-content;
-            overflow: hidden;
             text-overflow: ellipsis;
         }
 
@@ -37,6 +36,7 @@ limitations under the License.
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             white-space: pre-wrap;
+            overflow: hidden;
         }
 
         .mx_RoomSummaryCard_avatar {

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -19,7 +19,16 @@ limitations under the License.
         text-align: center;
         margin-top: $spacing-20;
 
-        h1 {
+        .mx_RoomSummaryCard_roomName,
+        .mx_RoomSummaryCard_alias {
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            white-space: pre-wrap;
+            overflow: hidden;
+        }
+
+        .mx_RoomSummaryCard_roomName {
             margin: $spacing-12 0 $spacing-4;
             font-weight: var(--font-semi-bold);
         }
@@ -28,15 +37,6 @@ limitations under the License.
             font-size: $font-13px;
             color: $secondary-content;
             text-overflow: ellipsis;
-        }
-
-        h1,
-        .mx_RoomSummaryCard_alias {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-            white-space: pre-wrap;
-            overflow: hidden;
         }
 
         .mx_RoomSummaryCard_avatar {

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -318,7 +318,13 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, permalinkCreator, onClose }) 
                 />
             </div>
 
-            <RoomName room={room}>{(name) => <h1 title={name}>{name}</h1>}</RoomName>
+            <RoomName room={room}>
+                {(name) => (
+                    <h1 className="mx_RoomSummaryCard_roomName" title={name}>
+                        {name}
+                    </h1>
+                )}
+            </RoomName>
             <div className="mx_RoomSummaryCard_alias" title={alias}>
                 {alias}
             </div>

--- a/test/components/views/right_panel/__snapshots__/RoomSummaryCard-test.tsx.snap
+++ b/test/components/views/right_panel/__snapshots__/RoomSummaryCard-test.tsx.snap
@@ -46,6 +46,7 @@ exports[`<RoomSummaryCard /> renders the room summary 1`] = `
         />
       </div>
       <h1
+        class="mx_RoomSummaryCard_roomName"
         title="!room:domain.org"
       >
         !room:domain.org


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25293

This PR intends to fix the long room address and room name not being clipped, updating class names on `_RoomSummaryCard.pcss`.

For `-webkit-line-clamp`, `overflow: hidden` is required to be added to clip the contents. See: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp;

> In most cases you will also want to set `overflow` to `hidden`, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines.

Indeed, on the screenshot below left, ellipses are shown after the two lines for the room address and room name but the contents are not clipped.

|Before|After|
|---------|------|
|![1](https://user-images.githubusercontent.com/3362943/236641265-22105155-fad3-4edd-ad32-a4c99dfed741.png)|![2](https://user-images.githubusercontent.com/3362943/236641267-4086b127-856f-4d85-87c8-52b7d51ac618.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix long room address and name not being clipped on room info card and update `_RoomSummaryCard.pcss` ([\#10811](https://github.com/matrix-org/matrix-react-sdk/pull/10811)). Fixes vector-im/element-web#25293. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->