### PR TITLE
Update analytics for SlashCommands

### DIFF
--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -773,7 +773,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
             return;
         }
 
-        fireFormattingAnalyticEvent(action);
+        trackFormattingAnalyticEvent(action);
 
         const range: Range = getRangeForSelection(this.editorRef.current, this.props.model, document.getSelection()!);
 
@@ -917,7 +917,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
  * @param action - the formatting action that will be recorded in the analytic event that is fired
  * @returns void
  */
-function fireFormattingAnalyticEvent(action: Formatting): void {
+function trackFormattingAnalyticEvent(action: Formatting): void {
     let formatAction: FormattedMessageEvent["formatAction"];
 
     switch (action) {

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -311,6 +311,8 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             inThread: !!editedEvent?.getThread(),
             isReply: !!editedEvent.replyEventId,
             isLocation: false,
+            editor: "Legacy",
+            isMarkdownEnabled: SettingsStore.getValue("MessageComposerInput.useMarkdown"),
         });
 
         // Replace emoticon at the end of the message

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -310,6 +310,7 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
             isEditing: true,
             inThread: !!editedEvent?.getThread(),
             isReply: !!editedEvent.replyEventId,
+            isLocation: false,
         });
 
         // Replace emoticon at the end of the message

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -450,6 +450,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             isReply: !!this.props.replyToEvent,
             inThread: this.props.relation?.rel_type === THREAD_RELATION_TYPE.name,
             isLocation: false,
