### PR TITLE
Conform _AppsDrawer.pcss to the naming policy - AppDrawer variants

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -29,10 +29,6 @@ limitations under the License.
     overflow: hidden;
     flex-grow: 1;
 
-    &.mx_AppsDrawer--maximise {
-        margin-bottom: var(--container-gap-width);
-    }
-
     .mx_AppsContainer_resizerHandleContainer {
         width: 100%;
         height: 10px;
@@ -94,6 +90,14 @@ limitations under the License.
     .mx_AppTile {
         width: 50%;
         min-width: var(--minWidth);
+    }
+
+    &.mx_AppsDrawer--maximise {
+        margin-bottom: var(--container-gap-width);
+    }
+
+    &.mx_AppsDrawer--resizing .mx_AppTile_persistedWrapper {
+        z-index: 1;
     }
 
     &.mx_AppsDrawer--2apps .mx_AppTile {
@@ -418,8 +422,4 @@ limitations under the License.
     to {
         opacity: 1;
     }
-}
-
-.mx_AppsDrawer--resizing .mx_AppTile_persistedWrapper {
-    z-index: 1;
 }

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -29,7 +29,7 @@ limitations under the License.
     overflow: hidden;
     flex-grow: 1;
 
-    &.mx_AppsDrawer_maximise {
+    &.mx_AppsDrawer--maximise {
         margin-bottom: var(--container-gap-width);
     }
 
@@ -96,7 +96,7 @@ limitations under the License.
         min-width: var(--minWidth);
     }
 
-    &.mx_AppsDrawer_2apps .mx_AppTile {
+    &.mx_AppsDrawer--2apps .mx_AppTile {
         width: 50%;
 
         &:nth-child(3) {
@@ -105,7 +105,7 @@ limitations under the License.
             min-width: var(--minWidth) !important;
         }
     }
-    &.mx_AppsDrawer_3apps .mx_AppTile {
+    &.mx_AppsDrawer--3apps .mx_AppTile {
         width: 33%;
 
         &:nth-child(3) {
@@ -420,6 +420,6 @@ limitations under the License.
     }
 }
 
-.mx_AppsDrawer_resizing .mx_AppTile_persistedWrapper {
+.mx_AppsDrawer--resizing .mx_AppTile_persistedWrapper {
     z-index: 1;
 }

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -92,7 +92,7 @@ limitations under the License.
         min-width: var(--minWidth);
     }
 
-    &.mx_AppsDrawer--maximise {
+    &.mx_AppsDrawer--maximised {
         margin-bottom: var(--container-gap-width);
     }
 

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -113,11 +113,11 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
         };
         const collapseConfig = {
             onResizeStart: () => {
-                this.resizeContainer?.classList.add("mx_AppsDrawer_resizing");
+                this.resizeContainer?.classList.add("mx_AppsDrawer--resizing");
                 this.setState({ resizingHorizontal: true });
             },
             onResizeStop: () => {
-                this.resizeContainer?.classList.remove("mx_AppsDrawer_resizing");
+                this.resizeContainer?.classList.remove("mx_AppsDrawer--resizing");
                 WidgetLayoutStore.instance.setResizerDistributions(
                     this.props.room,
                     Container.Top,
@@ -253,11 +253,11 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
         }
 
         const classes = classNames({
-            mx_AppsDrawer: true,
-            mx_AppsDrawer_maximise: widgetIsMaxmised,
-            mx_AppsDrawer_resizing: this.state.resizing,
-            mx_AppsDrawer_2apps: apps.length === 2,
-            mx_AppsDrawer_3apps: apps.length === 3,
+            "mx_AppsDrawer": true,
+            "mx_AppsDrawer--maximise": widgetIsMaxmised,
+            "mx_AppsDrawer--resizing": this.state.resizing,
+            "mx_AppsDrawer--2apps": apps.length === 2,
+            "mx_AppsDrawer--3apps": apps.length === 3,
         });
         const appContainers = (
             <div className="mx_AppsContainer" ref={this.collectResizer}>

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -254,7 +254,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
 
         const classes = classNames({
             "mx_AppsDrawer": true,
-            "mx_AppsDrawer--maximise": widgetIsMaxmised,
+            "mx_AppsDrawer--maximised": widgetIsMaxmised,
             "mx_AppsDrawer--resizing": this.state.resizing,
             "mx_AppsDrawer--2apps": apps.length === 2,
             "mx_AppsDrawer--3apps": apps.length === 3,


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25268

This is one of the PRs which intend to conform `_AppsDrawer.pcss` to our naming policy by clarifying that the `mx_AppsDrawer--maximised`, `mx_AppsDrawer--resizing`, etc. are the variants of `mx_AppsDrawer`.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->