### PR TITLE
Avoid calling prepareToEncrypt onKeyDown

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -107,7 +107,7 @@ interface IProps {
     initialCaret?: DocumentOffset;
     disabled?: boolean;
 
-    onChange?(): void;
+    onChange?(selection: Caret, inputType?: string, diff?: IDiff): void;
     onPaste?(event: ClipboardEvent<HTMLDivElement>, model: EditorModel): boolean;
 }
 
@@ -278,9 +278,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
             isTyping,
         );
 
-        if (this.props.onChange) {
-            this.props.onChange();
-        }
+        this.props.onChange?.(selection, inputType, diff);
     };
 
     private showPlaceholder(): void {

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -59,6 +59,8 @@ import { KeyBindingAction } from "../../../accessibility/KeyboardShortcuts";
 import { PosthogAnalytics } from "../../../PosthogAnalytics";
 import { addReplyToMessageContent } from "../../../utils/Reply";
 import { doMaybeLocalRoomAction } from "../../../utils/local-room";
+import { Caret } from "../../../editor/caret";
+import { IDiff } from "../../../editor/diff";
 
 /**
  * Build the mentions information based on the editor model (and any related events):
@@ -684,9 +686,11 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
         return false;
     };
 
-    private onChange = (): void => {
+    private onChange = (selection: Caret, inputType?: string, diff?: IDiff): void => {
         // We call this in here rather than onKeyDown as that would trip it on global shortcuts e.g. Ctrl-k also
-        this.prepareToEncrypt?.();
+        if (!!diff) {
+            this.prepareToEncrypt?.();
+        }
 
         this.props.onChange?.(this.model);
     };

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -353,11 +353,6 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                     context: this.context.timelineRenderingType,
                 });
                 break;
-            default:
-                if (this.prepareToEncrypt) {
-                    // This needs to be last!
-                    this.prepareToEncrypt();
-                }
         }
     };
 
@@ -690,7 +685,10 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
     };
 
     private onChange = (): void => {
-        if (this.props.onChange) this.props.onChange(this.model);
+        // We call this in here rather than onKeyDown as that would trip it on global shortcuts e.g. Ctrl-k also
+        this.prepareToEncrypt?.();
+
+        this.props.onChange?.(this.model);
     };
 
     private focusComposer = (): void => {


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/15476#issuecomment-1536698712

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Avoid calling prepareToEncrypt onKeyDown ([\#10828](https://github.com/matrix-org/matrix-react-sdk/pull/10828)).<!-- CHANGELOG_PREVIEW_END -->