### PR TITLE
Cypress: fix dodgy use of string as event name

### DIFF
--- a/cypress/e2e/crypto/utils.ts
+++ b/cypress/e2e/crypto/utils.ts
@@ -49,12 +49,15 @@ export function waitForVerificationRequest(cli: MatrixClient): Promise<Verificat
 export function handleVerificationRequest(request: VerificationRequest): Promise<EmojiMapping[]> {
     return new Promise<EmojiMapping[]>((resolve) => {
         const onShowSas = (event: ISasEvent) => {
+            // @ts-ignore VerifierEvent is a pain to get at here as we don't have a reference to matrixcs;
+            // using the string value here
             verifier.off("show_sas", onShowSas);
             event.confirm();
             resolve(event.sas.emoji);
         };
 
         const verifier = request.beginKeyVerification("m.sas.v1");
+        // @ts-ignore as above, avoiding reference to VerifierEvent
         verifier.on("show_sas", onShowSas);
         verifier.verify();
     });


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3386 tightened up the type safety of `VerificationBase<any,any>` as returned by `VerificationRequest.beginKeyVerification`: previously it was a `TypedEventEmitter<any,any>`, whereas it is now a `TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap>`.

This means that typescript now complains about our use of a stringy event name rather than the correct enum value in `verifier.{on,off}` in this Cypress test.

We have this problem elsewhere, and solve it by liberal use of `@ts-ignore`, so I have done the same here.