### PR TITLE
Fix visual regressions around widget permissions

### DIFF
--- a/res/css/_components.pcss
+++ b/res/css/_components.pcss
@@ -21,6 +21,7 @@
 @import "./components/views/dialogs/polls/_PollListItem.pcss";
 @import "./components/views/dialogs/polls/_PollListItemEnded.pcss";
 @import "./components/views/elements/_AppPermission.pcss";
+@import "./components/views/elements/_AppWarning.pcss";
 @import "./components/views/elements/_FilterDropdown.pcss";
 @import "./components/views/elements/_FilterTabGroup.pcss";
 @import "./components/views/elements/_LearnMore.pcss";

--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -27,40 +27,40 @@ limitations under the License.
             margin-block: 12px;
         }
 
-    h4 {
-        margin: 0;
-        padding: 0;
-    }
+        h4 {
+            margin: 0;
+            padding: 0;
+        }
 
-    .mx_AppPermission_content_largeText {
-        font-size: $font-16px;
-    }
+        .mx_AppPermission_content_largeText {
+            font-size: $font-16px;
+        }
 
-    .mx_AppPermission_content_bolder {
-        font-weight: var(--font-semi-bold);
-    }
+        .mx_AppPermission_content_bolder {
+            font-weight: var(--font-semi-bold);
+        }
 
-    .mx_AppPermission_content_helpIcon {
-        margin-top: 1px;
-        margin-right: 2px;
-        width: 10px;
-        height: 10px;
-        display: inline-block;
-
-        &::before {
+        .mx_AppPermission_content_helpIcon {
+            margin-top: 1px;
+            margin-right: 2px;
+            width: 10px;
+            height: 10px;
             display: inline-block;
-            background-color: $accent;
-            mask-repeat: no-repeat;
-            mask-size: 12px;
-            width: 12px;
-            height: 12px;
-            mask-position: center;
-            content: "";
-            vertical-align: middle;
-            mask-image: url("$(res)/img/feather-customised/help-circle.svg");
+
+            &::before {
+                display: inline-block;
+                background-color: $accent;
+                mask-repeat: no-repeat;
+                mask-size: 12px;
+                width: 12px;
+                height: 12px;
+                mask-position: center;
+                content: "";
+                vertical-align: middle;
+                mask-image: url("$(res)/img/feather-customised/help-circle.svg");
+            }
         }
     }
-}
 }
 
 .mx_Tooltip.mx_Tooltip--appPermission {

--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -31,24 +31,13 @@ limitations under the License.
             font-weight: var(--font-semi-bold);
         }
 
