### PR TITLE
Allow specifying help URLs in config.json

### DIFF
--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -152,6 +152,8 @@ export interface IConfigOptions {
     enable_presence_by_hs_url?: Record<string, boolean>; // <HomeserverName, Enabled>
 
     terms_and_conditions_links?: { url: string; text: string }[];
+    help_url: string;
+    help_encryption_url: string;
 
     latex_maths_delims?: {
         inline?: {

--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -26,6 +26,8 @@ import { DeepReadonly, Defaultize } from "./@types/common";
 // see element-web config.md for docs, or the IConfigOptions interface for dev docs
 export const DEFAULTS: DeepReadonly<IConfigOptions> = {
     brand: "Element",
+    help_url: "https://element.io/help",
+    help_encryption_url: "https://element.io/help#encryption",
     integrations_ui_url: "https://scalar.vector.im/",
     integrations_rest_url: "https://scalar.vector.im/api",
     uisi_autorageshake_app: "element-auto-uisi",

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -43,6 +43,7 @@ import PosthogTrackers from "../../../../../PosthogTrackers";
 import MatrixClientContext from "../../../../../contexts/MatrixClientContext";
 import { SettingsSection } from "../../shared/SettingsSection";
 import SettingsTab from "../SettingsTab";
+import SdkConfig from "../../../../../SdkConfig";
 
 interface IProps {
     room: Room;
@@ -163,7 +164,7 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
                     "may prevent many bots and bridges from working correctly. <a>Learn more about encryption.</a>",
                 {},
                 {
-                    a: (sub) => <ExternalLink href="https://element.io/help#encryption">{sub}</ExternalLink>,
+                    a: (sub) => <ExternalLink href={SdkConfig.get("help_encryption_url")}>{sub}</ExternalLink>,
                 },
             ),
             onFinished: (confirm) => {

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -251,7 +251,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                 brand,
             },
             {
-                a: (sub) => <ExternalLink href="https://element.io/help">{sub}</ExternalLink>,
+                a: (sub) => <ExternalLink href={SdkConfig.get("help_url")}>{sub}</ExternalLink>,
             },
         );
         if (SdkConfig.get("welcome_user_id") && getCurrentLanguage().startsWith("en")) {
@@ -265,7 +265,11 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                         },
                         {
                             a: (sub) => (
-                                <ExternalLink href="https://element.io/help" rel="noreferrer noopener" target="_blank">
+                                <ExternalLink
+                                    href={SdkConfig.get("help_url")}
+                                    rel="noreferrer noopener"
+                                    target="_blank"
+                                >
                                     {sub}
                                 </ExternalLink>
                             ),

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -70,6 +70,8 @@ describe("<MatrixChat />", () => {
     const defaultProps: ComponentProps<typeof MatrixChat> = {
         config: {
             brand: "Test",
+            help_url: "help_url",
+            help_encryption_url: "help_encryption_url",
             element_call: {},
             feedback: {
                 existing_issues_url: "https://feedback.org/existing",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/15268
Requires https://github.com/vector-im/element-web/pull/25549

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow specifying help URLs in config.json ([\#11070](https://github.com/matrix-org/matrix-react-sdk/pull/11070)). Fixes vector-im/element-web#15268.<!-- CHANGELOG_PREVIEW_END -->