### PR TITLE
Fix widget permission tooltip style rules by applying the naming policy properly

### DIFF
--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -53,25 +53,25 @@ limitations under the License.
             mask-image: url("$(res)/img/feather-customised/help-circle.svg");
         }
     }
+}
 
-    .mx_AppPermission_tooltip {
-        box-shadow: none;
-        background-color: $tooltip-timeline-bg-color;
-        color: $tooltip-timeline-fg-color;
-        border: none;
-        border-radius: 3px;
-        padding: 6px 8px;
+.mx_Tooltip.mx_Tooltip--appPermission {
+    box-shadow: none;
+    background-color: $tooltip-timeline-bg-color;
+    color: $tooltip-timeline-fg-color;
+    border: none;
+    border-radius: 3px;
+    padding: 6px 8px;
 
-        &.mx_AppPermission_tooltip--dark {
-            .mx_Tooltip_chevron::after {
-                border-right-color: $tooltip-timeline-bg-color;
-            }
+    &.mx_Tooltip--appPermission--dark {
+        .mx_Tooltip_chevron::after {
+            border-right-color: $tooltip-timeline-bg-color;
         }
+    }
 
-        ul {
-            list-style-position: inside;
-            padding-left: 2px;
-            margin-left: 0;
-        }
+    ul {
+        list-style-position: inside;
+        padding-left: 2px;
+        margin-left: 0;
     }
 }

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -115,7 +115,7 @@ export default class AppPermission extends React.Component<IProps, IState> {
         const warningTooltip = (
             <TextWithTooltip
                 tooltip={warningTooltipText}
-                tooltipClass="mx_AppPermission_tooltip mx_AppPermission_tooltip--dark"
+                tooltipClass="mx_Tooltip--appPermission mx_Tooltip--appPermission--dark"
             >
                 <span className="mx_AppPermission_helpIcon" />
             </TextWithTooltip>


### PR DESCRIPTION
This PR intends to fix a regression by https://github.com/matrix-org/matrix-react-sdk/pull/10824 of widget permission tooltip styling by applying our naming policy properly.

|Before|After|
|---------|------|
|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/9050a03d-0380-4cf5-9f19-cb2653c803e6)|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/c8e7f143-1ef7-4a3e-8684-c11f43710945)|


This PR should fix the regression by the PR, but It looks like the previous implementation (on app.element.io) should have been same as https://github.com/matrix-org/matrix-react-sdk/pull/3622.

![](https://user-images.githubusercontent.com/1190097/68976827-f8077480-07b3-11ea-911a-e77cf44bc437.png)

type: defect 

Notes: none

element-web notes: none

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->