### PR TITLE
Fix server picker not allowing you to switch from custom to default

### DIFF
--- a/src/components/views/dialogs/ServerPickerDialog.tsx
+++ b/src/components/views/dialogs/ServerPickerDialog.tsx
@@ -159,6 +159,7 @@ export default class ServerPickerDialog extends React.PureComponent<IProps, ISta
 
         if (this.state.defaultChosen) {
             this.props.onFinished(this.defaultServer);
+            return;
         }
 
         const valid = await this.fieldRef.current?.validate({ allowEmpty: false });
@@ -173,7 +174,7 @@ export default class ServerPickerDialog extends React.PureComponent<IProps, ISta
     };
 
     public render(): React.ReactNode {
-        let text;
+        let text: string | undefined;
         if (this.defaultServer.hsName === "matrix.org") {
             text = _t("Matrix.org is the biggest public homeserver in the world, so it's a good place for many.");
         }

--- a/test/components/views/dialogs/ServerPickerDialog-test.tsx
+++ b/test/components/views/dialogs/ServerPickerDialog-test.tsx
@@ -114,6 +114,35 @@ describe("<ServerPickerDialog />", () => {
             expect(onFinished).toHaveBeenCalledWith(defaultServerConfig);
         });
 
+        it("should allow user to revert from a custom server to the default", async () => {
+            fetchMock.get(`https://custom.org/_matrix/client/versions`, {
+                unstable_features: {},
+                versions: [],
+            });
+
+            const onFinished = jest.fn();
+            const serverConfig = {
+                hsUrl: "https://custom.org",
+                hsName: "custom.org",
+                hsNameIsDifferent: true,
+                isUrl: "https://is.org",
+                isDefault: false,
+                isNameResolvable: true,
+                warning: "",
+            };
+            getComponent({ onFinished, serverConfig });
+
+            fireEvent.click(screen.getByTestId("defaultHomeserver"));
+            expect(screen.getByTestId("defaultHomeserver")).toBeChecked();
+
+            fireEvent.click(screen.getByText("Continue"));
+            await flushPromises();
+
+            // closed dialog with default server and nothing else
+            expect(onFinished).toHaveBeenCalledWith(defaultServerConfig);
+            expect(onFinished).toHaveBeenCalledTimes(1);
+        });
+
         it("should submit successfully with a valid custom homeserver", async () => {
             const homeserver = "https://myhomeserver.site";
             fetchMock.get(`${homeserver}/_matrix/client/versions`, {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25650

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix server picker not allowing you to switch from custom to default ([\#11127](https://github.com/matrix-org/matrix-react-sdk/pull/11127)). Fixes vector-im/element-web#25650.<!-- CHANGELOG_PREVIEW_END -->