### PR TITLE
Fix display of devices without encryption support in Settings dialog

### DIFF
--- a/src/components/views/settings/devices/types.ts
+++ b/src/components/views/settings/devices/types.ts
@@ -18,7 +18,13 @@ import { IMyDevice } from "matrix-js-sdk/src/matrix";
 
 import { ExtendedDeviceInformation } from "../../../../utils/device/parseUserAgent";
 
-export type DeviceWithVerification = IMyDevice & { isVerified: boolean | null };
+export type DeviceWithVerification = IMyDevice & {
+    /**
+     * `null` if the device is unknown or has not published encryption keys; otherwise a boolean
+     * indicating whether the device has been cross-signed by a cross-signing key we trust.
+     */
+    isVerified: boolean | null;
+};
 export type ExtendedDeviceAppInfo = {
     // eg Element Web
     appName?: string;

--- a/src/utils/device/isDeviceVerified.ts
+++ b/src/utils/device/isDeviceVerified.ts
@@ -22,13 +22,17 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
  * @param client - reference to the MatrixClient
  * @param deviceId - ID of the device to be checked
  *
- * @returns `true` if the device has been correctly cross-signed. `false` if the device is unknown or not correctly
- *    cross-signed. `null` if there was an error fetching the device info.
+ * @returns `null` if the device is unknown or has not published encryption keys; otherwise a boolean
+ *    indicating whether the device has been cross-signed by a cross-signing key we trust.
  */
 export const isDeviceVerified = async (client: MatrixClient, deviceId: string): Promise<boolean | null> => {
     try {
         const trustLevel = await client.getCrypto()?.getDeviceVerificationStatus(client.getSafeUserId(), deviceId);
-        return trustLevel?.crossSigningVerified ?? false;
+        if (!trustLevel) {
+            // either no crypto, or an unknown/no-e2e device
+            return null;
+        }
+        return trustLevel.crossSigningVerified;
     } catch (e) {
         console.error("Error getting device cross-signing info", e);
         return null;

--- a/src/utils/device/isDeviceVerified.ts
+++ b/src/utils/device/isDeviceVerified.ts
@@ -26,15 +26,10 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
  *    indicating whether the device has been cross-signed by a cross-signing key we trust.
  */
 export const isDeviceVerified = async (client: MatrixClient, deviceId: string): Promise<boolean | null> => {
-    try {
-        const trustLevel = await client.getCrypto()?.getDeviceVerificationStatus(client.getSafeUserId(), deviceId);
-        if (!trustLevel) {
-            // either no crypto, or an unknown/no-e2e device
-            return null;
-        }
-        return trustLevel.crossSigningVerified;
-    } catch (e) {
-        console.error("Error getting device cross-signing info", e);
+    const trustLevel = await client.getCrypto()?.getDeviceVerificationStatus(client.getSafeUserId(), deviceId);
+    if (!trustLevel) {
+        // either no crypto, or an unknown/no-e2e device
         return null;
     }
+    return trustLevel.crossSigningVerified;
 };

--- a/test/components/views/settings/__snapshots__/DevicesPanel-test.tsx.snap
+++ b/test/components/views/settings/__snapshots__/DevicesPanel-test.tsx.snap
@@ -104,7 +104,7 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
         class="mx_DevicesPanel_deviceTrust"
       >
         <span
-          class="mx_DevicesPanel_icon mx_E2EIcon mx_E2EIcon_warning"
+          class="mx_DevicesPanel_icon mx_E2EIcon mx_E2EIcon_verified"
         />
       </div>
       <div
@@ -124,8 +124,8 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
             />
           </div>
           <div
-            aria-label="Unverified"
-            class="mx_DeviceTypeIcon_verificationIcon unverified"
+            aria-label="Verified"
+            class="mx_DeviceTypeIcon_verificationIcon verified"
             role="img"
           />
         </div>
@@ -143,7 +143,7 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
             <span
               data-testid="device-metadata-isVerified"
             >
-              Unverified
+              Verified
             </span>
              · 
             <span
@@ -164,13 +164,6 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
             Sign Out
           </div>
           <div
-            class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
-            role="button"
-            tabindex="0"
-          >
-            Verify
-          </div>
-          <div
             class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_outline"
             role="button"
             tabindex="0"
@@ -188,24 +181,13 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
         class="mx_DevicesPanel_header_trust"
       >
         <span
-          class="mx_DevicesPanel_header_icon mx_E2EIcon mx_E2EIcon_warning"
+          class="mx_DevicesPanel_header_icon mx_E2EIcon mx_E2EIcon_verified"
         />
       </div>
       <div
         class="mx_DevicesPanel_header_title"
       >
-        Unverified devices
-      </div>
-      <div
-        class="mx_DevicesPanel_header_button"
-      >
-        <div
-          class="mx_AccessibleButton mx_DevicesPanel_selectButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_secondary"
-          role="button"
-          tabindex="0"
-        >
-          Select all
-        </div>
+        Verified devices
       </div>
     </div>
     <div
@@ -250,8 +232,8 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
                     />
                   </div>
                   <div
-                    aria-label="Unverified"
-                    class="mx_DeviceTypeIcon_verificationIcon unverified"
+                    aria-label="Verified"
+                    class="mx_DeviceTypeIcon_verificationIcon verified"
                     role="img"
                   />
                 </div>
@@ -269,7 +251,7 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
                     <span
                       data-testid="device-metadata-isVerified"
                     >
-                      Unverified
+                      Verified
                     </span>
                      · 
                     <span
@@ -294,6 +276,23 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
             </div>
           </label>
         </span>
+      </div>
+    </div>
+    <hr />
+    <div
+      class="mx_DevicesPanel_header"
+    >
+      <div
+        class="mx_DevicesPanel_header_trust"
+      >
+        <span
+          class="mx_DevicesPanel_header_icon mx_E2EIcon mx_E2EIcon_warning"
+        />
+      </div>
+      <div
+        class="mx_DevicesPanel_header_title"
+      >
+        Unverified devices
       </div>
     </div>
     <div
@@ -364,6 +363,114 @@ exports[`<DevicesPanel /> renders device panel with devices 1`] = `
                       data-testid="device-metadata-deviceId"
                     >
                       device_3
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="mx_DeviceTile_actions"
+                >
+                  <div
+                    class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                    role="button"
+                    tabindex="0"
+                  >
+                    Verify
+                  </div>
+                  <div
+                    class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_outline"
+                    role="button"
+                    tabindex="0"
+                  >
+                    Rename
+                  </div>
+                </div>
+              </div>
+            </div>
+          </label>
+        </span>
+      </div>
+    </div>
+    <hr />
+    <div
+      class="mx_DevicesPanel_header"
+    >
+      <div
+        class="mx_DevicesPanel_header_trust"
+      />
+      <div
+        class="mx_DevicesPanel_header_title"
+      >
+        Devices without encryption support
+      </div>
+    </div>
+    <div
+      class="mx_DevicesPanel_device"
+    >
+      <div
+        class="mx_SelectableDeviceTile"
+      >
+        <span
+          class="mx_Checkbox mx_SelectableDeviceTile_checkbox mx_Checkbox_hasKind mx_Checkbox_kind_solid"
+        >
+          <input
+            data-testid="device-tile-checkbox-non_crypto"
+            id="device-tile-checkbox-non_crypto"
+            type="checkbox"
+          />
+          <label
+            for="device-tile-checkbox-non_crypto"
+          >
+            <div
+              class="mx_Checkbox_background"
+            >
+              <div
+                class="mx_Checkbox_checkmark"
+              />
+            </div>
+            <div>
+              <div
+                class="mx_DeviceTile"
+                data-testid="device-tile-non_crypto"
+              >
+                <div
+                  class="mx_DeviceTypeIcon"
+                >
+                  <div
+                    class="mx_DeviceTypeIcon_deviceIconWrapper"
+                  >
+                    <div
+                      aria-label="Unknown session type"
+                      class="mx_DeviceTypeIcon_deviceIcon"
+                      role="img"
+                    />
+                  </div>
+                  <div
+                    aria-label="Unverified"
+                    class="mx_DeviceTypeIcon_verificationIcon unverified"
+                    role="img"
+                  />
+                </div>
+                <div
+                  class="mx_DeviceTile_info"
+                >
+                  <h4
+                    class="mx_Heading_h4"
+                  >
+                    non_crypto
+                  </h4>
+                  <div
+                    class="mx_DeviceTile_metadata"
+                  >
+                    <span
+                      data-testid="device-metadata-isVerified"
+                    >
+                      Unverified
+                    </span>
+                     · 
+                    <span
+                      data-testid="device-metadata-deviceId"
+                    >
+                      non_crypto
                     </span>
                   </div>
                 </div>

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -263,7 +263,7 @@ describe("<SessionManagerTab />", () => {
                 return new DeviceVerificationStatus({});
             }
             // alicesOlderMobileDevice does not support encryption
-            throw new Error("encryption not supported");
+            return null;
         });
 
         const { getByTestId } = render(getComponent());
@@ -562,8 +562,7 @@ describe("<SessionManagerTab />", () => {
                     return new DeviceVerificationStatus({ crossSigningVerified: true, localVerified: true });
                 }
                 // but alicesMobileDevice doesn't support encryption
-                // XXX this is not what happens if a device doesn't support encryption.
-                throw new Error("encryption not supported");
+                return null;
             });
 
             const { getByTestId, queryByTestId } = render(getComponent());

--- a/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -227,27 +227,6 @@ describe("<SessionManagerTab />", () => {
         expect(container.getElementsByClassName("mx_Spinner").length).toBeFalsy();
     });
 
-    it("does not fail when checking device verification fails", async () => {
-        const logSpy = jest.spyOn(console, "error").mockImplementation((e) => {});
-        mockClient.getDevices.mockResolvedValue({
-            devices: [alicesDevice, alicesMobileDevice],
-        });
-        const failError = new Error("non-specific failure");
-        mockCrypto.getDeviceVerificationStatus.mockImplementation(() => {
-            throw failError;
-        });
-        render(getComponent());
-
-        await act(async () => {
-            await flushPromises();
-        });
-
-        // called for each device despite error
-        expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalledWith(aliceId, alicesDevice.device_id);
-        expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalledWith(aliceId, alicesMobileDevice.device_id);
-        expect(logSpy).toHaveBeenCalledWith("Error getting device cross-signing info", failError);
-    });
-
     it("sets device verification status correctly", async () => {
         mockClient.getDevices.mockResolvedValue({
             devices: [alicesDevice, alicesMobileDevice, alicesOlderMobileDevice],


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25413

Per the comments in the issue, the problem was that we had switched to an `isDeviceVerified` implementation which didn't distinguish between unverified devices, and those which didn't support E2E.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix display of devices without encryption support in Settings dialog ([\#10977](https://github.com/matrix-org/matrix-react-sdk/pull/10977)). Fixes vector-im/element-web#25413.<!-- CHANGELOG_PREVIEW_END -->