### PR TITLE
Fix flaky Cypress test - `invite-dialog.spec.ts`

### DIFF
--- a/cypress/e2e/invite/invite-dialog.spec.ts
+++ b/cypress/e2e/invite/invite-dialog.spec.ts
@@ -169,7 +169,6 @@ describe("Invite dialog", function () {
         cy.get(".mx_RoomHeader").within(() => {
             cy.get(".mx_RoomHeader_name--textonly")
                 .realHover()
-                .get(".mx_RoomHeader_name--textonly:hover")
                 .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
         });
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25485

This PR intends to fix a flaky Cypress test on `invite-dialog.spec.ts` presumably due to a race condition.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->