### PR TITLE
Avoid trying to set room account data for pinned events as guest

### DIFF
--- a/src/components/views/right_panel/PinnedMessagesCard.tsx
+++ b/src/components/views/right_panel/PinnedMessagesCard.tsx
@@ -103,10 +103,11 @@ const PinnedMessagesCard: React.FC<IProps> = ({ room, onClose, permalinkCreator 
     const readPinnedEvents = useReadPinnedEvents(room);
 
     useEffect(() => {
+        if (!cli || cli.isGuest()) return; // nothing to do
         const newlyRead = pinnedEventIds.filter((id) => !readPinnedEvents.has(id));
         if (newlyRead.length > 0) {
             // clear out any read pinned events which no longer are pinned
-            cli?.setRoomAccountData(room.roomId, ReadPinsEventId, {
+            cli.setRoomAccountData(room.roomId, ReadPinsEventId, {
                 event_ids: pinnedEventIds,
             });
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/6300

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Avoid trying to set room account data for pinned events as guest ([\#11216](https://github.com/matrix-org/matrix-react-sdk/pull/11216)). Fixes vector-im/element-web#6300.<!-- CHANGELOG_PREVIEW_END -->