### PR TITLE
Fix the color of the verified E2EE icon on `RoomSummaryCard`

### DIFF
--- a/cypress/e2e/crypto/crypto.spec.ts
+++ b/cypress/e2e/crypto/crypto.spec.ts
@@ -183,6 +183,16 @@ describe("Cryptography", function () {
         bobJoin.call(this);
         testMessages.call(this);
         verify.call(this);
+
+        // Assert that verified icon is rendered
+        cy.findByRole("button", { name: "Room members" }).click();
+        cy.findByRole("button", { name: "Room information" }).click();
+        cy.get(".mx_RoomSummaryCard_e2ee_verified").should("exist");
+
+        // Take a snapshot of RoomSummaryCard with a verified E2EE icon
+        cy.get(".mx_RightPanel").percySnapshotElement("RoomSummaryCard - with a verified E2EE icon", {
+            widths: [264], // Emulate the UI. The value is based on minWidth specified on MainSplit.tsx
+        });
     });
 
     it("should allow verification when there is no existing DM", function (this: CryptoTestContext) {

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -76,7 +76,7 @@ limitations under the License.
             }
 
             .mx_RoomSummaryCard_e2ee_verified {
-                background-color: #$e2e-verified-color;
+                background-color: $e2e-verified-color;
                 &::before {
                     mask-image: url("$(res)/img/e2e/verified.svg");
                 }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25295

This PR intends to fix the color of the verified E2EE icon on `RoomSummaryCard`, regressed by https://github.com/matrix-org/matrix-react-sdk/commit/d3ab11928b4eb6cd65917e0807f6be458874f90d#diff-5ebd5069b4e538ad8fa73c2904d5af71b6990da426fe1fec14301b170c629bfaR78. It also intends to update a test to have it take a Percy snapshot: `RoomSummaryCard - with a verified E2EE icon`

|Before|After|
|---------|------|
|![1](https://user-images.githubusercontent.com/3362943/236644664-ad06efc5-67b4-4190-9f25-6144cc6dc0f5.png)|![2](https://user-images.githubusercontent.com/3362943/236644666-21f25aec-32aa-4c3a-99ad-5c6c4bce8f7f.png)|

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the color of the verified E2EE icon on `RoomSummaryCard` ([\#10812](https://github.com/matrix-org/matrix-react-sdk/pull/10812)). Fixes vector-im/element-web#25295. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->