### PR TITLE
Fix link toggle error rte

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -61,11 +61,7 @@ import { SdkContextClass } from "../../../contexts/SDKContext";
 import { VoiceBroadcastInfoState } from "../../../voice-broadcast";
 import { createCantStartVoiceMessageBroadcastDialog } from "../dialogs/CantStartVoiceMessageBroadcastDialog";
 import { UIFeature } from "../../../settings/UIFeature";
-import {
-    convertLinksForParser,
-    decodeHtmlEntities,
-    encodeHtmlEntities,
-} from "./wysiwyg_composer/hooks/usePlainTextInitialization";
+import { convertLinksForParser, encodeHtmlEntities } from "./wysiwyg_composer/hooks/usePlainTextInitialization";
 
 let instanceCount = 0;
 

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
@@ -19,7 +19,41 @@ import { RefObject, useEffect } from "react";
 export function usePlainTextInitialization(initialContent = "", ref: RefObject<HTMLElement>): void {
     useEffect(() => {
         if (ref.current) {
-            ref.current.innerText = initialContent;
+            ref.current.innerHTML = initialContent;
         }
     }, [ref, initialContent]);
+}
+
+/**
+ * Decodes a string containing html character entities and returns the string with the entities replaced
+ * with regular characters, eg "&lt;" becomes "<"
+ */
+export function decodeHtmlEntities(html = ""): string {
+    const textArea = document.createElement("textarea");
+    textArea.innerHTML = html;
+    return textArea.value;
+}
+
+/**
+ * Encodes a string so that characters are replaced with their corresponding html entities
+ * eg "<" becomes "&lt;".
+ *
+ */
+export function encodeHtmlEntities(text = ""): string {
+    const textArea = document.createElement("textarea");
+    const textNode = document.createTextNode(text);
+    textArea.appendChild(textNode);
+    return textArea.innerHTML;
+}
+
+// A markdown link looks like [link text](<href>)
+// We need to stop the regex backtracking to avoid super-linear performance. To do this, we use a lookahead
+// assertion (?=...), which greedily matches up to the closing "]" and then match the contents of that assertion
+// with a backreference \1. Since the backreference matches something that has already matched, it will not backtrack.
+const escapedMdLinkRegex = /\[(?=([^\]]*))\1\]\(&lt;(.*)&gt;\)/g;
+
+export function convertLinksForParser(text: string): string {
+    return text.replace(escapedMdLinkRegex, (match, linkText, href) => {
+        return `[${linkText}](<${href}>)`;
+    });
 }

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
@@ -25,16 +25,6 @@ export function usePlainTextInitialization(initialContent = "", ref: RefObject<H
 }
 
 /**
- * Decodes a string containing html character entities and returns the string with the entities replaced
- * with regular characters, eg "&lt;" becomes "<"
- */
-export function decodeHtmlEntities(html = ""): string {
-    const textArea = document.createElement("textarea");
-    textArea.innerHTML = html;
-    return textArea.value;
-}
-
-/**
  * Encodes a string so that characters are replaced with their corresponding html entities
  * eg "<" becomes "&lt;".
  *

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextInitialization.ts
@@ -23,27 +23,3 @@ export function usePlainTextInitialization(initialContent = "", ref: RefObject<H
         }
     }, [ref, initialContent]);
 }
-
-/**
- * Encodes a string so that characters are replaced with their corresponding html entities
- * eg "<" becomes "&lt;".
- *
- */
-export function encodeHtmlEntities(text = ""): string {
-    const textArea = document.createElement("textarea");
-    const textNode = document.createTextNode(text);
-    textArea.appendChild(textNode);
-    return textArea.innerHTML;
-}
-
-// A markdown link looks like [link text](<href>)
-// We need to stop the regex backtracking to avoid super-linear performance. To do this, we use a lookahead
-// assertion (?=...), which greedily matches up to the closing "]" and then match the contents of that assertion
-// with a backreference \1. Since the backreference matches something that has already matched, it will not backtrack.
-const escapedMdLinkRegex = /\[(?=([^\]]*))\1\]\(&lt;(.*)&gt;\)/g;
-
-export function convertLinksForParser(text: string): string {
-    return text.replace(escapedMdLinkRegex, (match, linkText, href) => {
-        return `[${linkText}](<${href}>)`;
-    });
-}

