### PR TITLE
Search for users on paste

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -870,11 +870,17 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             return;
         }
 
+        const text = e.clipboardData.getData("text");
+        const potentialAddresses = this.parseFilter(text);
+        // one search term which is not a mxid or email address
+        if (potentialAddresses.length === 1 && !potentialAddresses[0].includes("@")) {
+            return;
+        }
+
         // Prevent the text being pasted into the input
         e.preventDefault();
 
         // Process it as a list of addresses to add instead
-        const text = e.clipboardData.getData("text");
         const possibleMembers = [
             // If we can avoid hitting the profile endpoint, we should.
             ...this.state.recents,
@@ -888,8 +894,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         // Addresses that could not be added.
         // Will be displayed as filter text to provide feedback.
         const unableToAddMore: string[] = [];
-
-        const potentialAddresses = this.parseFilter(text);
 
         for (const address of potentialAddresses) {
             const member = possibleMembers.find((m) => m.userId === address);

--- a/test/components/views/dialogs/InviteDialog-test.tsx
+++ b/test/components/views/dialogs/InviteDialog-test.tsx
@@ -86,6 +86,7 @@ const aliceEmail = "foobar@email.com";
 const bobId = "@bob:example.org";
 const bobEmail = "bobbob@example.com"; // bob@example.com is already used as an example in the invite dialog
 const carolId = "@carol:example.com";
+const bobbob = "bobbob";
 
 const aliceProfileInfo: IProfileInfo = {
     user_id: aliceId,
@@ -289,6 +290,19 @@ describe("InviteDialog", () => {
         await screen.findAllByText(bobId);
         await screen.findByText(aliceEmail);
         expect(input).toHaveValue("");
+    });
+    it("should support pasting one username that is not a mx id or email", async () => {
+        mockClient.getIdentityServerUrl.mockReturnValue("https://identity-server");
+        mockClient.lookupThreePid.mockResolvedValue({});
+
+        render(<InviteDialog kind={InviteKind.Invite} roomId={roomId} onFinished={jest.fn()} />);
+
+        const input = screen.getByTestId("invite-dialog-input");
+        input.focus();
+        await userEvent.paste(`${bobbob}`);
+
+        await screen.findAllByText(bobId);
+        expect(input).toHaveValue(`${bobbob}`);
     });
 
     it("should allow to invite multiple emails to a room", async () => {


### PR DESCRIPTION
Search for term on paste in the invite dialog instead of showing error dialog.

Keep behaviour for usernames/email or lists of users

Fixes https://github.com/vector-im/element-web/issues/17523

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))




<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Search for users on paste ([\#11304](https://github.com/matrix-org/matrix-react-sdk/pull/11304)). Fixes vector-im/element-web#17523. Contributed by @peterscheu-aceart.<!-- CHANGELOG_PREVIEW_END -->