### PR TITLE
Allow image pasting in plain mode in RTE

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
@@ -55,6 +55,7 @@ export function PlainTextComposer({
     const {
         ref: editorRef,
         autocompleteRef,
+        onBeforeInput,
         onInput,
         onPaste,
         onKeyDown,
@@ -78,6 +79,7 @@ export function PlainTextComposer({
             className={classNames(className, { [`${className}-focused`]: isFocused })}
             onFocus={onFocus}
             onBlur={onFocus}
+            onBeforeInput={onBeforeInput}
             onInput={onInput}
             onPaste={onPaste}
             onKeyDown={onKeyDown}

--- a/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
@@ -50,6 +50,7 @@ export function PlainTextComposer({
     initialContent,
     leftComponent,
     rightComponent,
+    eventRelation,
 }: PlainTextComposerProps): JSX.Element {
     const {
         ref: editorRef,
@@ -63,7 +64,7 @@ export function PlainTextComposer({
         onSelect,
         handleCommand,
         handleMention,
-    } = usePlainTextListeners(initialContent, onChange, onSend);
+    } = usePlainTextListeners(initialContent, onChange, onSend, eventRelation);
 
     const composerFunctions = useComposerFunctions(editorRef, setContent);
     usePlainTextInitialization(initialContent, editorRef);

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -258,7 +258,7 @@ function handleInputEvent(event: InputEvent, send: Send, isCtrlEnterToSend: bool
  */
 export function handleClipboardEvent(
     event: ClipboardEvent | InputEvent,
-    data: DataTransfer,
+    data: DataTransfer | null,
     roomContext: IRoomState,
     mxClient: MatrixClient,
     eventRelation?: IEventRelation,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -258,6 +258,7 @@ function handleInputEvent(event: InputEvent, send: Send, isCtrlEnterToSend: bool
  */
 export function handleClipboardEvent(
     clipboardEvent: ClipboardEvent | ReactClipboardEvent | InputEvent,
+    data: DataTransfer,
     roomContext: IRoomState,
     mxClient: MatrixClient,
     eventRelation?: IEventRelation,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Wysiwyg, WysiwygEvent } from "@matrix-org/matrix-wysiwyg";
-import { useCallback, ClipboardEvent as ReactClipboardEvent } from "react";
+import { useCallback } from "react";
 import { IEventRelation, MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { useSettingValue } from "../../../../../hooks/useSettings";
@@ -257,7 +257,7 @@ function handleInputEvent(event: InputEvent, send: Send, isCtrlEnterToSend: bool
  * @returns - boolean to show if the event was handled or not
  */
 export function handleClipboardEvent(
-    clipboardEvent: ClipboardEvent | ReactClipboardEvent | InputEvent,
+    event: ClipboardEvent | InputEvent,
     data: DataTransfer,
     roomContext: IRoomState,
     mxClient: MatrixClient,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Wysiwyg, WysiwygEvent } from "@matrix-org/matrix-wysiwyg";
-import { useCallback } from "react";
+import { useCallback, ClipboardEvent as ReactClipboardEvent } from "react";
 import { IEventRelation, MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { useSettingValue } from "../../../../../hooks/useSettings";
@@ -257,8 +257,7 @@ function handleInputEvent(event: InputEvent, send: Send, isCtrlEnterToSend: bool
  * @returns - boolean to show if the event was handled or not
  */
 export function handleClipboardEvent(
-    event: ClipboardEvent | InputEvent,
-    data: DataTransfer | null,
+    clipboardEvent: ClipboardEvent | ReactClipboardEvent | InputEvent,
     roomContext: IRoomState,
     mxClient: MatrixClient,
     eventRelation?: IEventRelation,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { KeyboardEvent, RefObject, SyntheticEvent, useCallback, useRef, useState } from "react";
+import { KeyboardEvent, RefObject, SyntheticEvent, ClipboardEvent, useCallback, useRef, useState } from "react";
 import { Attributes, MappedSuggestion } from "@matrix-org/matrix-wysiwyg";
 import { IEventRelation } from "matrix-js-sdk/src/matrix";
 
@@ -68,8 +68,8 @@ export function usePlainTextListeners(
     ref: RefObject<HTMLDivElement>;
     autocompleteRef: React.RefObject<Autocomplete>;
     content?: string;
-    onInput(event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>): void;
-    onPaste(event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>): void;
+    onInput(event: SyntheticEvent<HTMLDivElement, InputEvent> | ClipboardEvent): void;
+    onPaste(event: ClipboardEvent): void;
     onKeyDown(event: KeyboardEvent<HTMLDivElement>): void;
     setContent(text?: string): void;
     handleMention: (link: string, text: string, attributes: Attributes) => void;
@@ -113,7 +113,7 @@ export function usePlainTextListeners(
 
     const enterShouldSend = !useSettingValue<boolean>("MessageComposerInput.ctrlEnterToSend");
     const onInput = useCallback(
-        (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
+        (event: SyntheticEvent<HTMLDivElement, InputEvent> | ClipboardEvent) => {
             console.log("<<< handling ", event);
             if (isDivElement(event.target)) {
                 console.log("<<< setting ", event.target.innerHTML);
@@ -127,7 +127,7 @@ export function usePlainTextListeners(
     );
 
     const onPaste = useCallback(
-        (event: SyntheticEvent<HTMLDivElement, ClipboardEvent>) => {
+        (event: ClipboardEvent) => {
             const handled = handleClipboardEvent(event, roomContext, mxClient, eventRelation);
             if (handled) {
                 event.preventDefault(); // we only handle image pasting manually

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -128,7 +128,7 @@ export function usePlainTextListeners(
 
     const onPaste = useCallback(
         (event: ClipboardEvent) => {
-            const handled = handleClipboardEvent(event, roomContext, mxClient, eventRelation);
+            const handled = handleClipboardEvent(event, event.clipboardData, roomContext, mxClient, eventRelation);
             if (handled) {
                 event.preventDefault(); // we only handle image pasting manually
             } else {

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -134,16 +134,16 @@ export function usePlainTextListeners(
             // attempt to manually handle image paste events occurring from the clipboard or the special
             // case detailed in the above issue
             const isClipboardEvent = nativeEvent instanceof ClipboardEvent;
-            const isSpecialCaseInputEvent =
+            const isInputEventForClipboard =
                 nativeEvent instanceof InputEvent &&
                 nativeEvent.inputType === "insertFromPaste" &&
                 isNotNull(nativeEvent.dataTransfer);
 
-            const isEventToHandle = isClipboardEvent || isSpecialCaseInputEvent;
+            const shouldHandleAsClipboardEvent = isClipboardEvent || isInputEventForClipboard;
 
             let imagePasteWasHandled = false;
 
-            if (isEventToHandle) {
+            if (shouldHandleAsClipboardEvent) {
                 const data = isClipboardEvent ? nativeEvent.clipboardData : nativeEvent.dataTransfer;
                 imagePasteWasHandled = handleClipboardEvent(nativeEvent, data, roomContext, mxClient, eventRelation);
             }

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -125,11 +125,7 @@ export function usePlainTextListeners(
 
     const onPaste = useCallback(
         (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
-            // this is required to handle edge case image pasting in Safari, see
-            // https://github.com/vector-im/element-web/issues/25327 and it is caught by the
-            // `beforeinput` listener attached to the composer
             const { nativeEvent } = event;
-
             let imagePasteWasHandled = false;
 
             if (isEventToHandleAsClipboardEvent(nativeEvent)) {
@@ -138,7 +134,7 @@ export function usePlainTextListeners(
                 imagePasteWasHandled = handleClipboardEvent(nativeEvent, data, roomContext, mxClient, eventRelation);
             }
 
-            // only prevent default behaviour if the image paste event was handled
+            // prevent default behaviour and skip call to onInput if the image paste event was handled
             if (imagePasteWasHandled) {
                 event.preventDefault();
             } else {

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { KeyboardEvent, RefObject, SyntheticEvent, ClipboardEvent, useCallback, useRef, useState } from "react";
+import { KeyboardEvent, RefObject, SyntheticEvent, useCallback, useRef, useState } from "react";
 import { Attributes, MappedSuggestion } from "@matrix-org/matrix-wysiwyg";
 import { IEventRelation } from "matrix-js-sdk/src/matrix";
 
@@ -68,8 +68,8 @@ export function usePlainTextListeners(
     ref: RefObject<HTMLDivElement>;
     autocompleteRef: React.RefObject<Autocomplete>;
     content?: string;
-    onInput(event: SyntheticEvent<HTMLDivElement, InputEvent> | ClipboardEvent): void;
-    onPaste(event: ClipboardEvent): void;
+    onInput(event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>): void;
+    onPaste(event: SyntheticEvent<HTMLDivElement, ClipboardEvent>): void;
     onKeyDown(event: KeyboardEvent<HTMLDivElement>): void;
     setContent(text?: string): void;
     handleMention: (link: string, text: string, attributes: Attributes) => void;
@@ -113,7 +113,7 @@ export function usePlainTextListeners(
 
     const enterShouldSend = !useSettingValue<boolean>("MessageComposerInput.ctrlEnterToSend");
     const onInput = useCallback(
-        (event: SyntheticEvent<HTMLDivElement, InputEvent> | ClipboardEvent) => {
+        (event: SyntheticEvent<HTMLDivElement, InputEvent | ClipboardEvent>) => {
             console.log("<<< handling ", event);
             if (isDivElement(event.target)) {
                 console.log("<<< setting ", event.target.innerHTML);
@@ -127,8 +127,14 @@ export function usePlainTextListeners(
     );
 
     const onPaste = useCallback(
-        (event: ClipboardEvent) => {
-            const handled = handleClipboardEvent(event, event.clipboardData, roomContext, mxClient, eventRelation);
+        (event: SyntheticEvent<HTMLDivElement, ClipboardEvent>) => {
+            const handled = handleClipboardEvent(
+                event.nativeEvent,
+                event.nativeEvent.clipboardData,
+                roomContext,
+                mxClient,
+                eventRelation,
+            );
             if (handled) {
                 event.preventDefault(); // we only handle image pasting manually
             } else {

--- a/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/usePlainTextListeners.ts
@@ -21,10 +21,9 @@ import { IEventRelation } from "matrix-js-sdk/src/matrix";
 import { useSettingValue } from "../../../../../hooks/useSettings";
 import { IS_MAC, Key } from "../../../../../Keyboard";
 import Autocomplete from "../../Autocomplete";
-import { handleEventWithAutocomplete } from "./utils";
+import { handleClipboardEvent, handleEventWithAutocomplete, isEventToHandleAsClipboardEvent } from "./utils";
 import { useSuggestion } from "./useSuggestion";
 import { isNotNull, isNotUndefined } from "../../../../../Typeguards";
-import { handleClipboardEvent } from "./useInputEventProcessor";
 import { useRoomContext } from "../../../../../contexts/RoomContext";
 import { useMatrixClientContext } from "../../../../../contexts/MatrixClientContext";
 
@@ -131,20 +130,11 @@ export function usePlainTextListeners(
             // `beforeinput` listener attached to the composer
             const { nativeEvent } = event;
 
-            // attempt to manually handle image paste events occurring from the clipboard or the special
-            // case detailed in the above issue
-            const isClipboardEvent = nativeEvent instanceof ClipboardEvent;
-            const isInputEventForClipboard =
-                nativeEvent instanceof InputEvent &&
-                nativeEvent.inputType === "insertFromPaste" &&
-                isNotNull(nativeEvent.dataTransfer);
-
-            const shouldHandleAsClipboardEvent = isClipboardEvent || isInputEventForClipboard;
-
             let imagePasteWasHandled = false;
 
-            if (shouldHandleAsClipboardEvent) {
-                const data = isClipboardEvent ? nativeEvent.clipboardData : nativeEvent.dataTransfer;
+            if (isEventToHandleAsClipboardEvent(nativeEvent)) {
+                const data =
+                    nativeEvent instanceof ClipboardEvent ? nativeEvent.clipboardData : nativeEvent.dataTransfer;
                 imagePasteWasHandled = handleClipboardEvent(nativeEvent, data, roomContext, mxClient, eventRelation);
             }
 

--- a/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
@@ -122,6 +122,7 @@ export function handleEventWithAutocomplete(
  * https://github.com/vector-im/element-web/issues/25327
  *
  * @param event - event to process
+ * @param data - data from the event to process
  * @param roomContext - room in which the event occurs
  * @param mxClient - current matrix client
  * @param eventRelation - used to send the event to the correct place eg timeline vs thread
@@ -203,17 +204,16 @@ export function handleClipboardEvent(
 
 /**
  * Util to determine if an input event or clipboard event must be handled as a clipboard event.
- * Required due to https://github.com/vector-im/element-web/issues/25327, certain paste events
- * must be detected with an onBeforeInput handler and will be input events
- * @param event - the event to test
+ * Due to https://github.com/vector-im/element-web/issues/25327, certain paste events
+ * must be listenened for with an onBeforeInput handler and so will be caught as input events.
+ *
+ * @param event - the event to test, can be a WysiwygEvent if it comes from the rich text editor, or
+ * input of clipboard events if from the plain text editor
  * @returns - true if event should be handled as a clipboard event
  */
 export function isEventToHandleAsClipboardEvent(
     event: WysiwygEvent | InputEvent | ClipboardEvent,
 ): event is InputEvent | ClipboardEvent {
-    // this is required to handle edge case image pasting in Safari, see
-    // https://github.com/vector-im/element-web/issues/25327 and it is caught by the
-    // `beforeinput` listener attached to the composer
     const isInputEventForClipboard =
         event instanceof InputEvent && event.inputType === "insertFromPaste" && isNotNull(event.dataTransfer);
     const isClipboardEvent = event instanceof ClipboardEvent;

--- a/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IEventRelation, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { MutableRefObject, RefObject } from "react";
+import { IEventRelation, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { WysiwygEvent } from "@matrix-org/matrix-wysiwyg";
 
 import { TimelineRenderingType } from "../../../../../contexts/RoomContext";
 import { IRoomState } from "../../../../structures/RoomView";
@@ -25,7 +26,6 @@ import { KeyBindingAction } from "../../../../../accessibility/KeyboardShortcuts
 import { getBlobSafeMimeType } from "../../../../../utils/blobs";
 import ContentMessages from "../../../../../ContentMessages";
 import { isNotNull } from "../../../../../Typeguards";
-import { WysiwygEvent, WysiwygInputEvent } from "@matrix-org/matrix-wysiwyg";
 
 export function focusComposer(
     composerElement: MutableRefObject<HTMLElement | null>,

--- a/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
+++ b/src/components/views/rooms/wysiwyg_composer/hooks/utils.ts
@@ -208,7 +208,7 @@ export function handleClipboardEvent(
  * must be listenened for with an onBeforeInput handler and so will be caught as input events.
  *
  * @param event - the event to test, can be a WysiwygEvent if it comes from the rich text editor, or
- * input of clipboard events if from the plain text editor
+ * input or clipboard events if from the plain text editor
  * @returns - true if event should be handled as a clipboard event
  */
 export function isEventToHandleAsClipboardEvent(

--- a/test/components/views/rooms/wysiwyg_composer/components/PlainTextComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/PlainTextComposer-test.tsx
@@ -290,4 +290,16 @@ describe("PlainTextComposer", () => {
 
         expect(screen.getByTestId("autocomplete-wrapper")).toBeInTheDocument();
     });
+
+    it("Should allow pasting of text values", async () => {
+        customRender();
+
+        const textBox = screen.getByRole("textbox");
+
+        await userEvent.click(textBox);
+        await userEvent.type(textBox, "hello");
+        await userEvent.paste(" world");
+
+        expect(textBox).toHaveTextContent("hello world");
+    });
 });

--- a/test/components/views/rooms/wysiwyg_composer/hooks/utils-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/hooks/utils-test.tsx
@@ -20,7 +20,10 @@ import { TimelineRenderingType } from "../../../../../../src/contexts/RoomContex
 import { mkStubRoom, stubClient } from "../../../../../test-utils";
 import ContentMessages from "../../../../../../src/ContentMessages";
 import { IRoomState } from "../../../../../../src/components/structures/RoomView";
-import { handleClipboardEvent } from "../../../../../../src/components/views/rooms/wysiwyg_composer/hooks/utils";
+import {
+    handleClipboardEvent,
+    isEventToHandleAsClipboardEvent,
+} from "../../../../../../src/components/views/rooms/wysiwyg_composer/hooks/utils";
 
 const mockClient = stubClient();
 const mockRoom = mkStubRoom("mock room", "mock room", mockClient);
@@ -283,5 +286,28 @@ describe("handleClipboardEvent", () => {
             expect(logSpy).toHaveBeenCalledWith(mockErrorMessage);
         });
         expect(output).toBe(true);
+    });
+});
+
+describe("isEventToHandleAsClipboardEvent", () => {
+    it("returns true for ClipboardEvent", () => {
+        const input = new ClipboardEvent("clipboard");
+        expect(isEventToHandleAsClipboardEvent(input)).toBe(true);
+    });
+
+    it("returns true for special case input", () => {
+        const input = new InputEvent("insertFromPaste", { inputType: "insertFromPaste" });
+        Object.assign(input, { dataTransfer: "not null" });
+        expect(isEventToHandleAsClipboardEvent(input)).toBe(true);
+    });
+
+    it("returns false for regular InputEvent", () => {
+        const input = new InputEvent("input");
+        expect(isEventToHandleAsClipboardEvent(input)).toBe(false);
+    });
+
+    it("returns false for other input", () => {
+        const input = new KeyboardEvent("keyboard");
+        expect(isEventToHandleAsClipboardEvent(input)).toBe(false);
     });
 });

--- a/test/components/views/rooms/wysiwyg_composer/hooks/utils-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/hooks/utils-test.tsx
@@ -16,11 +16,11 @@ limitations under the License.
 import { IEventRelation, MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { waitFor } from "@testing-library/react";
 
-import { handleClipboardEvent } from "../../../../../../src/components/views/rooms/wysiwyg_composer/hooks/useInputEventProcessor";
 import { TimelineRenderingType } from "../../../../../../src/contexts/RoomContext";
 import { mkStubRoom, stubClient } from "../../../../../test-utils";
 import ContentMessages from "../../../../../../src/ContentMessages";
 import { IRoomState } from "../../../../../../src/components/structures/RoomView";
+import { handleClipboardEvent } from "../../../../../../src/components/views/rooms/wysiwyg_composer/hooks/utils";
 
 const mockClient = stubClient();
 const mockRoom = mkStubRoom("mock room", "mock room", mockClient);


### PR DESCRIPTION
This PR brings the plain text mode of the RTE in line with the rich text mode, in that pasting with an image on the clipboard now opens a modal giving the user the option to upload an image. Example below.

<img width="1132" alt="Element__2____Alun_Turner" src="https://github.com/matrix-org/matrix-react-sdk/assets/56027671/cadbeb7f-1c65-4c02-84c8-f8a71b0faadd">

The PR reuses as much of the logic used by the rich text mode as possible. This meant extracting the existing functions to a sensible place.

This PR:

- extracts the functions that are common to the rich and plain text modes to a `utils` file
- uses those functions for the plain text editor
- adds tests

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow image pasting in plain mode in RTE ([\#11056](https://github.com/matrix-org/matrix-react-sdk/pull/11056)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->