### PR TITLE
Explicitly specify the thread to which we want the read receipt sent to

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -28,7 +28,7 @@ import { debounce, findLastIndex, throttle } from "lodash";
 import { logger } from "matrix-js-sdk/src/logger";
 import { ClientEvent, MatrixClient } from "matrix-js-sdk/src/client";
 import { Thread, ThreadEvent } from "matrix-js-sdk/src/models/thread";
-import { ReceiptType } from "matrix-js-sdk/src/@types/read_receipts";
+import { MAIN_ROOM_TIMELINE, ReceiptType } from "matrix-js-sdk/src/@types/read_receipts";
 import { MatrixError } from "matrix-js-sdk/src/http-api";
 import { Relations } from "matrix-js-sdk/src/models/relations";
 
@@ -1187,7 +1187,7 @@ class TimelinePanel extends React.Component<IProps, IState> {
         const receiptType = await this.determineReceiptType(client);
 
         try {
-            await client.sendReadReceipt(event, receiptType);
+            await client.sendReadReceipt(event, receiptType, this.context.threadId ?? MAIN_ROOM_TIMELINE);
         } catch (err) {
             // it failed, so allow retries next time the user is active
             this.lastRRSentEventId = undefined;

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -73,7 +73,7 @@ export async function clearRoomNotification(room: Room, client: MatrixClient): P
             const receiptType = SettingsStore.getValue("sendReadReceipts", room.roomId)
                 ? ReceiptType.Read
                 : ReceiptType.ReadPrivate;
-            return await client.sendReadReceipt(lastEvent, receiptType, true);
+            return await client.sendReadReceipt(lastEvent, receiptType, null);
         } else {
             return {};
         }


### PR DESCRIPTION
As certain events (non-thread relations to the thread root can be read in both timelines individually)

Requires https://github.com/matrix-org/matrix-js-sdk/pull/3607

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Explicitly specify the thread to which we want the read receipt sent to ([\#11291](https://github.com/matrix-org/matrix-react-sdk/pull/11291)).<!-- CHANGELOG_PREVIEW_END -->