### PR TITLE
Minor cleanups to `handleVerificationRequest` in cypress tests

### DIFF
--- a/cypress/e2e/crypto/decryption-failure.spec.ts
+++ b/cypress/e2e/crypto/decryption-failure.spec.ts
@@ -15,11 +15,9 @@ limitations under the License.
 */
 
 import type { VerificationRequest } from "matrix-js-sdk/src/crypto/verification/request/VerificationRequest";
-import type { ISasEvent } from "matrix-js-sdk/src/crypto/verification/SAS";
 import type { MatrixClient } from "matrix-js-sdk/src/matrix";
 import { HomeserverInstance } from "../../plugins/utils/homeserver";
 import { UserCredentials } from "../../support/login";
-import Chainable = Cypress.Chainable;
 import { handleVerificationRequest } from "./utils";
 
 const ROOM_NAME = "Test room";

--- a/cypress/e2e/crypto/utils.ts
+++ b/cypress/e2e/crypto/utils.ts
@@ -38,21 +38,19 @@ export function waitForVerificationRequest(cli: MatrixClient): Promise<Verificat
 }
 
 /**
- * Handle an incoming verification request
+ * Automatically handle an incoming verification request
  *
  * Starts the key verification process, and, once it is accepted on the other side, confirms that the
  * emojis match.
  *
- * Returns a promise that resolves, with the emoji list, once we confirm the emojis
- *
  * @param request - incoming verification request
+ * @returns A promise that resolves, with the emoji list, once we confirm the emojis
  */
-export function handleVerificationRequest(request: VerificationRequest) {
+export function handleVerificationRequest(request: VerificationRequest): Promise<EmojiMapping[]> {
     return new Promise<EmojiMapping[]>((resolve) => {
         const onShowSas = (event: ISasEvent) => {
             verifier.off("show_sas", onShowSas);
             event.confirm();
-            verifier.done();
             resolve(event.sas.emoji);
         };
 


### PR DESCRIPTION
A couple of changes:
 * Remove a redundant call to `VerificationBase.done`
 * Remove duplication between test files

See the individual commits for more details.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/3382

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->