### PR TITLE
Add pressable eye in password input to display wrong password

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -527,6 +527,14 @@ legend {
     }
 }
 
+.mx_textInput_postfixComponent {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    padding: 0 3px;
+}
+
 @define-mixin mx_DialogButton {
     /* align images in buttons (eg spinners) */
     vertical-align: middle;

--- a/res/img/feather-customised/grey-eye.svg
+++ b/res/img/feather-customised/grey-eye.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="14" viewBox="0 0 18 14">
+    <g fill="none" fill-rule="evenodd" stroke="grey" stroke-linecap="round" stroke-linejoin="round" transform="translate(1 1)">
+        <path d="M0 6s3-6 8.25-6 8.25 6 8.25 6-3 6-8.25 6S0 6 0 6z"/>
+        <circle cx="8.25" cy="6" r="2.25"/>
+    </g>
+</svg>

--- a/src/components/views/auth/PasswordLogin.tsx
+++ b/src/components/views/auth/PasswordLogin.tsx
@@ -50,6 +50,7 @@ interface IProps {
 }
 
 interface IState {
+    displayPassword: boolean;
     fieldValid: Partial<Record<LoginField, boolean>>;
     loginType: LoginField.Email | LoginField.MatrixId | LoginField.Phone;
     password: string;
@@ -83,12 +84,17 @@ export default class PasswordLogin extends React.PureComponent<IProps, IState> {
     public constructor(props: IProps) {
         super(props);
         this.state = {
+            displayPassword: false,
             // Field error codes by field ID
             fieldValid: {},
             loginType: LoginField.MatrixId,
             password: "",
         };
     }
+
+    private setDisplayPassword = (value: boolean): void => {
+        this.setState({ displayPassword: value });
+    };
 
     private onForgotPasswordClick = (ev: ButtonEvent): void => {
         ev.preventDefault();
@@ -426,7 +432,7 @@ export default class PasswordLogin extends React.PureComponent<IProps, IState> {
                         id="mx_LoginForm_password"
                         className={pwFieldClass}
                         autoComplete="current-password"
-                        type="password"
+                        type={this.state.displayPassword ? "text": "password"}
                         name="password"
                         label={_t("Password")}
                         value={this.state.password}
@@ -435,6 +441,20 @@ export default class PasswordLogin extends React.PureComponent<IProps, IState> {
                         autoFocus={autoFocusPassword}
                         onValidate={this.onPasswordValidate}
                         ref={(field) => (this[LoginField.Password] = field)}
+                        postfixComponent={(
+                            <div
+                                className="mx_textInput_postfixComponent"
+                                onMouseDown={() => this.setDisplayPassword(true)}
+                                onMouseUp={() => this.setDisplayPassword(false)}
+                            >
+                                <img
+                                    src={require("../../../../res/img/feather-customised/grey-eye.svg").default}
+                                    width="24"
+                                    height="24"
+                                    alt={_t("Eye")}
+                                />
+                            </div>
+                        )}
                     />
                     {forgotPasswordJsx}
                     {!this.props.busy && (

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -48,6 +48,7 @@ interface IProps {
 }
 
 interface IState {
+    displayPassword: boolean;
     recoveryKey: string;
     recoveryKeyValid: boolean | null;
     recoveryKeyCorrect: boolean | null;
@@ -69,6 +70,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
         super(props);
 
         this.state = {
+            displayPassword: false,
             recoveryKey: "",
             recoveryKeyValid: null,
             recoveryKeyCorrect: null,
@@ -79,6 +81,10 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
             resetting: false,
         };
     }
+
+    private setDisplayPassword = (value: boolean): void => {
+        this.setState({ displayPassword: value });
+    };
 
     private onCancel = (): void => {
         if (this.state.resetting) {
@@ -403,7 +409,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
                         <div className="mx_AccessSecretStorageDialog_recoveryKeyEntry">
                             <div className="mx_AccessSecretStorageDialog_recoveryKeyEntry_textInput">
                                 <Field
-                                    type="password"
+                                    type={this.state.displayPassword ? "text": "password"}
                                     id="mx_securityKey"
                                     label={_t("Security Key")}
                                     value={this.state.recoveryKey}
@@ -411,6 +417,20 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
                                     autoFocus={true}
                                     forceValidity={this.state.recoveryKeyCorrect ?? undefined}
                                     autoComplete="off"
+                                    postfixComponent={(
+                                        <div
+                                            className="mx_textInput_postfixComponent"
+                                            onMouseDown={() => this.setDisplayPassword(true)}
+                                            onMouseUp={() => this.setDisplayPassword(false)}
+                                        >
+                                            <img
+                                                src={require("../../../../../res/img/feather-customised/grey-eye.svg").default}
+                                                width="24"
+                                                height="24"
+                                                alt={_t("Eye")}
+                                            />
+                                        </div>
+                                    )}
                                 />
                             </div>
                             <span className="mx_AccessSecretStorageDialog_recoveryKeyEntry_entryControlSeparatorText">


### PR DESCRIPTION
Addressed issue:
Users can make a typing mistake when entering their password.
An error message is then displayed, but the user cannot know where they made a mistake in entering their password since it is hidden.

Proposed solution:
Inside the input (in the right side of it), add an eye icon and when the user presses on it, show the previously hidden password (attention: when the user presses, not click, so that when the user stops touching the eye icon, the password is hidden once again).

Example:

- Current behavior
<img width="445" alt="Capture d’écran 2023-05-09 à 14 43 48" src="https://github.com/matrix-org/matrix-react-sdk/assets/6305268/4cc42e34-f67c-4efc-b46b-44c64ce0b8b1">

- Proposed solution
1. without pressing the eye:
<img width="468" alt="Capture d’écran 2023-05-09 à 14 44 07" src="https://github.com/matrix-org/matrix-react-sdk/assets/6305268/ea693e27-2571-4aad-b3f3-a78950005eb7">

2. while pressing the eye
<img width="419" alt="Capture d’écran 2023-05-09 à 14 44 18" src="https://github.com/matrix-org/matrix-react-sdk/assets/6305268/1f7a08f5-789e-418e-8566-554182689e8b">



<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->