### PR TITLE
Fix issues around room notification settings flaking out

### DIFF
--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -152,8 +152,6 @@ function setRoomNotifsStateUnmuted(cli: MatrixClient, roomId: string, newState: 
                 actions: [PushRuleActionName.DontNotify],
             }),
         );
-        // https://matrix.org/jira/browse/SPEC-400
-        promises.push(cli.setPushRuleEnabled("global", PushRuleKind.RoomSpecific, roomId, true));
     } else if (newState === RoomNotifState.AllMessagesLoud) {
         promises.push(
             cli.addPushRule("global", PushRuleKind.RoomSpecific, roomId, {
@@ -166,8 +164,6 @@ function setRoomNotifsStateUnmuted(cli: MatrixClient, roomId: string, newState: 
                 ],
             }),
         );
-        // https://matrix.org/jira/browse/SPEC-400
-        promises.push(cli.setPushRuleEnabled("global", PushRuleKind.RoomSpecific, roomId, true));
     }
 
     return Promise.all(promises);


### PR DESCRIPTION
When changing room notification settings
This happened due to a race condition between adding a push rule and enabling it, the latter being superfluous given the spec says

> When creating push rules, they MUST be enabled by default.

Fixes https://github.com/vector-im/element-web/issues/16472
Fixes https://github.com/vector-im/element-web/issues/21309
Fixes https://github.com/vector-im/element-web/issues/6828

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issues around room notification settings flaking out ([\#11306](https://github.com/matrix-org/matrix-react-sdk/pull/11306)). Fixes vector-im/element-web#16472 vector-im/element-web#21309 and vector-im/element-web#6828.<!-- CHANGELOG_PREVIEW_END -->