### PR TITLE
MatrixChat-test: stop mocking localStorage

### DIFF
--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -135,10 +135,6 @@ describe("<MatrixChat />", () => {
     };
     const getComponent = (props: Partial<ComponentProps<typeof MatrixChat>> = {}) =>
         render(<MatrixChat {...defaultProps} {...props} />);
-    let localStorageSetSpy = jest.spyOn(localStorage.__proto__, "setItem");
-    let localStorageGetSpy = jest.spyOn(localStorage.__proto__, "getItem").mockReturnValue(undefined);
-    let localStorageClearSpy = jest.spyOn(localStorage.__proto__, "clear");
-    let sessionStorageSetSpy = jest.spyOn(sessionStorage.__proto__, "setItem");
 
     // make test results readable
     filterConsole("Failed to parse localStorage object");
@@ -180,10 +176,6 @@ describe("<MatrixChat />", () => {
             unstable_features: {},
             versions: ["v1.1"],
         });
-        localStorageSetSpy = jest.spyOn(localStorage.__proto__, "setItem");
-        localStorageGetSpy = jest.spyOn(localStorage.__proto__, "getItem").mockReturnValue(undefined);
-        localStorageClearSpy = jest.spyOn(localStorage.__proto__, "clear");
-        sessionStorageSetSpy = jest.spyOn(sessionStorage.__proto__, "setItem");
 
         jest.spyOn(StorageManager, "idbLoad").mockReset();
         jest.spyOn(StorageManager, "idbSave").mockResolvedValue(undefined);
@@ -194,6 +186,8 @@ describe("<MatrixChat />", () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        localStorage.clear();
+        sessionStorage.clear();
     });
 
     it("should render spinner while app is loading", () => {
@@ -208,16 +202,13 @@ describe("<MatrixChat />", () => {
                 mx_access_token: accessToken,
             },
         };
-        const mockLocalStorage: Record<string, string> = {
-            mx_hs_url: serverConfig.hsUrl,
-            mx_is_url: serverConfig.isUrl,
-            mx_access_token: accessToken,
-            mx_user_id: userId,
-            mx_device_id: deviceId,
-        };
 
         beforeEach(() => {
-            localStorageGetSpy.mockImplementation((key: unknown) => mockLocalStorage[key as string] || "");
+            localStorage.setItem("mx_hs_url", serverConfig.hsUrl);
+            localStorage.setItem("mx_is_url", serverConfig.isUrl);
+            localStorage.setItem("mx_access_token", accessToken);
+            localStorage.setItem("mx_user_id", userId);
+            localStorage.setItem("mx_device_id", deviceId);
 
             jest.spyOn(StorageManager, "idbLoad").mockImplementation(async (table, key) => {
                 const safeKey = Array.isArray(key) ? key[0] : key;
@@ -521,17 +512,14 @@ describe("<MatrixChat />", () => {
 
     describe("with a soft-logged-out session", () => {
         const mockidb: Record<string, Record<string, string>> = {};
-        const mockLocalStorage: Record<string, string> = {
-            mx_hs_url: serverConfig.hsUrl,
-            mx_is_url: serverConfig.isUrl,
-            mx_access_token: accessToken,
-            mx_user_id: userId,
-            mx_device_id: deviceId,
-            mx_soft_logout: "true",
-        };
 
         beforeEach(() => {
-            localStorageGetSpy.mockImplementation((key: unknown) => mockLocalStorage[key as string] || "");
+            localStorage.setItem("mx_hs_url", serverConfig.hsUrl);
+            localStorage.setItem("mx_is_url", serverConfig.isUrl);
+            localStorage.setItem("mx_access_token", accessToken);
+            localStorage.setItem("mx_user_id", userId);
+            localStorage.setItem("mx_device_id", deviceId);
+            localStorage.setItem("mx_soft_logout", "true");
 
             mockClient.loginFlows.mockResolvedValue({ flows: [{ type: "m.login.password" }] });
 
@@ -727,14 +715,6 @@ describe("<MatrixChat />", () => {
             loginToken,
         };
 
-        const mockLocalStorage: Record<string, string> = {
-            mx_sso_hs_url: serverConfig.hsUrl,
-            mx_sso_is_url: serverConfig.isUrl,
-            // these are only going to be set during login
-            mx_hs_url: serverConfig.hsUrl,
-            mx_is_url: serverConfig.isUrl,
-        };
-
         let loginClient!: ReturnType<typeof getMockClientWithEventEmitter>;
         const userId = "@alice:server.org";
         const deviceId = "test-device-id";
@@ -746,17 +726,18 @@ describe("<MatrixChat />", () => {
         };
 
         beforeEach(() => {
+            localStorage.setItem("mx_sso_hs_url", serverConfig.hsUrl);
+            localStorage.setItem("mx_sso_is_url", serverConfig.isUrl);
             loginClient = getMockClientWithEventEmitter(getMockClientMethods());
             // this is used to create a temporary client during login
             jest.spyOn(MatrixJs, "createClient").mockReturnValue(loginClient);
 
             loginClient.login.mockClear().mockResolvedValue(clientLoginResponse);
-
-            localStorageGetSpy.mockImplementation((key: unknown) => mockLocalStorage[key as string] || "");
         });
 
         it("should show an error dialog when no homeserver is found in local storage", async () => {
-            localStorageGetSpy.mockReturnValue(undefined);
+            localStorage.removeItem("mx_sso_hs_url");
+            const localStorageGetSpy = jest.spyOn(localStorage.__proto__, "getItem");
             getComponent({ realQueryParams });
 
             expect(localStorageGetSpy).toHaveBeenCalledWith("mx_sso_hs_url");
@@ -830,12 +811,15 @@ describe("<MatrixChat />", () => {
                 );
             });
             it("should clear storage", async () => {
+                const localStorageClearSpy = jest.spyOn(localStorage.__proto__, "clear");
+
                 getComponent({ realQueryParams });
 
                 await flushPromises();
 
                 // just check we called the clearStorage function
                 expect(loginClient.clearStores).toHaveBeenCalled();
+                expect(localStorage.getItem("mx_sso_hs_url")).toBe(null);
                 expect(localStorageClearSpy).toHaveBeenCalled();
             });
 
@@ -844,17 +828,17 @@ describe("<MatrixChat />", () => {
 
                 await flushPromises();
 
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_hs_url", serverConfig.hsUrl);
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_user_id", userId);
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_has_access_token", "true");
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_device_id", deviceId);
+                expect(localStorage.getItem("mx_hs_url")).toEqual(serverConfig.hsUrl);
+                expect(localStorage.getItem("mx_user_id")).toEqual(userId);
+                expect(localStorage.getItem("mx_has_access_token")).toEqual("true");
+                expect(localStorage.getItem("mx_device_id")).toEqual(deviceId);
             });
 
             it("should set fresh login flag in session storage", async () => {
+                const sessionStorageSetSpy = jest.spyOn(sessionStorage.__proto__, "setItem");
                 getComponent({ realQueryParams });
 
                 await flushPromises();
-
                 expect(sessionStorageSetSpy).toHaveBeenCalledWith("mx_fresh_login", "true");
             });
 
@@ -873,7 +857,7 @@ describe("<MatrixChat />", () => {
 
                 await flushPromises();
 
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_hs_url", hsUrlFromWk);
+                expect(localStorage.getItem("mx_hs_url")).toEqual(hsUrlFromWk);
             });
 
             it("should continue to post login setup when no session is found in local storage", async () => {
@@ -901,14 +885,6 @@ describe("<MatrixChat />", () => {
         const userId = "@alice:server.org";
         const deviceId = "test-device-id";
         const accessToken = "test-access-token-from-oidc";
-
-        const mockLocalStorage: Record<string, string> = {
-            // these are only going to be set during login
-            mx_hs_url: homeserverUrl,
-            mx_is_url: identityServerUrl,
-            mx_user_id: userId,
-            mx_device_id: deviceId,
-        };
 
         const tokenResponse: BearerTokenResponse = {
             access_token: accessToken,
@@ -950,7 +926,6 @@ describe("<MatrixChat />", () => {
             jest.spyOn(logger, "error").mockClear();
             jest.spyOn(logger, "log").mockClear();
 
-            localStorageGetSpy.mockImplementation((key: unknown) => mockLocalStorage[key as string] || "");
             loginClient.whoami.mockResolvedValue({
                 user_id: userId,
                 device_id: deviceId,
@@ -1047,6 +1022,7 @@ describe("<MatrixChat />", () => {
             });
 
             it("should not store clientId or issuer", async () => {
+                const sessionStorageSetSpy = jest.spyOn(sessionStorage.__proto__, "setItem");
                 getComponent({ realQueryParams });
 
                 await flushPromises();
@@ -1058,7 +1034,6 @@ describe("<MatrixChat />", () => {
 
         describe("when login succeeds", () => {
             beforeEach(() => {
-                localStorageGetSpy.mockImplementation((key: unknown) => mockLocalStorage[key as string] || "");
                 jest.spyOn(StorageManager, "idbLoad").mockImplementation(
                     async (_table: string, key: string | string[]) => (key === "mx_access_token" ? accessToken : null),
                 );
@@ -1072,10 +1047,10 @@ describe("<MatrixChat />", () => {
 
                 await flushPromises();
 
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_hs_url", homeserverUrl);
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_user_id", userId);
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_has_access_token", "true");
-                expect(localStorageSetSpy).toHaveBeenCalledWith("mx_device_id", deviceId);
+                expect(localStorage.getItem("mx_hs_url")).toEqual(homeserverUrl);
+                expect(localStorage.getItem("mx_user_id")).toEqual(userId);
+                expect(localStorage.getItem("mx_has_access_token")).toEqual("true");
+                expect(localStorage.getItem("mx_device_id")).toEqual(deviceId);
             });
 
             it("should store clientId and issuer in session storage", async () => {
@@ -1083,8 +1058,8 @@ describe("<MatrixChat />", () => {
 
                 await flushPromises();
 
-                expect(sessionStorageSetSpy).toHaveBeenCalledWith("mx_oidc_client_id", clientId);
-                expect(sessionStorageSetSpy).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
+                expect(sessionStorage.getItem("mx_oidc_client_id")).toEqual(clientId);
+                expect(sessionStorage.getItem("mx_oidc_token_issuer")).toEqual(issuer);
             });
 
             it("should set logged in and start MatrixClient", async () => {
@@ -1104,7 +1079,7 @@ describe("<MatrixChat />", () => {
                         homeserverUrl +
                         " softLogout: " +
                         false,
-                    " freshLogin: " + false,
+                    " freshLogin: " + true,
                 );
 
                 // client successfully started


### PR DESCRIPTION
We have a perfectly good localStorage impl; no need to do a half-arsed mock of it.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->