### PR TITLE
Group common declarations of `mx_AppsDrawer--2apps` and `mx_AppsDrawer--3apps`

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -107,23 +107,21 @@ limitations under the License.
         z-index: 1;
     }
 
-    &.mx_AppsDrawer--2apps .mx_AppTile {
-        width: 50%;
-
-        &:nth-child(3) {
+    &.mx_AppsDrawer--2apps,
+    &.mx_AppsDrawer--3apps {
+        .mx_AppTile:nth-child(3) {
             flex-grow: 1;
             width: 0 !important;
             min-width: var(--minWidth) !important;
         }
     }
+
+    &.mx_AppsDrawer--2apps .mx_AppTile {
+        width: 50%;
+    }
+
     &.mx_AppsDrawer--3apps .mx_AppTile {
         width: 33%;
-
-        &:nth-child(3) {
-            flex-grow: 1;
-            width: 0 !important;
-            min-width: var(--minWidth) !important;
-        }
     }
 }
 

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -121,7 +121,7 @@ limitations under the License.
     }
 
     &.mx_AppsDrawer--3apps .mx_AppTile {
-        width: 33%;
+        width: calc(100% / 3);
     }
 }
 


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25268

This PR intends to group common declarations of `mx_AppsDrawer--2apps` and `mx_AppsDrawer--3apps` to improve maintainability.

Those class names were originally added by 7be5ff0 for a PR https://github.com/matrix-org/matrix-react-sdk/pull/5266 which initially implemented a pinned widget, and there does not seem to be a specific reason why "nth-child(3)" was applied for each class name. It also seems there was not a reason why '33%' was picked instead of `100%/3` to count 1%.

![0](https://github.com/matrix-org/matrix-react-sdk/assets/3362943/25aaf144-c7d7-4976-a50f-c5abc748ee56)

type: task

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->