### PR TITLE
Make a11y related lint rules more strict

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,7 +101,6 @@ module.exports = {
         "jsx-a11y/no-noninteractive-tabindex": "off",
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/role-supports-aria-props": "off",
-        "jsx-a11y/tabindex-no-positive": "off",
 
         "matrix-org/require-copyright-header": "error",
     },

--- a/cypress/e2e/register/register.spec.ts
+++ b/cypress/e2e/register/register.spec.ts
@@ -40,7 +40,14 @@ describe("Registration", () => {
         cy.findByRole("button", { name: "Continue" }).should("be.visible");
         // Only snapshot the server picker otherwise in the background `matrix.org` may or may not be available
         cy.get(".mx_Dialog").percySnapshotElement("Server Picker", { widths: [516] });
-        cy.checkA11y();
+        cy.checkA11y(undefined, {
+            rules: {
+                // Axe is unhappy with the configuration error's contrast here
+                "link-in-text-block": {
+                    enabled: false,
+                },
+            },
+        });
 
         cy.findByRole("textbox", { name: "Other homeserver" }).type(homeserver.baseUrl);
         cy.findByRole("button", { name: "Continue" }).click();

--- a/cypress/support/axe.ts
+++ b/cypress/support/axe.ts
@@ -59,10 +59,6 @@ Cypress.Commands.overwrite(
                     "color-contrast": {
                         enabled: false,
                     },
-                    // link-in-text-block also complains due to known contrast issues
-                    "link-in-text-block": {
-                        enabled: false,
-                    },
                     ...options.rules,
                 },
             },


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->