### PR TITLE
Manage style rules of `AppTile` on CallView and StickerPicker on `_AppDrawer.pcss`

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -154,6 +154,19 @@ limitations under the License.
     flex-direction: column;
     box-sizing: border-box;
     background-color: $widget-menu-bar-bg-color;
+
+    .mx_CallView & {
+        width: auto;
+        height: 100%;
+        border: none;
+        border-radius: inherit;
+        background-color: $call-background;
+    }
+
+    /* While the lobby is shown, the widget needs to stay loaded but hidden in the background */
+    .mx_CallView .mx_CallView_lobby ~ & {
+        display: none;
+    }
 }
 
 .mx_AppTileFullWidth {

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -178,6 +178,14 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     background-color: $widget-menu-bar-bg-color;
+
+    #mx_persistedElement_stickerPicker & {
+        height: unset;
+        box-sizing: border-box;
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+    }
 }
 
 .mx_AppTile_mini {
@@ -283,6 +291,10 @@ limitations under the License.
         &.mx_AppTileMenuBar_iconButton--menu::before {
             mask-image: url("$(res)/img/element-icons/room/ellipsis.svg");
         }
+    }
+
+    #mx_persistedElement_stickerPicker & {
+        padding: 0;
     }
 }
 

--- a/res/css/views/rooms/_Stickers.pcss
+++ b/res/css/views/rooms/_Stickers.pcss
@@ -8,18 +8,6 @@
 }
 
 #mx_persistedElement_stickerPicker {
-    .mx_AppTileFullWidth {
-        height: unset;
-        box-sizing: border-box;
-        border-left: none;
-        border-right: none;
-        border-bottom: none;
-    }
-
-    .mx_AppTileMenuBar {
-        padding: 0;
-    }
-
     iframe {
         /* Sticker picker depends on the fixed height previously used for all tiles */
         height: 283px; /* height of the popout minus the AppTile menu bar */

--- a/res/css/views/voip/_CallView.pcss
+++ b/res/css/views/voip/_CallView.pcss
@@ -27,19 +27,6 @@ limitations under the License.
     padding: 8px;
     border-radius: 8px;
 
-    .mx_AppTile {
-        width: auto;
-        height: 100%;
-        border: none;
-        border-radius: inherit;
-        background-color: $call-background;
-    }
-
-    /* While the lobby is shown, the widget needs to stay loaded but hidden in the background */
-    .mx_CallView_lobby ~ .mx_AppTile {
-        display: none;
-    }
-
     .mx_CallView_lobby {
         min-height: 0;
         flex-grow: 1;


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25269

This PR intends to move the rest of the CSS rules which style AppTile's components to `_AppDrawer.pcss` from the other files.

type: task

|AppTileFullWidth|AppTileMenuBar|
|-----------------------|----------------------|
|![1_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/a6592b4f-23fd-49ef-9d94-3cbe31ce9042)|![1_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/440d20a5-1a42-4d50-aa4a-d9d5050fe52d)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->