### PR TITLE
Remove hover effect from user name on a DM creation UI

### DIFF
--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -164,6 +164,15 @@ describe("Invite dialog", function () {
         // Assert that the invite dialog disappears
         cy.get(".mx_InviteDialog_other").should("not.exist");
 
+        // Assert that the hovered user name on invitation UI does not have background color
+        // TODO: implement the test on room-header.spec.ts
+        cy.get(".mx_RoomHeader").within(() => {
+            cy.get(".mx_RoomHeader_name--textonly")
+                .realHover()
+                .get(".mx_RoomHeader_name--textonly:hover")
+                .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
+        });
+
         // Send a message to invite the bots
         cy.getComposer().type("Hello{enter}");
 

--- a/res/css/views/rooms/_RoomHeader.pcss
+++ b/res/css/views/rooms/_RoomHeader.pcss
@@ -80,6 +80,7 @@ limitations under the License.
     padding: 1px 4px;
     display: flex;
     user-select: none;
+    cursor: pointer;
 
     &:hover {
         background-color: $quinary-content;
@@ -102,6 +103,14 @@ limitations under the License.
         background-color: $tertiary-content;
     }
 
+    &.mx_RoomHeader_name--textonly {
+        cursor: unset;
+
+        &:hover {
+            background-color: unset;
+        }
+    }
+
     &[aria-expanded="true"] {
         background-color: $quinary-content;
 
@@ -118,11 +127,6 @@ limitations under the License.
 .mx_RoomHeader_searchStatus {
     font-weight: normal;
     opacity: 0.6;
-}
-
-.mx_RoomHeader_name:not(.mx_RoomHeader_name--textonly),
-.mx_RoomHeader_avatar {
-    cursor: pointer;
 }
 
 .mx_RoomTopic {
@@ -157,6 +161,7 @@ limitations under the License.
     flex: 0;
     margin: 0 7px;
     position: relative;
+    cursor: pointer;
 }
 
 .mx_RoomHeader_avatar .mx_BaseAvatar_image {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25305

This PR intends to remove hover effect from user name on a DM creation UI. The effect is perceived as call for action, which is misleading since clicking the name does nothing.

|Before|After|
|---------|------|
|<video src="https://user-images.githubusercontent.com/3362943/236788649-c8ed3c53-bfd3-44ee-bdad-b2935f40b4af.mp4" />|<video src="https://github.com/matrix-org/matrix-react-sdk/assets/3362943/e0c97432-b263-4e26-9941-10a35efb9f4f" />|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove hover effect from user name on a DM creation UI ([\#10887](https://github.com/matrix-org/matrix-react-sdk/pull/10887)). Fixes vector-im/element-web#25305. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->