### PR TITLE
Remove obsolete style rules - mx_SpaceRoomView_inviteTeammates_betaDisclaimer

### DIFF
--- a/cypress/e2e/spaces/spaces.spec.ts
+++ b/cypress/e2e/spaces/spaces.spec.ts
@@ -140,6 +140,8 @@ describe("Spaces", () => {
         cy.findByPlaceholderText("Support").type("Projects");
         cy.findByRole("button", { name: "Continue" }).click();
 
+        cy.get(".mx_SpaceRoomView").percySnapshotElement("Space - 'Invite your teammates' dialog");
+
         cy.get(".mx_SpaceRoomView").within(() => {
             cy.get("h1").findByText("Invite your teammates");
             cy.findByRole("button", { name: "Skip for now" }).click();

--- a/res/css/structures/_SpaceRoomView.pcss
+++ b/res/css/structures/_SpaceRoomView.pcss
@@ -271,23 +271,6 @@ $SpaceRoomViewInnerWidth: 428px;
     }
 
     .mx_SpaceRoomView_inviteTeammates {
-        /* XXX remove this when spaces leaves Beta */
-        .mx_SpaceRoomView_inviteTeammates_betaDisclaimer {
-            padding: 16px;
-            position: relative;
-            border-radius: 8px;
-            background-color: $header-panel-bg-color;
-            max-width: $SpaceRoomViewInnerWidth;
-            margin: 20px 0 30px;
-            box-sizing: border-box;
-
-            .mx_BetaCard_betaPill {
-                position: absolute;
-                left: 16px;
-                top: 16px;
-            }
-        }
-
         .mx_SpaceRoomView_inviteTeammates_buttons {
             color: $secondary-content;
             margin-top: 28px;

--- a/src/components/structures/SpaceRoomView.tsx
+++ b/src/components/structures/SpaceRoomView.tsx
@@ -77,7 +77,6 @@ import MainSplit from "./MainSplit";
 import RightPanel from "./RightPanel";
 import SpaceHierarchy, { showRoom } from "./SpaceHierarchy";
 import { RoomPermalinkCreator } from "../../utils/permalinks/Permalinks";
-import ExternalLink from "../views/elements/ExternalLink";
 
 interface IProps {
     space: Room;

--- a/src/components/structures/SpaceRoomView.tsx
+++ b/src/components/structures/SpaceRoomView.tsx
@@ -586,22 +586,6 @@ const SpaceSetupPrivateInvite: React.FC<{
                 {_t("Make sure the right people have access. You can invite more later.")}
             </div>
 
-            <div className="mx_SpaceRoomView_inviteTeammates_betaDisclaimer">
-                {_t(
-                    "<b>This is an experimental feature.</b> For now, " +
-                        "new users receiving an invite will have to open the invite on <link/> to actually join.",
-                    {},
-                    {
-                        b: (sub) => <b>{sub}</b>,
-                        link: () => (
-                            <ExternalLink href="https://app.element.io/" rel="noreferrer noopener" target="_blank">
-                                app.element.io
-                            </ExternalLink>
-                        ),
-                    },
-                )}
-            </div>
-
             {error && <div className="mx_SpaceRoomView_errorText">{error}</div>}
             <form onSubmit={onClick} id="mx_SpaceSetupPrivateInvite">
                 {fields}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3479,7 +3479,6 @@
     "Inviting…": "Inviting…",
     "Invite your teammates": "Invite your teammates",
     "Make sure the right people have access. You can invite more later.": "Make sure the right people have access. You can invite more later.",
-    "<b>This is an experimental feature.</b> For now, new users receiving an invite will have to open the invite on <link/> to actually join.": "<b>This is an experimental feature.</b> For now, new users receiving an invite will have to open the invite on <link/> to actually join.",
     "Invite by username": "Invite by username",
     "What are some things you want to discuss in %(spaceName)s?": "What are some things you want to discuss in %(spaceName)s?",
     "Let's create a room for each of them.": "Let's create a room for each of them.",


### PR DESCRIPTION
This PR intends to remove `mx_SpaceRoomView_inviteTeammates_betaDisclaimer` style rules as the Space has left beta. This also suggests to add a Percy snapshot test as there has  not been one for dialogs related to Space. The snapshot should also help us to detect a regression if any, when we replace the invite mask-image with a SVG icon next to `Invite by username`.

|Before|After|
|---------|-------|
|![before](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/b5be2a12-9129-4c63-9d68-6d75da459b04)|![after](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/6f68be18-ccac-4d09-8988-620c8d8bf33e)|

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->