### PR TITLE
Make event info size consistent with state events

### DIFF
--- a/res/css/views/right_panel/_TimelineCard.pcss
+++ b/res/css/views/right_panel/_TimelineCard.pcss
@@ -66,6 +66,10 @@ limitations under the License.
                 .mx_EventTile_avatar {
                     inset-inline-start: 18px;
                 }
+
+                /* Info events should have the same size as state events, those
+                 * are usually wrapped in a generic event list summary */
+                font: var(--cpd-font-body-sm-regular);
             }
 
             .mx_EventTile_avatar {


### PR DESCRIPTION
Fixes the issue highlighted in the screenshot below

![Screenshot 2023-07-03 at 16 40 41](https://github.com/matrix-org/matrix-react-sdk/assets/769871/f81b222b-9e1c-4173-99db-fd101b31fb77)


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make event info size consistent with state events ([\#11181](https://github.com/matrix-org/matrix-react-sdk/pull/11181)).<!-- CHANGELOG_PREVIEW_END -->