### PR TITLE
Increase RTE resilience

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
@@ -31,7 +31,7 @@ export const dynamicImportSendMessage = async (
     isHTML: boolean,
     params: SendMessageParams,
 ): Promise<ISendEventResponse | undefined> => {
-    const { sendMessage } = await import("./utils/message");
+    const { sendMessage } = await retry(() => import("./utils/message"), RETRY_COUNT);
 
     return sendMessage(message, isHTML, params);
 };

--- a/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
@@ -20,9 +20,11 @@ import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 // we need to import the types for TS, but do not import the sendMessage
 // function to avoid importing from "@matrix-org/matrix-wysiwyg"
 import { SendMessageParams } from "./utils/message";
+import { retry } from "../../../../utils/promise";
 
-const SendComposer = lazy(() => import("./SendWysiwygComposer"));
-const EditComposer = lazy(() => import("./EditWysiwygComposer"));
+const RETRY_COUNT = 3;
+const SendComposer = lazy(() => retry(() => import("./SendWysiwygComposer"), RETRY_COUNT));
+const EditComposer = lazy(() => retry(() => import("./EditWysiwygComposer"), RETRY_COUNT));
 
 export const dynamicImportSendMessage = async (
     message: string,

--- a/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
@@ -22,6 +22,8 @@ import { ISendEventResponse } from "matrix-js-sdk/src/@types/requests";
 import { SendMessageParams } from "./utils/message";
 import { retry } from "../../../../utils/promise";
 
+// Due to issues such as https://github.com/vector-im/element-web/issues/25277, we add retry
+// attempts to all of the dynamic imports in this file
 const RETRY_COUNT = 3;
 const SendComposer = lazy(() => retry(() => import("./SendWysiwygComposer"), RETRY_COUNT));
 const EditComposer = lazy(() => retry(() => import("./EditWysiwygComposer"), RETRY_COUNT));

--- a/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/DynamicImportWysiwygComposer.tsx
@@ -40,7 +40,7 @@ export const dynamicImportConversionFunctions = async (): Promise<{
     richToPlain(rich: string): Promise<string>;
     plainToRich(plain: string): Promise<string>;
 }> => {
-    const { richToPlain, plainToRich } = await import("@matrix-org/matrix-wysiwyg");
+    const { richToPlain, plainToRich } = await retry(() => import("@matrix-org/matrix-wysiwyg"), RETRY_COUNT);
 
     return { richToPlain, plainToRich };
 };

--- a/src/components/views/rooms/wysiwyg_composer/SendWysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/SendWysiwygComposer.tsx
@@ -40,7 +40,7 @@ const Content = forwardRef<HTMLElement, ContentProps>(function Content(
     return null;
 });
 
-interface SendWysiwygComposerProps {
+export interface SendWysiwygComposerProps {
     initialContent?: string;
     isRichTextEnabled: boolean;
     placeholder?: string;


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/25277

When investigating the above issue, it was highlighted to me that the composers can fail if network issues prevent fetching the code required for them to run. This PR aims to mitigate that risk by adding retry mechanisms to the dynamic imports for the rich text editor. 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Increase RTE resilience ([\#11111](https://github.com/matrix-org/matrix-react-sdk/pull/11111)). Fixes vector-im/element-web#25277. Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->