### PR TITLE
Allow requesting to join knock rooms via spotlight

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -74,6 +74,7 @@
         "resend": "Resend",
         "next": "Next",
         "view": "View",
+        "ask_to_join": "Ask to join",
         "forward": "Forward",
         "copy_link": "Copy link",
         "logout": "Logout",


### PR DESCRIPTION
We @nordeck are currently implementing the knock rooms behind the feature flag `feature_ask_to_join` (introduced in https://github.com/matrix-org/matrix-react-sdk/pull/11182).

This pull request allows requesting to join knock rooms via spotlight.

Follow up of: https://github.com/matrix-org/matrix-react-sdk/pull/11464
Epic: https://github.com/vector-im/element-web/issues/18655

#### Relates to

- https://github.com/matrix-org/matrix-react-sdk/pull/11404
  - https://github.com/matrix-org/matrix-js-sdk/pull/3673
- https://github.com/matrix-org/matrix-react-sdk/pull/11353
  - https://github.com/matrix-org/matrix-js-sdk/pull/3647
- https://github.com/matrix-org/matrix-react-sdk/pull/11248
- https://github.com/matrix-org/matrix-react-sdk/pull/11182
- https://github.com/vector-im/element-web/pull/25923

### Screens

![SpotlightDialog](https://github.com/matrix-org/matrix-react-sdk/assets/1422657/1b016476-14a3-450c-919c-aff222e7682d)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow requesting to join knock rooms via spotlight ([\#11482](https://github.com/matrix-org/matrix-react-sdk/pull/11482)). Contributed by @charlynguyen.<!-- CHANGELOG_PREVIEW_END -->