### PR TITLE
Fix test types

### DIFF
--- a/test/components/views/messages/MessageActionBar-test.tsx
+++ b/test/components/views/messages/MessageActionBar-test.tsx
@@ -165,7 +165,12 @@ describe("<MessageActionBar />", () => {
                 // ''decrypt'' the event
                 decryptingEvent.event.type = alicesMessageEvent.getType();
                 decryptingEvent.event.content = alicesMessageEvent.getContent();
-                decryptingEvent.emit(MatrixEventEvent.Decrypted, decryptingEvent);
+                decryptingEvent.emit(
+                    MatrixEventEvent.Decrypted,
+                    decryptingEvent,
+                    undefined,
+                    decryptingEvent.getPushDetails(),
+                );
             });
 
             // new available actions after decryption

--- a/test/stores/AutoRageshakeStore-test.ts
+++ b/test/stores/AutoRageshakeStore-test.ts
@@ -68,7 +68,7 @@ describe("AutoRageshakeStore", () => {
 
         describe("and an undecryptable event occurs", () => {
             beforeEach(() => {
-                client.emit(MatrixEventEvent.Decrypted, utdEvent);
+                client.emit(MatrixEventEvent.Decrypted, utdEvent, undefined, utdEvent.getPushDetails());
                 // simulate event grace period
                 jest.advanceTimersByTime(5500);
             });

--- a/test/stores/notifications/RoomNotificationState-test.ts
+++ b/test/stores/notifications/RoomNotificationState-test.ts
@@ -88,7 +88,7 @@ describe("RoomNotificationState", () => {
             getRoomId: () => room.roomId,
         } as unknown as MatrixEvent;
         room.getUnreadNotificationCount = jest.fn().mockReturnValue(1);
-        client.emit(MatrixEventEvent.Decrypted, testEvent, undefined, testEvent.getPushDetails());
+        client.emit(MatrixEventEvent.Decrypted, testEvent, undefined, {});
         expect(listener).toHaveBeenCalled();
     });
 

--- a/test/stores/notifications/RoomNotificationState-test.ts
+++ b/test/stores/notifications/RoomNotificationState-test.ts
@@ -88,7 +88,7 @@ describe("RoomNotificationState", () => {
             getRoomId: () => room.roomId,
         } as unknown as MatrixEvent;
         room.getUnreadNotificationCount = jest.fn().mockReturnValue(1);
-        client.emit(MatrixEventEvent.Decrypted, testEvent);
+        client.emit(MatrixEventEvent.Decrypted, testEvent, undefined, testEvent.getPushDetails());
         expect(listener).toHaveBeenCalled();
     });
 

--- a/test/voice-broadcast/models/VoiceBroadcastPlayback-test.tsx
+++ b/test/voice-broadcast/models/VoiceBroadcastPlayback-test.tsx
@@ -316,7 +316,12 @@ describe("VoiceBroadcastPlayback", () => {
                 describe("and the chunk is decrypted", () => {
                     beforeEach(() => {
                         mocked(chunk1Event.isDecryptionFailure).mockReturnValue(false);
-                        chunk1Event.emit(MatrixEventEvent.Decrypted, chunk1Event);
+                        chunk1Event.emit(
+                            MatrixEventEvent.Decrypted,
+                            chunk1Event,
+                            undefined,
+                            chunk1Event.getPushDetails(),
+                        );
                     });
 
                     itShouldSetTheStateTo(VoiceBroadcastPlaybackState.Paused);


### PR DESCRIPTION
Due to https://github.com/matrix-org/matrix-js-sdk/pull/3634 landing and our tests asserting internal types

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->