### PR TITLE
Make widgets take up the full height of the PiP again

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -15,8 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AppsDrawer {
+:root {
     --AppTile_mini-height: 220px;
+}
+
+.mx_AppsDrawer {
     --minWidth: 240px; /* TODO this should be 300px but that's too large */
 
     margin: var(--container-gap-width);


### PR DESCRIPTION
This fixes a visual regression introduced in 73007d6dd6f6e714d30bbe2292f80133c14538dd: `AppTiles` with the class `mx_AppTile_mini` don't get an `mx_AppsDrawer` as their parent, so the `--AppTile_mini-height` variable needs a broader scope.

Before|After
-|-
![Screenshot 2023-05-12 at 17-23-41 Element 3 Test room](https://github.com/matrix-org/matrix-react-sdk/assets/48614497/a3d71857-e6ec-42ca-9da4-c9cac4241ece)|![Screenshot 2023-05-12 at 17-24-01 Element 2 Test room](https://github.com/matrix-org/matrix-react-sdk/assets/48614497/34b2d7a4-a8d1-4337-887b-8f3302d6330c)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->