### PR TITLE
Fix call to `startSingleSignOn` passing enum in place of idpId

### DIFF
--- a/src/components/structures/auth/Login.tsx
+++ b/src/components/structures/auth/Login.tsx
@@ -313,6 +313,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState> 
                 this.loginLogic.createTemporaryClient(),
                 ssoKind,
                 this.props.fragmentAfterLogin,
+                undefined,
                 SSOAction.REGISTER,
             );
         } else {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24953

Tests for this are non-trivial and more important is TS improvements to catch this at the type level: https://github.com/matrix-org/matrix-js-sdk/pull/3415