### PR TITLE
Fix log spam during cypress CI

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -169,12 +169,12 @@ jobs:
                   # The built-in Electron runner seems to grind to a halt trying to run the tests, so use chrome.
                   browser: ${{ steps.setup-chrome.outputs.chrome-path }}
                   headed: true
-                  start: npx serve -p 8080 ../webapp
+                  start: npx serve -p 8080 -L ../webapp
                   wait-on: "http://localhost:8080"
                   record: true
                   parallel: true
                   command-prefix: "yarn percy exec --parallel --"
-                  config: '{"reporter":"cypress-multi-reporters", "reporterOptions": { "configFile": "cypress-ci-reporter-config.json" }, "morgan": false }'
+                  config: '{"reporter":"cypress-multi-reporters", "reporterOptions": { "configFile": "cypress-ci-reporter-config.json" } }'
                   ci-build-id: ${{ needs.prepare.outputs.uuid }}
               env:
                   # pass the Dashboard record key as an environment variable


### PR DESCRIPTION
Tell the web server not to log requests, to reduce the amount of noise in the CI logs.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->