### PR TITLE
Pin the action buttons to the bottom of the scrollable dialogs

### DIFF
--- a/res/css/views/dialogs/_CompoundDialog.pcss
+++ b/res/css/views/dialogs/_CompoundDialog.pcss
@@ -58,12 +58,13 @@ limitations under the License.
         display: flex;
         flex-direction: column;
         min-height: 0;
-        max-height: 100%;
+        flex: 1;
     }
 
     .mx_CompoundDialog_content {
         overflow: auto;
         padding: 8px 32px;
+        flex: 1;
     }
 
     .mx_CompoundDialog_footer {
@@ -81,9 +82,10 @@ limitations under the License.
     flex-direction: column;
 
     width: 544px; /* fixed */
+    height: 516px; /* fixed */
     max-width: 100%;
     min-height: 0;
-    max-height: min(516px, 80vh);
+    max-height: 80%;
 
     .mx_CompoundDialog_footer {
         box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.05); /* hardcoded colour for both themes */

--- a/res/css/views/dialogs/_CompoundDialog.pcss
+++ b/res/css/views/dialogs/_CompoundDialog.pcss
@@ -81,10 +81,9 @@ limitations under the License.
     flex-direction: column;
 
     width: 544px; /* fixed */
-    height: 516px; /* fixed */
     max-width: 100%;
     min-height: 0;
-    max-height: 80%;
+    max-height: min(516px, 80vh);
 
     .mx_CompoundDialog_footer {
         box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.05); /* hardcoded colour for both themes */


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

This fixes the location of the action buttons in the dialog that is used by the [Module API](https://github.com/matrix-org/matrix-react-sdk-module-api), for example by the [ILAG module](https://github.com/vector-im/element-web-ilag-module).

| Before | After |
|--|--|
| <img width="300" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/720821/37f23bbb-7b3e-4805-90c8-e9cde4ef5626"> | <img width="300" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/720821/4427e909-35e0-4637-ad1f-07236563b685"> |

It would also be nice if the "shadow" would disappear when the content is not actually scrolling, but I didn't have a good idea on how to solve that easily. For now, the size is our main concern.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Pin the action buttons to the bottom of the scrollable dialogs ([\#11407](https://github.com/matrix-org/matrix-react-sdk/pull/11407)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->