### PR TITLE
Add string for membership event where both displayname & avatar change

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -501,6 +501,7 @@
     "%(senderName)s invited %(targetName)s": "%(senderName)s invited %(targetName)s",
     "%(senderName)s banned %(targetName)s: %(reason)s": "%(senderName)s banned %(targetName)s: %(reason)s",
     "%(senderName)s banned %(targetName)s": "%(senderName)s banned %(targetName)s",
+    "%(oldDisplayName)s changed their display name and profile picture": "%(oldDisplayName)s changed their display name and profile picture",
     "%(oldDisplayName)s changed their display name to %(displayName)s": "%(oldDisplayName)s changed their display name to %(displayName)s",
     "%(senderName)s set their display name to %(displayName)s": "%(senderName)s set their display name to %(displayName)s",
     "%(senderName)s removed their display name (%(oldDisplayName)s)": "%(senderName)s removed their display name (%(oldDisplayName)s)",

--- a/test/TextForEvent-test.ts
+++ b/test/TextForEvent-test.ts
@@ -480,4 +480,32 @@ describe("TextForEvent", () => {
             });
         });
     });
+
+    describe("textForMemberEvent()", () => {
+        beforeEach(() => {
+            stubClient();
+        });
+
+        it("should handle both displayname and avatar changing in one event", () => {
+            expect(
+                textForEvent(
+                    new MatrixEvent({
+                        type: "m.room.member",
+                        sender: "@a:foo",
+                        content: {
+                            membership: "join",
+                            avatar_url: "b",
+                            displayname: "Bob",
+                        },
+                        prev_content: {
+                            membership: "join",
+                            avatar_url: "a",
+                            displayname: "Andy",
+                        },
+                        state_key: "@a:foo",
+                    }),
+                ),
+            ).toMatchInlineSnapshot(`"Andy changed their display name and profile picture"`);
+        });
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/18026

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add string for membership event where both displayname & avatar change ([\#10880](https://github.com/matrix-org/matrix-react-sdk/pull/10880)). Fixes vector-im/element-web#18026.<!-- CHANGELOG_PREVIEW_END -->