### PR TITLE
DeviceListener: replace calls to deprecated APIs

### DIFF
--- a/test/DeviceListener-test.ts
+++ b/test/DeviceListener-test.ts
@@ -81,6 +81,8 @@ describe("DeviceListener", () => {
                 crossSigningVerified: false,
             }),
             getUserDeviceInfo: jest.fn().mockResolvedValue(new Map()),
+            isCrossSigningReady: jest.fn().mockResolvedValue(true),
+            isSecretStorageReady: jest.fn().mockResolvedValue(true),
         } as unknown as Mocked<CryptoApi>;
         mockClient = getMockClientWithEventEmitter({
             isGuest: jest.fn(),
@@ -89,15 +91,11 @@ describe("DeviceListener", () => {
             getKeyBackupVersion: jest.fn().mockResolvedValue(undefined),
             getRooms: jest.fn().mockReturnValue([]),
             isVersionSupported: jest.fn().mockResolvedValue(true),
-            isCrossSigningReady: jest.fn().mockResolvedValue(true),
-            isSecretStorageReady: jest.fn().mockResolvedValue(true),
-            isCryptoEnabled: jest.fn().mockReturnValue(true),
             isInitialSyncComplete: jest.fn().mockReturnValue(true),
             getKeyBackupEnabled: jest.fn(),
             getCrossSigningId: jest.fn(),
             getStoredCrossSigningForUser: jest.fn(),
             waitForClientWellKnown: jest.fn(),
-            downloadKeys: jest.fn(),
             isRoomEncrypted: jest.fn(),
             getClientWellKnown: jest.fn(),
             getDeviceId: jest.fn().mockReturnValue(deviceId),
@@ -288,7 +286,7 @@ describe("DeviceListener", () => {
                 mocked(isSecretStorageBeingAccessed).mockReturnValue(true);
                 await createAndStart();
 
-                expect(mockClient!.downloadKeys).not.toHaveBeenCalled();
+                expect(mockCrypto!.getUserDeviceInfo).not.toHaveBeenCalled();
                 expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
             });
 
@@ -296,7 +294,7 @@ describe("DeviceListener", () => {
                 mockClient!.isRoomEncrypted.mockReturnValue(false);
                 await createAndStart();
 
-                expect(mockClient!.downloadKeys).not.toHaveBeenCalled();
+                expect(mockCrypto!.getUserDeviceInfo).not.toHaveBeenCalled();
                 expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
             });
 
@@ -309,7 +307,7 @@ describe("DeviceListener", () => {
                     mockClient!.getStoredCrossSigningForUser.mockReturnValue(new CrossSigningInfo(userId));
                     await createAndStart();
 
-                    expect(mockClient!.downloadKeys).toHaveBeenCalled();
+                    expect(mockCrypto!.getUserDeviceInfo).toHaveBeenCalled();
                     expect(SetupEncryptionToast.showToast).toHaveBeenCalledWith(
                         SetupEncryptionToast.Kind.VERIFY_THIS_SESSION,
                     );

--- a/test/DeviceListener-test.ts
+++ b/test/DeviceListener-test.ts
@@ -243,34 +243,34 @@ describe("DeviceListener", () => {
             await createAndStart();
 
             expect(mockClient!.isVersionSupported).toHaveBeenCalledWith("v1.1");
-            expect(mockClient!.isCrossSigningReady).not.toHaveBeenCalled();
+            expect(mockCrypto!.isCrossSigningReady).not.toHaveBeenCalled();
         });
         it("does nothing when crypto is not enabled", async () => {
-            mockClient!.isCryptoEnabled.mockReturnValue(false);
+            mockClient!.getCrypto.mockReturnValue(undefined);
             await createAndStart();
 
-            expect(mockClient!.isCrossSigningReady).not.toHaveBeenCalled();
+            expect(mockCrypto!.isCrossSigningReady).not.toHaveBeenCalled();
         });
         it("does nothing when initial sync is not complete", async () => {
             mockClient!.isInitialSyncComplete.mockReturnValue(false);
             await createAndStart();
 
-            expect(mockClient!.isCrossSigningReady).not.toHaveBeenCalled();
+            expect(mockCrypto!.isCrossSigningReady).not.toHaveBeenCalled();
         });
 
         describe("set up encryption", () => {
             const rooms = [{ roomId: "!room1" }, { roomId: "!room2" }] as unknown as Room[];
 
             beforeEach(() => {
-                mockClient!.isCrossSigningReady.mockResolvedValue(false);
-                mockClient!.isSecretStorageReady.mockResolvedValue(false);
+                mockCrypto!.isCrossSigningReady.mockResolvedValue(false);
+                mockCrypto!.isSecretStorageReady.mockResolvedValue(false);
                 mockClient!.getRooms.mockReturnValue(rooms);
                 mockClient!.isRoomEncrypted.mockReturnValue(true);
             });
 
             it("hides setup encryption toast when cross signing and secret storage are ready", async () => {
-                mockClient!.isCrossSigningReady.mockResolvedValue(true);
-                mockClient!.isSecretStorageReady.mockResolvedValue(true);
+                mockCrypto!.isCrossSigningReady.mockResolvedValue(true);
+                mockCrypto!.isSecretStorageReady.mockResolvedValue(true);
                 await createAndStart();
                 expect(SetupEncryptionToast.hideToast).toHaveBeenCalled();
             });
@@ -282,19 +282,17 @@ describe("DeviceListener", () => {
                 expect(SetupEncryptionToast.hideToast).toHaveBeenCalled();
             });
 
-            it("does not do any checks or show any toasts when secret storage is being accessed", async () => {
+            it("does not show any toasts when secret storage is being accessed", async () => {
                 mocked(isSecretStorageBeingAccessed).mockReturnValue(true);
                 await createAndStart();
 
-                expect(mockCrypto!.getUserDeviceInfo).not.toHaveBeenCalled();
                 expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
             });
 
-            it("does not do any checks or show any toasts when no rooms are encrypted", async () => {
+            it("does not show any toasts when no rooms are encrypted", async () => {
                 mockClient!.isRoomEncrypted.mockReturnValue(false);
                 await createAndStart();
 
-                expect(mockCrypto!.getUserDeviceInfo).not.toHaveBeenCalled();
                 expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
             });
 
@@ -348,7 +346,7 @@ describe("DeviceListener", () => {
             });
 
             it("checks keybackup status when setup encryption toast has been dismissed", async () => {
-                mockClient!.isCrossSigningReady.mockResolvedValue(false);
+                mockCrypto!.isCrossSigningReady.mockResolvedValue(false);
                 const instance = await createAndStart();
 
                 instance.dismissEncryptionSetup();
@@ -400,7 +398,7 @@ describe("DeviceListener", () => {
             const deviceTrustUnverified = new DeviceVerificationStatus({});
 
             beforeEach(() => {
-                mockClient!.isCrossSigningReady.mockResolvedValue(true);
+                mockCrypto!.isCrossSigningReady.mockResolvedValue(true);
                 mockCrypto!.getUserDeviceInfo.mockResolvedValue(
                     new Map([[userId, new Map([currentDevice, device2, device3].map((d) => [d.deviceId, d]))]]),
                 );
@@ -413,7 +411,7 @@ describe("DeviceListener", () => {
             });
             describe("bulk unverified sessions toasts", () => {
                 it("hides toast when cross signing is not ready", async () => {
-                    mockClient!.isCrossSigningReady.mockResolvedValue(false);
+                    mockCrypto!.isCrossSigningReady.mockResolvedValue(false);
                     await createAndStart();
                     expect(BulkUnverifiedSessionsToast.hideToast).toHaveBeenCalled();
                     expect(BulkUnverifiedSessionsToast.showToast).not.toHaveBeenCalled();


### PR DESCRIPTION
DeviceListener is using a few APIs which have been replaced. Time to update it.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->