### PR TITLE
Fix PR lookup for `fetchdep.sh`

### DIFF
--- a/.github/workflows/element-web.yaml
+++ b/.github/workflows/element-web.yaml
@@ -15,10 +15,11 @@ on:
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
+
 env:
-    # These must be set for fetchdep.sh to get the right branch
-    REPOSITORY: ${{ github.repository }}
+    # fetchdep.sh needs to know our PR number
     PR_NUMBER: ${{ github.event.pull_request.number }}
+
 jobs:
     build:
         name: "Build Element-Web"

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -10,10 +10,11 @@ on:
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
+
 env:
-    # These must be set for fetchdep.sh to get the right branch
-    REPOSITORY: ${{ github.repository }}
+    # fetchdep.sh needs to know our PR number
     PR_NUMBER: ${{ github.event.pull_request.number }}
+
 jobs:
     ts_lint:
         name: "Typescript Syntax Check"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,12 @@ on:
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
+
 env:
     ENABLE_COVERAGE: ${{ github.event_name != 'merge_group' && inputs.disable_coverage != 'true' }}
-    # These must be set for fetchdep.sh to get the right branch
-    REPOSITORY: ${{ github.repository }}
+    # fetchdep.sh needs to know our PR number
     PR_NUMBER: ${{ github.event.pull_request.number }}
+
 jobs:
     jest:
         name: Jest

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -10,8 +10,15 @@ defbranch="$3"
 
 rm -r "$defrepo" || true
 
-PR_ORG=${PR_ORG:-"matrix-org"}
-PR_REPO=${PR_REPO:-"matrix-react-sdk"}
+# figure out where to look for pull requests:
+#   - We may have been told an explicit repo via the PR_ORG/PR_REPO/PR_NUMBER env vars
+#   - otherwise, check the $GITHUB_ env vars which are set by Github Actions
+#   - failing that, fall back to the matrix-org/matrix-react-sdk repo.
+#
+# in ether case, the PR_NUMBER variable must be set explicitly.
+default_org_repo=${GITHUB_REPOSITORY:-"matrix-org/matrix-react-sdk"}
+PR_ORG=${PR_ORG:-${default_org_repo%%/*}}
+PR_REPO=${PR_REPO:-${default_org_repo##*/}}
 
 # A function that clones a branch of a repo based on the org, repo and branch
 clone() {


### PR DESCRIPTION
Context: `fetchdep.sh` attempts to check out a github repository based on the details in a pull request. To do this, it needs to know how to find the pull request. So, the github workflows attempt to set environment variables to tell it. Unfortunately, they currently disagree about what the names of the environment variables should be.

So, when the workflows are called from workflows in other repositories, we end up looking at the wrong PR for information. 99% of the time that will be fine, but it's just possible we'll end up checking out a branch we didn't expect.

This appears to have been introduced by #8498.

To simplify matters, we may as well have the script use `${GITHUB_REPOSITORY}` directly, and remove the unused `REPOSITORY` env var from the workflows.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->