### PR TITLE
Improve message body output from plain text editor

### DIFF
--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -20,7 +20,7 @@ import { IContent, IEventRelation, MatrixEvent, MsgType } from "matrix-js-sdk/sr
 import SettingsStore from "../../../../../settings/SettingsStore";
 import { parsePermalink, RoomPermalinkCreator } from "../../../../../utils/permalinks/Permalinks";
 import { addReplyToMessageContent } from "../../../../../utils/Reply";
-import { isNotNull, isNotUndefined } from "../../../../../Typeguards";
+import { isNotNull } from "../../../../../Typeguards";
 
 export const EMOTE_PREFIX = "/me ";
 

--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -95,7 +95,7 @@ export async function createMessageContent(
 
     // if we're editing rich text, the message content is pure html
     // BUT if we're not, the message content will be plain text
-    const body = isHTML ? await richToPlain(message) : message;
+    const body = isHTML ? await richToPlain(message) : convertMdMessageToMatrixMessage(message);
     const bodyPrefix = (isReplyAndEditing && getTextReplyFallback(editedEvent)) || "";
     const formattedBodyPrefix = (isReplyAndEditing && getHtmlReplyFallback(editedEvent)) || "";
 
@@ -139,5 +139,15 @@ export async function createMessageContent(
         });
     }
 
+    return content;
+}
+
+/**
+ * Without a model, we need to manually amend uncontrolled message content to make sure that mentions
+ * meet the matrix specification
+ * @param content - the output from the `MessageComposer` state when in plain text mode
+ * @returns - a string formatted with the mentions replaced as necessary
+ */
+function convertMdMessageToMatrixMessage(content: string): string {
     return content;
 }

--- a/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -154,4 +154,11 @@ describe("createMessageContent", () => {
 
         expect(content).toMatchObject({ msgtype: MsgType.Emote });
     });
+
+    it("Should replace at-room mentions with `@room` text", async () => {
+        const html = '​<a href="#" contenteditable="false" data-mention-type="at-room" style="some styling">@room</a> ';
+        const content = await createMessageContent(html, false, { permalinkCreator });
+
+        expect(content).toMatchObject({ body: "@room " });
+    });
 });

--- a/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -41,124 +41,146 @@ describe("createMessageContent", () => {
         jest.resetAllMocks();
     });
 
