### PR TITLE
DRAFT: Add e2e tests for the module system

### DIFF
--- a/cypress/e2e/module-system/roomViewLifecycle.spec.ts
+++ b/cypress/e2e/module-system/roomViewLifecycle.spec.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+describe("RoomViewLifecycle", () => {
+    let homeserver: HomeserverInstance;
+
+    beforeEach(() => {
+        cy.window().then((win) => {
+            win.localStorage.setItem("mx_local_settings", '{"language":"en"}'); // Ensure the language is set to a consistent value
+        });
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+
+            cy.intercept(
+                { method: "GET", pathname: "/config.json" },
+                { body: { default_server_config: { "m.homeserver": { base_url: data.baseUrl } } } },
+            );
+        });
+    });
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should show login without the PreviewRoomNotLoggedIn lifecycle", () => {
+        cy.visit(`/#/room/!example:localhost`);
+
+        cy.contains("Join the conversation with an account");
+        cy.contains("Sign Up");
+        cy.contains("Sign In");
+    });
+
+    it("should show login with the PreviewRoomNotLoggedIn lifecycle", () => {
+        // we must reload the page first, otherwise, the module system settings get lost...
+        cy.visit("/");
+        cy.contains("Welcome");
+
+        // we need to set the data to local storage again because of the reload
+        cy.window().then((win) => {
+            win.localStorage.setItem("mx_local_settings", '{"language":"en"}'); // Ensure the language is set to a consistent value
+        });
+        cy.enableModuleSystem();
+        cy.moduleSystemPreviewRoom("!example:localhost");
+
+        cy.visit(`/#/room/!example:localhost`);
+        cy.reload();
+
+        cy.contains("Join the room to participate");
+        cy.contains("Join");
+    });
+});

--- a/cypress/e2e/module-system/translations.spec.ts
+++ b/cypress/e2e/module-system/translations.spec.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+import { HomeserverInstance } from "../../plugins/utils/homeserver";
+
+describe("Custom translations module", () => {
+    let homeserver: HomeserverInstance;
+
+    beforeEach(() => {
+        cy.enableModuleSystem();
+
+        cy.window().then((win) => {
+            win.localStorage.setItem("mx_lhs_size", "0"); // Collapse left panel for these tests
+        });
+        cy.startHomeserver("default").then((data) => {
+            homeserver = data;
+
+            cy.initTestUser(homeserver, "Tom");
+        });
+    });
+
+    afterEach(() => {
+        cy.stopHomeserver(homeserver);
+    });
+
+    it("should override the 'Welcome' translation", () => {
+        cy.get("Howdy Tom (Changed by the Module System)");
+    });
+});

--- a/cypress/example_module/ExampleModule.ts
+++ b/cypress/example_module/ExampleModule.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModuleApi } from "@matrix-org/react-sdk-module-api/lib/ModuleApi";
+import { RuntimeModule } from "@matrix-org/react-sdk-module-api/lib/RuntimeModule";
+import {
+    RoomPreviewListener,
+    RoomViewLifecycle,
+} from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
+
+export default class ExampleModule extends RuntimeModule {
+    public constructor(moduleApi: ModuleApi) {
+        super(moduleApi);
+
+        // Only apply the module when it is activated so we don't interfere with
+        // other tests that should not be affected by this module.
+        if (window.localStorage.getItem("cypress_module_system_enable") !== "true") {
+            return;
+        }
+
+        this.moduleApi.registerTranslations({
+            "Welcome %(name)s": {
+                en: "Howdy %(name)s (Changed by the Module System)",
+            },
+        });
+
+        this.on(RoomViewLifecycle.PreviewRoomNotLoggedIn, this.onRoomPreview);
+    }
+
+    protected onRoomPreview: RoomPreviewListener = (opts, roomId) => {
+        if (window.localStorage.getItem("cypress_module_system_preview_room_id") === roomId) {
+            opts.canJoin = true;
+        }
+    };
+}

--- a/cypress/example_module/build_config.yaml
+++ b/cypress/example_module/build_config.yaml
@@ -1,0 +1,5 @@
+# This file is included by the `yarn start:e2e` task in element-web. It will
+# register the module in this folder as a module in the dev mode so that the
+# Cypress tests can be executed correctly.
+modules:
+  - "file:node_modules/matrix-react-sdk/cypress/example_module"

--- a/cypress/example_module/package.json
+++ b/cypress/example_module/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "example_module",
+    "version": "1.0.0",
+    "main": "ExampleModule.ts",
+    "dependencies": {
+        "@matrix-org/react-sdk-module-api": "*"
+    }
+}

--- a/cypress/plugins/synapsedocker/templates/default/homeserver.yaml
+++ b/cypress/plugins/synapsedocker/templates/default/homeserver.yaml
@@ -74,3 +74,5 @@ suppress_key_server_warning: true
 
 ui_auth:
     session_timeout: "300s"
+
+allow_guest_access: true

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -40,6 +40,7 @@ import "./network";
 import "./composer";
 import "./proxy";
 import "./axe";
+import "./moduleSystem";
 
 installLogsCollector({
     // specify the types of logs to collect (and report to the node console at the end of the test)

--- a/cypress/support/moduleSystem.ts
+++ b/cypress/support/moduleSystem.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// <reference types="cypress" />
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Cypress {
+        interface Chainable {
+            // Enables the module system for the current session.
+            enableModuleSystem(): void;
+            moduleSystemPreviewRoom(roomId: string): void;
+        }
+    }
+}
+
+beforeEach(() => {
+    cy.window().then((win) => {
+        win.localStorage.removeItem("cypress_module_system_enable");
+        win.localStorage.removeItem("cypress_module_system_preview_room_id");
+    });
+});
+
+Cypress.Commands.add("enableModuleSystem", (): void => {
+    cy.window().then((win) => {
+        win.localStorage.setItem("cypress_module_system_enable", "true");
+    });
+});
+
+Cypress.Commands.add("moduleSystemPreviewRoom", (roomId: string): void => {
+    cy.window().then((win) => {
+        win.localStorage.setItem("cypress_module_system_preview_room_id", roomId);
+    });
+});
+
+// Needed to make this file a module
+export {};


### PR DESCRIPTION
This PR implements a proposal for testing the Module System with Cypress. It needs to be viewed together with https://github.com/vector-im/element-web/pull/25951.

The changes:

1. We create a module in the `cypress/example_module` (tbd) folder. It has a minimal setup with a package.json, but we don't expect that anyone calls `yarn install` we expect it to be used directly as a TypeScript file, so Webpack is advised to run babel for it (-> change in element-web).
2. We add a `ELEMENT_BUILD_CONFIG` variable that can change the location of the `build_config.yaml` file that is used in the build process. A `yarn start:e2e` script is adding the `example_module` created in **1.** (-> change in element-web)
3. Cypress runs and we use flags in the localStorage to "enable" the module. (1) This takes case that the module doesn't interfere with any other tests and (2) it allows us to put the tests into the existing Cypress setup without the need for a different build of Element to test the modules. Individual parts of the module could also be enabled/disabled via localStorage flags in certain tests (this PR).

I added two example tests for the translations and the `RoomViewLifecycle.PreviewRoomNotLoggedIn` lifecycle to show how a test could look like.

@germain-gg we discussed this before, and I wanted to propose this so we have a base for our discussions. Do you think this setup would work for us? I would be happy to receive feedback, and other ideas on how to make the module system testable.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->
Type: task
Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->