### PR TITLE
Revert "Add isLocation to ComposerEvent analytics events"

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -308,7 +308,6 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
         PosthogAnalytics.instance.trackEvent<ComposerEvent>({
             eventName: "Composer",
             isEditing: true,
-            isLocation: false,
             inThread: !!editedEvent?.getThread(),
             isReply: !!editedEvent.replyEventId,
         });

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -447,7 +447,6 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
         const posthogEvent: ComposerEvent = {
             eventName: "Composer",
             isEditing: false,
-            isLocation: false,
             isReply: !!this.props.replyToEvent,
             inThread: this.props.relation?.rel_type === THREAD_RELATION_TYPE.name,
         };

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -64,7 +64,6 @@ export async function sendMessage(
     const posthogEvent: ComposerEvent = {
         eventName: "Composer",
         isEditing: false,
-        isLocation: false,
         isReply: Boolean(replyToEvent),
         // TODO thread
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
@@ -200,7 +199,6 @@ export async function editMessage(
     PosthogAnalytics.instance.trackEvent<ComposerEvent>({
         eventName: "Composer",
         isEditing: true,
-        isLocation: false,
         inThread: Boolean(editedEvent?.getThread()),
         isReply: Boolean(editedEvent.replyEventId),
     });


### PR DESCRIPTION
... because although it fixed CI, it broke local development, and the right fix for CI is to land https://github.com/matrix-org/matrix-react-sdk/pull/11186 and https://github.com/vector-im/element-web/pull/25712

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->