### PR TITLE
Deflake `spotlight` cypress tests

### DIFF
--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -212,8 +212,12 @@ describe("Spotlight", () => {
 
     it("should be able to add and remove filters via keyboard", () => {
         cy.openSpotlightDialog().within(() => {
-            cy.spotlightSearch().type("{downArrow}");
+            cy.wait(1000); // wait for the dialog to settle, otherwise our keypresses might race with an update
+
+            // initially, publicrooms should be highlighted (because there are no other suggestions)
             cy.get("#mx_SpotlightDialog_button_explorePublicRooms").should("have.attr", "aria-selected", "true");
+
+            // hitting enter should enable the publicrooms filter
             cy.spotlightSearch().type("{enter}");
             cy.get(".mx_SpotlightDialog_filter").should("contain", "Public rooms");
             cy.spotlightSearch().type("{backspace}");

--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -203,6 +203,10 @@ describe("Spotlight", () => {
                     cy.get(".mx_RoomSublist_skeletonUI").should("not.exist");
                 });
         });
+        // wait for the room to have the right name
+        cy.get(".mx_RoomHeader").within(() => {
+            cy.findByText(room1Name);
+        });
     });
 
     afterEach(() => {

--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -241,7 +241,6 @@ describe("Spotlight", () => {
         cy.openSpotlightDialog()
             .within(() => {
                 cy.spotlightSearch().clear().type(room1Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", room1Name);
                 cy.spotlightResults().eq(0).click();
@@ -257,7 +256,6 @@ describe("Spotlight", () => {
             .within(() => {
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room1Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", room1Name);
                 cy.spotlightResults().eq(0).should("contain", "View");
@@ -274,7 +272,6 @@ describe("Spotlight", () => {
             .within(() => {
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room2Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", room2Name);
                 cy.spotlightResults().eq(0).should("contain", "Join");
@@ -292,7 +289,6 @@ describe("Spotlight", () => {
             .within(() => {
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room3Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", room3Name);
                 cy.spotlightResults().eq(0).should("contain", "View");
@@ -334,7 +330,6 @@ describe("Spotlight", () => {
             .within(() => {
                 cy.spotlightFilter(Filter.People);
                 cy.spotlightSearch().clear().type(bot1Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", bot1Name);
                 cy.spotlightResults().eq(0).click();
@@ -349,7 +344,6 @@ describe("Spotlight", () => {
             .within(() => {
                 cy.spotlightFilter(Filter.People);
                 cy.spotlightSearch().clear().type(bot2Name);
-                cy.wait(3000); // wait for the dialog code to settle
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", bot2Name);
                 cy.spotlightResults().eq(0).click();
@@ -367,7 +361,6 @@ describe("Spotlight", () => {
         cy.openSpotlightDialog().within(() => {
             cy.spotlightFilter(Filter.People);
             cy.spotlightSearch().clear().type(bot2Name);
-            cy.wait(3000); // wait for the dialog code to settle
             cy.spotlightResults().should("have.length", 1);
             cy.spotlightResults().eq(0).should("contain", bot2Name);
             cy.spotlightResults().eq(0).click();


### PR DESCRIPTION
Some changes aimed at deflaking and speeding up these tests.

In [38f26ca](https://github.com/matrix-org/matrix-react-sdk/pull/10943/commits/38f26ca856a214322f3117c1c56592112c30ab27): it turns out that, currently, the test is only passing because our down arrow is racing with the dialog being updated:
 * we press downarrow, highlighting "People" (rather than "Public Rooms")
 * the dialog updates, resetting the focus
 * now "Public Rooms" is highlighted and the test proceeds.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->