### PR TITLE
Collect `console.debug` logs during cypress tests

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -50,7 +50,9 @@ installLogsCollector({
         "cons:info",
         "cons:warn",
         "cons:error",
-        // "cons:debug",
+        // most of our logs go through `loglevel`, which sets `logger.log` to be an alias of `logger.debug`.
+        // Hence, if we want to capture `logger.log` lines, we need to enable `cons:debug` here.
+        "cons:debug",
         "cy:log",
         "cy:xhr",
         "cy:fetch",


### PR DESCRIPTION
The logging I added in https://github.com/matrix-org/matrix-react-sdk/pull/11467 is currently basically useless.

In order for the logs collected by cypress to actually be useful, we really need `cons:debug`.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->