### PR TITLE
Remove obsolete style blocks from _MemberInfo.pcss

### DIFF
--- a/res/css/views/rooms/_MemberInfo.pcss
+++ b/res/css/views/rooms/_MemberInfo.pcss
@@ -115,19 +115,3 @@ limitations under the License.
     margin-left: 8px;
     line-height: $font-23px;
 }
-
-.mx_MemberInfo label {
-    font-size: $font-13px;
-}
-
-.mx_MemberInfo label .mx_MemberInfo_label_text {
-    display: inline-block;
-    max-width: 180px;
-    vertical-align: text-top;
-}
-
-.mx_MemberInfo input[type="radio"] {
-    vertical-align: -2px;
-    margin-right: 5px;
-    margin-left: 8px;
-}

--- a/res/css/views/rooms/_MemberInfo.pcss
+++ b/res/css/views/rooms/_MemberInfo.pcss
@@ -116,18 +116,6 @@ limitations under the License.
     line-height: $font-23px;
 }
 
-.mx_MemberInfo_createRoom {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    padding: 0 8px;
-}
-
-.mx_MemberInfo_createRoom_label {
-    width: initial !important;
-    cursor: pointer;
-}
-
 .mx_MemberInfo label {
     font-size: $font-13px;
 }
@@ -142,15 +130,4 @@ limitations under the License.
     vertical-align: -2px;
     margin-right: 5px;
     margin-left: 8px;
-}
-
-.mx_MemberInfo_statusMessage {
-    font-size: $font-11px;
-    opacity: 0.5;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: clip;
-}
-.mx_MemberInfo .mx_MemberInfo_scrollContainer {
-    flex: 1;
 }


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/13817

This PR intends to remove obsolete style blocks from `_MemberInfo.pcss`.

The blocks were deprecated by 2b432b0d82346915de6d5928399ff0b13c701337 (https://github.com/matrix-org/matrix-react-sdk/pull/4655) and fce36ec8266e08b3456673da1177eff105bca563 (https://github.com/matrix-org/matrix-react-sdk/pull/8027).

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->