### PR TITLE
Don't run SonarCloud when a change is in the merge queue

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
     sonarqube:
         name: 🩻 SonarQube
+        if: github.event.workflow_run.event != 'merge_group'
         uses: matrix-org/matrix-js-sdk/.github/workflows/sonarcloud.yml@develop
         secrets:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
We are not interested in coverage information when a PR has already been approved, and we were seeing flakiness with SonarCloud with the "no artifacts found" error (https://github.com/vector-im/element-web/issues/25334).


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->