### PR TITLE
Fix cypress test in spotlight tests

### DIFF
--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -170,10 +170,9 @@ describe("Spotlight", () => {
                 )
                 .then(() =>
                     cy.window({ log: false }).then(({ matrixcs: { Visibility } }) => {
-                        cy.createRoom({ name: room1Name, visibility: Visibility.Public }).then((_room1Id) => {
+                        cy.createRoom({ name: room1Name, visibility: Visibility.Public }).then(async (_room1Id) => {
                             room1Id = _room1Id;
-                            bot1.joinRoom(room1Id);
-                            cy.visit("/#/room/" + room1Id);
+                            await bot1.joinRoom(room1Id);
                         });
                         bot2.createRoom({ name: room2Name, visibility: Visibility.Public }).then(
                             ({ room_id: _room2Id }) => {
@@ -199,7 +198,10 @@ describe("Spotlight", () => {
                         });
                     }),
                 )
-                .then(() => cy.get(".mx_RoomSublist_skeletonUI").should("not.exist"));
+                .then(() => {
+                    cy.visit("/#/room/" + room1Id);
+                    cy.get(".mx_RoomSublist_skeletonUI").should("not.exist");
+                });
         });
     });
 


### PR DESCRIPTION
Sometimes, when I ran these tests locally, they would fail. The problem appears to be that the join takes some time and can end up racing against the body of the test. The solution is to wait for the join to complete before proceeding.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->