-        .mx_AppPermission_content_helpIcon {
-            margin-top: 1px;
-            margin-right: 2px;
-            width: 10px;
-            height: 10px;
+        .mx_TextWithTooltip_target--helpIcon {
             display: inline-block;
+            height: $font-14px; /* align with characters on the same line */
+            vertical-align: middle;
 
-            &::before {
-                display: inline-block;
-                background-color: $accent;
-                mask-repeat: no-repeat;
-                mask-size: 12px;
-                width: 12px;
-                height: 12px;
-                mask-position: center;
-                content: "";
-                vertical-align: middle;
-                mask-image: url("$(res)/img/feather-customised/help-circle.svg");
+            .mx_Icon {
+                color: $accent;
             }
         }
     }

--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -17,25 +17,30 @@ limitations under the License.
 
 .mx_AppPermission {
     font-size: $font-12px;
+    width: 100%; /* make mx_AppPermission fill width of mx_AppTileBody so that scroll bar appears on the edge */
+    overflow-y: scroll;
 
-    > div {
-        margin-bottom: 12px;
-    }
+    .mx_AppPermission_content {
+        margin-block: auto; /* place at the center */
+
+        > div {
+            margin-block: 12px;
+        }
 
     h4 {
         margin: 0;
         padding: 0;
     }
 
-    .mx_AppPermission_largeText {
+    .mx_AppPermission_content_largeText {
         font-size: $font-16px;
     }
 
-    .mx_AppPermission_bolder {
+    .mx_AppPermission_content_bolder {
         font-weight: var(--font-semi-bold);
     }
 
-    .mx_AppPermission_helpIcon {
+    .mx_AppPermission_content_helpIcon {
         margin-top: 1px;
         margin-right: 2px;
         width: 10px;
@@ -55,6 +60,7 @@ limitations under the License.
             mask-image: url("$(res)/img/feather-customised/help-circle.svg");
         }
     }
+}
 }
 
 .mx_Tooltip.mx_Tooltip--appPermission {

--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -27,15 +27,6 @@ limitations under the License.
             margin-block: 12px;
         }
 
-        h4 {
-            margin: 0;
-            padding: 0;
-        }
-
-        .mx_AppPermission_content_largeText {
-            font-size: $font-16px;
-        }
-
         .mx_AppPermission_content_bolder {
             font-weight: var(--font-semi-bold);
         }

--- a/res/css/components/views/elements/_AppPermission.pcss
+++ b/res/css/components/views/elements/_AppPermission.pcss
@@ -16,6 +16,8 @@ limitations under the License.
 */
 
 .mx_AppPermission {
+    font-size: $font-12px;
+
     > div {
         margin-bottom: 12px;
     }
@@ -25,8 +27,8 @@ limitations under the License.
         padding: 0;
     }
 
-    .mx_AppPermission_smallText {
-        font-size: $font-12px;
+    .mx_AppPermission_largeText {
+        font-size: $font-16px;
     }
 
     .mx_AppPermission_bolder {

--- a/res/css/components/views/elements/_AppWarning.pcss
+++ b/res/css/components/views/elements/_AppWarning.pcss
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_AppWarning {
+    font-size: $font-16px;
+}

--- a/res/css/components/views/elements/_AppWarning.pcss
+++ b/res/css/components/views/elements/_AppWarning.pcss
@@ -16,4 +16,5 @@ limitations under the License.
 
 .mx_AppWarning {
     font-size: $font-16px;
+    justify-content: center;
 }

--- a/res/css/components/views/elements/_AppWarning.pcss
+++ b/res/css/components/views/elements/_AppWarning.pcss
@@ -17,4 +17,9 @@ limitations under the License.
 .mx_AppWarning {
     font-size: $font-16px;
     justify-content: center;
+
+    h4 {
+        margin: 0;
+        padding: 0;
+    }
 }

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -326,7 +326,6 @@ limitations under the License.
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    font-weight: bold;
     position: relative;
     height: 100%;
 

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -311,7 +311,6 @@ limitations under the License.
     display: flex;
     height: 100%;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
 
     h4 {

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -312,11 +312,6 @@ limitations under the License.
     height: 100%;
     flex-direction: column;
     align-items: center;
-
-    h4 {
-        margin: 0;
-        padding: 0;
-    }
 }
 
 .mx_AppTile_loading {

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -313,7 +313,6 @@ limitations under the License.
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    font-size: $font-16px;
 
     h4 {
         margin: 0;

--- a/res/img/feather-customised/help-circle.svg
+++ b/res/img/feather-customised/help-circle.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-    <g fill="none" fill-rule="evenodd" stroke="#454545" stroke-linecap="round" stroke-linejoin="round" transform="translate(1 1)">
+    <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="translate(1 1)">
         <circle cx="6" cy="6" r="6"/>
         <path d="M4.254 4.2a1.8 1.8 0 0 1 3.498.6c0 1.2-1.8 1.8-1.8 1.8M6 8.991"/>
     </g>

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -118,7 +118,7 @@ export default class AppPermission extends React.Component<IProps, IState> {
                 tooltip={warningTooltipText}
                 tooltipClass="mx_Tooltip--appPermission mx_Tooltip--appPermission--dark"
             >
-                <span className="mx_AppPermission_helpIcon" />
+                <span className="mx_AppPermission_content_helpIcon" />
             </TextWithTooltip>
         );
 
@@ -139,10 +139,11 @@ export default class AppPermission extends React.Component<IProps, IState> {
 
         return (
             <div className="mx_AppPermission">
-                <div className="mx_AppPermission_bolder">{_t("Widget added by")}</div>
+            <div className="mx_AppPermission_content">
+                <div className="mx_AppPermission_content_bolder">{_t("Widget added by")}</div>
                 <div>
                     {avatar}
-                    <h4 className="mx_AppPermission_bolder mx_AppPermission_largeText">{displayName}</h4>
+                    <h4 className="mx_AppPermission_content_bolder mx_AppPermission_content_largeText">{displayName}</h4>
                     <div>{userId}</div>
                 </div>
                 <div>{warning}</div>
@@ -153,6 +154,7 @@ export default class AppPermission extends React.Component<IProps, IState> {
                     <AccessibleButton kind="primary_sm" onClick={this.props.onPermissionGranted}>
                         {_t("Continue")}
                     </AccessibleButton>
+                </div>
                 </div>
             </div>
         );

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -29,6 +29,7 @@ import Heading from "../typography/Heading";
 import AccessibleButton from "./AccessibleButton";
 import TextWithTooltip from "./TextWithTooltip";
 import { parseUrl } from "../../../utils/UrlUtils";
+import { Icon as HelpIcon } from "../../../../res/img/feather-customised/help-circle.svg";
 
 interface IProps {
     url: string;
@@ -118,8 +119,9 @@ export default class AppPermission extends React.Component<IProps, IState> {
             <TextWithTooltip
                 tooltip={warningTooltipText}
                 tooltipClass="mx_Tooltip--appPermission mx_Tooltip--appPermission--dark"
+                class="mx_TextWithTooltip_target--helpIcon"
             >
-                <span className="mx_AppPermission_content_helpIcon" />
+                <HelpIcon className="mx_Icon mx_Icon_12" />
             </TextWithTooltip>
         );
 

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -139,22 +139,24 @@ export default class AppPermission extends React.Component<IProps, IState> {
 
         return (
             <div className="mx_AppPermission">
-            <div className="mx_AppPermission_content">
-                <div className="mx_AppPermission_content_bolder">{_t("Widget added by")}</div>
-                <div>
-                    {avatar}
-                    <h4 className="mx_AppPermission_content_bolder mx_AppPermission_content_largeText">{displayName}</h4>
-                    <div>{userId}</div>
-                </div>
-                <div>{warning}</div>
-                <div>
-                    {_t("This widget may use cookies.")}&nbsp;{encryptionWarning}
-                </div>
-                <div>
-                    <AccessibleButton kind="primary_sm" onClick={this.props.onPermissionGranted}>
-                        {_t("Continue")}
-                    </AccessibleButton>
-                </div>
+                <div className="mx_AppPermission_content">
+                    <div className="mx_AppPermission_content_bolder">{_t("Widget added by")}</div>
+                    <div>
+                        {avatar}
+                        <h4 className="mx_AppPermission_content_bolder mx_AppPermission_content_largeText">
+                            {displayName}
+                        </h4>
+                        <div>{userId}</div>
+                    </div>
+                    <div>{warning}</div>
+                    <div>
+                        {_t("This widget may use cookies.")}&nbsp;{encryptionWarning}
+                    </div>
+                    <div>
+                        <AccessibleButton kind="primary_sm" onClick={this.props.onPermissionGranted}>
+                            {_t("Continue")}
+                        </AccessibleButton>
+                    </div>
                 </div>
             </div>
         );

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -139,14 +139,14 @@ export default class AppPermission extends React.Component<IProps, IState> {
 
         return (
             <div className="mx_AppPermission">
-                <div className="mx_AppPermission_bolder mx_AppPermission_smallText">{_t("Widget added by")}</div>
+                <div className="mx_AppPermission_bolder">{_t("Widget added by")}</div>
                 <div>
                     {avatar}
-                    <h4 className="mx_AppPermission_bolder">{displayName}</h4>
-                    <div className="mx_AppPermission_smallText">{userId}</div>
+                    <h4 className="mx_AppPermission_bolder mx_AppPermission_largeText">{displayName}</h4>
+                    <div>{userId}</div>
                 </div>
-                <div className="mx_AppPermission_smallText">{warning}</div>
-                <div className="mx_AppPermission_smallText">
+                <div>{warning}</div>
+                <div>
                     {_t("This widget may use cookies.")}&nbsp;{encryptionWarning}
                 </div>
                 <div>

--- a/src/components/views/elements/AppPermission.tsx
+++ b/src/components/views/elements/AppPermission.tsx
@@ -25,6 +25,7 @@ import WidgetUtils from "../../../utils/WidgetUtils";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import MemberAvatar from "../avatars/MemberAvatar";
 import BaseAvatar from "../avatars/BaseAvatar";
+import Heading from "../typography/Heading";
 import AccessibleButton from "./AccessibleButton";
 import TextWithTooltip from "./TextWithTooltip";
 import { parseUrl } from "../../../utils/UrlUtils";
@@ -143,9 +144,7 @@ export default class AppPermission extends React.Component<IProps, IState> {
                     <div className="mx_AppPermission_content_bolder">{_t("Widget added by")}</div>
                     <div>
                         {avatar}
-                        <h4 className="mx_AppPermission_content_bolder mx_AppPermission_content_largeText">
-                            {displayName}
-                        </h4>
+                        <Heading size="h4">{displayName}</Heading>
                         <div>{userId}</div>
                     </div>
                     <div>{warning}</div>

--- a/test/components/views/elements/AppTile-test.tsx
+++ b/test/components/views/elements/AppTile-test.tsx
@@ -392,7 +392,7 @@ describe("AppTile", () => {
             expect(moveToContainerSpy).toHaveBeenCalledWith(r1, app1, Container.Center);
         });
 
-        it("should render permission request", () => {
+        it("should not display 'Continue' button on permission load", () => {
             jest.spyOn(ModuleRunner.instance, "invoke").mockImplementation((lifecycleEvent, opts, widgetInfo) => {
                 if (lifecycleEvent === WidgetLifecycle.PreLoadRequest && (widgetInfo as WidgetInfo).id === app1.id) {
                     (opts as ApprovalOpts).approved = false;
@@ -412,6 +412,23 @@ describe("AppTile", () => {
             expect(asFragment()).toMatchSnapshot();
 
             expect(renderResult.queryByRole("button", { name: "Continue" })).toBeInTheDocument();
+        });
+
+        it("should display 'Continue' button on permission load", () => {
+            jest.spyOn(ModuleRunner.instance, "invoke").mockImplementation((lifecycleEvent, opts, widgetInfo) => {
+                if (lifecycleEvent === WidgetLifecycle.PreLoadRequest && (widgetInfo as WidgetInfo).id === app1.id) {
+                    (opts as ApprovalOpts).approved = true;
+                }
+            });
+
+            // userId and creatorUserId are different
+            const renderResult = render(
+                <MatrixClientContext.Provider value={cli}>
+                    <AppTile key={app1.id} app={app1} room={r1} userId="@user1" creatorUserId="@userAnother" />
+                </MatrixClientContext.Provider>,
+            );
+
+            expect(renderResult.queryByRole("button", { name: "Continue" })).not.toBeInTheDocument();
         });
 
         describe("for a maximised (centered) widget", () => {
@@ -472,22 +489,5 @@ describe("AppTile", () => {
             expect(container.querySelector(".mx_Spinner")).toBeFalsy();
             expect(asFragment()).toMatchSnapshot();
         });
-    });
-
-    it("for a pinned widget permission load", () => {
-        jest.spyOn(ModuleRunner.instance, "invoke").mockImplementation((lifecycleEvent, opts, widgetInfo) => {
-            if (lifecycleEvent === WidgetLifecycle.PreLoadRequest && (widgetInfo as WidgetInfo).id === app1.id) {
-                (opts as ApprovalOpts).approved = true;
-            }
-        });
-
-        // userId and creatorUserId are different
-        const renderResult = render(
-            <MatrixClientContext.Provider value={cli}>
-                <AppTile key={app1.id} app={app1} room={r1} userId="@user1" creatorUserId="@userAnother" />
-            </MatrixClientContext.Provider>,
-        );
-
-        expect(renderResult.queryByRole("button", { name: "Continue" })).not.toBeInTheDocument();
     });
 });

--- a/test/components/views/elements/AppTile-test.tsx
+++ b/test/components/views/elements/AppTile-test.tsx
@@ -392,7 +392,7 @@ describe("AppTile", () => {
             expect(moveToContainerSpy).toHaveBeenCalledWith(r1, app1, Container.Center);
         });
 
-        it("should not display 'Continue' button on permission load", () => {
+        it("should render permission request", () => {
             jest.spyOn(ModuleRunner.instance, "invoke").mockImplementation((lifecycleEvent, opts, widgetInfo) => {
                 if (lifecycleEvent === WidgetLifecycle.PreLoadRequest && (widgetInfo as WidgetInfo).id === app1.id) {
                     (opts as ApprovalOpts).approved = false;
@@ -414,7 +414,7 @@ describe("AppTile", () => {
             expect(renderResult.queryByRole("button", { name: "Continue" })).toBeInTheDocument();
         });
 
-        it("should display 'Continue' button on permission load", () => {
+        it("should not display 'Continue' button on permission load", () => {
             jest.spyOn(ModuleRunner.instance, "invoke").mockImplementation((lifecycleEvent, opts, widgetInfo) => {
                 if (lifecycleEvent === WidgetLifecycle.PreLoadRequest && (widgetInfo as WidgetInfo).id === app1.id) {
                     (opts as ApprovalOpts).approved = true;

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -88,7 +88,82 @@ exports[`AppTile for a persistent app should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`AppTile for a pinned widget should not display 'Continue' button on permission load 1`] = `
+exports[`AppTile for a pinned widget should render 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_AppTile"
+    id="1"
+  >
+    <div
+      class="mx_AppTileMenuBar"
+    >
+      <span
+        class="mx_AppTileMenuBar_title"
+        style="pointer-events: none;"
+      >
+        <span>
+          <img
+            alt=""
+            class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
+            data-testid="avatar-img"
+            loading="lazy"
+            src="image-file-stub"
+            style="width: 20px; height: 20px;"
+          />
+          <b>
+            Example 1
+          </b>
+          <span />
+        </span>
+      </span>
+      <span
+        class="mx_AppTileMenuBar_widgets"
+      >
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Un-maximise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Minimise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Options"
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Options"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+      </span>
+    </div>
+    <div
+      class="mx_AppTile_persistedWrapper"
+    >
+      <div />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AppTile for a pinned widget should render permission request 1`] = `
 <DocumentFragment>
   <div
     class="mx_AppTile"
@@ -226,81 +301,6 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`AppTile for a pinned widget should render 1`] = `
-<DocumentFragment>
-  <div
-    class="mx_AppTile"
-    id="1"
-  >
-    <div
-      class="mx_AppTileMenuBar"
-    >
-      <span
-        class="mx_AppTileMenuBar_title"
-        style="pointer-events: none;"
-      >
-        <span>
-          <img
-            alt=""
-            class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
-            data-testid="avatar-img"
-            loading="lazy"
-            src="image-file-stub"
-            style="width: 20px; height: 20px;"
-          />
-          <b>
-            Example 1
-          </b>
-          <span />
-        </span>
-      </span>
-      <span
-        class="mx_AppTileMenuBar_widgets"
-      >
-        <div
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Un-maximise"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-        <div
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Minimise"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-        <div
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Options"
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Options"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-      </span>
-    </div>
-    <div
-      class="mx_AppTile_persistedWrapper"
-    >
-      <div />
     </div>
   </div>
 </DocumentFragment>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -161,64 +161,68 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
         class="mx_AppPermission"
       >
         <div
-          class="mx_AppPermission_bolder"
+          class="mx_AppPermission_content"
         >
-          Widget added by
-        </div>
-        <div>
-          <span
-            class="mx_BaseAvatar"
-            role="presentation"
+          <div
+            class="mx_AppPermission_content_bolder"
           >
+            Widget added by
+          </div>
+          <div>
             <span
-              aria-hidden="true"
-              class="mx_BaseAvatar_initial"
-              style="font-size: 24.7px; width: 38px; line-height: 38px;"
-            >
-              U
-            </span>
-            <img
-              alt=""
-              aria-hidden="true"
-              class="mx_BaseAvatar_image"
-              data-testid="avatar-img"
-              loading="lazy"
-              src="data:image/png;base64,00"
-              style="width: 38px; height: 38px;"
-            />
-          </span>
-          <h4
-            class="mx_AppPermission_bolder mx_AppPermission_largeText"
-          >
-            @userAnother
-          </h4>
-          <div />
-        </div>
-        <div>
-          <span>
-            Using this widget may share data 
-            <div
-              aria-describedby="mx_TooltipTarget_abdefghi"
-              class="mx_TextWithTooltip_target"
-              tabindex="0"
+              class="mx_BaseAvatar"
+              role="presentation"
             >
               <span
-                class="mx_AppPermission_helpIcon"
+                aria-hidden="true"
+                class="mx_BaseAvatar_initial"
+                style="font-size: 24.7px; width: 38px; line-height: 38px;"
+              >
+                U
+              </span>
+              <img
+                alt=""
+                aria-hidden="true"
+                class="mx_BaseAvatar_image"
+                data-testid="avatar-img"
+                loading="lazy"
+                src="data:image/png;base64,00"
+                style="width: 38px; height: 38px;"
               />
+            </span>
+            <h4
+              class="mx_AppPermission_content_bolder mx_AppPermission_content_largeText"
+            >
+              @userAnother
+            </h4>
+            <div />
+          </div>
+          <div>
+            <span>
+              Using this widget may share data 
+              <div
+                aria-describedby="mx_TooltipTarget_abdefghi"
+                class="mx_TextWithTooltip_target"
+                tabindex="0"
+              >
+                <span
+                  class="mx_AppPermission_content_helpIcon"
+                />
+              </div>
+               with example.com.
+            </span>
+          </div>
+          <div>
+            This widget may use cookies. 
+          </div>
+          <div>
+            <div
+              class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_sm"
+              role="button"
+              tabindex="0"
+            >
+              Continue
             </div>
-             with example.com.
-          </span>
-        </div>
-        <div>
-          This widget may use cookies. 
-        </div>
-        <div>
-          <div
-            class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_sm"
-            role="button"
-            tabindex="0"
-          >
-            Continue
           </div>
         </div>
       </div>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -161,7 +161,7 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
         class="mx_AppPermission"
       >
         <div
-          class="mx_AppPermission_bolder mx_AppPermission_smallText"
+          class="mx_AppPermission_bolder"
         >
           Widget added by
         </div>
@@ -188,17 +188,13 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
             />
           </span>
           <h4
-            class="mx_AppPermission_bolder"
+            class="mx_AppPermission_bolder mx_AppPermission_largeText"
           >
             @userAnother
           </h4>
-          <div
-            class="mx_AppPermission_smallText"
-          />
+          <div />
         </div>
-        <div
-          class="mx_AppPermission_smallText"
-        >
+        <div>
           <span>
             Using this widget may share data 
             <div
@@ -213,9 +209,7 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
              with example.com.
           </span>
         </div>
-        <div
-          class="mx_AppPermission_smallText"
-        >
+        <div>
           This widget may use cookies. 
         </div>
         <div>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -202,11 +202,11 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
               Using this widget may share data 
               <div
                 aria-describedby="mx_TooltipTarget_abdefghi"
-                class="mx_TextWithTooltip_target"
+                class="mx_TextWithTooltip_target mx_TextWithTooltip_target--helpIcon"
                 tabindex="0"
               >
-                <span
-                  class="mx_AppPermission_content_helpIcon"
+                <div
+                  class="mx_Icon mx_Icon_12"
                 />
               </div>
                with example.com.

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -191,7 +191,7 @@ exports[`AppTile for a pinned widget should not display 'Continue' button on per
               />
             </span>
             <h4
-              class="mx_AppPermission_content_bolder mx_AppPermission_content_largeText"
+              class="mx_Heading_h4"
             >
               @userAnother
             </h4>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -88,82 +88,7 @@ exports[`AppTile for a persistent app should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`AppTile for a pinned widget should render 1`] = `
-<DocumentFragment>
-  <div
-    class="mx_AppTile"
-    id="1"
-  >
-    <div
-      class="mx_AppTileMenuBar"
-    >
-      <span
-        class="mx_AppTileMenuBar_title"
-        style="pointer-events: none;"
-      >
-        <span>
-          <img
-            alt=""
-            class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
-            data-testid="avatar-img"
-            loading="lazy"
-            src="image-file-stub"
-            style="width: 20px; height: 20px;"
-          />
-          <b>
-            Example 1
-          </b>
-          <span />
-        </span>
-      </span>
-      <span
-        class="mx_AppTileMenuBar_widgets"
-      >
-        <div
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Un-maximise"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-        <div
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Minimise"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-        <div
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Options"
-          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
-          role="button"
-          tabindex="0"
-          title="Options"
-        >
-          <div
-            class="mx_Icon mx_Icon_12"
-          />
-        </div>
-      </span>
-    </div>
-    <div
-      class="mx_AppTile_persistedWrapper"
-    >
-      <div />
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`AppTile for a pinned widget should render permission request 1`] = `
+exports[`AppTile for a pinned widget should not display 'Continue' button on permission load 1`] = `
 <DocumentFragment>
   <div
     class="mx_AppTile"
@@ -303,6 +228,81 @@ exports[`AppTile for a pinned widget should render permission request 1`] = `
           </div>
         </div>
       </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AppTile for a pinned widget should render 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_AppTile"
+    id="1"
+  >
+    <div
+      class="mx_AppTileMenuBar"
+    >
+      <span
+        class="mx_AppTileMenuBar_title"
+        style="pointer-events: none;"
+      >
+        <span>
+          <img
+            alt=""
+            class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
+            data-testid="avatar-img"
+            loading="lazy"
+            src="image-file-stub"
+            style="width: 20px; height: 20px;"
+          />
+          <b>
+            Example 1
+          </b>
+          <span />
+        </span>
+      </span>
+      <span
+        class="mx_AppTileMenuBar_widgets"
+      >
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Un-maximise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Minimise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Options"
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Options"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+      </span>
+    </div>
+    <div
+      class="mx_AppTile_persistedWrapper"
+    >
+      <div />
     </div>
   </div>
 </DocumentFragment>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -163,6 +163,151 @@ exports[`AppTile for a pinned widget should render 1`] = `
 </DocumentFragment>
 `;
 
+exports[`AppTile for a pinned widget should render permission request 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_AppTile"
+    id="1"
+  >
+    <div
+      class="mx_AppTileMenuBar"
+    >
+      <span
+        class="mx_AppTileMenuBar_title"
+        style="pointer-events: none;"
+      >
+        <span>
+          <img
+            alt=""
+            class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
+            data-testid="avatar-img"
+            loading="lazy"
+            src="image-file-stub"
+            style="width: 20px; height: 20px;"
+          />
+          <b>
+            Example 1
+          </b>
+          <span />
+        </span>
+      </span>
+      <span
+        class="mx_AppTileMenuBar_widgets"
+      >
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Un-maximise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Minimise"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Options"
+          class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+          role="button"
+          tabindex="0"
+          title="Options"
+        >
+          <div
+            class="mx_Icon mx_Icon_12"
+          />
+        </div>
+      </span>
+    </div>
+    <div
+      class="mx_AppTileBody"
+    >
+      <div
+        class="mx_AppPermission"
+      >
+        <div
+          class="mx_AppPermission_bolder mx_AppPermission_smallText"
+        >
+          Widget added by
+        </div>
+        <div>
+          <span
+            class="mx_BaseAvatar"
+            role="presentation"
+          >
+            <span
+              aria-hidden="true"
+              class="mx_BaseAvatar_initial"
+              style="font-size: 24.7px; width: 38px; line-height: 38px;"
+            >
+              U
+            </span>
+            <img
+              alt=""
+              aria-hidden="true"
+              class="mx_BaseAvatar_image"
+              data-testid="avatar-img"
+              loading="lazy"
+              src="data:image/png;base64,00"
+              style="width: 38px; height: 38px;"
+            />
+          </span>
+          <h4
+            class="mx_AppPermission_bolder"
+          >
+            @userAnother
+          </h4>
+          <div
+            class="mx_AppPermission_smallText"
+          />
+        </div>
+        <div
+          class="mx_AppPermission_smallText"
+        >
+          <span>
+            Using this widget may share data 
+            <div
+              aria-describedby="mx_TooltipTarget_abdefghi"
+              class="mx_TextWithTooltip_target"
+              tabindex="0"
+            >
+              <span
+                class="mx_AppPermission_helpIcon"
+              />
+            </div>
+             with example.com.
+          </span>
+        </div>
+        <div
+          class="mx_AppPermission_smallText"
+        >
+          This widget may use cookies. 
+        </div>
+        <div>
+          <div
+            class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_sm"
+            role="button"
+            tabindex="0"
+          >
+            Continue
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`AppTile preserves non-persisted widget on container move 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25438
Closes https://github.com/vector-im/element-web/issues/25511

This PR intends to update `AppPermission` by fixing a font weight regression introduced by https://github.com/matrix-org/matrix-react-sdk/pull/10939, making the pane scrollable so that `Continue` can be clicked on a small AppsDrawer without resizing it, and applying `Icon` and `Heading` components.

Steps to confirm the fix:

1. Create a room
2. Create another user
2. Invite and accept the user
3. log in with the user
4. Add a widget
5. Re-login with the original user
6. Open the widget to display the permission pane
7. Make the pane small
8. Scroll the pane


|Before|After|
|---------|------|
|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/79ba5ffa-debc-4712-9639-667996a76a27)|![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/cd97de47-8228-4e28-8e90-fc1b744b059a)|
|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/00528d07-293d-4e33-a0a7-e7e952ad72b6)<br>The pane cannot be scrolled| <video src="https://github.com/matrix-org/matrix-react-sdk/assets/3362943/05f0000b-f879-4790-8219-aaf410ecf6f4"> |

Type: enhancement
Notes: Make AppPermission pane scrollable

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make AppPermission pane scrollable ([\#10954](https://github.com/matrix-org/matrix-react-sdk/pull/10954)). Fixes vector-im/element-web#25438 and vector-im/element-web#25511. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->