### PR TITLE
Fix icon on empty notification panel

### DIFF
--- a/cypress/e2e/right-panel/notification-panel.spec.ts
+++ b/cypress/e2e/right-panel/notification-panel.spec.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+const ROOM_NAME = "Test room";
+const NAME = "Alice";
+
+describe("NotificationPanel", () => {
+    let homeserver: HomeserverInstance;
+
+    beforeEach(() => {
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+            cy.initTestUser(homeserver, NAME).then(() => {
+                cy.createRoom({ name: ROOM_NAME });
+            });
+        });
+    });
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should render empty state", () => {
+        cy.viewRoomByName(ROOM_NAME);
+        cy.findByRole("button", { name: "Notifications" }).click();
+
+        // Wait until the information about the empty state is rendered
+        cy.get(".mx_NotificationPanel_empty").should("exist");
+
+        // Take a snapshot of RightPanel
+        cy.get(".mx_RightPanel").percySnapshotElement("Notification Panel - empty", {
+            widths: [264], // Emulate the UI. The value is based on minWidth specified on MainSplit.tsx
+        });
+    });
+});

--- a/res/css/_components.pcss
+++ b/res/css/_components.pcss
@@ -69,6 +69,7 @@
 @import "./structures/_MainSplit.pcss";
 @import "./structures/_MatrixChat.pcss";
 @import "./structures/_NonUrgentToastContainer.pcss";
+@import "./structures/_NotificationPanel.pcss";
 @import "./structures/_QuickSettingsButton.pcss";
 @import "./structures/_RightPanel.pcss";
 @import "./structures/_RoomSearch.pcss";

--- a/res/css/structures/_FilePanel.pcss
+++ b/res/css/structures/_FilePanel.pcss
@@ -113,5 +113,5 @@ limitations under the License.
 }
 
 .mx_FilePanel_empty::before {
-    mask-image: url("$(res)/img/element-icons/room/files.svg");
+    --maskImage: url("$(res)/img/element-icons/room/files.svg"); /* See: _RightPanel.pcss */
 }

--- a/res/css/structures/_NotificationPanel.pcss
+++ b/res/css/structures/_NotificationPanel.pcss
@@ -1,0 +1,19 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_NotificationPanel_empty::before {
+    --maskImage: url("$(res)/img/element-icons/notifications.svg"); /* See: _RightPanel.pcss */
+}

--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -180,6 +180,7 @@ $pulse-color: $alert;
         height: 42px;
         width: 42px;
         background-color: $header-panel-text-primary-color;
+        mask-image: var(--maskImage);
         mask-repeat: no-repeat;
         mask-size: contain;
         mask-position: center;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25298
Closes https://github.com/vector-im/element-web/issues/25302

This PR intends to fix the icon on empty notification panel, adding a E2E test for `NotificationPanel`.

After:

![2](https://user-images.githubusercontent.com/3362943/236698228-02fe1d11-4c24-44b9-95c7-e9a887972fed.png)

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix icon on empty notification panel ([\#10817](https://github.com/matrix-org/matrix-react-sdk/pull/10817)). Fixes vector-im/element-web#25298 and vector-im/element-web#25302. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->