### PR TITLE
Conform to the naming policy - from `mx_AppsContainer` to `mx_AppsDrawer_appsContainer`

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -127,7 +127,7 @@ limitations under the License.
     }
 }
 
-.mx_AppsContainer {
+.mx_AppsDrawer_appsContainer {
     display: flex;
     flex-direction: row;
     align-items: stretch;

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -71,6 +71,35 @@ limitations under the License.
         }
     }
 
+    /* Note appsContainer is not included in PersistentVResizer (mx_AppsDrawer_resizer) if widgetIsMaxmised is true */
+    .mx_AppsDrawer_appsContainer {
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: center;
+        height: 100%;
+        width: 100%;
+        flex: 1;
+        min-height: 0;
+
+        .mx_AppTile:first-of-type {
+            border-left-width: var(--container-border-width);
+            border-radius: 10px 0 0 10px;
+        }
+        .mx_AppTile:last-of-type {
+            border-right-width: var(--container-border-width);
+            border-radius: 0 10px 10px 0;
+        }
+
+        .mx_ResizeHandle--horizontal {
+            position: relative;
+
+            > div {
+                width: 0;
+            }
+        }
+    }
+
     &:hover {
         .mx_AppsDrawer_resizer_container_handle::after {
             opacity: 0.8;
@@ -123,34 +152,6 @@ limitations under the License.
             flex-grow: 1;
             width: 0 !important;
             min-width: var(--minWidth) !important;
-        }
-    }
-}
-
-.mx_AppsDrawer_appsContainer {
-    display: flex;
-    flex-direction: row;
-    align-items: stretch;
-    justify-content: center;
-    height: 100%;
-    width: 100%;
-    flex: 1;
-    min-height: 0;
-
-    .mx_AppTile:first-of-type {
-        border-left-width: var(--container-border-width);
-        border-radius: 10px 0 0 10px;
-    }
-    .mx_AppTile:last-of-type {
-        border-right-width: var(--container-border-width);
-        border-radius: 0 10px 10px 0;
-    }
-
-    .mx_ResizeHandle--horizontal {
-        position: relative;
-
-        > div {
-            width: 0;
         }
     }
 }

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -74,7 +74,6 @@ limitations under the License.
     /* Note appsContainer is not included in PersistentVResizer (mx_AppsDrawer_resizer) if widgetIsMaxmised is true */
     .mx_AppsDrawer_appsContainer {
         display: flex;
-        flex-direction: row;
         align-items: stretch;
         justify-content: center;
         height: 100%;

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -261,7 +261,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
             "mx_AppsDrawer--3apps": apps.length === 3,
         });
         const appsContainer = (
-            <div className="mx_AppsContainer" ref={this.collectResizer}>
+            <div className="mx_AppsDrawer_appsContainer" ref={this.collectResizer}>
                 {apps.map((app, i) => {
                     if (i < 1) return app;
                     return (

--- a/src/components/views/rooms/AppsDrawer.tsx
+++ b/src/components/views/rooms/AppsDrawer.tsx
@@ -260,7 +260,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
             "mx_AppsDrawer--2apps": apps.length === 2,
             "mx_AppsDrawer--3apps": apps.length === 3,
         });
-        const appContainers = (
+        const appsContainer = (
             <div className="mx_AppsContainer" ref={this.collectResizer}>
                 {apps.map((app, i) => {
                     if (i < 1) return app;
@@ -276,7 +276,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
 
         let drawer;
         if (widgetIsMaxmised) {
-            drawer = appContainers;
+            drawer = appsContainer;
         } else {
             drawer = (
                 <PersistentVResizer
@@ -288,7 +288,7 @@ export default class AppsDrawer extends React.Component<IProps, IState> {
                     handleClass="mx_AppsDrawer_resizer_container_handle"
                     resizeNotifier={this.props.resizeNotifier}
                 >
-                    {appContainers}
+                    {appsContainer}
                 </PersistentVResizer>
             );
         }

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -274,7 +274,7 @@ exports[`AppTile for a pinned widget should render permission request 1`] = `
           </div>
           <div>
             <span>
-              Using this widget may share data
+              Using this widget may share data 
               <div
                 aria-describedby="mx_TooltipTarget_abdefghi"
                 class="mx_TextWithTooltip_target mx_TextWithTooltip_target--helpIcon"

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -274,7 +274,7 @@ exports[`AppTile for a pinned widget should render permission request 1`] = `
           </div>
           <div>
             <span>
-              Using this widget may share data 
+              Using this widget may share data
               <div
                 aria-describedby="mx_TooltipTarget_abdefghi"
                 class="mx_TextWithTooltip_target mx_TextWithTooltip_target--helpIcon"
@@ -316,7 +316,7 @@ exports[`AppTile preserves non-persisted widget on container move 1`] = `
       style="position: relative; user-select: auto; width: auto; height: 280px; max-height: 576px; min-height: 100px; box-sizing: border-box; flex-shrink: 0;"
     >
       <div
-        class="mx_AppsContainer"
+        class="mx_AppsDrawer_appsContainer"
       >
         <div
           class="mx_AppTileFullWidth"


### PR DESCRIPTION
Close https://github.com/vector-im/element-web/issues/25268

This is one of the PRs which intend to conform `_AppsDrawer.pcss` to the naming policy. This PR intends to change the class name `mx_AppsContainer` to `mx_AppsDrawer_appsContainer` to close https://github.com/vector-im/element-web/issues/25268.

The class name `mx_AppsContainer` is defined by const `appsContainer`, and `appsContainer` is either equal to `drawer` (if `widgetIsMaxmised` is true) or included in it.

Since `drawer` is wrapped by a div, whose class name is defined by the const `classes`, and one of the `classes` is `mx_AppsDrawer`, it is sensible to regard `mx_AppsContainer`(`mx_AppsDrawer_appsContainer`) is defined by `mx_AppsDrawer`.

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/e9507878-0970-4127-97ac-a23e8a6af627)

Please note `appsContainer` is not defined by `PersistentVResizer` (`mx_AppsDrawer_resizer`) if `widgetIsMaxmised` is true, which means that the appsContainer will not be properly styled on a maximized widget when you set the class name to `mx_AppsDrawer_resizer_appsContainer` and style the component following the name.

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->