### PR TITLE
Make event highliht use primary content token

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -138,7 +138,7 @@ $left-gutter: 64px;
     &.mx_EventTile_highlight,
     &.mx_EventTile_highlight .markdown-body,
     &.mx_EventTile_highlight .mx_EventTile_edited {
-        color: $secondary-content;
+        color: $primary-content;
     }
 
     &.mx_EventTile_bubbleContainer {


### PR DESCRIPTION
There's no reasons why it uses `$secondary-content`

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make event highliht use primary content token ([\#11255](https://github.com/matrix-org/matrix-react-sdk/pull/11255)).<!-- CHANGELOG_PREVIEW_END -->