### PR TITLE
Align inline buttons on `FilteredDeviceListHeader` on Sessions user settings tab

### DIFF
--- a/res/css/views/settings/tabs/_SettingsTab.pcss
+++ b/res/css/views/settings/tabs/_SettingsTab.pcss
@@ -29,16 +29,19 @@ limitations under the License.
         gap: $spacing-8;
         flex-grow: 1;
     }
-    // never want full width buttons
-    // event when other content is 100% width
-    .mx_AccessibleButton {
-        align-self: flex-start;
-        justify-self: flex-start;
-    }
 
     .mx_Field {
         margin: 0;
         flex: 1;
+    }
+
+    #mx_tabpanel_USER_GENERAL_TAB & {
+        /* On General settings tab never want full width buttons */
+        /* event when other content is 100% width */
+        .mx_AccessibleButton {
+            align-self: flex-start;
+            justify-self: flex-start;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25545

Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/10972/files#diff-0c6139dd8fb5707cd9ac7874d270d5a8df772679956e2f6e43f11a45494cf3e2R36-R39 (https://github.com/matrix-org/matrix-react-sdk/pull/10972)

Before:
![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/b5299d3f-5e5c-4103-aaf2-cdafca9773db)

After:
![1](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/cd7d95b9-41d6-4d99-938f-780bbf763e1d)

`.mx_SettingsTab .mx_AccessibleButton` is a very broad selector and matches buttons on every settings tab. This PR intends to fix the issue by limiting the selector to have it match the buttons on `General` user settings tab which #10972 addressed. Since the selector `mx_GeneralUserSettingsTab` has been deprecated, `mx_tabpanel_USER_GENERAL_TAB` is used instead.

It is technically possible to "fix" the issue by overriding the values with or without `!important` flag, but obviously it is the default values that should be modified, so that declarations for overriding them are not required in the first place.

This fix is rather temporary. Later, a component can be created for buttons on `SettingsTab` if needed, to normalize how the buttons are rendered there.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

type: defect


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Align inline buttons on `FilteredDeviceListHeader` on Sessions user settings tab ([\#11067](https://github.com/matrix-org/matrix-react-sdk/pull/11067)). Fixes vector-im/element-web#25545. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->