--- a/src/components/views/rooms/wysiwyg_composer/utils/encoding.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/encoding.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Encodes a string so that characters are replaced with their corresponding html entities
+ * eg "<" becomes "&lt;".
+ */
+export function encodeHtmlEntities(text = ""): string {
+    const textArea = document.createElement("textarea");
+    const textNode = document.createTextNode(text);
+    textArea.appendChild(textNode);
+    return textArea.innerHTML;
+}
+
+// A markdown link looks like [link text](<href>)
+// An html encoded markdown link looks like [link text](&lt;href&gt;)
+// We need to stop the regex backtracking to avoid super-linear performance. To do this, we use a lookahead
+// assertion (?=...), which greedily matches up to the closing "]" and then match the contents of that assertion
+// with a backreference \1. Since the backreference matches something that has already matched, it will not backtrack.
+const escapedMdLinkRegex = /\[(?=([^\]]*))\1\]\(&lt;(.*)&gt;\)/g;
+
+/**
+ * Takes a string of html entity encoded markdown and replaces the angle bracket html entities with their
+ * plain text equivalents. This ensures the rust model can parse the link correctly.
+ * @param text - the string of markdown
+ * @returns - a string with the link href section surrounded by plain text angle brackets
+ */
+export function amendMarkdownLinks(text: string): string {
+    return text.replace(escapedMdLinkRegex, (match, linkText, href) => {
+        return `[${linkText}](<${href}>)`;
+    });
+}

--- a/test/components/views/rooms/wysiwyg_composer/utils/encoding-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/encoding-test.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+    amendMarkdownLinks,
+    encodeHtmlEntities,
+} from "../../../../../../src/components/views/rooms/wysiwyg_composer/utils/encoding";
+
+describe("encodeHtmlEntities", () => {
+    it("converts strings with encoding", () => {
+        const input = "&amp;";
+        const expected = "&amp;amp;";
+
+        expect(encodeHtmlEntities(input)).toBe(expected);
+    });
+    it("converts markdown links in text to html encoded equivalent", () => {
+        const input = "[example](<https://www.markdownlink.com>)";
+        const expected = "[example](&lt;https://www.markdownlink.com&gt;)";
+
+        expect(encodeHtmlEntities(input)).toBe(expected);
+    });
+});
+
+describe("amendMarkdownLinks", () => {
+    it("does not alter markdown links without angle brackets surrounding the href", () => {
+        const input = "[example](https://www.markdownlink.com)";
+
+        expect(amendMarkdownLinks(input)).toBe(input);
+    });
+
+    it("converts angle brackets surrounding link hrefs in markdown from html encoding to plain text", () => {
+        const input = "[example](&lt;https://www.markdownlink.com&gt;)";
+        const expected = "[example](<https://www.markdownlink.com>)";
+
+        expect(amendMarkdownLinks(input)).toBe(expected);
+    });
+});


### PR DESCRIPTION
When toggling between rich and plain modes, URI character encoding was causing an issue for links. STR then demo below.
STR:

- in rich text mode, create a link
- toggle to plain text mode, add a single character
- toggle back to rich text mode
- send the link => link does not work as expected
- inspect the link - there will be URI encoded characters in the link (< has become %3C;)

Video of issue:

https://github.com/matrix-org/matrix-react-sdk/assets/56027671/a417e018-1e59-4ffd-8b0b-a5f9a9d3afce

By decoding the html before storing the composer content as state, we can ensure that whenever the toggle button is pressed, the rust model is given content in the correct format of text to ensure links work correctly.

Video with fix:

https://github.com/matrix-org/matrix-react-sdk/assets/56027671/a6362b34-f9ab-47d9-9198-4d8dabd1756a



<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix link toggle error rte ([\#10933](https://github.com/matrix-org/matrix-react-sdk/pull/10933)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->