### PR TITLE
Fix changelog dialog heading size

### DIFF
--- a/src/components/views/dialogs/ChangelogDialog.tsx
+++ b/src/components/views/dialogs/ChangelogDialog.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { _t } from "../../../languageHandler";
 import QuestionDialog from "./QuestionDialog";
 import Spinner from "../elements/Spinner";
+import Heading from "../typography/Heading";
 
 interface IProps {
     newVersion: string;
@@ -100,7 +101,9 @@ export default class ChangelogDialog extends React.Component<IProps, State> {
             }
             return (
                 <div key={repo}>
-                    <h2>{repo}</h2>
+                    <Heading as="h2" size="4">
+                        {repo}
+                    </Heading>
                     <ul>{content}</ul>
                 </div>
             );

--- a/test/components/views/dialogs/__snapshots__/ChangelogDialog-test.tsx.snap
+++ b/test/components/views/dialogs/__snapshots__/ChangelogDialog-test.tsx.snap
@@ -38,7 +38,9 @@ exports[`<ChangelogDialog /> should fetch github proxy url for each repo with ol
         class="mx_ChangelogDialog_content"
       >
         <div>
-          <h2>
+          <h2
+            class="mx_Heading_h4"
+          >
             vector-im/element-web
           </h2>
           <ul>
@@ -56,7 +58,9 @@ exports[`<ChangelogDialog /> should fetch github proxy url for each repo with ol
           </ul>
         </div>
         <div>
-          <h2>
+          <h2
+            class="mx_Heading_h4"
+          >
             matrix-org/matrix-react-sdk
           </h2>
           <ul>
@@ -74,7 +78,9 @@ exports[`<ChangelogDialog /> should fetch github proxy url for each repo with ol
           </ul>
         </div>
         <div>
-          <h2>
+          <h2
+            class="mx_Heading_h4"
+          >
             matrix-org/matrix-js-sdk
           </h2>
           <ul>


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25789
Regressed by https://github.com/matrix-org/matrix-react-sdk/pull/11103

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix changelog dialog heading size ([\#11286](https://github.com/matrix-org/matrix-react-sdk/pull/11286)). Fixes vector-im/element-web#25789.<!-- CHANGELOG_PREVIEW_END -->