### PR TITLE
Conform `_RoomSummaryCard.pcss` -  under `mx_RoomSummaryCard_e2ee`

### DIFF
--- a/cypress/e2e/crypto/crypto.spec.ts
+++ b/cypress/e2e/crypto/crypto.spec.ts
@@ -187,7 +187,7 @@ describe("Cryptography", function () {
         // Assert that verified icon is rendered
         cy.findByRole("button", { name: "Room members" }).click();
         cy.findByRole("button", { name: "Room information" }).click();
-        cy.get(".mx_RoomSummaryCard_e2ee_verified").should("exist");
+        cy.get(".mx_RoomSummaryCard_avatar_e2ee--verified").should("exist");
 
         // Take a snapshot of RoomSummaryCard with a verified E2EE icon
         cy.get(".mx_RightPanel").percySnapshotElement("RoomSummaryCard - with a verified E2EE icon", {

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -42,7 +42,7 @@ limitations under the License.
         .mx_RoomSummaryCard_avatar {
             display: inline-flex;
 
-            .mx_RoomSummaryCard_e2ee {
+            .mx_RoomSummaryCard_avatar_e2ee {
                 display: inline-block;
                 position: relative;
                 width: 54px;
@@ -68,21 +68,21 @@ limitations under the License.
                 }
             }
 
-            .mx_RoomSummaryCard_e2ee_normal {
+            .mx_RoomSummaryCard_avatar_e2ee_normal {
                 background-color: #424446;
                 &::before {
                     mask-image: url("$(res)/img/e2e/normal.svg");
                 }
             }
 
-            .mx_RoomSummaryCard_e2ee_verified {
+            .mx_RoomSummaryCard_avatar_e2ee_verified {
                 background-color: $e2e-verified-color;
                 &::before {
                     mask-image: url("$(res)/img/e2e/verified.svg");
                 }
             }
 
-            .mx_RoomSummaryCard_e2ee_warning {
+            .mx_RoomSummaryCard_avatar_e2ee_warning {
                 background-color: $e2e-warning-color;
                 &::before {
                     mask-image: url("$(res)/img/e2e/warning.svg");

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -48,12 +48,10 @@ limitations under the License.
                 width: 54px;
                 height: 54px;
                 border-radius: 50%;
-                background-color: var(--backgroundColor);
+                background-color: #737d8c;
                 margin-top: -3px; /* alignment */
                 margin-left: -10px; /* overlap */
                 border: 3px solid $dark-panel-bg-color;
-
-                --backgroundColor: #737d8c;
 
                 &::before {
                     content: "";
@@ -65,30 +63,28 @@ limitations under the License.
                     mask-size: cover;
                     mask-repeat: no-repeat;
                     mask-position: center;
-                    mask-image: var(--maskImage);
+                    mask-image: url("$(res)/img/e2e/disabled.svg");
                     background-color: #ffffff;
-
-                    --maskImage: url("$(res)/img/e2e/disabled.svg");
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--normal {
-                    --backgroundColor: #424446;
+                    background-color: #424446;
                     &::before {
-                        --maskImage: url("$(res)/img/e2e/normal.svg");
+                        mask-image: url("$(res)/img/e2e/normal.svg");
                     }
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--verified {
-                    --backgroundColor: $e2e-verified-color;
+                    background-color: $e2e-verified-color;
                     &::before {
-                        --maskImage: url("$(res)/img/e2e/verified.svg");
+                        mask-image: url("$(res)/img/e2e/verified.svg");
                     }
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--warning {
-                    --backgroundColor: $e2e-warning-color;
+                    background-color: $e2e-warning-color;
                     &::before {
-                        --maskImage: url("$(res)/img/e2e/warning.svg");
+                        mask-image: url("$(res)/img/e2e/warning.svg");
                     }
                 }
             }

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -66,26 +66,26 @@ limitations under the License.
                     mask-image: url("$(res)/img/e2e/disabled.svg");
                     background-color: #ffffff;
                 }
-            }
 
-            .mx_RoomSummaryCard_avatar_e2ee_normal {
-                background-color: #424446;
-                &::before {
-                    mask-image: url("$(res)/img/e2e/normal.svg");
+                &.mx_RoomSummaryCard_avatar_e2ee--normal {
+                    background-color: #424446;
+                    &::before {
+                        mask-image: url("$(res)/img/e2e/normal.svg");
+                    }
                 }
-            }
 
-            .mx_RoomSummaryCard_avatar_e2ee_verified {
-                background-color: $e2e-verified-color;
-                &::before {
-                    mask-image: url("$(res)/img/e2e/verified.svg");
+                &.mx_RoomSummaryCard_avatar_e2ee--verified {
+                    background-color: $e2e-verified-color;
+                    &::before {
+                        mask-image: url("$(res)/img/e2e/verified.svg");
+                    }
                 }
-            }
 
-            .mx_RoomSummaryCard_avatar_e2ee_warning {
-                background-color: $e2e-warning-color;
-                &::before {
-                    mask-image: url("$(res)/img/e2e/warning.svg");
+                &.mx_RoomSummaryCard_avatar_e2ee--warning {
+                    background-color: $e2e-warning-color;
+                    &::before {
+                        mask-image: url("$(res)/img/e2e/warning.svg");
+                    }
                 }
             }
         }

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -48,10 +48,12 @@ limitations under the License.
                 width: 54px;
                 height: 54px;
                 border-radius: 50%;
-                background-color: #737d8c;
+                background-color: var(--backgroundColor);
                 margin-top: -3px; /* alignment */
                 margin-left: -10px; /* overlap */
                 border: 3px solid $dark-panel-bg-color;
+
+                --backgroundColor: #737d8c;
 
                 &::before {
                     content: "";
@@ -63,28 +65,30 @@ limitations under the License.
                     mask-size: cover;
                     mask-repeat: no-repeat;
                     mask-position: center;
-                    mask-image: url("$(res)/img/e2e/disabled.svg");
+                    mask-image: var(--maskImage);
                     background-color: #ffffff;
+
+                    --maskImage: url("$(res)/img/e2e/disabled.svg");
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--normal {
-                    background-color: #424446;
+                    --backgroundColor: #424446;
                     &::before {
-                        mask-image: url("$(res)/img/e2e/normal.svg");
+                        --maskImage: url("$(res)/img/e2e/normal.svg");
                     }
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--verified {
-                    background-color: $e2e-verified-color;
+                    --backgroundColor: $e2e-verified-color;
                     &::before {
-                        mask-image: url("$(res)/img/e2e/verified.svg");
+                        --maskImage: url("$(res)/img/e2e/verified.svg");
                     }
                 }
 
                 &.mx_RoomSummaryCard_avatar_e2ee--warning {
-                    background-color: $e2e-warning-color;
+                    --backgroundColor: $e2e-warning-color;
                     &::before {
-                        mask-image: url("$(res)/img/e2e/warning.svg");
+                        --maskImage: url("$(res)/img/e2e/warning.svg");
                     }
                 }
             }

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -311,9 +311,9 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, permalinkCreator, onClose }) 
                 <TextWithTooltip
                     tooltip={isRoomEncrypted ? _t("Encrypted") : _t("Not encrypted")}
                     class={classNames("mx_RoomSummaryCard_avatar_e2ee", {
-                        mx_RoomSummaryCard_avatar_e2ee_normal: isRoomEncrypted,
-                        mx_RoomSummaryCard_avatar_e2ee_warning: isRoomEncrypted && e2eStatus === E2EStatus.Warning,
-                        mx_RoomSummaryCard_avatar_e2ee_verified: isRoomEncrypted && e2eStatus === E2EStatus.Verified,
+                        "mx_RoomSummaryCard_avatar_e2ee--normal": isRoomEncrypted,
+                        "mx_RoomSummaryCard_avatar_e2ee--warning": isRoomEncrypted && e2eStatus === E2EStatus.Warning,
+                        "mx_RoomSummaryCard_avatar_e2ee--verified": isRoomEncrypted && e2eStatus === E2EStatus.Verified,
                     })}
                 />
             </div>

--- a/src/components/views/right_panel/RoomSummaryCard.tsx
+++ b/src/components/views/right_panel/RoomSummaryCard.tsx
@@ -310,10 +310,10 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, permalinkCreator, onClose }) 
                 <RoomAvatar room={room} height={54} width={54} viewAvatarOnClick />
                 <TextWithTooltip
                     tooltip={isRoomEncrypted ? _t("Encrypted") : _t("Not encrypted")}
-                    class={classNames("mx_RoomSummaryCard_e2ee", {
-                        mx_RoomSummaryCard_e2ee_normal: isRoomEncrypted,
-                        mx_RoomSummaryCard_e2ee_warning: isRoomEncrypted && e2eStatus === E2EStatus.Warning,
-                        mx_RoomSummaryCard_e2ee_verified: isRoomEncrypted && e2eStatus === E2EStatus.Verified,
+                    class={classNames("mx_RoomSummaryCard_avatar_e2ee", {
+                        mx_RoomSummaryCard_avatar_e2ee_normal: isRoomEncrypted,
+                        mx_RoomSummaryCard_avatar_e2ee_warning: isRoomEncrypted && e2eStatus === E2EStatus.Warning,
+                        mx_RoomSummaryCard_avatar_e2ee_verified: isRoomEncrypted && e2eStatus === E2EStatus.Verified,
                     })}
                 />
             </div>

--- a/test/components/views/right_panel/__snapshots__/RoomSummaryCard-test.tsx.snap
+++ b/test/components/views/right_panel/__snapshots__/RoomSummaryCard-test.tsx.snap
@@ -41,7 +41,7 @@ exports[`<RoomSummaryCard /> renders the room summary 1`] = `
         </span>
         <div
           aria-label="Not encrypted"
-          class="mx_TextWithTooltip_target mx_RoomSummaryCard_e2ee"
+          class="mx_TextWithTooltip_target mx_RoomSummaryCard_avatar_e2ee"
           tabindex="0"
         />
       </div>


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25297

This is one of the PRs which intend to conform `_RoomSummaryCard.pcss` to the naming policy of our style guide.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->