### PR TITLE
Fix font-family definition for emojis

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -49,7 +49,6 @@ limitations under the License.
     --dialog-zIndex-static: calc(var(--dialog-zIndex-static-background) + 1); /* 4010 */
     --dialog-zIndex-standard-background: calc(var(--dialog-zIndex-static) + 1); /* 4011 */
     --dialog-zIndex-standard: calc(var(--dialog-zIndex-standard-background) + 1); /* 4012 */
-
 }
 
 /**

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -52,7 +52,8 @@ limitations under the License.
 }
 
 /**
- * Doubling the selector to increase specificity as Compound defines it as such
+ * We need to increase the specificity of the selector to override the 
+ * custom property set by the design tokens package
  */
 [class^="cpd-theme"][class^="cpd-theme"] {
     /**

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -49,6 +49,20 @@ limitations under the License.
     --dialog-zIndex-static: calc(var(--dialog-zIndex-static-background) + 1); /* 4010 */
     --dialog-zIndex-standard-background: calc(var(--dialog-zIndex-static) + 1); /* 4011 */
     --dialog-zIndex-standard: calc(var(--dialog-zIndex-standard-background) + 1); /* 4012 */
+
+}
+
+/**
+ * Doubling the selector to increase specificity as Compound defines it as such
+ */
+[class^="cpd-theme"][class^="cpd-theme"] {
+    /**
+     * The design tokens package currently does not expose the fallback fonts
+     * We want to keep on re-using `$font-family` to not break custom themes
+     * and because we can to use `Twemoji` to display emoji rather than using
+     * system ones
+     */
+    --cpd-font-family-sans: $font-family;
 }
 
 @media only percy {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25686

A further fix would be to have the font fallback definition as part of the Compound Design Tokens package, but some limitations with Figma made us not do that in the first place.
Tracked as part of https://github.com/vector-im/compound/issues/155

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix font-family definition for emojis ([\#11170](https://github.com/matrix-org/matrix-react-sdk/pull/11170)). Fixes vector-im/element-web#25686.<!-- CHANGELOG_PREVIEW_END -->