### PR TITLE
Update analytics for Composer events

### DIFF
--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -311,6 +311,8 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             inThread: !!editedEvent?.getThread(),
             isReply: !!editedEvent.replyEventId,
             isLocation: false,
+            editor: "Legacy",
+            isMarkdownEnabled: SettingsStore.getValue("MessageComposerInput.useMarkdown"),
         });
 
         // Replace emoticon at the end of the message

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -310,6 +310,7 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             isEditing: true,
             inThread: !!editedEvent?.getThread(),
             isReply: !!editedEvent.replyEventId,
+            isLocation: false,
         });
 
         // Replace emoticon at the end of the message

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -450,6 +450,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             isReply: !!this.props.replyToEvent,
             inThread: this.props.relation?.rel_type === THREAD_RELATION_TYPE.name,
             isLocation: false,
+            editor: "Legacy",
+            isMarkdownEnabled: SettingsStore.getValue("MessageComposerInput.useMarkdown"),
         };
         if (posthogEvent.inThread && this.props.relation!.event_id) {
             const threadRoot = this.props.room.findEventById(this.props.relation!.event_id);

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -449,6 +449,7 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             isEditing: false,
             isReply: !!this.props.replyToEvent,
             inThread: this.props.relation?.rel_type === THREAD_RELATION_TYPE.name,
+            isLocation: false,
         };
         if (posthogEvent.inThread && this.props.relation!.event_id) {
             const threadRoot = this.props.room.findEventById(this.props.relation!.event_id);

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -66,6 +66,7 @@ export async function sendMessage(
         isEditing: false,
         isReply: Boolean(replyToEvent),
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
+        isLocation: false,
     };
 
     if (posthogEvent.inThread) {
@@ -199,6 +200,7 @@ export async function editMessage(
         isEditing: true,
         inThread: Boolean(editedEvent?.getThread()),
         isReply: Boolean(editedEvent.replyEventId),
+        isLocation: false,
     });
 
     // TODO emoji

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -67,6 +67,8 @@ export async function sendMessage(
         isReply: Boolean(replyToEvent),
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
         isLocation: false,
+        editor: isHTML ? "RteFormatting" : "RtePlain",
+        isMarkdownEnabled: false,
     };
 
     if (posthogEvent.inThread) {
@@ -201,6 +203,8 @@ export async function editMessage(
         inThread: Boolean(editedEvent?.getThread()),
         isReply: Boolean(editedEvent.replyEventId),
         isLocation: false,
+        editor: "RteFormatting", // it is always the rich text mode when editing a message
+        isMarkdownEnabled: false,
     });
 
     // TODO emoji

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -65,15 +65,13 @@ export async function sendMessage(
         eventName: "Composer",
         isEditing: false,
         isReply: Boolean(replyToEvent),
-        // TODO thread
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
     };
 
-    // TODO thread
-    /*if (posthogEvent.inThread) {
-        const threadRoot = room.findEventById(relation?.event_id);
+    if (posthogEvent.inThread) {
+        const threadRoot = room.findEventById(relation?.event_id ?? "");
         posthogEvent.startsThread = threadRoot?.getThread()?.events.length === 1;
-    }*/
+    }
     PosthogAnalytics.instance.trackEvent<ComposerEvent>(posthogEvent);
 
     let content: IContent | null = null;


### PR DESCRIPTION
**Handover notes**
This PR is part of a sequence of 4 PRs, currently in draft, that do the element web work to integrate the analytics work associated with this PR: https://github.com/matrix-org/matrix-analytics-events/pull/80

The PRs are all around 90% there and most of them have tests setup and implemented, although perhaps these may need extending for coverage reasons. If you're going to try and extend the coverage, I warn you now that testing the autocomplete on the existing composer is not easy - spent about half a day on that and could not figure out how to do it. I think adding testing there may take quite a lot of effort for minimal return (plus I imagine it would be clear if the analytics on it were failing as there would be no use of mentions from the current composer according to posthog).

These branches and PRs were made in the following order:
- https://github.com/matrix-org/matrix-react-sdk/pull/11245
- https://github.com/matrix-org/matrix-react-sdk/pull/11246
- https://github.com/matrix-org/matrix-react-sdk/pull/11265
- https://github.com/matrix-org/matrix-react-sdk/pull/11264 

The first PR bumps the analytics repo and adds the Composer event tracking. Each subsequent PR adds a single analytic to both the rich text editor (both modes) and the current composer. 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->