### PR TITLE
Update Percy snapshots for the font scaling slider

### DIFF
--- a/cypress/e2e/settings/appearance-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/appearance-user-settings-tab.spec.ts
@@ -115,8 +115,9 @@ describe("Appearance user settings tab", () => {
                 cy.get("output .mx_Slider_selection_label").findByText("13");
             });
 
-            cy.get(".mx_FontScalingPanel_fontSlider").percySnapshotElement("Font size slider - smallest (13)", {
-                widths: [486], // actual size (content-box, including inline padding)
+            // Take a snapshot of FontScalingPanel
+            cy.get(".mx_FontScalingPanel").percySnapshotElement("Font scaling panel - smallest (13) font", {
+                widths: [592], // actual size (content-box, including inline padding)
             });
 
             cy.get(".mx_FontScalingPanel_fontSlider").within(() => {
@@ -128,8 +129,9 @@ describe("Appearance user settings tab", () => {
                 cy.get("output .mx_Slider_selection_label").findByText("18");
             });
 
-            cy.get(".mx_FontScalingPanel_fontSlider").percySnapshotElement("Font size slider - largest (18)", {
-                widths: [486],
+            // Take a snapshot of FontScalingPanel
+            cy.get(".mx_FontScalingPanel").percySnapshotElement("Font scaling panel - largest (18) font", {
+                widths: [592], // actual size (content-box, including inline padding)
             });
         });
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25333

This PR intends to update Percy snapshots for the font scaling slider in order to have Percy take the font scaling panel, instead of the slider since it seems that Percy does not take the `align-items` and `background` values into consideration.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->