### PR TITLE
GHA: require kiwi creds in cypress.yaml

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -27,7 +27,7 @@ on:
                 required: true
             TCMS_PASSWORD:
                 required: true
-                
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.run_id }}
     cancel-in-progress: ${{ github.event.workflow_run.event == 'pull_request' }}

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -23,7 +23,11 @@ on:
         secrets:
             CYPRESS_RECORD_KEY:
                 required: true
-
+            TCMS_USERNAME:
+                required: true
+            TCMS_PASSWORD:
+                required: true
+                
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.run_id }}
     cancel-in-progress: ${{ github.event.workflow_run.event == 'pull_request' }}


### PR DESCRIPTION
#10969 made the `cypress.yaml` workflow callbable, but failed to declare the needed kiwi secrets.

Together with https://github.com/matrix-org/matrix-js-sdk/pull/3461, hopefully fixes https://github.com/vector-im/element-web/issues/25542.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->