### PR TITLE
Add `security-user-settings-tab.spec.ts`

### DIFF
--- a/cypress/e2e/settings/security-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/security-user-settings-tab.spec.ts
@@ -25,15 +25,6 @@ describe("Security user settings tab", () => {
         cy.stopHomeserver(homeserver);
     });
 
-    it("should be rendered properly", () => {
-        cy.startHomeserver("default").then((data) => {
-            homeserver = data;
-            cy.initTestUser(homeserver, "Hanako");
-        });
-
-        cy.openUserSettings("Security");
-    });
-
     describe("with posthog enabled", () => {
         beforeEach(() => {
             // Enable posthog
@@ -60,7 +51,7 @@ describe("Security user settings tab", () => {
                 .should("exist")
                 .closest(".mx_Toast_toast")
                 .within(() => {
-                    cy.get(".mx_Toast_buttons .mx_AccessibleButton_kind_danger_outline").click(); // Click "Dismiss"
+                    cy.findByRole("button", { name: "Dismiss" }).click();
                 });
 
             cy.get(".mx_Toast_buttons").within(() => {

--- a/cypress/e2e/settings/security-user-settings-tab.spec.ts
+++ b/cypress/e2e/settings/security-user-settings-tab.spec.ts
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+describe("Security user settings tab", () => {
+    let homeserver: HomeserverInstance;
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should be rendered properly", () => {
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+            cy.initTestUser(homeserver, "Hanako");
+        });
+
+        cy.openUserSettings("Security");
+    });
+
+    describe("with posthog enabled", () => {
+        beforeEach(() => {
+            // Enable posthog
+            cy.intercept("/config.json?cachebuster=*", (req) => {
+                req.continue((res) => {
+                    res.send(200, {
+                        ...res.body,
+                        posthog: {
+                            project_api_key: "foo",
+                            api_host: "bar",
+                        },
+                        privacy_policy_url: "example.tld", // Set privacy policy URL to enable privacyPolicyLink
+                    });
+                });
+            });
+
+            cy.startHomeserver("default").then((data) => {
+                homeserver = data;
+                cy.initTestUser(homeserver, "Hanako");
+            });
+
+            // Hide "Notification" toast on Cypress Cloud
+            cy.contains(".mx_Toast_toast h2", "Notifications")
+                .should("exist")
+                .closest(".mx_Toast_toast")
+                .within(() => {
+                    cy.get(".mx_Toast_buttons .mx_AccessibleButton_kind_danger_outline").click(); // Click "Dismiss"
+                });
+
+            cy.get(".mx_Toast_buttons").within(() => {
+                cy.findByRole("button", { name: "Yes" }).should("exist").click(); // Allow analytics
+            });
+
+            cy.openUserSettings("Security");
+        });
+
+        describe("AnalyticsLearnMoreDialog", () => {
+            it("should be rendered properly", () => {
+                cy.findByRole("button", { name: "Learn more" }).click();
+
+                cy.get(".mx_AnalyticsLearnMoreDialog_wrapper").percySnapshotElement("AnalyticsLearnMoreDialog");
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR intends to add `security-user-settings-tab.spec.ts` as a follow-up to https://github.com/matrix-org/matrix-react-sdk/pull/10924. The test this PR suggests to add is simple for now, and other scenarios should be implemented later.

This suggests to take a Percy snapshot of `AnalyticsLearnMoreDialog`.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->