+            editor: "Legacy",
+            isMarkdownEnabled: SettingsStore.getValue("MessageComposerInput.useMarkdown"),
         };
         if (posthogEvent.inThread && this.props.relation!.event_id) {
             const threadRoot = this.props.room.findEventById(this.props.relation!.event_id);

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -62,6 +62,7 @@ import { doMaybeLocalRoomAction } from "../../../utils/local-room";
 import { Caret } from "../../../editor/caret";
 import { IDiff } from "../../../editor/diff";
 import { getBlobSafeMimeType } from "../../../utils/blobs";
+import { trackSlashCommandAnalyticEvent } from "./wysiwyg_composer/utils/message";
 
 /**
  * Build the mentions information based on the editor model (and any related events):
@@ -181,6 +182,7 @@ export function createMessageContent(
     const isEmote = containsEmote(model);
     if (isEmote) {
         model = stripEmoteCommand(model);
+        trackSlashCommandAnalyticEvent("me", "Legacy");
     }
     if (startsWith(model, "//")) {
         model = stripPrefix(model, "/");
@@ -490,6 +492,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                 if (!commandSuccessful) {
                     return; // errored
                 }
+
+                trackSlashCommandAnalyticEvent(cmd.command, "Legacy");
 
                 if (content && [CommandCategories.messages, CommandCategories.effects].includes(cmd.category)) {
                     // Attach any mentions which might be contained in the command content.

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -449,6 +449,7 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             isEditing: false,
             isReply: !!this.props.replyToEvent,
             inThread: this.props.relation?.rel_type === THREAD_RELATION_TYPE.name,
+            isLocation: false,
         };
         if (posthogEvent.inThread && this.props.relation!.event_id) {
             const threadRoot = this.props.room.findEventById(this.props.relation!.event_id);

--- a/src/components/views/rooms/wysiwyg_composer/components/FormattingButtons.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/FormattingButtons.tsx
@@ -68,7 +68,7 @@ interface ButtonProps extends TooltipProps {
 function Button({ analyticsKey, label, keyCombo, onClick, actionState, icon }: ButtonProps): JSX.Element {
     const prevActionState = React.useRef(actionState);
     if (isNotUndefined(analyticsKey) && prevActionState.current !== actionState && actionState === "reversed") {
-        fireFormattingAnalyticEvent(analyticsKey);
+        trackFormattingAnalyticEvent(analyticsKey);
     }
     prevActionState.current = actionState;
     return (
@@ -155,7 +155,7 @@ export function FormattingButtons({ composer, actionStates }: FormattingButtonsP
                     label={_td("Indent increase")}
                     onClick={() => {
                         composer.indent();
-                        fireFormattingAnalyticEvent("Indent");
+                        trackFormattingAnalyticEvent("Indent");
                     }}
                     icon={<IndentIcon className="mx_FormattingButtons_Icon" />}
                 />
@@ -166,7 +166,7 @@ export function FormattingButtons({ composer, actionStates }: FormattingButtonsP
                     label={_td("Indent decrease")}
                     onClick={() => {
                         composer.unindent();
-                        fireFormattingAnalyticEvent("Unindent");
+                        trackFormattingAnalyticEvent("Unindent");
                     }}
                     icon={<UnIndentIcon className="mx_FormattingButtons_Icon" />}
                 />
@@ -201,7 +201,7 @@ export function FormattingButtons({ composer, actionStates }: FormattingButtonsP
                 label={_td("Link")}
                 onClick={() => {
                     openLinkModal(composer, composerContext, actionStates.link === "reversed");
-                    fireFormattingAnalyticEvent("Link");
+                    trackFormattingAnalyticEvent("Link");
                 }}
                 icon={<LinkIcon className="mx_FormattingButtons_Icon" />}
             />
@@ -214,7 +214,7 @@ export function FormattingButtons({ composer, actionStates }: FormattingButtonsP
  * @param formatAction - the action that will be recorded in the analytic event that is fired
  * @returns void
  */
-function fireFormattingAnalyticEvent(formatAction: FormattedMessageEvent["formatAction"]): void {
+function trackFormattingAnalyticEvent(formatAction: FormattedMessageEvent["formatAction"]): void {
     PosthogAnalytics.instance.trackEvent<FormattedMessageEvent>({
         eventName: "FormattedMessage",
         editor: "RteFormatting",

--- a/src/components/views/rooms/wysiwyg_composer/components/FormattingButtons.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/FormattingButtons.tsx
@@ -40,6 +40,7 @@ import { ButtonEvent } from "../../../elements/AccessibleButton";
 import { openLinkModal } from "./LinkModal";
 import { useComposerContext } from "../ComposerContext";
 import { isNotUndefined } from "../../../../../Typeguards";
+import { PosthogAnalytics } from "../../../../../PosthogAnalytics";
 
 interface TooltipProps {
     label: string;
@@ -211,8 +212,12 @@ export function FormattingButtons({ composer, actionStates }: FormattingButtonsP
 /**
  * Util function to fire a formatting analytic event
  * @param formatAction - the action that will be recorded in the analytic event that is fired
- * @returns
+ * @returns void
  */
 function fireFormattingAnalyticEvent(formatAction: FormattedMessageEvent["formatAction"]): void {
-    console.log("<<<", formatAction);
+    PosthogAnalytics.instance.trackEvent<FormattedMessageEvent>({
+        eventName: "FormattedMessage",
+        editor: "RteFormatting",
+        formatAction,
+    });
 }

--- a/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/PlainTextComposer.tsx
@@ -87,6 +87,7 @@ export function PlainTextComposer({
             onSelect={onSelect}
         >
             <WysiwygAutocomplete
+                analyticsEditor="RtePlain"
                 ref={autocompleteRef}
                 suggestion={suggestion}
                 handleMention={handleMention}

--- a/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
@@ -134,8 +134,9 @@ WysiwygAutocomplete.displayName = "WysiwygAutocomplete";
 export { WysiwygAutocomplete };
 
 /**
- * Util function to fire a formatting analytic event
- * @param formatAction - the action that will be recorded in the analytic event that is fired
+ * Util function to fire a mention analytic event
+ *
+ * @param targetType - the editor type that will be recorded in the analytic event that is fired
  * @returns void
  */
 function trackMentionAnalyticEvent(targetType: MentionEvent["targetType"]): void {

--- a/src/components/views/rooms/wysiwyg_composer/components/WysiwygComposer.tsx
+++ b/src/components/views/rooms/wysiwyg_composer/components/WysiwygComposer.tsx
@@ -114,6 +114,7 @@ export const WysiwygComposer = memo(function WysiwygComposer({
             onBlur={onFocus}
         >
             <WysiwygAutocomplete
+                analyticsEditor="RteFormatting"
                 ref={autocompleteRef}
                 suggestion={suggestion}
                 handleMention={wysiwyg.mention}

--- a/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -21,6 +21,7 @@ import SettingsStore from "../../../../../settings/SettingsStore";
 import { parsePermalink, RoomPermalinkCreator } from "../../../../../utils/permalinks/Permalinks";
 import { addReplyToMessageContent } from "../../../../../utils/Reply";
 import { isNotNull } from "../../../../../Typeguards";
+import { trackSlashCommandAnalyticEvent } from "./message";
 
 export const EMOTE_PREFIX = "/me ";
 
@@ -85,6 +86,7 @@ export async function createMessageContent(
     if (isEmote) {
         // if we are dealing with an emote we want to remove the prefix so that `/me` does not
         // appear after the `* <userName>` text in the timeline
+        trackSlashCommandAnalyticEvent("me", isHTML ? "RteFormatting" : "RtePlain");
         message = message.slice(EMOTE_PREFIX.length);
     }
     if (message.startsWith("//")) {

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -263,10 +263,7 @@ export async function editMessage(
  * @param command - the slash command that will be recorded in the analytic event that is fired
  * @returns void
  */
-export function trackSlashCommandAnalyticEvent(
-    command: string,
-    editor: Exclude<SlashCommand["editor"], "Legacy">,
-): void {
+export function trackSlashCommandAnalyticEvent(command: string, editor: SlashCommand["editor"]): void {
     PosthogAnalytics.instance.trackEvent<SlashCommand>({
         eventName: "SlashCommand",
         editor,

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -66,6 +66,7 @@ export async function sendMessage(
         isEditing: false,
         isReply: Boolean(replyToEvent),
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
+        isLocation: false,
     };
 
     if (posthogEvent.inThread) {
@@ -199,6 +200,7 @@ export async function editMessage(
         isEditing: true,
         inThread: Boolean(editedEvent?.getThread()),
         isReply: Boolean(editedEvent.replyEventId),
+        isLocation: false,
     });
 
     // TODO emoji

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -67,6 +67,8 @@ export async function sendMessage(
         isReply: Boolean(replyToEvent),
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
         isLocation: false,
+        editor: isHTML ? "RteFormatting" : "RtePlain",
+        isMarkdownEnabled: false,
     };
 
     if (posthogEvent.inThread) {
@@ -201,6 +203,8 @@ export async function editMessage(
         inThread: Boolean(editedEvent?.getThread()),
         isReply: Boolean(editedEvent.replyEventId),
         isLocation: false,
+        editor: "RteFormatting", // it is always the rich text mode when editing a message
+        isMarkdownEnabled: false,
     });
 
     // TODO emoji

--- a/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -65,15 +65,13 @@ export async function sendMessage(
         eventName: "Composer",
         isEditing: false,
         isReply: Boolean(replyToEvent),
-        // TODO thread
         inThread: relation?.rel_type === THREAD_RELATION_TYPE.name,
     };
 
-    // TODO thread
-    /*if (posthogEvent.inThread) {
-        const threadRoot = room.findEventById(relation?.event_id);
+    if (posthogEvent.inThread) {
+        const threadRoot = room.findEventById(relation?.event_id ?? "");
         posthogEvent.startsThread = threadRoot?.getThread()?.events.length === 1;
-    }*/
+    }
     PosthogAnalytics.instance.trackEvent<ComposerEvent>(posthogEvent);
 
     let content: IContent | null = null;

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete-test.tsx
@@ -81,6 +81,7 @@ describe("WysiwygAutocomplete", () => {
             <MatrixClientContext.Provider value={mockClient}>
                 <RoomContext.Provider value={mockRoomContext}>
                     <WysiwygAutocomplete
+                        analyticsEditor="RteFormatting"
                         ref={autocompleteRef}
                         suggestion={null}
                         handleMention={mockHandleMention}
@@ -96,6 +97,7 @@ describe("WysiwygAutocomplete", () => {
     it("does not show the autocomplete when room is undefined", () => {
         render(
             <WysiwygAutocomplete
+                analyticsEditor="RteFormatting"
                 ref={autocompleteRef}
                 suggestion={null}
                 handleMention={mockHandleMention}

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -421,6 +421,51 @@ describe("WysiwygComposer", () => {
             // check that it we still have the initial text
             expect(screen.getByText(initialInput)).toBeInTheDocument();
         });
+
+        describe("Analytics", () => {
+            beforeEach(async () => {
+                jest.spyOn(mockPosthogAnalytics.PosthogAnalytics.instance, "trackEvent").mockImplementation(() => {});
+            });
+            afterEach(() => {
+                jest.restoreAllMocks();
+            });
+
+            it("fires an User type analytic event for a user selection", async () => {
+                await insertMentionInput();
+                await userEvent.click(screen.getByText("user_1"));
+
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledTimes(1);
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledWith({
+                    eventName: "Mention",
+                    targetType: "User",
+                    editor: "RteFormatting",
+                });
+            });
+
+            it("fires a Room type analytic event for a room selection", async () => {
+                await insertMentionInput();
+                await userEvent.click(screen.getByText("room_with_completion_id"));
+
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledTimes(1);
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledWith({
+                    eventName: "Mention",
+                    targetType: "Room",
+                    editor: "RteFormatting",
+                });
+            });
+
+            it("fires a Room type analytic event for an at-room selection", async () => {
+                await insertMentionInput();
+                await userEvent.click(screen.getByText("@room"));
+
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledTimes(1);
+                expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledWith({
+                    eventName: "Mention",
+                    targetType: "Room",
+                    editor: "RteFormatting",
+                });
+            });
+        });
     });
 
     describe("When settings require Ctrl+Enter to send", () => {

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -868,6 +868,9 @@ describe("WysiwygComposer", () => {
             { name: "Code block", formatAction: "CodeBlock" },
         ];
 
+        // indent and unindent buttons are tested in `FormattingButtons-test.tsx` due to difficulty simulating
+        // the user behaviour to use these buttons
+
         it.each([...buttonsWithShortcuts, ...buttonsWithoutShortcuts])(
             "Fires single analytic event on click for: $name",
             async ({ name, formatAction }) => {

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -430,7 +430,7 @@ describe("WysiwygComposer", () => {
                 jest.restoreAllMocks();
             });
 
-            it("fires an User type analytic event for a user selection", async () => {
+            it("fires a User type analytic event for a user selection", async () => {
                 await insertMentionInput();
                 await userEvent.click(screen.getByText("user_1"));
 

--- a/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
+++ b/test/components/views/rooms/wysiwyg_composer/components/WysiwygComposer-test.tsx
@@ -853,10 +853,10 @@ describe("WysiwygComposer", () => {
 
         // test that these buttons work both on click and on use of keyboard shortcut
         const buttonsWithShortcuts = [
-            { name: "Bold", formatAction: "Bold", ctrlOrCommandShortcut: "b" },
-            { name: "Italic", formatAction: "Italic", ctrlOrCommandShortcut: "i" },
-            { name: "Underline", formatAction: "Underline", ctrlOrCommandShortcut: "u" },
-            { name: "Code", formatAction: "InlineCode", ctrlOrCommandShortcut: "e" },
+            { name: "Bold", formatAction: "Bold", keyboardShortcut: "{Control>}b{/Control}" },
+            { name: "Italic", formatAction: "Italic", keyboardShortcut: "{Control>}i{/Control}" },
+            { name: "Underline", formatAction: "Underline", keyboardShortcut: "{Control>}u{/Control}" },
+            { name: "Code", formatAction: "InlineCode", keyboardShortcut: "{Control>}e{/Control}" },
         ];
 
         // test that these buttons work on click
@@ -899,10 +899,10 @@ describe("WysiwygComposer", () => {
 
         it.each(buttonsWithShortcuts)(
             "Fires single analytic event on use of keyboard shortcut for: $name",
-            async ({ formatAction, ctrlOrCommandShortcut: ctrlOrCommandShortcut }) => {
+            async ({ formatAction, keyboardShortcut }) => {
                 // activate the button using the keyboard shortcut
                 await act(async () => {
-                    await userEvent.keyboard(`{Control>}${ctrlOrCommandShortcut}{/Control}`);
+                    await userEvent.keyboard(keyboardShortcut);
                 });
 
                 // check that the analytics tracking has fired once with the expected formattingAction
@@ -915,7 +915,7 @@ describe("WysiwygComposer", () => {
 
                 // check that deactivating the button with the keyboard shortcut does not fire another tracking event
                 await act(async () => {
-                    await userEvent.keyboard(`{Control>}${ctrlOrCommandShortcut}{/Control}`);
+                    await userEvent.keyboard(`{Control>}${keyboardShortcut}{/Control}`);
                 });
 
                 expect(mockPosthogAnalytics.PosthogAnalytics.instance.trackEvent).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
**Handover notes**
This PR is part of a sequence of 4 PRs, currently in draft, that do the element web work to integrate the analytics work associated with this PR: https://github.com/matrix-org/matrix-analytics-events/pull/80

The PRs are all around 90% there and most of them have tests setup and implemented, although perhaps these may need extending for coverage reasons. If you're going to try and extend the coverage, I warn you now that testing the autocomplete on the existing composer is not easy - spent about half a day on that and could not figure out how to do it. I think adding testing there may take quite a lot of effort for minimal return (plus I imagine it would be clear if the analytics on it were failing as there would be no use of mentions from the current composer according to posthog).

These branches and PRs were made in the following order:
- https://github.com/matrix-org/matrix-react-sdk/pull/11245
- https://github.com/matrix-org/matrix-react-sdk/pull/11246
- https://github.com/matrix-org/matrix-react-sdk/pull/11265
- https://github.com/matrix-org/matrix-react-sdk/pull/11264 

The first PR bumps the analytics repo and adds the Composer event tracking. Each subsequent PR adds a single analytic to both the rich text editor (both modes) and the current composer. 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->