### PR TITLE
Settings panels: avoid exceptions with rust crypto

### DIFF
--- a/src/components/views/settings/CrossSigningPanel.tsx
+++ b/src/components/views/settings/CrossSigningPanel.tsx
@@ -90,9 +90,12 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
 
     private async getUpdatedStatus(): Promise<void> {
         const cli = MatrixClientPeg.get();
+        const crypto = cli.crypto;
+        if (!crypto) return;
+
         const pkCache = cli.getCrossSigningCacheCallbacks();
-        const crossSigning = cli.crypto!.crossSigningInfo;
-        const secretStorage = cli.crypto!.secretStorage;
+        const crossSigning = crypto.crossSigningInfo;
+        const secretStorage = cli.secretStorage;
         const crossSigningPublicKeysOnDevice = Boolean(crossSigning.getId());
         const crossSigningPrivateKeysInStorage = Boolean(await crossSigning.isStoredInSecretStorage(secretStorage));
         const masterPrivateKeyCached = !!(await pkCache?.getCrossSigningKeyCache?.("master"));

--- a/src/components/views/settings/SecureBackupPanel.tsx
+++ b/src/components/views/settings/SecureBackupPanel.tsx
@@ -146,14 +146,17 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
 
     private async getUpdatedDiagnostics(): Promise<void> {
         const cli = MatrixClientPeg.get();
-        const secretStorage = cli.crypto!.secretStorage;
+        const crypto = cli.crypto;
+        if (!crypto) return;
+
+        const secretStorage = cli.secretStorage;
 
         const backupKeyStored = !!(await cli.isKeyBackupKeyStored());
-        const backupKeyFromCache = await cli.crypto!.getSessionBackupPrivateKey();
+        const backupKeyFromCache = await crypto.getSessionBackupPrivateKey();
         const backupKeyCached = !!backupKeyFromCache;
         const backupKeyWellFormed = backupKeyFromCache instanceof Uint8Array;
         const secretStorageKeyInAccount = await secretStorage.hasKey();
-        const secretStorageReady = await cli.isSecretStorageReady();
+        const secretStorageReady = await crypto.isSecretStorageReady();
 
         if (this.unmounted) return;
         this.setState({


### PR DESCRIPTION
If we are using rust crypto, `client.crypto` is undefined. We'll need to fix these up better in future (https://github.com/vector-im/element-web/issues/24828 and https://github.com/vector-im/element-web/issues/25318), but for now, just return early to suppress the uncaught exception which is making my cypress tests sad.