### PR TITLE
Ensure consistency when rendering the sent event indicator

### DIFF
--- a/src/components/structures/MessagePanel.tsx
+++ b/src/components/structures/MessagePanel.tsx
@@ -615,6 +615,7 @@ export default class MessagePanel extends React.Component<IProps, IState> {
 
     private isSentState(ev: MatrixEvent): boolean {
         const status = ev.getAssociatedStatus();
+        // A falsey state applies to events which have come down sync, including remote echoes
         return !status || status === EventStatus.SENT;
     }
 
@@ -1066,8 +1067,10 @@ export default class MessagePanel extends React.Component<IProps, IState> {
 }
 
 /**
- * Holds on to an event, caching the information about whether it should be
- * shown. Avoids calling shouldShowEvent more times than we need to.
+ * Holds on to an event, caching the information about it in the context of the current messages list.
+ * Avoids calling shouldShowEvent more times than we need to.
+ * Simplifies threading of event context like whether it's the last successful event we sent which cannot be determined
+ * by a consumer from the event alone, so has to be done by the event list processing code earlier.
  */
 interface WrappedEvent {
     event: MatrixEvent;

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -246,6 +246,31 @@ interface IState {
     threadNotification?: NotificationCountType;
 }
 
+/**
+ * When true, the tile qualifies for some sort of special read receipt.
+ * This could be a 'sending' or 'sent' receipt, for example.
+ * @returns {boolean}
+ */
+export function isEligibleForSpecialReceipt(event: MatrixEvent, myUserId: string): boolean {
+    // Check to see if the event was sent by us. If it wasn't, it won't qualify for special read receipts.
+    if (event.getSender() !== myUserId) return false;
+
+    // Determine if the type is relevant to the user. This notably excludes state
+    // events and pretty much anything that can't be sent by the composer as a message. For
+    // those we rely on local echo giving the impression of things changing, and expect them
+    // to be quick.
+    const simpleSendableEvents = [
+        EventType.Sticker,
+        EventType.RoomMessage,
+        EventType.RoomMessageEncrypted,
+        EventType.PollStart,
+    ];
+    if (!simpleSendableEvents.includes(event.getType() as EventType)) return false;
+
+    // Default case
+    return true;
+}
+
 // MUST be rendered within a RoomContext with a set timelineRenderingType
 export class UnwrappedEventTile extends React.Component<EventTileProps, IState> {
     private suppressReadReceiptAnimation: boolean;
@@ -313,23 +338,8 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
 
         // Quickly check to see if the event was sent by us. If it wasn't, it won't qualify for
         // special read receipts.
-        const myUserId = MatrixClientPeg.safeGet().getUserId();
-        if (this.props.mxEvent.getSender() !== myUserId) return false;
-
-        // Finally, determine if the type is relevant to the user. This notably excludes state
-        // events and pretty much anything that can't be sent by the composer as a message. For
-        // those we rely on local echo giving the impression of things changing, and expect them
-        // to be quick.
-        const simpleSendableEvents = [
-            EventType.Sticker,
-            EventType.RoomMessage,
-            EventType.RoomMessageEncrypted,
-            EventType.PollStart,
-        ];
-        if (!simpleSendableEvents.includes(this.props.mxEvent.getType() as EventType)) return false;
-
-        // Default case
-        return true;
+        const myUserId = MatrixClientPeg.safeGet().getSafeUserId();
+        return isEligibleForSpecialReceipt(this.props.mxEvent, myUserId);
     }
 
     private get shouldShowSentReceipt(): boolean {

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -255,17 +255,10 @@ export function isEligibleForSpecialReceipt(event: MatrixEvent, myUserId: string
     // Check to see if the event was sent by us. If it wasn't, it won't qualify for special read receipts.
     if (event.getSender() !== myUserId) return false;
 
-    // Determine if the type is relevant to the user. This notably excludes state
-    // events and pretty much anything that can't be sent by the composer as a message. For
-    // those we rely on local echo giving the impression of things changing, and expect them
-    // to be quick.
-    const simpleSendableEvents = [
-        EventType.Sticker,
-        EventType.RoomMessage,
-        EventType.RoomMessageEncrypted,
-        EventType.PollStart,
-    ];
-    if (!simpleSendableEvents.includes(event.getType() as EventType)) return false;
+    // Determine if the type is relevant to the user.
+    // This notably excludes state events and pretty much anything that can't be sent by the composer as a message.
+    // For those we rely on local echo giving the impression of things changing, and expect them to be quick.
+    if (!isMessageEvent(event) && event.getType() !== EventType.RoomMessageEncrypted) return false;
 
     // Default case
     return true;

--- a/test/components/structures/MessagePanel-test.tsx
+++ b/test/components/structures/MessagePanel-test.tsx
@@ -735,6 +735,34 @@ describe("MessagePanel", function () {
 
         expect(cpt).toMatchSnapshot();
     });
+
+    it("should set lastSuccessful=true on non-last event if last event is not eligible for special receipt", () => {
+        client.getRoom.mockImplementation((id) => (id === room.roomId ? room : null));
+        const events = [
+            TestUtilsMatrix.mkMessage({
+                event: true,
+                room: room.roomId,
+                user: client.getSafeUserId(),
+                ts: 1000,
+            }),
+            TestUtilsMatrix.mkEvent({
+                event: true,
+                room: room.roomId,
+                user: client.getSafeUserId(),
+                ts: 1000,
+                type: "m.room.topic",
+                skey: "",
+                content: { topic: "TOPIC" },
+            }),
+        ];
+        const { container } = render(getComponent({ events, showReadReceipts: true }));
+
+        // just check we have the right number of tiles for now
+        const tiles = container.getElementsByClassName("mx_EventTile");
+        expect(tiles.length).toEqual(2);
+        expect(tiles[0].querySelector(".mx_EventTile_receiptSent")).toBeTruthy();
+        expect(tiles[1].querySelector(".mx_EventTile_receiptSent")).toBeFalsy();
+    });
 });
 
 describe("shouldFormContinuation", () => {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17937

The main change to how we find the last successful event we sent is in the first commit, the remaining work is tests & ensuring all code paths pass the newly calculated value around

Before
![image](https://github.com/vector-im/element-web/assets/2403652/fd59a1f6-b639-4bd3-ba55-5c9f116e3616)

After
![image](https://github.com/vector-im/element-web/assets/2403652/01787813-db50-49b1-b0cd-281281c5b28e)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ensure consistency when rendering the sent event indicator ([\#11314](https://github.com/matrix-org/matrix-react-sdk/pull/11314)). Fixes vector-im/element-web#17937.<!-- CHANGELOG_PREVIEW_END -->