-    it("Should create html message", async () => {
-        // When
-        const content = await createMessageContent(message, true, { permalinkCreator });
+    describe("Richtext composer input", () => {
+        it("Should create html message", async () => {
+            // When
+            const content = await createMessageContent(message, true, { permalinkCreator });
 
-        // Then
-        expect(content).toEqual({
-            body: "*__hello__ world*",
-            format: "org.matrix.custom.html",
-            formatted_body: message,
-            msgtype: "m.text",
-        });
-    });
-
-    it("Should add reply to message content", async () => {
-        // When
-        const content = await createMessageContent(message, true, { permalinkCreator, replyToEvent: mockEvent });
-
-        // Then
-        expect(content).toEqual({
-            "body": "> <myfakeuser> Replying to this\n\n*__hello__ world*",
-            "format": "org.matrix.custom.html",
-            "formatted_body":
-                '<mx-reply><blockquote><a href="$$permalink$$">In reply to</a>' +
-                ' <a href="https://matrix.to/#/myfakeuser">myfakeuser</a>' +
-                "<br>Replying to this</blockquote></mx-reply><em><b>hello</b> world</em>",
-            "msgtype": "m.text",
-            "m.relates_to": {
-                "m.in_reply_to": {
-                    event_id: mockEvent.getId(),
-                },
-            },
-        });
-    });
-
-    it("Should add relation to message", async () => {
-        // When
-        const relation = {
-            rel_type: "m.thread",
-            event_id: "myFakeThreadId",
-        };
-        const content = await createMessageContent(message, true, { permalinkCreator, relation });
-
-        // Then
-        expect(content).toEqual({
-            "body": "*__hello__ world*",
-            "format": "org.matrix.custom.html",
-            "formatted_body": message,
-            "msgtype": "m.text",
-            "m.relates_to": {
-                event_id: "myFakeThreadId",
-                rel_type: "m.thread",
-            },
-        });
-    });
-
-    it("Should add fields related to edition", async () => {
-        // When
-        const editedEvent = mkEvent({
-            type: "m.room.message",
-            room: "myfakeroom",
-            user: "myfakeuser2",
-            content: {
-                "msgtype": "m.text",
-                "body": "First message",
-                "formatted_body": "<b>First Message</b>",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        event_id: "eventId",
-                    },
-                },
-            },
-            event: true,
-        });
-        const content = await createMessageContent(message, true, { permalinkCreator, editedEvent });
-
-        // Then
-        expect(content).toEqual({
-            "body": " * *__hello__ world*",
-            "format": "org.matrix.custom.html",
-            "formatted_body": ` * ${message}`,
-            "msgtype": "m.text",
-            "m.new_content": {
+            // Then
+            expect(content).toEqual({
                 body: "*__hello__ world*",
                 format: "org.matrix.custom.html",
                 formatted_body: message,
                 msgtype: "m.text",
-            },
-            "m.relates_to": {
-                event_id: editedEvent.getId(),
-                rel_type: "m.replace",
-            },
+            });
+        });
+
+        it("Should add reply to message content", async () => {
+            // When
+            const content = await createMessageContent(message, true, { permalinkCreator, replyToEvent: mockEvent });
+
+            // Then
+            expect(content).toEqual({
+                "body": "> <myfakeuser> Replying to thisnn*__hello__ world*",
+                "format": "org.matrix.custom.html",
+                "formatted_body":
+                    '<mx-reply><blockquote><a href="$$permalink$$">In reply to</a>' +
+                    ' <a href="https://matrix.to/#/myfakeuser">myfakeuser</a>' +
+                    "<br>Replying to this</blockquote></mx-reply><em><b>hello</b> world</em>",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "m.in_reply_to": {
+                        event_id: mockEvent.getId(),
+                    },
+                },
+            });
+        });
+
+        it("Should add relation to message", async () => {
+            // When
+            const relation = {
+                rel_type: "m.thread",
+                event_id: "myFakeThreadId",
+            };
+            const content = await createMessageContent(message, true, { permalinkCreator, relation });
+
+            // Then
+            expect(content).toEqual({
+                "body": "*__hello__ world*",
+                "format": "org.matrix.custom.html",
+                "formatted_body": message,
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    event_id: "myFakeThreadId",
+                    rel_type: "m.thread",
+                },
+            });
+        });
+
+        it("Should add fields related to edition", async () => {
+            // When
+            const editedEvent = mkEvent({
+                type: "m.room.message",
+                room: "myfakeroom",
+                user: "myfakeuser2",
+                content: {
+                    "msgtype": "m.text",
+                    "body": "First message",
+                    "formatted_body": "<b>First Message</b>",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            event_id: "eventId",
+                        },
+                    },
+                },
+                event: true,
+            });
+            const content = await createMessageContent(message, true, { permalinkCreator, editedEvent });
+
+            // Then
+            expect(content).toEqual({
+                "body": " * *__hello__ world*",
+                "format": "org.matrix.custom.html",
+                "formatted_body": ` * ${message}`,
+                "msgtype": "m.text",
+                "m.new_content": {
+                    body: "*__hello__ world*",
+                    format: "org.matrix.custom.html",
+                    formatted_body: message,
+                    msgtype: "m.text",
+                },
+                "m.relates_to": {
+                    event_id: editedEvent.getId(),
+                    rel_type: "m.replace",
+                },
+            });
+        });
+
+        it("Should strip the /me prefix from a message", async () => {
+            const textBody = "some body text";
+            const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+
+            expect(content).toMatchObject({ body: textBody, formatted_body: textBody });
+        });
+
+        it("Should strip single / from message prefixed with //", async () => {
+            const content = await createMessageContent("//twoSlashes", true, { permalinkCreator });
+
+            expect(content).toMatchObject({ body: "/twoSlashes", formatted_body: "/twoSlashes" });
+        });
+
+        it("Should set the content type to MsgType.Emote when /me prefix is used", async () => {
+            const textBody = "some body text";
+            const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+
+            expect(content).toMatchObject({ msgtype: MsgType.Emote });
         });
     });
 
