### PR TITLE
Update file-panel.spec.ts to take a snapshot of the empty file panel

### DIFF
--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -70,6 +70,16 @@ describe("FilePanel", () => {
     });
 
     describe("render", () => {
+        it("should render empty state", () => {
+            // Wait until the information about the empty state is rendered
+            cy.get(".mx_FilePanel_empty").should("exist");
+
+            // Take a snapshot of empty FilePanel
+            cy.get(".mx_FilePanel").percySnapshotElement("File Panel - empty", {
+                widths: [264], // Emulate the UI. The value is based on minWidth specified on MainSplit.tsx
+            });
+        });
+
         it("should list tiles on the panel", () => {
             // Upload multiple files
             uploadFile("cypress/fixtures/riot.png"); // Image


### PR DESCRIPTION
This PR intends to update `file-panel.spec.ts` to take a snapshot of the empty file panel.

![1_1](https://user-images.githubusercontent.com/3362943/236676278-7ca10522-34a5-425a-871a-accded5cfa1c.png)

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->