### PR TITLE
Fix the state shown for call in rooms

### DIFF
--- a/src/components/structures/LegacyCallEventGrouper.ts
+++ b/src/components/structures/LegacyCallEventGrouper.ts
@@ -37,10 +37,6 @@ const CONNECTING_STATES = [
 
 const SUPPORTED_STATES = [CallState.Connected, CallState.Ringing, CallState.Ended];
 
-export enum CustomCallState {
-    Missed = "missed",
-}
-
 const isCallEventType = (eventType: string): boolean =>
     eventType.startsWith("m.call.") || eventType.startsWith("org.matrix.call.");
 
@@ -73,7 +69,7 @@ export function buildLegacyCallEventGroupers(
 export default class LegacyCallEventGrouper extends EventEmitter {
     private events: Set<MatrixEvent> = new Set<MatrixEvent>();
     private call: MatrixCall | null = null;
-    public state: CallState | CustomCallState;
+    public state: CallState;
 
     public constructor() {
         super();
@@ -130,8 +126,11 @@ export default class LegacyCallEventGrouper extends EventEmitter {
     /**
      * Returns true if there are only events from the other side - we missed the call
      */
-    private get callWasMissed(): boolean {
-        return ![...this.events].some((event) => event.sender?.userId === MatrixClientPeg.get().getUserId());
+    public get callWasMissed(): boolean {
+        return (
+            this.state === CallState.Ended &&
+            ![...this.events].some((event) => event.sender?.userId === MatrixClientPeg.get().getUserId())
+        );
     }
 
     private get callId(): string | undefined {
@@ -188,10 +187,13 @@ export default class LegacyCallEventGrouper extends EventEmitter {
         } else if (this.call && SUPPORTED_STATES.includes(this.call.state)) {
             this.state = this.call.state;
         } else {
-            if (this.callWasMissed) this.state = CustomCallState.Missed;
-            else if (this.reject) this.state = CallState.Ended;
-            else if (this.hangup) this.state = CallState.Ended;
-            else if (this.invite && this.call) this.state = CallState.Connecting;
+            if (this.reject) {
+                this.state = CallState.Ended;
+            } else if (this.hangup) {
+                this.state = CallState.Ended;
+            } else if (this.invite && this.call) {
+                this.state = CallState.Connecting;
+            }
         }
         this.emit(LegacyCallEventGrouperEvent.StateChanged, this.state);
     };

--- a/src/components/views/messages/LegacyCallEvent.tsx
+++ b/src/components/views/messages/LegacyCallEvent.tsx
@@ -21,10 +21,7 @@ import classNames from "classnames";
 
 import { _t } from "../../../languageHandler";
 import MemberAvatar from "../avatars/MemberAvatar";
-import LegacyCallEventGrouper, {
-    LegacyCallEventGrouperEvent,
-    CustomCallState,
-} from "../../structures/LegacyCallEventGrouper";
+import LegacyCallEventGrouper, { LegacyCallEventGrouperEvent } from "../../structures/LegacyCallEventGrouper";
 import AccessibleButton from "../elements/AccessibleButton";
 import InfoTooltip, { InfoTooltipKind } from "../elements/InfoTooltip";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
@@ -40,7 +37,7 @@ interface IProps {
 }
 
 interface IState {
-    callState: CallState | CustomCallState;
+    callState: CallState;
     silenced: boolean;
     narrow: boolean;
     length: number;
@@ -125,8 +122,8 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
         );
     }
 
-    private renderContent(state: CallState | CustomCallState): JSX.Element {
-        if (state === CallState.Ringing) {
+    private renderContent(): JSX.Element {
+        if (this.state.callState === CallState.Ringing) {
             let silenceIcon;
             if (!this.state.narrow) {
                 silenceIcon = this.renderSilenceIcon();
@@ -153,7 +150,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                 </div>
             );
         }
-        if (state === CallState.Ended) {
+        if (this.state.callState === CallState.Ended) {
             const hangupReason = this.props.callEventGrouper.hangupReason;
             const gotRejected = this.props.callEventGrouper.gotRejected;
 
@@ -161,6 +158,21 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                 return (
                     <div className="mx_LegacyCallEvent_content">
                         {_t("Call declined")}
+                        {this.renderCallBackButton(_t("Call back"))}
+                        {this.props.timestamp}
+                    </div>
+                );
+            } else if (hangupReason === CallErrorCode.AnsweredElsewhere) {
+                return (
+                    <div className="mx_LegacyCallEvent_content">
+                        {_t("Answered elsewhere")}
+                        {this.props.timestamp}
+                    </div>
+                );
+            } else if (this.props.callEventGrouper.callWasMissed) {
+                return (
+                    <div className="mx_LegacyCallEvent_content">
+                        {_t("Missed call")}
                         {this.renderCallBackButton(_t("Call back"))}
                         {this.props.timestamp}
                     </div>
@@ -188,13 +200,6 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                     <div className="mx_LegacyCallEvent_content">
                         {_t("No answer")}
                         {this.renderCallBackButton(_t("Call back"))}
-                        {this.props.timestamp}
-                    </div>
-                );
-            } else if (hangupReason === CallErrorCode.AnsweredElsewhere) {
-                return (
-                    <div className="mx_LegacyCallEvent_content">
-                        {_t("Answered elsewhere")}
                         {this.props.timestamp}
                     </div>
                 );
@@ -234,7 +239,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                 </div>
             );
         }
-        if (state === CallState.Connected) {
+        if (this.state.callState === CallState.Connected) {
             return (
                 <div className="mx_LegacyCallEvent_content">
                     <Clock seconds={this.state.length} aria-live="off" />
@@ -242,19 +247,10 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                 </div>
             );
         }
-        if (state === CallState.Connecting) {
+        if (this.state.callState === CallState.Connecting) {
             return (
                 <div className="mx_LegacyCallEvent_content">
                     {_t("Connecting")}
-                    {this.props.timestamp}
-                </div>
-            );
-        }
-        if (state === CustomCallState.Missed) {
-            return (
-                <div className="mx_LegacyCallEvent_content">
-                    {_t("Missed call")}
-                    {this.renderCallBackButton(_t("Call back"))}
                     {this.props.timestamp}
                 </div>
             );
@@ -275,12 +271,12 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
         const callType = isVoice ? _t("Voice call") : _t("Video call");
         const callState = this.state.callState;
         const hangupReason = this.props.callEventGrouper.hangupReason;
-        const content = this.renderContent(callState);
+        const content = this.renderContent();
         const className = classNames("mx_LegacyCallEvent", {
             mx_LegacyCallEvent_voice: isVoice,
             mx_LegacyCallEvent_video: !isVoice,
             mx_LegacyCallEvent_narrow: this.state.narrow,
-            mx_LegacyCallEvent_missed: callState === CustomCallState.Missed,
+            mx_LegacyCallEvent_missed: this.props.callEventGrouper.callWasMissed,
             mx_LegacyCallEvent_noAnswer: callState === CallState.Ended && hangupReason === CallErrorCode.InviteTimeout,
             mx_LegacyCallEvent_rejected: callState === CallState.Ended && this.props.callEventGrouper.gotRejected,
         });


### PR DESCRIPTION
We split out a separate state for 'missed' separate to 'ended' which caused confusion as the state got set to this when it shouldn't have, so calls that wouldn't have been shown as missed were.

Remove the csutom call state and just have the missed state as a variant of the ended state. Re-order the if clauses so they hit the right ones. Also don't pass the callState variable into renderContent() which is a class method and so has access to the same info anyway.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
