### PR TITLE
Remove references to `VerificationBase`

### DIFF
--- a/src/components/views/dialogs/IncomingSasDialog.tsx
+++ b/src/components/views/dialogs/IncomingSasDialog.tsx
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 import React, { ReactNode } from "react";
-import { VerificationBase } from "matrix-js-sdk/src/crypto/verification/Base";
-import { GeneratedSas, ShowSasCallbacks, VerifierEvent } from "matrix-js-sdk/src/crypto-api/verification";
+import { GeneratedSas, ShowSasCallbacks, Verifier, VerifierEvent } from "matrix-js-sdk/src/crypto-api/verification";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -37,7 +36,7 @@ const PHASE_VERIFIED = 3;
 const PHASE_CANCELLED = 4;
 
 interface IProps {
-    verifier: VerificationBase<VerifierEvent, any>;
+    verifier: Verifier;
     onFinished(verified?: boolean): void;
 }
 

--- a/test/components/views/dialogs/IncomingSasDialog-test.tsx
+++ b/test/components/views/dialogs/IncomingSasDialog-test.tsx
@@ -17,10 +17,10 @@ limitations under the License.
 import { act, render } from "@testing-library/react";
 import React from "react";
 import { Mocked } from "jest-mock";
-import { VerificationBase } from "matrix-js-sdk/src/crypto/verification/Base";
 import {
     EmojiMapping,
     ShowSasCallbacks,
+    Verifier,
     VerifierEvent,
     VerifierEventHandlerMap,
 } from "matrix-js-sdk/src/crypto-api/verification";
@@ -58,16 +58,16 @@ describe("IncomingSasDialog", () => {
     });
 });
 
-function renderComponent(verifier: VerificationBase, onFinished = () => true) {
+function renderComponent(verifier: Verifier, onFinished = () => true) {
     return render(<IncomingSasDialog verifier={verifier} onFinished={onFinished} />);
 }
 
-function makeMockVerifier(): Mocked<VerificationBase> {
+function makeMockVerifier(): Mocked<Verifier> {
     const verifier = new TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap>();
     Object.assign(verifier, {
         cancel: jest.fn(),
     });
-    return verifier as unknown as Mocked<VerificationBase>;
+    return verifier as unknown as Mocked<Verifier>;
 }
 
 function makeMockSasCallbacks(): ShowSasCallbacks {

--- a/test/components/views/right_panel/VerificationPanel-test.tsx
+++ b/test/components/views/right_panel/VerificationPanel-test.tsx
@@ -24,10 +24,10 @@ import {
 import { TypedEventEmitter } from "matrix-js-sdk/src/models/typed-event-emitter";
 import { User } from "matrix-js-sdk/src/models/user";
 import { Mocked } from "jest-mock";
-import { VerificationBase } from "matrix-js-sdk/src/crypto/verification/Base";
 import {
     EmojiMapping,
     ShowSasCallbacks,
+    Verifier,
     VerifierEvent,
     VerifierEventHandlerMap,
 } from "matrix-js-sdk/src/crypto-api/verification";
@@ -94,13 +94,13 @@ describe("<VerificationPanel />", () => {
     });
 
     describe("'Verify by emoji' flow", () => {
-        let mockVerifier: Mocked<VerificationBase>;
+        let mockVerifier: Mocked<Verifier>;
         let mockRequest: Mocked<VerificationRequest>;
 
         beforeEach(() => {
             mockVerifier = makeMockVerifier();
             mockRequest = makeMockVerificationRequest({
-                verifier: mockVerifier,
+                verifier: mockVerifier as unknown as VerificationRequest["verifier"],
                 chosenMethod: "m.sas.v1",
             });
         });
@@ -158,7 +158,7 @@ function makeMockVerificationRequest(props: Partial<VerificationRequest> = {}): 
     return request as unknown as Mocked<VerificationRequest>;
 }
 
-function makeMockVerifier(): Mocked<VerificationBase> {
+function makeMockVerifier(): Mocked<Verifier> {
     const verifier = new TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap>();
     Object.assign(verifier, {
         cancel: jest.fn(),
@@ -166,7 +166,7 @@ function makeMockVerifier(): Mocked<VerificationBase> {
         getShowSasCallbacks: jest.fn(),
         getReciprocateQrCodeCallbacks: jest.fn(),
     });
-    return verifier as unknown as Mocked<VerificationBase>;
+    return verifier as unknown as Mocked<Verifier>;
 }
 
 function makeMockSasCallbacks(): ShowSasCallbacks {


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3414 deprecates this class and adds a new interface we can use instead.

Fixes https://github.com/vector-im/crypto-internal/issues/95

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->