### PR TITLE
Use `Icon` component - `TrashcanIcon` and `RetryIcon` on `RoomStatusBar`

### DIFF
--- a/res/css/structures/_RoomStatusBar.pcss
+++ b/res/css/structures/_RoomStatusBar.pcss
@@ -105,46 +105,33 @@ limitations under the License.
     }
 
     .mx_RoomStatusBar_unsentButtonBar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
         flex-grow: 1;
-        text-align: right;
         margin-right: 22px;
         color: $muted-fg-color;
 
         .mx_AccessibleButton {
+            display: flex;
+            align-items: center; /* align the icon with its label */
+            column-gap: 2px;
+            width: fit-content;
             padding: 5px 10px;
-            padding-left: 30px; /* 18px for the icon, 2px margin to text, 10px regular padding */
-            display: inline-block;
-            position: relative;
             user-select: none;
+
+            .mx_Icon {
+                flex: 0 0 18px;
+                height: 18px;
+                width: 18px;
+            }
 
             &:nth-child(2) {
                 border-left: 1px solid $resend-button-divider-color;
             }
 
-            &::before {
-                content: "";
-                position: absolute;
-                left: 10px; /* inset for regular button padding */
-                background-color: $muted-fg-color;
-                mask-repeat: no-repeat;
-                mask-position: center;
-                mask-size: contain;
-                width: 18px;
-                height: 18px;
-                top: 50%; /* text sizes are dynamic */
-                transform: translateY(-50%);
-            }
-
-            &.mx_RoomStatusBar_unsentCancelAllBtn::before {
-                mask-image: url("$(res)/img/element-icons/trashcan.svg");
-            }
-
             &.mx_RoomStatusBar_unsentRetry {
-                padding-left: 34px; /* 28px from above, but +6px to account for the wider icon */
-
-                &::before {
-                    mask-image: url("$(res)/img/element-icons/retry.svg");
-                }
+                column-gap: 6px; /* +4px (6px - 2px) to account for the wider icon */
             }
         }
 

--- a/src/components/structures/RoomStatusBar.tsx
+++ b/src/components/structures/RoomStatusBar.tsx
@@ -32,6 +32,8 @@ import InlineSpinner from "../views/elements/InlineSpinner";
 import MatrixClientContext from "../../contexts/MatrixClientContext";
 import { RoomStatusBarUnsentMessages } from "./RoomStatusBarUnsentMessages";
 import ExternalLink from "../views/elements/ExternalLink";
+import { Icon as TrashcanIcon } from "../../../res/img/element-icons/trashcan.svg";
+import { Icon as RetryIcon } from "../../../res/img/element-icons/retry.svg";
 
 const STATUS_BAR_HIDDEN = 0;
 const STATUS_BAR_EXPANDED = 1;
@@ -246,10 +248,12 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
 
         let buttonRow = (
             <>
-                <AccessibleButton onClick={this.onCancelAllClick} className="mx_RoomStatusBar_unsentCancelAllBtn">
+                <AccessibleButton onClick={this.onCancelAllClick}>
+                    <TrashcanIcon className="mx_Icon" />
                     {_t("Delete all")}
                 </AccessibleButton>
                 <AccessibleButton onClick={this.onResendAllClick} className="mx_RoomStatusBar_unsentRetry">
+                    <RetryIcon className="mx_Icon" />
                     {_t("Retry all")}
                 </AccessibleButton>
             </>

--- a/test/components/structures/__snapshots__/RoomStatusBar-test.tsx.snap
+++ b/test/components/structures/__snapshots__/RoomStatusBar-test.tsx.snap
@@ -50,10 +50,13 @@ exports[`RoomStatusBar <RoomStatusBar /> unsent messages should render warning w
         class="mx_RoomStatusBar_unsentButtonBar"
       >
         <div
-          class="mx_AccessibleButton mx_RoomStatusBar_unsentCancelAllBtn"
+          class="mx_AccessibleButton"
           role="button"
           tabindex="0"
         >
+          <div
+            class="mx_Icon"
+          />
           Delete all
         </div>
         <div
@@ -61,6 +64,9 @@ exports[`RoomStatusBar <RoomStatusBar /> unsent messages should render warning w
           role="button"
           tabindex="0"
         >
+          <div
+            class="mx_Icon"
+          />
           Retry all
         </div>
       </div>
@@ -106,10 +112,13 @@ exports[`RoomStatusBar <RoomStatusBar /> unsent messages should render warning w
         class="mx_RoomStatusBar_unsentButtonBar"
       >
         <div
-          class="mx_AccessibleButton mx_RoomStatusBar_unsentCancelAllBtn"
+          class="mx_AccessibleButton"
           role="button"
           tabindex="0"
         >
+          <div
+            class="mx_Icon"
+          />
           Delete all
         </div>
         <div
@@ -117,6 +126,9 @@ exports[`RoomStatusBar <RoomStatusBar /> unsent messages should render warning w
           role="button"
           tabindex="0"
         >
+          <div
+            class="mx_Icon"
+          />
           Retry all
         </div>
       </div>


### PR DESCRIPTION

Before:

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/0d8eecbc-8d70-4dbf-8de5-ed04395e7c66)
![0_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/f9d10312-1fca-4559-942c-6801f0040c4c)

After:

![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/8f086dc6-4420-4a1e-833b-e1892ce43d5d)
![1_1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/5ea9f465-a459-409b-a0ce-387694bd2288)

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->