### PR TITLE
Share history in rooms in spaces by default

### DIFF
--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -233,7 +233,7 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
         createOpts.initial_state.push(makeSpaceParentEvent(opts.parentSpace, true));
         if (!opts.historyVisibility) {
             opts.historyVisibility =
-                createOpts.preset === Preset.PublicChat ? HistoryVisibility.WorldReadable : HistoryVisibility.Invited;
+                createOpts.preset === Preset.PublicChat ? HistoryVisibility.WorldReadable : HistoryVisibility.Shared;
         }
 
         if (opts.joinRule === JoinRule.Restricted) {


### PR DESCRIPTION
Signed-off-by: Gabriel Rodríguez <rgabriel@mit.edu>

Fixes https://github.com/vector-im/element-meta/issues/377. Fixes https://github.com/vector-im/element-meta/issues/1999. Both Element iOS and Element Android already do this by default (which seems to be inherited from the homeserver's behavior). Only Element Web has inconsistent behavior. This PR is opinionated in deliberately choosing the same behavior as on mobile.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible) - N/A: change is very small
-   [ ] Linter and other CI checks pass 
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: history_visibility on rooms in spaces is now `shared` by default

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: New rooms created in spaces have their future history shared to all room members

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

Notes: history_visibility on rooms in spaces is now `shared` by default

element-web notes: New rooms created in spaces have their future history shared to all room members

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * history_visibility on rooms in spaces is now `shared` by default ([\#11446](https://github.com/matrix-org/matrix-react-sdk/pull/11446)). Fixes vector-im/element-meta#377. Contributed by @gabrc52.<!-- CHANGELOG_PREVIEW_END -->