### PR TITLE
Align list items on the tooltip to the start

### DIFF
--- a/res/css/views/elements/_Tooltip.pcss
+++ b/res/css/views/elements/_Tooltip.pcss
@@ -87,6 +87,11 @@ limitations under the License.
     &.mx_Tooltip_invisible {
         animation: mx_fadeout 0.1s forwards;
     }
+
+    ul,
+    ol {
+        text-align: start; /* for list items */
+    }
 }
 
 /* These tooltips use an older style with a chevron */


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25355

See below what this PR intends to change.

|Before|After|
|---------|------|
|![Screenshot from 2023-06-04 12-19-08](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/18e6e013-06dd-405a-b9f2-9258df808778)|![Screenshot from 2023-06-04 12-18-32](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/366a0812-46a4-4d66-8652-43cd8e933d2a)|

The change realizes the design which https://github.com/matrix-org/matrix-react-sdk/pull/3622 implemented initially.

![](https://user-images.githubusercontent.com/1190097/68976827-f8077480-07b3-11ea-911a-e77cf44bc437.png)

There might be another instance where list items are rendered on the tooltip, but I do not think the list items should be aligned to the center on this case either. Please point out, if there is such a case.

Also, please note because the chevron between the tooltip and the question mark is specific to `AppPermisson`, implementing it is out of scope of this PR.

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->
