### PR TITLE
Cypress: workaround for EventTile being remounted

### DIFF
--- a/cypress/e2e/audio-player/audio-player.spec.ts
+++ b/cypress/e2e/audio-player/audio-player.spec.ts
@@ -333,30 +333,33 @@ describe("Audio player", () => {
 
         // On a thread
         cy.get(".mx_ThreadView").within(() => {
-            cy.get(".mx_EventTile_last")
-                .within(() => {
-                    // Assert that the player is correctly rendered on a thread
-                    cy.get(".mx_EventTile_mediaLine .mx_MAudioBody .mx_AudioPlayer_container").within(() => {
-                        // Assert that the counter is zero before clicking the play button
-                        cy.contains(".mx_AudioPlayer_seek [role='timer']", "00:00").should("exist");
+            cy.get(".mx_EventTile_last").within(() => {
+                // Assert that the player is correctly rendered on a thread
+                cy.get(".mx_EventTile_mediaLine .mx_MAudioBody .mx_AudioPlayer_container").within(() => {
+                    // Assert that the counter is zero before clicking the play button
+                    cy.contains(".mx_AudioPlayer_seek [role='timer']", "00:00").should("exist");
 
-                        // Find and click "Play" button, the wait is to make the test less flaky
-                        cy.findByRole("button", { name: "Play" }).should("exist");
-                        cy.wait(500).findByRole("button", { name: "Play" }).click();
+                    // Find and click "Play" button, the wait is to make the test less flaky
+                    cy.findByRole("button", { name: "Play" }).should("exist");
+                    cy.wait(500).findByRole("button", { name: "Play" }).click();
 
-                        // Assert that "Pause" button can be found
-                        cy.findByRole("button", { name: "Pause" }).should("exist");
+                    // Assert that "Pause" button can be found
+                    cy.findByRole("button", { name: "Pause" }).should("exist");
 
-                        // Assert that the timer is reset when the audio file finished playing
-                        cy.contains(".mx_AudioPlayer_seek [role='timer']", "00:00").should("exist");
+                    // Assert that the timer is reset when the audio file finished playing
+                    cy.contains(".mx_AudioPlayer_seek [role='timer']", "00:00").should("exist");
 
-                        // Assert that "Play" button can be found
-                        cy.findByRole("button", { name: "Play" }).should("exist").should("not.have.attr", "disabled");
-                    });
-                })
-                .realHover()
-                .findByRole("button", { name: "Reply" })
-                .click(); // Find and click "Reply" button
+                    // Assert that "Play" button can be found
+                    cy.findByRole("button", { name: "Play" }).should("exist").should("not.have.attr", "disabled");
+                });
+            });
+
+            // Find and click "Reply" button
+            //
+            // Calling cy.get(".mx_EventTile_last") again here is a workaround for
+            // https://github.com/matrix-org/matrix-js-sdk/issues/3394: the event tile may have been re-mounted while
+            // the audio was playing.
+            cy.get(".mx_EventTile_last").realHover().findByRole("button", { name: "Reply" }).click();
 
             cy.get(".mx_MessageComposer--compact").within(() => {
                 // Assert that the reply preview is rendered on the message composer


### PR DESCRIPTION
(Hopefully) fixes https://github.com/vector-im/element-web/issues/25417

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->