### PR TITLE
Flaky cypress test: `composer.spec > Rich text editor > autocomplete behaviour tests`

### DIFF
--- a/cypress/support/views.ts
+++ b/cypress/support/views.ts
@@ -54,7 +54,8 @@ declare global {
 }
 
 Cypress.Commands.add("viewRoomByName", (name: string): Chainable<JQuery<HTMLElement>> => {
-    return cy.findByRole("treeitem", { name: name }).should("have.class", "mx_RoomTile").click();
+    // long timeout to wait for new room to appear in room list
+    return cy.findByRole("treeitem", { name: name, timeout: 30000 }).should("have.class", "mx_RoomTile").click();
 });
 
 Cypress.Commands.add("getSpacePanelButton", (name: string): Chainable<JQuery<HTMLElement>> => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/25527
Attempt to fix flaky test by increasing timeout in `viewRoomByName`
Hypothesis is that when calling `viewRoomByName` straight after `createRoom` the room list doesn't have time to update.

🚨 auto merge enabled

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->