### PR TITLE
Use semantically correct elements for room sublist context menu

### DIFF
--- a/src/components/views/rooms/RoomSublist.tsx
+++ b/src/components/views/rooms/RoomSublist.tsx
@@ -577,8 +577,8 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                 otherSections = (
                     <React.Fragment>
                         <hr />
-                        <div>
-                            <div className="mx_RoomSublist_contextMenu_title">{_t("Appearance")}</div>
+                        <fieldset>
+                            <legend className="mx_RoomSublist_contextMenu_title">{_t("Appearance")}</legend>
                             <StyledMenuItemCheckbox
                                 onClose={this.onCloseMenu}
                                 onChange={this.onUnreadFirstChanged}
@@ -593,7 +593,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                             >
                                 {_t("Show previews of messages")}
                             </StyledMenuItemCheckbox>
-                        </div>
+                        </fieldset>
                     </React.Fragment>
                 );
             }
@@ -606,8 +606,8 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                     onFinished={this.onCloseMenu}
                 >
                     <div className="mx_RoomSublist_contextMenu">
-                        <div>
-                            <div className="mx_RoomSublist_contextMenu_title">{_t("Sort by")}</div>
+                        <fieldset>
+                            <legend className="mx_RoomSublist_contextMenu_title">{_t("Sort by")}</legend>
                             <StyledMenuItemRadio
                                 onClose={this.onCloseMenu}
                                 onChange={() => this.onTagSortChanged(SortAlgorithm.Recent)}
@@ -624,7 +624,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
                             >
                                 {_t("A-Z")}
                             </StyledMenuItemRadio>
-                        </div>
+                        </fieldset>
                         {otherSections}
                     </div>
                 </ContextMenu>


### PR DESCRIPTION
Fixes https://github.com/vector-im/customer-retainer/issues/46

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use semantically correct elements for room sublist context menu ([\#10831](https://github.com/matrix-org/matrix-react-sdk/pull/10831)). Fixes vector-im/customer-retainer#46.<!-- CHANGELOG_PREVIEW_END -->