### PR TITLE
Matrix matrix scheme permalink constructor not stripping query params

### DIFF
--- a/src/utils/permalinks/MatrixSchemePermalinkConstructor.ts
+++ b/src/utils/permalinks/MatrixSchemePermalinkConstructor.ts
@@ -72,7 +72,8 @@ export default class MatrixSchemePermalinkConstructor extends PermalinkConstruct
             throw new Error("Does not appear to be a permalink");
         }
 
-        const parts = fullUrl.substring("matrix:".length).split("/");
+        const url = new URL(fullUrl);
+        const parts = url.pathname.split("/");
 
         const identifier = parts[0];
         const entityNoSigil = parts[1];

--- a/test/utils/permalinks/MatrixSchemePermalinkConstructor-test.ts
+++ b/test/utils/permalinks/MatrixSchemePermalinkConstructor-test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { PermalinkParts } from "../../../src/utils/permalinks/PermalinkConstructor";
+import MatrixSchemePermalinkConstructor from "../../../src/utils/permalinks/MatrixSchemePermalinkConstructor";
+
+describe("MatrixSchemePermalinkConstructor", () => {
+    const peramlinkConstructor = new MatrixSchemePermalinkConstructor();
+
+    describe("parsePermalink", () => {
+        it("should strip ?action=chat from user links", () => {
+            expect(peramlinkConstructor.parsePermalink("matrix:u/user:example.com?action=chat")).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25535

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Matrix matrix scheme permalink constructor not stripping query params ([\#11060](https://github.com/matrix-org/matrix-react-sdk/pull/11060)). Fixes vector-im/element-web#25535.<!-- CHANGELOG_PREVIEW_END -->