### PR TITLE
Use `Icon` component for play and pause buttons

### DIFF
--- a/res/css/views/audio_messages/_PlayPauseButton.pcss
+++ b/res/css/views/audio_messages/_PlayPauseButton.pcss
@@ -23,31 +23,29 @@ limitations under the License.
     border-radius: 32px;
     background-color: $system;
 
-    &::before {
-        content: "";
-        position: absolute; /* sizing varies by icon */
-        background-color: $secondary-content;
-        mask-repeat: no-repeat;
-        mask-size: contain;
-    }
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    &.mx_PlayPauseButton_disabled::before {
-        opacity: 0.5;
-    }
+    .mx_Icon {
+        color: $secondary-content;
 
-    &.mx_PlayPauseButton_play::before {
-        width: 13px;
-        height: 16px;
-        top: 8px; /* center */
-        left: 12px; /* center */
-        mask-image: url("$(res)/img/element-icons/play.svg");
-    }
+        &.mx_Icon--disabled {
+            opacity: 0.5;
+        }
 
-    &.mx_PlayPauseButton_pause::before {
-        width: 10px;
-        height: 12px;
-        top: 10px; /* center */
-        left: 11px; /* center */
-        mask-image: url("$(res)/img/element-icons/pause.svg");
+        &.mx_Icon--play {
+            width: 13px;
+            height: 16px;
+
+            /* move slightly to have the play icon perceived as actually placed at the center of the button */
+            position: relative;
+            inset-inline-start: 2px;
+        }
+
+        &.mx_Icon--pause {
+            width: 10px;
+            height: 12px;
+        }
     }
 }

--- a/src/components/views/audio_messages/PlayPauseButton.tsx
+++ b/src/components/views/audio_messages/PlayPauseButton.tsx
@@ -20,6 +20,8 @@ import classNames from "classnames";
 import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
 import { _t } from "../../../languageHandler";
 import { Playback, PlaybackState } from "../../../audio/Playback";
+import { Icon as PlayIcon } from "../../../../res/img/element-icons/play.svg";
+import { Icon as PauseIcon } from "../../../../res/img/element-icons/pause.svg";
 
 // omitted props are handled by render function
 interface IProps extends Omit<React.ComponentProps<typeof AccessibleTooltipButton>, "title" | "onClick" | "disabled"> {
@@ -52,21 +54,28 @@ export default class PlayPauseButton extends React.PureComponent<IProps> {
         const { playback, playbackPhase, ...restProps } = this.props;
         const isPlaying = playback.isPlaying;
         const isDisabled = playbackPhase === PlaybackState.Decoding;
-        const classes = classNames("mx_PlayPauseButton", {
-            mx_PlayPauseButton_play: !isPlaying,
-            mx_PlayPauseButton_pause: isPlaying,
-            mx_PlayPauseButton_disabled: isDisabled,
+        const classes = classNames("mx_Icon", {
+            "mx_Icon--disabled": isDisabled,
         });
+
+        let button;
+        if (!isPlaying) {
+            button = <PlayIcon className={classNames(classes, "mx_Icon--play")} />;
+        } else if (isPlaying) {
+            button = <PauseIcon className={classNames(classes, "mx_Icon--pause")} />;
+        }
 
         return (
             <AccessibleTooltipButton
                 data-testid="play-pause-button"
-                className={classes}
+                className="mx_PlayPauseButton"
                 title={isPlaying ? _t("Pause") : _t("Play")}
                 onClick={this.onClick}
                 disabled={isDisabled}
                 {...restProps}
-            />
+            >
+                {button}
+            </AccessibleTooltipButton>
         );
     }
 }


### PR DESCRIPTION
This PR suggests to use `Icon` component for icons on play and pause buttons.

Before:
![a0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/29be2d13-f33e-495a-bbc5-5a6f03ba5437)![Screenshot from 2023-05-29 01-15-27](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/338918e2-6e66-4a62-853d-babaaa8cede5)

After:
![a1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/8e4e89e5-b1bc-4346-8e59-e7fbb915765b)![Screenshot from 2023-05-29 01-14-43](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/ef51df7d-d55c-4b88-bf2d-ab77bcf5b61c)

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->