### PR TITLE
Fix event info events size and color

### DIFF
--- a/res/css/views/messages/_RoomAvatarEvent.pcss
+++ b/res/css/views/messages/_RoomAvatarEvent.pcss
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_RoomAvatarEvent {
-    opacity: 0.5;
-    overflow-y: hidden;
-}
-
 .mx_RoomAvatarEvent_avatar {
     display: inline;
     position: relative;

--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -31,6 +31,11 @@ $left-gutter: 64px;
     padding-top: 18px;
     position: relative;
 
+    &.mx_EventTile_info {
+        font-size: var(--cpd-font-size-body-sm);
+        color: $secondary-content;
+    }
+
     .mx_EventTile_avatar {
         cursor: pointer;
         user-select: none;

--- a/src/components/views/messages/RoomAvatarEvent.tsx
+++ b/src/components/views/messages/RoomAvatarEvent.tsx
@@ -71,7 +71,7 @@ export default class RoomAvatarEvent extends React.Component<IProps> {
         };
 
         return (
-            <div className="mx_RoomAvatarEvent">
+            <>
                 {_t(
                     "%(senderDisplayName)s changed the room avatar to <img/>",
                     { senderDisplayName: senderDisplayName },
@@ -87,7 +87,7 @@ export default class RoomAvatarEvent extends React.Component<IProps> {
                         ),
                     },
                 )}
-            </div>
+            </>
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25778
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/11079

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix event info events size and color ([\#11252](https://github.com/matrix-org/matrix-react-sdk/pull/11252)). Fixes vector-im/element-web#25778.<!-- CHANGELOG_PREVIEW_END -->