### PR TITLE
Remove unused class names from `AppWarning`

### DIFF
--- a/src/components/views/elements/AppWarning.tsx
+++ b/src/components/views/elements/AppWarning.tsx
@@ -23,11 +23,11 @@ interface IProps {
 const AppWarning: React.FC<IProps> = (props) => {
     return (
         <div className="mx_AppPermissionWarning">
-            <div className="mx_AppPermissionWarningImage">
+            <div>
                 <img src={require("../../../../res/img/warning.svg").default} alt="" />
             </div>
-            <div className="mx_AppPermissionWarningText">
-                <span className="mx_AppPermissionWarningTextLabel">{props.errorMsg || "Error"}</span>
+            <div>
+                <span>{props.errorMsg || "Error"}</span>
             </div>
         </div>
     );


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25269

This PR suggests to remove class names from `AppWarning` which was added by https://github.com/matrix-org/matrix-react-sdk/pull/1263 and never been used since then.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->