### PR TITLE
Take a snapshot of `UserSettingsDialog` including the menu list

### DIFF
--- a/cypress/e2e/settings/user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/user-settings-tab.spec.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+const USER_NAME = "Bob";
+
+describe("UserSettingsDialog", () => {
+    let homeserver: HomeserverInstance;
+
+    beforeEach(() => {
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+            cy.initTestUser(homeserver, USER_NAME);
+        });
+    });
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should be rendered properly", () => {
+        cy.openUserMenu().within(() => {
+            cy.findByRole("menuitem", { name: "All settings" }).click();
+        });
+
+        // Assert that UserSettingsDialog is rendered
+        cy.get(".mx_UserSettingsDialog").should("exist");
+
+        // Exclude userId from a snapshot
+        const percyCSS = ".mx_ProfileSettings_profile_controls_userId { visibility: hidden !important; }";
+
+        // Take a snapshot of the dialog including its wrapper
+        cy.get(".mx_Dialog_wrapper").percySnapshotElement("User settings dialog (General user settings tab)", {
+            percyCSS,
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/10907

This PR intends to add a E2E test to take a snapshot of `UserSettingsDialog` including `mx_TabbedView` (the menu list on the left side of the dialog). [The existing Percy tests](https://percy.io/dfde73bd/matrix-react-sdk/builds/27391048/search?searchParam=user%20settings%20tab) take the content of the tab, but without the menu list. The Percy test this PR is going to add should take the dialog itself.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->