### PR TITLE
Fix: Threads button is highlighted when I create a new room

### DIFF
--- a/src/components/views/right_panel/RoomHeaderButtons.tsx
+++ b/src/components/views/right_panel/RoomHeaderButtons.tsx
@@ -301,7 +301,7 @@ export default class RoomHeaderButtons extends HeaderButtons<IProps> {
                 title={_t("Threads")}
                 onClick={this.onThreadsPanelClicked}
                 isHighlighted={this.isPhase(RoomHeaderButtons.THREAD_PHASES)}
-                isUnread={this.state.threadNotificationColor > 0}
+                isUnread={this.state.threadNotificationColor > NotificationColor.None}
             >
                 <UnreadIndicator color={this.state.threadNotificationColor} />
             </HeaderButton>,

--- a/test/components/views/right_panel/RoomHeaderButtons-test.tsx
+++ b/test/components/views/right_panel/RoomHeaderButtons-test.tsx
@@ -70,10 +70,10 @@ describe("RoomHeaderButtons-test.tsx", function () {
 
     it("thread notification does change the thread button", () => {
         const { container } = getComponent(room);
-        expect(getThreadButton(container).className.includes("mx_RightPanel_headerButton_unread")).toBeFalsy();
-        
+        expect(getThreadButton(container)!.className.includes("mx_RightPanel_headerButton_unread")).toBeFalsy();
+
         room.setThreadUnreadNotificationCount("$123", NotificationCountType.Total, 1);
-        expect(getThreadButton(container).className.includes("mx_RightPanel_headerButton_unread")).toBeTruthy();
+        expect(getThreadButton(container)!.className.includes("mx_RightPanel_headerButton_unread")).toBeTruthy();
         expect(isIndicatorOfType(container, "gray")).toBe(true);
 
         room.setThreadUnreadNotificationCount("$123", NotificationCountType.Highlight, 1);

--- a/test/components/views/right_panel/RoomHeaderButtons-test.tsx
+++ b/test/components/views/right_panel/RoomHeaderButtons-test.tsx
@@ -70,8 +70,10 @@ describe("RoomHeaderButtons-test.tsx", function () {
 
     it("thread notification does change the thread button", () => {
         const { container } = getComponent(room);
-
+        expect(getThreadButton(container).className.includes("mx_RightPanel_headerButton_unread")).toBeFalsy();
+        
         room.setThreadUnreadNotificationCount("$123", NotificationCountType.Total, 1);
+        expect(getThreadButton(container).className.includes("mx_RightPanel_headerButton_unread")).toBeTruthy();
         expect(isIndicatorOfType(container, "gray")).toBe(true);
 
         room.setThreadUnreadNotificationCount("$123", NotificationCountType.Highlight, 1);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes: https://github.com/vector-im/element-web/issues/25284

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: Threads button is highlighted when I create a new room ([\#10819](https://github.com/matrix-org/matrix-react-sdk/pull/10819)). Fixes vector-im/element-web#25284. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->