### PR TITLE
Fix spurious error sending receipt in thread errors

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -1135,7 +1135,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
         const lastReadEventIndex = this.getLastDisplayedEventIndex({
             ignoreOwn: true,
         });
-        const lastReadEvent: MatrixEvent | null = this.state.events[lastReadEventIndex ?? 0] ?? null;
+        const lastReadEvent = this.state.events[lastReadEventIndex ?? this.state.events.length - 1] ?? null;
 
         const shouldSendReadReceipt = this.shouldSendReadReceipt(
             currentReadReceiptEventId,


### PR DESCRIPTION
Trying to send an RR to the first event fails in threads as that event is a thread root and cannot carry a threaded RR so instead target the last event

![image](https://github.com/matrix-org/matrix-react-sdk/assets/2403652/02965734-801a-40b8-bef1-bcf4c43d00ac)



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix spurious error sending receipt in thread errors ([\#11157](https://github.com/matrix-org/matrix-react-sdk/pull/11157)).<!-- CHANGELOG_PREVIEW_END -->