### PR TITLE
Add E2E tests to `left-panel.spec.ts`

### DIFF
--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -27,6 +27,8 @@ describe("LeftPanel", () => {
 
             cy.initTestUser(homeserver, "Hanako");
         });
+
+        cy.get(".mx_LeftPanel").should("exist");
     });
 
     afterEach(() => {

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -48,7 +48,7 @@ describe("LeftPanel", () => {
         it("should display a message preview", () => {
             const message = "Message";
 
-            cy.createRoom({ name: "Apple" }).viewRoomByName("Apple");
+            cy.createRoom({ name: roomName }).viewRoomByName(roomName);
 
             cy.getComposer().type(`${message}{enter}`);
 

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -159,7 +159,25 @@ describe("LeftPanel", () => {
     });
 
     describe("for room list wrapper", () => {
+        let bot: MatrixClient;
+        const botName = "BotBob";
         const message = "Message";
+
+        const createBotDM = () => {
+            // Create a bot
+            cy.getBot(homeserver, { displayName: botName }).then((_bot) => {
+                bot = _bot;
+            });
+
+            // Create DM with the bot
+            cy.getClient().then(async (cli) => {
+                const botRoom = await cli.createRoom({ is_direct: true });
+                await cli.invite(botRoom.room_id, bot.getUserId());
+                await cli.setAccountData("m.direct" as EventType, {
+                    [bot.getUserId()]: [botRoom.room_id],
+                });
+            });
+        };
 
         beforeEach(() => {
             cy.get(".mx_LeftPanel_roomListWrapper").should("exist");
@@ -168,7 +186,6 @@ describe("LeftPanel", () => {
         it("should sort rooms by activity and alphabetically", () => {
             const room1Name = "Test Room A";
             const room2Name = "Test Room B";
-            let bot: MatrixClient;
             let roomId: string;
 
             cy.getBot(homeserver, { displayName: "BotBob", autoAcceptInvites: false }).then((_bot) => {
@@ -361,23 +378,8 @@ describe("LeftPanel", () => {
         });
 
         describe("for People", () => {
-            let bot: MatrixClient;
-            const botName = "BotBob";
-
             beforeEach(() => {
-                // Create a bot
-                cy.getBot(homeserver, { displayName: botName }).then((_bot) => {
-                    bot = _bot;
-                });
-
-                // Create DM with the bot
-                cy.getClient().then(async (cli) => {
-                    const botRoom = await cli.createRoom({ is_direct: true });
-                    await cli.invite(botRoom.room_id, bot.getUserId());
-                    await cli.setAccountData("m.direct" as EventType, {
-                        [bot.getUserId()]: [botRoom.room_id],
-                    });
-                });
+                createBotDM();
             });
 
             it("should render a sublist", () => {
@@ -603,23 +605,8 @@ describe("LeftPanel", () => {
             });
 
             describe("with 'People' setting enabled", () => {
-                let bot: MatrixClient;
-                const botName = "BotBob";
-
                 beforeEach(() => {
-                    // Create a bot
-                    cy.getBot(homeserver, { displayName: botName }).then((_bot) => {
-                        bot = _bot;
-                    });
-
-                    // Create DM with the bot
-                    cy.getClient().then(async (cli) => {
-                        const botRoom = await cli.createRoom({ is_direct: true });
-                        await cli.invite(botRoom.room_id, bot.getUserId());
-                        await cli.setAccountData("m.direct" as EventType, {
-                            [bot.getUserId()]: [botRoom.room_id],
-                        });
-                    });
+                    createBotDM();
 
                     cy.findByTestId("Sidebar").within(() => {
                         // Force click because the size of the checkbox is zero

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -45,7 +45,8 @@ describe("LeftPanel", () => {
         it("should display spotlight dialog by clicking trigger", () => {
             // Assert the filter container is rendered
             cy.get(".mx_LeftPanel_filterContainer").within(() => {
-                cy.get(".mx_RoomSearch_spotlightTrigger").click();
+                // Force click as Notification toast covers the button on Cypress Cloud
+                cy.get(".mx_RoomSearch_spotlightTrigger").click({ force: true });
             });
 
             cy.findByRole("dialog", { name: "Search Dialog" }).should("exist");
@@ -127,7 +128,8 @@ describe("LeftPanel", () => {
 
                 cy.get(".mx_RoomListHeader").within(() => {
                     // Click the menu button on the header
-                    cy.findByRole("button", { name: `${spaceName} menu` }).click();
+                    // Force click as Notification toast covers the button on Cypress Cloud
+                    cy.findByRole("button", { name: `${spaceName} menu` }).click({ force: true });
                 });
 
                 // Assert that context menu for Space is rendered

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -35,10 +35,24 @@ describe("LeftPanel", () => {
         cy.stopHomeserver(homeserver);
     });
 
-    it("should render the Rooms list", () => {
-        // create rooms and check room names are correct
-        cy.createRoom({ name: "Apple" }).then(() => cy.findByRole("treeitem", { name: "Apple" }));
-        cy.createRoom({ name: "Pineapple" }).then(() => cy.findByRole("treeitem", { name: "Pineapple" }));
-        cy.createRoom({ name: "Orange" }).then(() => cy.findByRole("treeitem", { name: "Orange" }));
+    describe("for room list wrapper", () => {
+        beforeEach(() => {
+            cy.get(".mx_LeftPanel_roomListWrapper").should("exist");
+        });
+
+        describe("for Rooms", () => {
+            it("should render a sublist", () => {
+                cy.get(".mx_LeftPanel_roomListWrapper").within(() => {
+                    cy.findByRole("group", { name: "Rooms" }).within(() => {
+                        // create rooms and check room names are correct
+                        cy.createRoom({ name: "Apple" }).then(() => cy.findByRole("treeitem", { name: "Apple" }));
+                        cy.createRoom({ name: "Pineapple" }).then(() =>
+                            cy.findByRole("treeitem", { name: "Pineapple" }),
+                        );
+                        cy.createRoom({ name: "Orange" }).then(() => cy.findByRole("treeitem", { name: "Orange" }));
+                    });
+                });
+            });
+        });
     });
 });

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -41,6 +41,37 @@ describe("LeftPanel", () => {
         cy.stopHomeserver(homeserver);
     });
 
+    describe("for filter container", () => {
+        it("should display spotlight dialog by clicking trigger", () => {
+            // Assert the filter container is rendered
+            cy.get(".mx_LeftPanel_filterContainer").within(() => {
+                cy.get(".mx_RoomSearch_spotlightTrigger").click();
+            });
+
+            cy.findByRole("dialog", { name: "Search Dialog" }).should("exist");
+        });
+
+        it("should display spotlight dialog by clicking 'Explore rooms' button", () => {
+            cy.get(".mx_LeftPanel_filterContainer").within(() => {
+                cy.findByRole("button", { name: "Explore rooms" }).click();
+            });
+
+            cy.findByRole("dialog", { name: "Search Dialog" }).within(() => {
+                // Assert that the spotlight dialog for searching public rooms
+                cy.get(".mx_SpotlightDialog_filterPublicRooms").should("exist");
+            });
+        });
+
+        it("should display v2 breadcrumbs", () => {
+            cy.setSettingValue("feature_breadcrumbs_v2", null, SettingLevel.DEVICE, true);
+
+            cy.get(".mx_LeftPanel_filterContainer").within(() => {
+                // Assert that the v2 breadcrumbs are rendered
+                cy.findByTitle("Recently viewed").should("exist");
+            });
+        });
+    });
+
     describe("for room list header", () => {
         beforeEach(() => {
             // Assert the room list header is rendered

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -159,13 +159,30 @@ describe("LeftPanel", () => {
     });
 
     describe("for room list wrapper", () => {
+        const message = "Message";
+
         beforeEach(() => {
             cy.get(".mx_LeftPanel_roomListWrapper").should("exist");
         });
 
-        it("should display a message preview", () => {
-            const message = "Message";
+        it("should hide and unhide the room tile by clicking the list header", () => {
+            cy.createRoom({ name: roomName });
 
+            cy.get(".mx_LeftPanel_roomListWrapper").within(() => {
+                // Assert the room tile is rendered by default
+                cy.findByRole("treeitem", { name: roomName }).should("exist");
+
+                // Click the header to hide the room tile
+                cy.findByRole("button", { name: "Rooms" }).click();
+                cy.findByRole("treeitem", { name: roomName }).should("not.exist");
+
+                // Click again to redisplay the room tile
+                cy.findByRole("button", { name: "Rooms" }).click();
+                cy.findByRole("treeitem", { name: roomName }).should("exist");
+            });
+        });
+
+        it("should display a message preview", () => {
             cy.createRoom({ name: roomName }).viewRoomByName(roomName);
 
             cy.getComposer().type(`${message}{enter}`);

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -40,6 +40,32 @@ describe("LeftPanel", () => {
             cy.get(".mx_LeftPanel_roomListWrapper").should("exist");
         });
 
+        it("should display a message preview", () => {
+            const message = "Message";
+
+            cy.createRoom({ name: "Apple" }).viewRoomByName("Apple");
+
+            cy.getComposer().type(`${message}{enter}`);
+
+            // Enable message preview
+            cy.get(".mx_LeftPanel_roomListWrapper").within(() => {
+                cy.findByRole("treeitem", { name: "Rooms" })
+                    .realHover()
+                    .findByRole("button", { name: "List options" })
+                    .click();
+            });
+
+            // Force click because the size of the checkbox is zero
+            cy.findByLabelText("Show previews of messages").click({ force: true });
+
+            // Assert that the preview is visible on the room tile
+            cy.get(".mx_LeftPanel_roomListWrapper").within(() => {
+                cy.findByRole("group", { name: "Rooms" }).within(() => {
+                    cy.get(".mx_RoomTile_subtitle").findByText(message).should("be.visible");
+                });
+            });
+        });
+
         describe("for Rooms", () => {
             it("should render a sublist", () => {
                 cy.get(".mx_LeftPanel_roomListWrapper").within(() => {

--- a/cypress/e2e/left-panel/left-panel.spec.ts
+++ b/cypress/e2e/left-panel/left-panel.spec.ts
@@ -286,7 +286,7 @@ describe("LeftPanel", () => {
             // Force click because the size of the checkbox is zero
             cy.findByLabelText("A-Z").click({ force: true });
 
-            // Foce click to close the context menu
+            // Force click to close the context menu
             cy.get(".mx_ContextualMenu_background").click({ force: true });
 
             // Assert the context menu was closed
@@ -378,11 +378,10 @@ describe("LeftPanel", () => {
                     .findByRole("button", { name: "List options" })
                     .click();
             });
-
             // Force click because the size of the checkbox is zero
             cy.findByLabelText("Show previews of messages").click({ force: true });
 
-            // Foce click to close the context menu
+            // Force click to close the context menu
             cy.get(".mx_ContextualMenu_background").click({ force: true });
 
             // Assert the context menu was closed

--- a/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
@@ -63,7 +63,7 @@ const SidebarUserSettingsTab: React.FC = () => {
     };
 
     return (
-        <SettingsTab>
+        <SettingsTab data-testid="Sidebar">
             <SettingsSection heading={_t("Sidebar")}>
                 <SettingsSubsection
                     heading={_t("Spaces to show")}

--- a/test/components/views/settings/tabs/user/__snapshots__/SidebarUserSettingsTab-test.tsx.snap
+++ b/test/components/views/settings/tabs/user/__snapshots__/SidebarUserSettingsTab-test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<SidebarUserSettingsTab /> renders sidebar settings 1`] = `
 <div>
   <div
     class="mx_SettingsTab"
+    data-testid="Sidebar"
   >
     <div
       class="mx_SettingsTab_sections"


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25564

This PR intends to add tests to `left-panel.spec.ts` in order to have it cover scenarios as comprehensively as possible. Please note this PR does not add tests of `SpacePanel` itself, which is implemented on LeftPanel.

This PR also suggests to add a Percy snapshot of `.mx_LeftPanel_wrapper--user`, on which all of the categories are rendered (`LeftPanel with all groups`). Percy should take a snapshot like below. Avatars' color will be normalized with the media query for Percy:

![all](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/d265ca62-79c0-4bdf-a596-796a4fd11049)

By the way, it turned out that current naming exercise around the area was badly confusing, though I myself will not work on it due to the possibility of a review that calls the change as "overly specific".

Two wrappers not clearly structured:
![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/cf577003-02b0-4486-9bde-2b84d7224785)



type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->