### PR TITLE
Restoring optional ligatures by resetting letter-spacing

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -99,7 +99,7 @@ body {
      * `font-feature-settings` allows us to override this behaviour and have the
      * correct ligatures and the proper dynamic metric spacing.
      */
-    font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+    font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
 
     background-color: $background;
     color: $primary-content;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -92,6 +92,14 @@ html {
 body {
     font: var(--cpd-font-body-md-regular);
     letter-spacing: var(--cpd-font-letter-spacing-body-md);
+    /**
+     * We want to apply Inter Dynamic metrics (https://rsms.me/inter/dynmetrics/)
+     * We need to tweak the `letter-spacing` property and doing so, disables by
+     * default the optional ligatures
+     * `font-feature-settings` allows us to override this behaviour and have the
+     * correct ligatures and the proper dynamic metric spacing.
+     */
+    font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
 
     background-color: $background;
     color: $primary-content;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -91,7 +91,6 @@ html {
 
 body {
     font: var(--cpd-font-body-md-regular);
-    letter-spacing: var(--cpd-font-letter-spacing-body-md);
 
     background-color: $background;
     color: $primary-content;
@@ -134,7 +133,6 @@ b {
 h2 {
     color: $primary-content;
     font: var(--cpd-font-heading-lg-regular);
-    letter-spacing: var(--cpd-font-letter-spacing-heading-lg);
     margin-top: 16px;
     margin-bottom: 16px;
 }
@@ -351,7 +349,6 @@ legend {
     /* Styles copied/inspired by GroupLayout, ReplyTile, and EventTile variants. */
     .markdown-body {
         font: var(--cpd-font-body-md-regular) !important;
-        letter-spacing: var(--cpd-font-letter-spacing-body-md);
         font-family: inherit !important;
         white-space: normal !important;
         line-height: inherit !important;

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -91,6 +91,7 @@ html {
 
 body {
     font: var(--cpd-font-body-md-regular);
+    letter-spacing: var(--cpd-font-letter-spacing-body-md);
 
     background-color: $background;
     color: $primary-content;
@@ -133,6 +134,7 @@ b {
 h2 {
     color: $primary-content;
     font: var(--cpd-font-heading-lg-regular);
+    letter-spacing: var(--cpd-font-letter-spacing-heading-lg);
     margin-top: 16px;
     margin-bottom: 16px;
 }
@@ -349,6 +351,7 @@ legend {
     /* Styles copied/inspired by GroupLayout, ReplyTile, and EventTile variants. */
     .markdown-body {
         font: var(--cpd-font-body-md-regular) !important;
+        letter-spacing: var(--cpd-font-letter-spacing-body-md);
         font-family: inherit !important;
         white-space: normal !important;
         line-height: inherit !important;

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -697,6 +697,7 @@ $left-gutter: 64px;
 
     .markdown-body {
         font: var(--cpd-font-body-md-regular) !important;
+        letter-spacing: var(--cpd-font-letter-spacing-body-md);
         font-family: inherit !important;
         white-space: normal !important;
         line-height: inherit !important;

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -697,7 +697,6 @@ $left-gutter: 64px;
 
     .markdown-body {
         font: var(--cpd-font-body-md-regular) !important;
-        letter-spacing: var(--cpd-font-letter-spacing-body-md);
         font-family: inherit !important;
         white-space: normal !important;
         line-height: inherit !important;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25727

Setting the `letter-spacing` property disables optional ligatures, as per spec mandates, https://drafts.csswg.org/css-text/#letter-spacing-property

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Restoring optional ligatures by resetting letter-spacing ([\#11202](https://github.com/matrix-org/matrix-react-sdk/pull/11202)). Fixes vector-im/element-web#25727.<!-- CHANGELOG_PREVIEW_END -->