### PR TITLE
Replace `beginKeyVerification` with `startVerification`

### DIFF
--- a/src/components/views/right_panel/VerificationPanel.tsx
+++ b/src/components/views/right_panel/VerificationPanel.tsx
@@ -399,12 +399,7 @@ export default class VerificationPanel extends React.PureComponent<IProps, IStat
 
     private startSAS = async (): Promise<void> => {
         this.setState({ emojiButtonClicked: true });
-        const verifier = this.props.request.beginKeyVerification(verificationMethods.SAS);
-        try {
-            await verifier.verify();
-        } catch (err) {
-            logger.error(err);
-        }
+        await this.props.request.startVerification(verificationMethods.SAS);
     };
 
     private onSasMatchesClick = (): void => {


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3528 deprecated `VerificationRequest.beginKeyVerification` in favour of `startVerification`. Let's switch over, for compatibility with the rusty crypto stack.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->