### PR TITLE
Avoid importing mkEvent from matrix-js-sdk/spec since that is not in the package

### DIFF
--- a/test/components/views/dialogs/RoomSettingsDialog-test.tsx
+++ b/test/components/views/dialogs/RoomSettingsDialog-test.tsx
@@ -16,7 +16,6 @@ limitations under the License.
 
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { mkEvent } from "matrix-js-sdk/spec/test-utils/test-utils";
 import {
     EventTimeline,
     EventType,
@@ -133,7 +132,7 @@ describe("<RoomSettingsDialog />", () => {
                 jest.spyOn(room, "getJoinRule").mockReturnValue(JoinRule.Invite);
                 mockClient.emit(
                     RoomStateEvent.Events,
-                    new MatrixEvent(mkEvent({ content: {}, type: EventType.RoomJoinRules })),
+                    new MatrixEvent({ content: {}, type: EventType.RoomJoinRules }),
                     room.getLiveTimeline().getState(EventTimeline.FORWARDS)!,
                     null,
                 );


### PR DESCRIPTION
Attempts to fix this build error that we saw during the release process: https://github.com/matrix-org/matrix-react-sdk/actions/runs/5940228003/attempts/3

```
2023-08-22T14:52:45.5606965Z ##[debug]$ tsc --emitDeclarationOnly --jsx react
2023-08-22T14:52:45.5607361Z ##[debug]test/components/views/dialogs/RoomSettingsDialog-test.tsx(19,25): error TS2307: Cannot find module 'matrix-js-sdk/spec/test-utils/test-utils' or its corresponding type declarations.
```

Caused by https://github.com/matrix-org/matrix-react-sdk/pull/11404 linking to test code in matrix-js-sdk from test code in matrix-react-sdk, which doesn't work (and shouldn't work) but there is zero warning from any of our lints or CI for this, which we should definitely fix.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->