### PR TITLE
Fix layout regression in session dropdown

### DIFF
--- a/res/css/views/elements/_Dropdown.pcss
+++ b/res/css/views/elements/_Dropdown.pcss
@@ -121,6 +121,12 @@ input.mx_Dropdown_option:focus {
     min-height: 35px;
 }
 
+.mx_Dropdown_menu li.mx_Dropdown_option {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
 .mx_Dropdown_menu .mx_Dropdown_option_highlight {
     background-color: $focus-bg-color;
 }

--- a/res/css/views/elements/_Dropdown.pcss
+++ b/res/css/views/elements/_Dropdown.pcss
@@ -58,8 +58,8 @@ limitations under the License.
 .mx_Dropdown_option {
     height: 35px;
     line-height: $font-35px;
-    padding-left: 8px;
-    padding-right: 8px;
+    // Overwrites the default padding for any li elements
+    padding: 0 8px;
 }
 
 .mx_Dropdown_input > .mx_Dropdown_option {
@@ -121,9 +121,7 @@ input.mx_Dropdown_option:focus {
     min-height: 35px;
 }
 
-.mx_Dropdown_menu li.mx_Dropdown_option {
-    margin: 0;
-    padding: 0;
+ul.mx_Dropdown_menu li.mx_Dropdown_option {
     list-style: none;
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25448

Seemingly all other consumers of Dropdown weren't affected due to their own styling/specificities.

<img width="316" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/2403652/8600c5f4-8d04-46a9-8aa2-b98647ce3473">


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix layout regression in session dropdown ([\#10999](https://github.com/matrix-org/matrix-react-sdk/pull/10999)). Fixes vector-im/element-web#25448.<!-- CHANGELOG_PREVIEW_END -->