### PR TITLE
Add commented-out waitForIFrameLoad option to Element Call widget

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -688,6 +688,13 @@ export class ElementCall extends Call {
                     name: "Element Call",
                     type: MatrixWidgetType.Custom,
                     url: url.toString(),
+                    // This option makes the widget API wait for the 'contentLoaded' event instead
+                    // of waiting for a 'load' event from the iframe, which means the widget code isn't
+                    // racing to set up its listener before the 'load' event is fired. EC sends this event
+                    // of of https://github.com/matrix-org/matrix-js-sdk/pull/3556 so we should uncomment
+                    // the line below once we've made both livekit and full-mesh releases that include that
+                    // PR, and everything will be less racy.
+                    //waitForIframeLoad: false,
                 },
                 groupCall.room.roomId,
             ),


### PR DESCRIPTION
As hopefully all explained in comment.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->