### PR TITLE
Remove default margin and padding from `mx_TabbedView_tabLabels`

### DIFF
--- a/res/css/structures/_TabbedView.pcss
+++ b/res/css/structures/_TabbedView.pcss
@@ -33,6 +33,8 @@ limitations under the License.
         width: 170px;
         max-width: 170px;
         position: fixed;
+        margin: 0; /* Remove the default value */
+        padding: 0; /* Remove the default value */
     }
 
     .mx_TabbedView_tabPanel {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25373

This PR intends to remove default margin and padding from `ul` with the class name `mx_TabbedView_tabLabels`.

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/640fd651-3265-4797-b1be-10a49252dfe7)


type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->