### PR TITLE
Extract style rules specific to `ThreadsList` to prevent a visual regression

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -1120,29 +1120,6 @@ $left-gutter: 64px;
         box-sizing: border-box;
         padding-bottom: 0;
         padding-inline-start: var(--leftOffset);
-
-        .mx_ThreadPanel_replies {
-            margin-top: $spacing-8;
-            display: flex;
-            align-items: center;
-            position: relative;
-
-            &::before {
-                @mixin ThreadSummaryIcon;
-            }
-
-            .mx_ThreadPanel_replies_amount {
-                @mixin ThreadRepliesAmount;
-                line-height: var(--EventTile_ThreadSummary-line-height);
-                font-size: $font-12px; /* Same font size as the counter on the main panel */
-            }
-
-            .mx_ThreadSummary_content {
-                text-overflow: ellipsis;
-                overflow: hidden;
-                white-space: nowrap;
-            }
-        }
     }
 
     .mx_MessageTimestamp {
@@ -1163,6 +1140,31 @@ $left-gutter: 64px;
         .mx_EventTile_line {
             background-color: $system; /* override $event-selected-color */
             box-shadow: none; /* don't show the verification left stroke in the thread list */
+        }
+    }
+}
+
+.mx_EventTile[data-shape="ThreadsList"] {
+    .mx_ThreadPanel_replies {
+        margin-top: $spacing-8;
+        display: flex;
+        align-items: center;
+        position: relative;
+
+        &::before {
+            @mixin ThreadSummaryIcon;
+        }
+
+        .mx_ThreadPanel_replies_amount {
+            @mixin ThreadRepliesAmount;
+            line-height: var(--EventTile_ThreadSummary-line-height);
+            font-size: $font-12px; /* Same font size as the counter on the main panel */
+        }
+
+        .mx_ThreadSummary_content {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
         }
     }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/matrix-org/matrix-react-sdk/commit/bef8e077f6fda7d0abb2e4061c50ba7ffaf8b988#diff-5d3e25eb1d22dd7a96e0e87ea9c1298dc7dbce8eb965d30b2d1ebc1436bfec3fR840.

This PR intends to prevent a visual regression by extracting style rules specific to `ThreadsList` and not applying them to `Notification`. Obviously `mx_ThreadPanel_replies` is not required for `EventTile` on `NotificationPanel`, and the rules should be updated not to be applied to it.

![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/0cce42fc-9e47-4bca-8e73-33f75fc4322d)


type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->