### PR TITLE
Treat thumbnail upload failures as complete upload failures

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -22,7 +22,14 @@ import encrypt from "matrix-encrypt-attachment";
 import extractPngChunks from "png-chunks-extract";
 import { IImageInfo } from "matrix-js-sdk/src/@types/partials";
 import { logger } from "matrix-js-sdk/src/logger";
-import { IEventRelation, ISendEventResponse, MatrixEvent, UploadOpts, UploadProgress } from "matrix-js-sdk/src/matrix";
+import {
+    HTTPError,
+    IEventRelation,
+    ISendEventResponse,
+    MatrixEvent,
+    UploadOpts,
+    UploadProgress,
+} from "matrix-js-sdk/src/matrix";
 import { THREAD_RELATION_TYPE } from "matrix-js-sdk/src/models/thread";
 import { removeElement } from "matrix-js-sdk/src/utils";
 
@@ -526,7 +533,11 @@ export default class ContentMessages {
                     const imageInfo = await infoForImageFile(matrixClient, roomId, file);
                     Object.assign(content.info, imageInfo);
                 } catch (e) {
-                    // Failed to thumbnail, fall back to uploading an m.file
+                    if (e instanceof HTTPError) {
+                        // re-throw to main upload error handler
+                        throw e;
+                    }
+                    // Otherwise we failed to thumbnail, fall back to uploading an m.file
                     logger.error(e);
                     content.msgtype = MsgType.File;
                 }


### PR DESCRIPTION
Without this it'll be treated the same as a thumbnailing failure which falls back to m.file

Fixes https://github.com/vector-im/element-web/issues/7069