### PR TITLE
Update style rules under `mx_AppTileMenuBar_title`

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -204,13 +204,10 @@ limitations under the License.
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        margin-left: 9px;
 
         .mx_WidgetAvatar {
             margin-right: 12px;
-        }
-
-        > :last-child {
-            margin-left: 9px;
         }
     }
 

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -205,9 +205,14 @@ limitations under the License.
         overflow: hidden;
         text-overflow: ellipsis;
         margin-left: 9px;
+        pointer-events: none;
 
         .mx_WidgetAvatar {
             margin-right: 12px;
+        }
+
+        &.mx_AppTileMenuBar_title--pointer {
+            pointer-events: all;
         }
     }
 

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -205,14 +205,9 @@ limitations under the License.
         overflow: hidden;
         text-overflow: ellipsis;
         margin-left: 9px;
-        pointer-events: none;
 
         .mx_AppTileMenuBar_title_widgetAvatar {
             margin-right: 12px;
-        }
-
-        &.mx_AppTileMenuBar_title--pointer {
-            pointer-events: all;
         }
     }
 

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -207,7 +207,7 @@ limitations under the License.
         margin-left: 9px;
         pointer-events: none;
 
-        .mx_WidgetAvatar {
+        .mx_AppTileMenuBar_title_widgetAvatar {
             margin-right: 12px;
         }
 

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -508,14 +508,17 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
 
         return (
-            <span>
+            <div
+                className="mx_AppTileMenuBar_title"
+                style={{ pointerEvents: this.props.handleMinimisePointerEvents ? "all" : "none" }}
+            >
                 <WidgetAvatar app={this.props.app} />
                 <b>{name}</b>
                 <span>
                     {title ? titleSpacer : ""}
                     {title}
                 </span>
-            </span>
+            </div>
         );
     }
 
@@ -745,12 +748,7 @@ export default class AppTile extends React.Component<IProps, IState> {
                 <div className={appTileClasses} id={this.props.app.id}>
                     {this.props.showMenubar && (
                         <div className="mx_AppTileMenuBar">
-                            <span
-                                className="mx_AppTileMenuBar_title"
-                                style={{ pointerEvents: this.props.handleMinimisePointerEvents ? "all" : "none" }}
-                            >
-                                {this.props.showTitle && this.getTileTitle()}
-                            </span>
+                            {this.props.showTitle && this.getTileTitle()}
                             <span className="mx_AppTileMenuBar_widgets">
                                 {layoutButtons}
                                 {this.props.showPopout && !this.state.requiresClient && (

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -500,6 +500,11 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private getTileTitle(): JSX.Element {
+        const classnamesTitle = classNames({
+            "mx_AppTileMenuBar_title": true,
+            "mx_AppTileMenuBar_title--pointer": this.props.handleMinimisePointerEvents,
+        });
+
         const name = this.formatAppTileName();
         const titleSpacer = <span>&nbsp;-&nbsp;</span>;
         let title = "";
@@ -508,10 +513,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
 
         return (
-            <div
-                className="mx_AppTileMenuBar_title"
-                style={{ pointerEvents: this.props.handleMinimisePointerEvents ? "all" : "none" }}
-            >
+            <div className={classnamesTitle}>
                 <WidgetAvatar app={this.props.app} />
                 <b>{name}</b>
                 <span>

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -514,7 +514,7 @@ export default class AppTile extends React.Component<IProps, IState> {
 
         return (
             <div className={classnamesTitle}>
-                <WidgetAvatar app={this.props.app} />
+                <WidgetAvatar app={this.props.app} className="mx_AppTileMenuBar_title_widgetAvatar" />
                 <b>{name}</b>
                 <span>
                     {title ? titleSpacer : ""}

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -500,11 +500,6 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private getTileTitle(): JSX.Element {
-        const classnamesTitle = classNames({
-            "mx_AppTileMenuBar_title": true,
-            "mx_AppTileMenuBar_title--pointer": this.props.handleMinimisePointerEvents,
-        });
-
         const name = this.formatAppTileName();
         const titleSpacer = <span>&nbsp;-&nbsp;</span>;
         let title = "";
@@ -513,7 +508,10 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
 
         return (
-            <div className={classnamesTitle}>
+            <div
+                className="mx_AppTileMenuBar_title"
+                style={{ pointerEvents: this.props.handleMinimisePointerEvents ? "all" : "none" }}
+            >
                 <WidgetAvatar app={this.props.app} className="mx_AppTileMenuBar_title_widgetAvatar" />
                 <b>{name}</b>
                 <span>


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25269

This is one of the PRs which intend to conform style rules of `_AppDrawer.pcss` to our naming policy. This PR intends to address the structure of the style rules under `mx_AppTileMenuBar_title`.

|Before|After|
|---------|------|
|![0_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/4895aee7-f34a-44f1-b428-1a93de9ba339)|![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/27125656-d82b-43c0-8962-f1479c6f5e8c)|
|![0_2](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/e5fbb15b-ef0a-4b19-b449-63265bf51381)<br/>![0_3](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/fac164e4-d385-4de2-84f3-8396aed38513)||
|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/ab1396bf-4309-4200-ab1a-13675b9360c9)|![1_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/c06e084c-7372-4aa3-87e4-f5b69b111e34)|

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->