### PR TITLE
Allow emoji presentation selector to not break BigEmoji styling

### DIFF
--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -54,8 +54,7 @@ const SYMBOL_PATTERN = /([\u2100-\u2bff])/;
 
 // Regex pattern for non-emoji characters that can appear in an "all-emoji" message
 // (Zero-Width Joiner, Zero-Width Space, Emoji presentation character, other whitespace)
-// eslint-disable-next-line no-misleading-character-class
-const EMOJI_SEPARATOR_REGEX = /[\u200D\u200B\uFE0F\s]/g;
+const EMOJI_SEPARATOR_REGEX = /[\u200D\u200B\s]|\uFE0F/g;
 
 const BIGEMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})+$`, "i");
 

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -52,8 +52,10 @@ const SURROGATE_PAIR_PATTERN = /([\ud800-\udbff])([\udc00-\udfff])/;
 // (with plenty of false positives, but that's OK)
 const SYMBOL_PATTERN = /([\u2100-\u2bff])/;
 
-// Regex pattern for non-emoji characters that can appear in an "all-emoji" message (Zero-Width Joiner, Zero-Width Space, other whitespace)
-const EMOJI_SEPARATOR_REGEX = /[\u200D\u200B\s]/g;
+// Regex pattern for non-emoji characters that can appear in an "all-emoji" message
+// (Zero-Width Joiner, Zero-Width Space, Emoji presentation character, other whitespace)
+// eslint-disable-next-line no-misleading-character-class
+const EMOJI_SEPARATOR_REGEX = /[\u200D\u200B\uFE0F\s]/g;
 
 const BIGEMOJI_REGEX = new RegExp(`^(${EMOJIBASE_REGEX.source})+$`, "i");
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17848

![image](https://github.com/matrix-org/matrix-react-sdk/assets/2403652/65bf5da7-63d7-45b8-973f-8ecca63d3147)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Allow emoji presentation selector to not break BigEmoji styling ([\#11253](https://github.com/matrix-org/matrix-react-sdk/pull/11253)). Fixes vector-im/element-web#17848.<!-- CHANGELOG_PREVIEW_END -->