-    it("Should strip the /me prefix from a message", async () => {
-        const textBody = "some body text";
-        const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+    describe("Plaintext composer input", () => {
+        it.only("Should replace at-room mentions with `@room` text", async () => {
+            const messageComposerState = `<a href="#" contenteditable="false" data-mention-type="at-room" style="some styling">@room</a> `;
 
-        expect(content).toMatchObject({ body: textBody, formatted_body: textBody });
-    });
+            const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
+            expect(content).toMatchObject({ body: "@room ", formatted_body: "@room " });
+        });
 
-    it("Should strip single / from message prefixed with //", async () => {
-        const content = await createMessageContent("//twoSlashes", true, { permalinkCreator });
+        it("Should replace user mentions with user name in body text", async () => {
+            const messageComposerState = `<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> `;
 
-        expect(content).toMatchObject({ body: "/twoSlashes", formatted_body: "/twoSlashes" });
-    });
+            const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
 
-    it("Should set the content type to MsgType.Emote when /me prefix is used", async () => {
-        const textBody = "some body text";
-        const content = await createMessageContent(EMOTE_PREFIX + textBody, true, { permalinkCreator });
+            expect(content).toMatchObject({ body: "a test user " });
+        });
 
-        expect(content).toMatchObject({ msgtype: MsgType.Emote });
-    });
+        it("Should strip attributges from user mentions in formatted_body", async () => {
+            const messageComposerState = `<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> `;
 
-    it("Should replace at-room mentions with `@room` text", async () => {
-        const html = '​<a href="#" contenteditable="false" data-mention-type="at-room" style="some styling">@room</a> ';
-        const content = await createMessageContent(html, false, { permalinkCreator });
+            const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
 
-        expect(content).toMatchObject({ body: "@room " });
+            expect(content).toMatchObject({
+                formatted_body: `<a href="https://matrix.to/#/@test_user:element.io">a test user</a> `,
+            });
+        });
     });
 });

--- a/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/test/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -61,7 +61,7 @@ describe("createMessageContent", () => {
 
             // Then
             expect(content).toEqual({
-                "body": "> <myfakeuser> Replying to thisnn*__hello__ world*",
+                "body": "> <myfakeuser> Replying to this\n\n*__hello__ world*",
                 "format": "org.matrix.custom.html",
                 "formatted_body":
                     '<mx-reply><blockquote><a href="$$permalink$$">In reply to</a>' +
@@ -158,14 +158,14 @@ describe("createMessageContent", () => {
     });
 
     describe("Plaintext composer input", () => {
-        it.only("Should replace at-room mentions with `@room` text", async () => {
+        it("Should replace at-room mentions with `@room` in body", async () => {
             const messageComposerState = `<a href="#" contenteditable="false" data-mention-type="at-room" style="some styling">@room</a> `;
 
             const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
-            expect(content).toMatchObject({ body: "@room ", formatted_body: "@room " });
+            expect(content).toMatchObject({ body: "@room " });
         });
 
-        it("Should replace user mentions with user name in body text", async () => {
+        it("Should replace user mentions with user name in body", async () => {
             const messageComposerState = `<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> `;
 
             const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
@@ -173,13 +173,13 @@ describe("createMessageContent", () => {
             expect(content).toMatchObject({ body: "a test user " });
         });
 
-        it("Should strip attributges from user mentions in formatted_body", async () => {
-            const messageComposerState = `<a href="https://matrix.to/#/@test_user:element.io" contenteditable="false" data-mention-type="user" style="some styling">a test user</a> `;
+        it("Should replace room mentions with room mxid in body", async () => {
+            const messageComposerState = `<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="room" style="some styling">a test room</a> `;
 
             const content = await createMessageContent(messageComposerState, false, { permalinkCreator });
 
             expect(content).toMatchObject({
-                formatted_body: `<a href="https://matrix.to/#/@test_user:element.io">a test user</a> `,
+                body: "#test_room:element.io ",
             });
         });
     });


### PR DESCRIPTION
When writing a message with mentions in the plain text editor, the `body` content on the sent message was not what we wanted - it was the html from the composer and so contained spurious html. 

This change fixes that and formats a mention in the message.body as expected for a room, user and at room mention.

Before:
<img width="611" alt="Element__2____Alun_Turner" src="https://github.com/matrix-org/matrix-react-sdk/assets/56027671/9bd7684e-0666-4093-b7fe-4846ba5f4309">

After:
<img width="600" alt="Element__2____Alun_Turner" src="https://github.com/matrix-org/matrix-react-sdk/assets/56027671/7a79fb7c-dcb8-4438-99ab-e8719a409fa2">



<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve message body output from plain text editor ([\#11124](https://github.com/matrix-org/matrix-react-sdk/pull/11124)). Contributed by @alunturner.<!-- CHANGELOG_PREVIEW_END -->