### PR TITLE
Bump pagination sizes due to hidden events

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -58,8 +58,10 @@ import { getKeyBindingsManager } from "../../KeyBindingsManager";
 import { KeyBindingAction } from "../../accessibility/KeyboardShortcuts";
 import { haveRendererForEvent } from "../../events/EventTileFactory";
 
-const PAGINATE_SIZE = 20;
-const INITIAL_SIZE = 20;
+// These pagination sizes are higher than they may possibly need be
+// once https://github.com/matrix-org/matrix-spec-proposals/pull/3874 lands
+const PAGINATE_SIZE = 50;
+const INITIAL_SIZE = 30;
 const READ_RECEIPT_INTERVAL_MS = 500;
 
 const READ_MARKER_DEBOUNCE_MS = 100;


### PR DESCRIPTION
Such as threaded events in the main timeline causing no events to be added to the timeline

For https://github.com/vector-im/element-web/issues/25873
Requires https://github.com/matrix-org/matrix-react-sdk/pull/11341

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Bump pagination sizes due to hidden events ([\#11342](https://github.com/matrix-org/matrix-react-sdk/pull/11342)).<!-- CHANGELOG_PREVIEW_END -->