### PR TITLE
Fix ResizeHandle of the third pinned widget

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -265,6 +265,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         resizer.setClassNames({
             handle: "mx_ResizeHandle",
             vertical: "mx_ResizeHandle--vertical",
+            reverse: "mx_ResizeHandle_reverse",
         });
         return resizer;
     }

--- a/src/components/views/elements/ResizeHandle.tsx
+++ b/src/components/views/elements/ResizeHandle.tsx
@@ -32,7 +32,7 @@ const ResizeHandle: React.FC<IResizeHandleProps> = ({ vertical, reverse, id, pas
         classNames.push("mx_ResizeHandle--horizontal");
     }
     if (reverse) {
-        classNames.push("mx_ResizeHandle_reverse");
+        classNames.push("mx_ResizeHandle_reverse"); // required for the resizer of the third pinned widget to work
     }
     return (
         <div ref={passRef} className={classNames.join(" ")} data-id={id}>

--- a/src/components/views/elements/ResizeHandle.tsx
+++ b/src/components/views/elements/ResizeHandle.tsx
@@ -19,16 +19,20 @@ import React from "react"; // eslint-disable-line no-unused-vars
 //see src/resizer for the actual resizing code, this is just the DOM for the resize handle
 interface IResizeHandleProps {
     vertical?: boolean;
+    reverse?: boolean;
     id?: string;
     passRef?: React.RefObject<HTMLDivElement>;
 }
 
-const ResizeHandle: React.FC<IResizeHandleProps> = ({ vertical, id, passRef }) => {
+const ResizeHandle: React.FC<IResizeHandleProps> = ({ vertical, reverse, id, passRef }) => {
     const classNames = ["mx_ResizeHandle"];
     if (vertical) {
         classNames.push("mx_ResizeHandle--vertical");
     } else {
         classNames.push("mx_ResizeHandle--horizontal");
+    }
+    if (reverse) {
+        classNames.push("mx_ResizeHandle_reverse");
     }
     return (
         <div ref={passRef} className={classNames.join(" ")} data-id={id}>

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -110,6 +110,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
         const classNames = {
             handle: "mx_ResizeHandle",
             vertical: "mx_ResizeHandle--vertical",
+            reverse: "mx_ResizeHandle_reverse",
         };
         const collapseConfig = {
             onResizeStart: () => {
@@ -265,7 +266,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     if (i < 1) return app;
                     return (
                         <React.Fragment key={app.key}>
-                            <ResizeHandle />
+                            <ResizeHandle reverse={i > apps.length / 2} />
                             {app}
                         </React.Fragment>
                     );


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25363

This reverts commit 62569e209e063ae1ce59e1851cceac975e7b816b (Remove unused prop from ResizeHandle - reverse (#10771))

https://github.com/matrix-org/matrix-react-sdk/assets/3362943/d3404768-3afd-4f28-8665-054164dff328

type: defect

Notes: none

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->