### PR TITLE
Edit `room-header.spec.ts` to check apps button

### DIFF
--- a/cypress/e2e/room/room-header.spec.ts
+++ b/cypress/e2e/room/room-header.spec.ts
@@ -261,7 +261,7 @@ describe("Room Header", () => {
             cy.get(".mx_AppsDrawer").should("exist");
 
             cy.get(".mx_RoomHeader").within(() => {
-                // Assert that "Hide Widgets" button is rendered  and aria-checked is set to true
+                // Assert that "Hide Widgets" button is rendered and aria-checked is set to true
                 cy.findByRole("button", { name: "Hide Widgets" })
                     .should("exist")
                     .should("have.attr", "aria-checked", "true");

--- a/cypress/e2e/room/room-header.spec.ts
+++ b/cypress/e2e/room/room-header.spec.ts
@@ -261,17 +261,10 @@ describe("Room Header", () => {
             cy.get(".mx_AppsDrawer").should("exist");
 
             cy.get(".mx_RoomHeader").within(() => {
+                // Assert that "Hide Widgets" button is rendered  and aria-checked is set to true
                 cy.findByRole("button", { name: "Hide Widgets" })
-                    .should("exist") // Assert that the apps button is rendered
-                    .then(($btn) => {
-                        // Note it is not possible to get CSS values of a pseudo class with "have.css".
-                        const color = $btn[0].ownerDocument.defaultView // get window reference from element
-                            .getComputedStyle($btn[0], "before") // get the pseudo selector
-                            .getPropertyValue("background-color"); // get "background-color" value
-
-                        // Assert the value is equal to $accent == hex #0dbd8b == rgba(13, 189, 139)
-                        expect(color).to.eq("rgb(13, 189, 139)");
-                    });
+                    .should("exist")
+                    .should("have.attr", "aria-checked", "true");
             });
 
             cy.get(".mx_RoomHeader").percySnapshotElement("Room header - with apps button (highlighted)");
@@ -283,6 +276,11 @@ describe("Room Header", () => {
             cy.get(".mx_RoomHeader").within(() => {
                 // Click the apps button to hide AppsDrawer
                 cy.findByRole("button", { name: "Hide Widgets" }).should("exist").click();
+
+                // Assert that "Show widgets" button is rendered and aria-checked is set to false
+                cy.findByRole("button", { name: "Show Widgets" })
+                    .should("exist")
+                    .should("have.attr", "aria-checked", "false");
             });
 
             // Assert that AppsDrawer is not rendered

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -591,6 +591,7 @@ export default class RoomHeader extends React.Component<IProps, IState> {
                     })}
                     onClick={this.props.onAppsClick}
                     title={this.props.appsShown ? _t("Hide Widgets") : _t("Show Widgets")}
+                    aria-checked={this.props.appsShown}
                     alignment={Alignment.Bottom}
                     key="apps"
                 />,


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/10495

This PR suggests to edit `room-header.spec.ts` to check apps button for a widget on the room header. The code to display a widget is based on `layout.spec.ts`.

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/67393e60-4066-42bf-80aa-e6e4e80c499a)

This PR intends to add two Percy snapshots:
- `Room header - with apps button (highlighted)`
- `Room header - with apps button (not highlighted)`

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->