### PR TITLE
Prevent auto-translation within composer

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -850,6 +850,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
                     dir="auto"
                     aria-disabled={this.props.disabled}
                     data-testid="basicmessagecomposer"
+                    translate="no"
                 />
             </div>
         );

--- a/test/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -505,6 +505,7 @@ exports[`RoomView for a local room in state NEW should match the snapshot 1`] = 
                   role="textbox"
                   style="--placeholder: 'Send a message…';"
                   tabindex="0"
+                  translate="no"
                 >
                   <div>
                     <br />
@@ -768,6 +769,7 @@ exports[`RoomView for a local room in state NEW that is encrypted should match t
                   role="textbox"
                   style="--placeholder: 'Send a message…';"
                   tabindex="0"
+                  translate="no"
                 >
                   <div>
                     <br />


### PR DESCRIPTION
Fixes: vector-im/element-web#25624

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent auto-translation within composer ([\#11114](https://github.com/matrix-org/matrix-react-sdk/pull/11114)). Fixes vector-im/element-web#25624.<!-- CHANGELOG_PREVIEW_END -->