### PR TITLE
Conform to the naming policy - AppsContainer resizer

### DIFF
--- a/cypress/e2e/widgets/layout.spec.ts
+++ b/cypress/e2e/widgets/layout.spec.ts
@@ -102,7 +102,7 @@ describe("Widget Layout", () => {
     it("manually resize the height of the top container layout", () => {
         cy.get('iframe[title="widget"]').invoke("height").should("be.lessThan", 250);
 
-        cy.get(".mx_AppsContainer_resizerHandle")
+        cy.get(".mx_AppsContainer_resizer_container_handle")
             .trigger("mousedown")
             .trigger("mousemove", { clientX: 0, clientY: 550, force: true })
             .trigger("mouseup", { clientX: 0, clientY: 550, force: true });

--- a/cypress/e2e/widgets/layout.spec.ts
+++ b/cypress/e2e/widgets/layout.spec.ts
@@ -102,7 +102,7 @@ describe("Widget Layout", () => {
     it("manually resize the height of the top container layout", () => {
         cy.get('iframe[title="widget"]').invoke("height").should("be.lessThan", 250);
 
-        cy.get(".mx_AppsContainer_resizer_container_handle")
+        cy.get(".mx_AppsDrawer_resizer_container_handle")
             .trigger("mousedown")
             .trigger("mousemove", { clientX: 0, clientY: 550, force: true })
             .trigger("mouseup", { clientX: 0, clientY: 550, force: true });

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -32,14 +32,14 @@ limitations under the License.
     overflow: hidden;
     flex-grow: 1;
 
-    .mx_AppsContainer_resizerHandleContainer {
+    .mx_AppsContainer_resizer_container {
         width: 100%;
         height: 10px;
         display: block;
         position: relative;
     }
 
-    .mx_AppsContainer_resizerHandle {
+    .mx_AppsContainer_resizer_container_handle {
         cursor: ns-resize;
 
         /* Override styles from library, making the whole area the target area */
@@ -68,7 +68,7 @@ limitations under the License.
     }
 
     &:hover {
-        .mx_AppsContainer_resizerHandle::after {
+        .mx_AppsContainer_resizer_container_handle::after {
             opacity: 0.8;
             background: $primary-content;
         }

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -32,13 +32,17 @@ limitations under the License.
     overflow: hidden;
     flex-grow: 1;
 
-    .mx_AppsContainer_resizer_container {
+    .mx_AppsDrawer_resizer {
+        margin-bottom: var(--container-gap-width);
+    }
+
+    .mx_AppsDrawer_resizer_container {
         width: 100%;
         height: 10px;
         display: block;
         position: relative;
 
-        .mx_AppsContainer_resizer_container_handle {
+        .mx_AppsDrawer_resizer_container_handle {
             cursor: ns-resize;
 
             /* Override styles from library, making the whole area the target area */
@@ -68,7 +72,7 @@ limitations under the License.
     }
 
     &:hover {
-        .mx_AppsContainer_resizer_container_handle::after {
+        .mx_AppsDrawer_resizer_container_handle::after {
             opacity: 0.8;
             background: $primary-content;
         }
@@ -121,10 +125,6 @@ limitations under the License.
             min-width: var(--minWidth) !important;
         }
     }
-}
-
-.mx_AppsContainer_resizer {
-    margin-bottom: var(--container-gap-width);
 }
 
 .mx_AppsContainer {

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -37,33 +37,33 @@ limitations under the License.
         height: 10px;
         display: block;
         position: relative;
-    }
 
-    .mx_AppsContainer_resizer_container_handle {
-        cursor: ns-resize;
+        .mx_AppsContainer_resizer_container_handle {
+            cursor: ns-resize;
 
-        /* Override styles from library, making the whole area the target area */
-        width: 100% !important;
-        height: 100% !important;
+            /* Override styles from library, making the whole area the target area */
+            width: 100% !important;
+            height: 100% !important;
 
-        /* This is positioned directly below frame */
-        position: absolute;
-        bottom: 50% !important; /* override from library */
-
-        /* We then render the pill handle in an ::after to keep it in the handle's */
-        /* area without being a massive line across the screen */
-        &::after {
-            content: "";
+            /* This is positioned directly below frame */
             position: absolute;
-            border-radius: 3px;
+            bottom: 50% !important; /* override from library */
 
-            height: 4px;
-            bottom: 0;
+            /* We then render the pill handle in an ::after to keep it in the handle's */
+            /* area without being a massive line across the screen */
+            &::after {
+                content: "";
+                position: absolute;
+                border-radius: 3px;
 
-            /* Together, these make the bar 64px wide */
-            /* These are also overridden from the library */
-            left: calc(50% - 32px);
-            right: calc(50% - 32px);
+                height: 4px;
+                bottom: 0;
+
+                /* Together, these make the bar 64px wide */
+                /* These are also overridden from the library */
+                left: calc(50% - 32px);
+                right: calc(50% - 32px);
+            }
         }
     }
 

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -283,9 +283,9 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     room={this.props.room}
                     minHeight={100}
                     maxHeight={this.props.maxHeight - 50}
-                    handleClass="mx_AppsContainer_resizer_container_handle"
-                    handleWrapperClass="mx_AppsContainer_resizer_container"
                     className="mx_AppsContainer_resizer"
+                    handleWrapperClass="mx_AppsContainer_resizer_container"
+                    handleClass="mx_AppsContainer_resizer_container_handle"
                     resizeNotifier={this.props.resizeNotifier}
                 >
                     {appContainers}
@@ -358,9 +358,9 @@ const PersistentVResizer: React.FC<IPersistentResizerProps> = ({
 
                 resizeNotifier.stopResizing();
             }}
+            className={className}
             handleWrapperClass={handleWrapperClass}
             handleClasses={{ bottom: handleClass }}
-            className={className}
             enable={{ bottom: true }}
         >
             {children}

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -283,8 +283,8 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     room={this.props.room}
                     minHeight={100}
                     maxHeight={this.props.maxHeight - 50}
-                    handleClass="mx_AppsContainer_resizerHandle"
-                    handleWrapperClass="mx_AppsContainer_resizerHandleContainer"
+                    handleClass="mx_AppsContainer_resizer_container_handle"
+                    handleWrapperClass="mx_AppsContainer_resizer_container"
                     className="mx_AppsContainer_resizer"
                     resizeNotifier={this.props.resizeNotifier}
                 >

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -283,9 +283,9 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     room={this.props.room}
                     minHeight={100}
                     maxHeight={this.props.maxHeight - 50}
-                    className="mx_AppsContainer_resizer"
-                    handleWrapperClass="mx_AppsContainer_resizer_container"
-                    handleClass="mx_AppsContainer_resizer_container_handle"
+                    className="mx_AppsDrawer_resizer"
+                    handleWrapperClass="mx_AppsDrawer_resizer_container"
+                    handleClass="mx_AppsDrawer_resizer_container_handle"
                     resizeNotifier={this.props.resizeNotifier}
                 >
                     {appContainers}

--- a/test/components/views/elements/AppTile-test.tsx
+++ b/test/components/views/elements/AppTile-test.tsx
@@ -327,6 +327,9 @@ describe("AppTile", () => {
         expect(renderResult.getByText("Example 1")).toBeInTheDocument();
         expect(ActiveWidgetStore.instance.isLive("1", "r1")).toBe(true);
 
+        const { asFragment } = renderResult;
+        expect(asFragment()).toMatchSnapshot(); // Take snapshot of AppsDrawer with AppTile
+
         // We want to verify that as we move the widget to the center container,
         // the widget frame remains running.
 

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -169,7 +169,7 @@ exports[`AppTile preserves non-persisted widget on container move 1`] = `
     class="mx_AppsDrawer"
   >
     <div
-      class="mx_AppsContainer_resizer"
+      class="mx_AppsDrawer_resizer"
       style="position: relative; user-select: auto; width: auto; height: 280px; max-height: 576px; min-height: 100px; box-sizing: border-box; flex-shrink: 0;"
     >
       <div
@@ -267,10 +267,10 @@ exports[`AppTile preserves non-persisted widget on container move 1`] = `
         </div>
       </div>
       <div
-        class="mx_AppsContainer_resizer_container"
+        class="mx_AppsDrawer_resizer_container"
       >
         <div
-          class="mx_AppsContainer_resizer_container_handle"
+          class="mx_AppsDrawer_resizer_container_handle"
           style="position: absolute; user-select: none; width: 100%; height: 10px; left: 0px; cursor: row-resize; bottom: -5px;"
         />
       </div>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -267,10 +267,10 @@ exports[`AppTile preserves non-persisted widget on container move 1`] = `
         </div>
       </div>
       <div
-        class="mx_AppsContainer_resizerHandleContainer"
+        class="mx_AppsContainer_resizer_container"
       >
         <div
-          class="mx_AppsContainer_resizerHandle"
+          class="mx_AppsContainer_resizer_container_handle"
           style="position: absolute; user-select: none; width: 100%; height: 10px; left: 0px; cursor: row-resize; bottom: -5px;"
         />
       </div>

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -162,3 +162,119 @@ exports[`AppTile for a pinned widget should render 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`AppTile preserves non-persisted widget on container move 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_AppsDrawer"
+  >
+    <div
+      class="mx_AppsContainer_resizer"
+      style="position: relative; user-select: auto; width: auto; height: 280px; max-height: 576px; min-height: 100px; box-sizing: border-box; flex-shrink: 0;"
+    >
+      <div
+        class="mx_AppsContainer"
+      >
+        <div
+          class="mx_AppTileFullWidth"
+          id="1"
+        >
+          <div
+            class="mx_AppTileMenuBar"
+          >
+            <span
+              class="mx_AppTileMenuBar_title"
+              style="pointer-events: none;"
+            >
+              <span>
+                <img
+                  alt=""
+                  class="mx_BaseAvatar mx_BaseAvatar_image mx_WidgetAvatar"
+                  data-testid="avatar-img"
+                  loading="lazy"
+                  src="image-file-stub"
+                  style="width: 20px; height: 20px;"
+                />
+                <b>
+                  Example 1
+                </b>
+                <span />
+              </span>
+            </span>
+            <span
+              class="mx_AppTileMenuBar_widgets"
+            >
+              <div
+                class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+                role="button"
+                tabindex="0"
+                title="Maximise"
+              >
+                <div
+                  class="mx_Icon mx_Icon_12"
+                />
+              </div>
+              <div
+                class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+                role="button"
+                tabindex="0"
+                title="Minimise"
+              >
+                <div
+                  class="mx_Icon mx_Icon_12"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Options"
+                class="mx_AccessibleButton mx_AppTileMenuBar_widgets_button"
+                role="button"
+                tabindex="0"
+                title="Options"
+              >
+                <div
+                  class="mx_Icon mx_Icon_12"
+                />
+              </div>
+            </span>
+          </div>
+          <div
+            class="mx_AppTileBody mx_AppTile_loading"
+          >
+            <div
+              class="mx_AppTileBody_fadeInSpinner"
+            >
+              <div
+                class="mx_Spinner"
+              >
+                <div
+                  class="mx_Spinner_Msg"
+                >
+                  Loading…
+                </div>
+                 
+                <div
+                  aria-label="Loading…"
+                  class="mx_Spinner_icon"
+                  data-testid="spinner"
+                  role="progressbar"
+                  style="width: 32px; height: 32px;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="mx_AppsContainer_resizerHandleContainer"
+      >
+        <div
+          class="mx_AppsContainer_resizerHandle"
+          style="position: absolute; user-select: none; width: 100%; height: 10px; left: 0px; cursor: row-resize; bottom: -5px;"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
This PR intends to help developers to understand how elements of `PersistentVResizer` are structured. The hierarchy is:

````
- mx_AppsDrawer_resizer
- mx_AppsDrawer_resizer_container
- mx_AppsDrawer_resizer_container_handle
````

It also nests styles of `mx_AppsContainer_resizer_container_handle` to increase their specificity. There are indeed bunch of comments for the declarations, but they neither enforce nor ensure styling by themselves. Providing a proper specificity does. Specifying those declarations loosely for general use adds zero merit.

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/e3a9107a-65a4-4813-a404-d08a5321704c)


type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->