### PR TITLE
Set the same font-size to emoji inside a code block

### DIFF
--- a/cypress/e2e/timeline/timeline.spec.ts
+++ b/cypress/e2e/timeline/timeline.spec.ts
@@ -824,6 +824,26 @@ describe("Timeline", () => {
                 cy.get(".mx_RoomView_searchResultsPanel").percySnapshotElement("Search results - with TextualEvent");
             });
         });
+
+        describe("with emoji", () => {
+            it("should not push down a line on a code block", () => {
+                const fontSize = "14px"; // This value is based on _EventTile.pcss
+
+                cy.visit("/#/room/" + roomId);
+
+                // Create a code block message with emoji
+                cy.sendEvent(roomId, null, "m.room.message" as EventType, {
+                    msgtype: "m.text" as MsgType,
+                    body: "```\nℹ ｢wdm｣: Compiled with warnings\nThis is another line\n```",
+                    format: "org.matrix.custom.html",
+                    formatted_body: "<pre><code>ℹ ｢wdm｣: Compiled with warnings\nThis is another line\n</code></pre>\n",
+                });
+
+                // Assert that the same font-size value is applied to the message and the emoji
+                cy.get(".mx_EventTile_content .markdown-body").should("have.css", "font-size", fontSize);
+                cy.get(".mx_EventTile_content .markdown-body .mx_Emoji").should("have.css", "font-size", fontSize);
+            });
+        });
     });
 
     describe("message sending", () => {

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -744,6 +744,10 @@ $left-gutter: 64px;
                 > * {
                     display: inline;
                 }
+
+                .mx_Emoji {
+                    font-size: inherit; /* set the same font-size to emoji inside a code block */
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25525

![1](https://github.com/vector-im/element-web/assets/3362943/04cf8bf8-02e8-45de-99b3-7ee61094e30f)

type: defect

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set the same font-size to emoji inside a code block ([\#11072](https://github.com/matrix-org/matrix-react-sdk/pull/11072)). Fixes vector-im/element-web#25525. Contributed by @luixxiul.<!-- CHANGELOG_PREVIEW_END -->