### PR TITLE
Make checkboxes less rounded

### DIFF
--- a/res/css/views/elements/_StyledCheckbox.pcss
+++ b/res/css/views/elements/_StyledCheckbox.pcss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_Checkbox {
     $size: $font-16px;
-    $border-radius: 0.4rem;
+    $border-radius: 0.27rem;
 
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
The `border-radius` property of `mx_Checkbox` was changed from `$font-4px` to `0.4rem` in 9c7d935aae8a86c which leaves checkboxes looking a little round.

Reducing that value to `0.27rem` restores something very similar to their previous appearance:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/76812/4e9ea1d1-eff5-4c66-bc33-c6e8d081482b)

("Staging" means before 9c7d935aae8a86c, "develop" means immediately before this change, and "0.27rem" means after this change)

Fixes [#25715](https://github.com/vector-im/element-web/issues/25715)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make checkboxes less rounded ([\#11224](https://github.com/matrix-org/matrix-react-sdk/pull/11224)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->