### PR TITLE
Use semantic headings in space preferences

### DIFF
--- a/res/css/views/dialogs/_SpacePreferencesDialog.pcss
+++ b/res/css/views/dialogs/_SpacePreferencesDialog.pcss
@@ -31,16 +31,6 @@ limitations under the License.
 
         .mx_SettingsTab {
             min-width: unset;
-
-            .mx_SettingsTab_section {
-                font-size: $font-15px;
-                line-height: $font-24px;
-
-                .mx_Checkbox + p {
-                    color: $secondary-content;
-                    margin: 0 20px 0 24px;
-                }
-            }
         }
     }
 }

--- a/res/css/views/dialogs/_SpaceSettingsDialog.pcss
+++ b/res/css/views/dialogs/_SpaceSettingsDialog.pcss
@@ -37,12 +37,6 @@ limitations under the License.
             margin-bottom: 20px;
         }
 
-        & + .mx_SettingsTab_subheading {
-            border-top: 1px solid $menu-border-color;
-            margin-top: 0;
-            padding-top: 24px;
-        }
-
         .mx_StyledRadioButton {
             margin-top: 8px;
             margin-bottom: 4px;

--- a/res/css/views/settings/tabs/_SettingsTab.pcss
+++ b/res/css/views/settings/tabs/_SettingsTab.pcss
@@ -46,16 +46,6 @@ limitations under the License.
     color: $alert;
 }
 
-.mx_SettingsTab_subheading {
-    font-size: $font-16px;
-    display: block;
-    font-weight: var(--font-semi-bold);
-    color: $primary-content;
-    margin-top: $spacing-12;
-    margin-bottom: 10px; /* TODO: Use a spacing variable */
-    margin-right: 100px; /* TODO: Use a spacing variable */
-}
-
 .mx_SettingsTab_subsectionText {
     color: $secondary-content;
     font-size: $font-14px;

--- a/res/css/views/settings/tabs/_SettingsTab.pcss
+++ b/res/css/views/settings/tabs/_SettingsTab.pcss
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 .mx_SettingsTab {
-    --SettingsTab_heading_nth_child-margin-top: 30px; /* TODO: Use a spacing variable */
     --SettingsTab_tooltip-max-width: 120px; /* So it fits in the space provided by the page */
 
     color: $primary-content;
@@ -45,19 +44,6 @@ limitations under the License.
 
 .mx_SettingsTab_warningText {
     color: $alert;
-}
-
-.mx_SettingsTab_heading {
-    font-size: $font-20px;
-    font-weight: var(--font-semi-bold);
-    color: $primary-content;
-    margin-top: 10px; /* TODO: Use a spacing variable */
-    margin-bottom: 10px; /* TODO: Use a spacing variable */
-    margin-right: 100px; /* TODO: Use a spacing variable */
-
-    &:nth-child(n + 2) {
-        margin-top: var(--SettingsTab_heading_nth_child-margin-top);
-    }
 }
 
 .mx_SettingsTab_subheading {

--- a/src/components/views/dialogs/SpacePreferencesDialog.tsx
+++ b/src/components/views/dialogs/SpacePreferencesDialog.tsx
@@ -27,6 +27,9 @@ import { SettingLevel } from "../../../settings/SettingLevel";
 import RoomName from "../elements/RoomName";
 import { SpacePreferenceTab } from "../../../dispatcher/payloads/OpenSpacePreferencesPayload";
 import { NonEmptyArray } from "../../../@types/common";
+import SettingsTab from "../settings/tabs/SettingsTab";
+import { SettingsSection } from "../settings/shared/SettingsSection";
+import SettingsSubsection, { SettingsSubsectionText } from "../settings/shared/SettingsSubsection";
 
 interface IProps {
     space: Room;
@@ -38,34 +41,34 @@ const SpacePreferencesAppearanceTab: React.FC<Pick<IProps, "space">> = ({ space 
     const showPeople = useSettingValue("Spaces.showPeopleInSpace", space.roomId);
 
     return (
-        <div className="mx_SettingsTab">
-            <div className="mx_SettingsTab_heading">{_t("Sections to show")}</div>
-
-            <div className="mx_SettingsTab_section">
-                <StyledCheckbox
-                    checked={!!showPeople}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                        SettingsStore.setValue(
-                            "Spaces.showPeopleInSpace",
-                            space.roomId,
-                            SettingLevel.ROOM_ACCOUNT,
-                            !showPeople,
-                        );
-                    }}
-                >
-                    {_t("People")}
-                </StyledCheckbox>
-                <p>
-                    {_t(
-                        "This groups your chats with members of this space. " +
-                            "Turning this off will hide those chats from your view of %(spaceName)s.",
-                        {
-                            spaceName: space.name,
-                        },
-                    )}
-                </p>
-            </div>
-        </div>
+        <SettingsTab>
+            <SettingsSection heading={_t("Sections to show")}>
+                <SettingsSubsection>
+                    <StyledCheckbox
+                        checked={!!showPeople}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            SettingsStore.setValue(
+                                "Spaces.showPeopleInSpace",
+                                space.roomId,
+                                SettingLevel.ROOM_ACCOUNT,
+                                !showPeople,
+                            );
+                        }}
+                    >
+                        {_t("People")}
+                    </StyledCheckbox>
+                    <SettingsSubsectionText>
+                        {_t(
+                            "This groups your chats with members of this space. " +
+                                "Turning this off will hide those chats from your view of %(spaceName)s.",
+                            {
+                                spaceName: space.name,
+                            },
+                        )}
+                    </SettingsSubsectionText>
+                </SettingsSubsection>
+            </SettingsSection>
+        </SettingsTab>
     );
 };
 

--- a/test/components/views/dialogs/UserSettingsDialog-test.tsx
+++ b/test/components/views/dialogs/UserSettingsDialog-test.tsx
@@ -75,7 +75,6 @@ describe("<UserSettingsDialog />", () => {
     const getActiveTabLabel = (container: Element) =>
         container.querySelector(".mx_TabbedView_tabLabel_active")?.textContent;
     const getActiveTabHeading = (container: Element) =>
-        container.querySelector(".mx_SettingsTab_heading")?.textContent ||
         container.querySelector(".mx_SettingsSection .mx_Heading_h2")?.textContent;
 
     it("should render general settings tab when no initialTabId", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/24922

- Use semantic settings components in space preferences
- Tidy up some unused styles

<img width="774" alt="Screenshot 2023-05-31 at 14 42 05" src="https://github.com/matrix-org/matrix-react-sdk/assets/3055605/3ec609ee-042f-4b26-bb35-8abf96b81a98">


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use semantic headings in space preferences ([\#11021](https://github.com/matrix-org/matrix-react-sdk/pull/11021)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->