### PR TITLE
Fix corrupt thread timeline for sending events

### DIFF
--- a/src/components/structures/ThreadView.tsx
+++ b/src/components/structures/ThreadView.tsx
@@ -214,7 +214,12 @@ export default class ThreadView extends React.Component<IProps, IState> {
         let thread = this.props.room.getThread(eventId);
 
         if (!thread) {
-            thread = this.props.room.createThread(eventId, mxEv, [mxEv], true);
+            const events = [];
+            // if the event is still being sent, don't include it in the Thread yet - otherwise the timeline panel
+            // will attempt to show it twice (once as a regular event, once as a pending event) and everything will
+            // blow up
+            if (mxEv.status === null) events.push(mxEv);
+            thread = this.props.room.createThread(eventId, mxEv, events, true);
         }
 
         this.updateThread(thread);

--- a/test/test-utils/threads.ts
+++ b/test/test-utils/threads.ts
@@ -136,10 +136,6 @@ export const mkThread = ({
 
     const thread = room.createThread(rootEvent.getId()!, rootEvent, events, true);
 
-    events.forEach((event) => {
-        thread.timeline.push(event);
-    });
-
     // So that we do not have to mock the thread loading
     thread.initialEventsFetched = true;
 


### PR DESCRIPTION
Events which are still in the process of being sent should *not* be included in the `EventTimeline`. Doing so means that we will attempt to render them twice, which makes react explode.

Fixes https://github.com/vector-im/element-web/issues/25770


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->