### PR TITLE
Fix snapshot `File Panel - empty`

### DIFF
--- a/cypress/e2e/right-panel/file-panel.spec.ts
+++ b/cypress/e2e/right-panel/file-panel.spec.ts
@@ -74,8 +74,8 @@ describe("FilePanel", () => {
             // Wait until the information about the empty state is rendered
             cy.get(".mx_FilePanel_empty").should("exist");
 
-            // Take a snapshot of empty FilePanel
-            cy.get(".mx_FilePanel").percySnapshotElement("File Panel - empty", {
+            // Take a snapshot of RightPanel - fix https://github.com/vector-im/element-web/issues/25332
+            cy.get(".mx_RightPanel").percySnapshotElement("File Panel - empty", {
                 widths: [264], // Emulate the UI. The value is based on minWidth specified on MainSplit.tsx
             });
         });


### PR DESCRIPTION
Should fixes https://github.com/vector-im/element-web/issues/25332

This PR intends to fix that the snapshot `File Panel - empty` is not taken as expected. Taking a snapshot of `mx_RightPanel` instead should fix the issue, as `notification-panel.spec.ts` takes the snapshot of it.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->