### PR TITLE
Remove unused class name - `mx_AppsDrawer_fullWidth`

### DIFF
--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -255,7 +255,6 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
         const classes = classNames({
             mx_AppsDrawer: true,
             mx_AppsDrawer_maximise: widgetIsMaxmised,
-            mx_AppsDrawer_fullWidth: apps.length < 2,
             mx_AppsDrawer_resizing: this.state.resizing,
             mx_AppsDrawer_2apps: apps.length === 2,
             mx_AppsDrawer_3apps: apps.length === 3,


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25269

This PR intends to remove unused class name `mx_AppsDrawer_fullWidth`. It was added by e897e97fd6e15b39aec89080d0096d570dcdfd63 and deprecated by bf3c49b8dfe6bdeeb4558579a489f63f3d534d7a on the same PR: https://github.com/matrix-org/matrix-react-sdk/pull/5138

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->