### PR TITLE
Fix placement of `Loading…` with the spinner on pinned widgets being reloaded

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -266,6 +266,19 @@ limitations under the License.
         width: 100%;
         height: 100%;
     }
+
+    /* const loadingElement */
+    .mx_AppTileBody_fadeInSpinner {
+        /* place spinner and the message at the center of mx_AppTileBody */
+        height: 100%;
+        width: 100%;
+
+        font-weight: bold; /* message next to the spinner */
+        animation-fill-mode: backwards;
+        animation-duration: 200ms;
+        animation-delay: 500ms;
+        animation-name: mx_AppTileBody_fadeInSpinnerAnimation;
+    }
 }
 
 .mx_AppTileBody {
@@ -324,22 +337,9 @@ limitations under the License.
     iframe {
         display: none;
     }
-
-    /* const loadingElement */
-    .mx_AppTile_loading_fadeInSpinner {
-        animation-fill-mode: backwards;
-        animation-duration: 200ms;
-        animation-delay: 500ms;
-        animation-name: mx_AppTile_loading_fadeInSpinnerAnimation;
-
-        .mx_Spinner {
-            position: absolute;
-            inset: 0;
-        }
-    }
 }
 
-@keyframes mx_AppTile_loading_fadeInSpinnerAnimation {
+@keyframes mx_AppTileBody_fadeInSpinnerAnimation {
     from {
         opacity: 0;
     }

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -606,7 +606,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         }
 
         const loadingElement = (
-            <div className="mx_AppTile_loading_fadeInSpinner">
+            <div className="mx_AppTileBody_fadeInSpinner">
                 <Spinner message={_t("Loading…")} />
             </div>
         );

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -46,7 +46,7 @@ exports[`AppTile destroys non-persisted right panel widget on room change 1`] = 
           class="mx_AppTileBody mx_AppTile_loading"
         >
           <div
-            class="mx_AppTile_loading_fadeInSpinner"
+            class="mx_AppTileBody_fadeInSpinner"
           >
             <div
               class="mx_Spinner"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25431

The PR intends to fix a regression by [one of my PRs](https://github.com/matrix-org/matrix-react-sdk/pull/10783) that the style rules are not applied to `Loading…` message and the spinner, which is displayed when you switch places of pinned widgets from left to right or vice versa. Please note that the loader with the message is rendered properly on other cases.

It turned out that `mx_AppTileBody_fadeInSpinner` was defined by AppTileBody, not `mx_AppTile_loading`.

| |app.element.io|After|
|-|---------|------|
|Loading spinners on pinned widgets being switched|![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/7d7969c0-49ee-4d21-9cca-1fd6a5b1ae30)|![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/3170c816-9171-4e6a-b054-0283765e796a)|
|Videos|<video src="https://github.com/matrix-org/matrix-react-sdk/assets/3362943/81567f09-b19a-4000-9567-c180d4b8afbe">|<video src="https://github.com/matrix-org/matrix-react-sdk/assets/3362943/e9293b3f-e4c4-422e-844e-7ced0fcaf782">|
|DOM trees|![0_2](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/66d88325-c384-4c4e-8d41-3fa9820a46a3)|![1_2](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/419782b7-3651-4246-b25d-6d30d278ab0c)|

type: defect

Notes: Fix spinner placement on pinned widgets being reloaded

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix spinner placement on pinned widgets being reloaded ([\#10970](https://github.com/matrix-org/matrix-react-sdk/pull/10970)). Fixes vector-im/element-web#25431. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->