### PR TITLE
Remove a duplicate external link icon from `AnalyticsLearnMoreDialog`

### DIFF
--- a/res/css/views/dialogs/_AnalyticsLearnMoreDialog.pcss
+++ b/res/css/views/dialogs/_AnalyticsLearnMoreDialog.pcss
@@ -39,18 +39,6 @@ limitations under the License.
         text-decoration: none;
     }
 
-    .mx_AnalyticsPolicyLink {
-        display: inline-block;
-        mask-image: url("$(res)/img/external-link.svg");
-        background-color: $accent;
-        mask-repeat: no-repeat;
-        mask-size: contain;
-        width: 12px;
-        height: 12px;
-        margin-left: 3px;
-        vertical-align: middle;
-    }
-
     .mx_AnalyticsLearnMore_bullets {
         padding-left: 0px;
     }

--- a/src/components/views/dialogs/AnalyticsLearnMoreDialog.tsx
+++ b/src/components/views/dialogs/AnalyticsLearnMoreDialog.tsx
@@ -58,7 +58,6 @@ export const AnalyticsLearnMoreDialog: React.FC<IProps> = ({
                         return (
                             <ExternalLink href={privacyPolicyUrl} rel="norefferer noopener" target="_blank">
                                 {sub}
-                                <span className="mx_AnalyticsPolicyLink" />
                             </ExternalLink>
                         );
                     },


### PR DESCRIPTION
This PR intends to remove a duplicate external link icon from `AnalyticsLearnMoreDialog`. ~~It also suggests to add a E2E test with a Percy snapshot test.~~

The issue is essentially the same one as https://github.com/vector-im/element-web/issues/25384 (https://github.com/matrix-org/matrix-react-sdk/commit/37b7dfe9431a413d3bb123a0413ba3b83fcee68c#diff-5c6639bce05427539d7491614ced8865c159ce506a05bae549ee545716fe6b88R59-R62).

|Before|After|
|---------|------|
|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/bd15cc9f-ede1-44aa-8c2c-71c5b6bf2248)|![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/6fdfc08f-ed80-47a6-96fb-5de97860aa2e)|

type: defect

Notes: none

element-web notes: none

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->