### PR TITLE
Fix: Flaky cypress test: `Audio player > should be rendered, play and support replying on a thread`

### DIFF
--- a/cypress/e2e/audio-player/audio-player.spec.ts
+++ b/cypress/e2e/audio-player/audio-player.spec.ts
@@ -43,6 +43,8 @@ describe("Audio player", () => {
         // Wait until the file is sent
         cy.get(".mx_RoomView_statusArea_expanded").should("not.exist");
         cy.get(".mx_EventTile.mx_EventTile_last .mx_EventTile_receiptSent").should("exist");
+        // wait for the tile to finish loading
+        cy.get(".mx_AudioPlayer_mediaName").should("exist");
     };
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes: https://github.com/vector-im/element-web/issues/25770

![image](https://github.com/matrix-org/matrix-react-sdk/assets/3055605/b94710fd-b729-445f-9994-e2c3010ac043)

Multiple loading audio tiles in the thread composer is caused by opening the thread composer while the audio tile is not loaded. Technically this might be a real bug, but only a robot can click fast enough to trigger it.

Hopefully fix by waiting for the audio tile name to be in the DOM as part of `uploadFile`

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->