### PR TITLE
Fix docker entrypoint for Dendrite image

### DIFF
--- a/cypress/plugins/dendritedocker/index.ts
+++ b/cypress/plugins/dendritedocker/index.ts
@@ -96,7 +96,7 @@ async function dendritePineconeStart(template: string): Promise<HomeserverInstan
 
 async function containerStart(template: string, usePinecone: boolean): Promise<HomeserverInstance> {
     let dendriteImage = "matrixdotorg/dendrite-monolith:main";
-    let dendriteEntrypoint = "/usr/bin/dendrite-monolith-server";
+    let dendriteEntrypoint = "/usr/bin/dendrite";
     if (usePinecone) {
         dendriteImage = "matrixdotorg/dendrite-demo-pinecone:main";
         dendriteEntrypoint = "/usr/bin/dendrite-demo-pinecone";


### PR DESCRIPTION
The binary was renamed some time ago and our CI isn't too happy about it (well..).
The image name is unchanged.

> docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/bin/dendrite-monolith-server": stat /usr/bin/dendrite-monolith-server: no such file or directory: unknown.

https://github.com/matrix-org/dendrite/actions/runs/6018936248/job/16327998043#step:9:9735

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->