### PR TITLE
In the stickers test, check for the download URL of a thumbnail only

### DIFF
--- a/cypress/e2e/widgets/stickers.spec.ts
+++ b/cypress/e2e/widgets/stickers.spec.ts
@@ -86,10 +86,10 @@ function expectTimelineSticker(roomId: string) {
     // Make sure it's in the right room
     cy.get(".mx_EventTile_sticker > a").should("have.attr", "href").and("include", `/${roomId}/`);
 
-    // Make sure the image points at the sticker image
-    cy.get<HTMLImageElement>(`img[alt="${STICKER_NAME}"]`)
-        .should("have.attr", "src")
-        .and("match", /thumbnail\/somewhere\?/);
+    // Make sure the image points at the sticker image. We will briefly show it
+    // using the thumbnail URL, but as soon as that fails, we will switch to the
+    // download URL.
+    cy.get<HTMLImageElement>(`img[alt="${STICKER_NAME}"][src*="download/somewhere"]`).should("exist");
 }
 
 describe("Stickers", () => {


### PR DESCRIPTION
First part of fixing https://github.com/vector-im/element-web/issues/26017 .

I tried to do 2 things at once in https://github.com/matrix-org/matrix-react-sdk/pull/11440 but the other one proved tricky. This one should be easier.

When we are looking for a sticker in the timeline in this test, it first appears as a thumbnail, but when Element Web sees that the thumbnail 404s, it changes the URL to a download URL.

Before this change, we were looking for the thumbnail URL, but if we are not quick enough it has already changed to a download URL.

After this change, we just look for the download URL, which will appear very quickly when the thumbnail fails to load.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->