### PR TITLE
Edit widths of Percy snapshots of "User settings tab - Appearance"

### DIFF
--- a/cypress/e2e/settings/appearance-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/appearance-user-settings-tab.spec.ts
@@ -42,6 +42,12 @@ describe("Appearance user settings tab", () => {
 
         cy.get(".mx_SettingsTab.mx_AppearanceUserSettingsTab").percySnapshotElement(
             "User settings tab - Appearance (advanced options collapsed)",
+            {
+                // Emulate TabbedView's actual min and max widths
+                // 580: '.mx_UserSettingsDialog .mx_TabbedView' min-width
+                // 796: 1036 (mx_TabbedView_tabsOnLeft actual width) - 240 (mx_TabbedView_tabPanel margin-right)
+                widths: [580, 796],
+            },
         );
 
         // Click "Show advanced" link button
@@ -52,6 +58,12 @@ describe("Appearance user settings tab", () => {
 
         cy.get(".mx_SettingsTab.mx_AppearanceUserSettingsTab").percySnapshotElement(
             "User settings tab - Appearance (advanced options expanded)",
+            {
+                // Emulate TabbedView's actual min and max widths
+                // 580: '.mx_UserSettingsDialog .mx_TabbedView' min-width
+                // 796: 1036 (mx_TabbedView_tabsOnLeft actual width) - 240 (mx_TabbedView_tabPanel margin-right)
+                widths: [580, 796],
+            },
         );
     });
 


### PR DESCRIPTION
This PR intends to edit widths of Percy snapshots of "[User settings tab - Appearance](https://percy.io/dfde73bd/matrix-react-sdk/builds/27316147/search?searchParam=appearance)", so that snapshots are captured in the actual UI's width. The values are based on https://github.com/matrix-org/matrix-react-sdk/pull/10737.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->