### PR TITLE
Revert "Switch to updating presence via /sync calls instead of PUT /presence"

### DIFF
--- a/src/Presence.ts
+++ b/src/Presence.ts
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import { logger } from "matrix-js-sdk/src/logger";
-import { SetPresence } from "matrix-js-sdk/src/sync";
 
 import { MatrixClientPeg } from "./MatrixClientPeg";
 import dis from "./dispatcher/dispatcher";
@@ -27,10 +26,16 @@ import { ActionPayload } from "./dispatcher/payloads";
 // Time in ms after that a user is considered as unavailable/away
 const UNAVAILABLE_TIME_MS = 3 * 60 * 1000; // 3 mins
 
+enum State {
+    Online = "online",
+    Offline = "offline",
+    Unavailable = "unavailable",
+}
+
 class Presence {
     private unavailableTimer: Timer | null = null;
     private dispatcherRef: string | null = null;
-    private state: SetPresence | null = null;
+    private state: State | null = null;
 
     /**
      * Start listening the user activity to evaluate his presence state.
@@ -43,7 +48,7 @@ class Presence {
         while (this.unavailableTimer) {
             try {
                 await this.unavailableTimer.finished();
-                this.setState(SetPresence.Unavailable);
+                this.setState(State.Unavailable);
             } catch (e) {
                 /* aborted, stop got called */
             }
@@ -68,13 +73,13 @@ class Presence {
      * Get the current presence state.
      * @returns {string} the presence state (see PRESENCE enum)
      */
-    public getState(): SetPresence | null {
+    public getState(): State | null {
         return this.state;
     }
 
     private onAction = (payload: ActionPayload): void => {
         if (payload.action === "user_activity") {
-            this.setState(SetPresence.Online);
+            this.setState(State.Online);
             this.unavailableTimer?.restart();
         }
     };
@@ -84,7 +89,7 @@ class Presence {
      * If the state has changed, the homeserver will be notified.
      * @param {string} newState the new presence state (see PRESENCE enum)
      */
-    private async setState(newState: SetPresence): Promise<void> {
+    private async setState(newState: State): Promise<void> {
         if (newState === this.state) {
             return;
         }
@@ -97,7 +102,7 @@ class Presence {
         }
 
         try {
-            await MatrixClientPeg.safeGet().setSyncPresence(this.state);
+            await MatrixClientPeg.safeGet().setPresence({ presence: this.state });
             logger.info("Presence:", newState);
         } catch (err) {
             logger.error("Failed to set presence:", err);


### PR DESCRIPTION
This reverts commit 7e5739494b1f956d03dc668d2e4431b457e7faa1. Original PR: https://github.com/matrix-org/matrix-react-sdk/pull/11223

Reverting because this triggers a nasty performance problem in Synapse: https://github.com/matrix-org/synapse/issues/16039