### PR TITLE
Link directly to a user's profile in the e2ee room card

### DIFF
--- a/src/components/views/messages/EncryptionEvent.tsx
+++ b/src/components/views/messages/EncryptionEvent.tsx
@@ -80,8 +80,8 @@ const EncryptionEvent = forwardRef<HTMLDivElement, IProps>(({ mxEvent, timestamp
                         <AccessibleButton kind="link_inline" onClick={profileLinkOnClick}>
                             {sub}
                         </AccessibleButton>
-                    )
-                }
+                    ),
+                },
             );
         } else if (room && isLocalRoom(room)) {
             subtitle = _t("Messages in this chat will be end-to-end encrypted.");

--- a/src/components/views/messages/EncryptionEvent.tsx
+++ b/src/components/views/messages/EncryptionEvent.tsx
@@ -56,11 +56,9 @@ const EncryptionEvent = forwardRef<HTMLDivElement, IProps>(({ mxEvent, timestamp
         if (prevContent.algorithm === ALGORITHM) {
             subtitle = _t("Some encryption parameters have been changed.");
         } else if (dmPartner) {
-            console.log("dmPartner is", dmPartner);
             const dmPartnerRoomMember = room?.getMember(dmPartner);
-            console.log("dmPartnerRoomMember is", dmPartnerRoomMember);
             const displayName = dmPartnerRoomMember?.rawDisplayName || dmPartner;
-            const profileLinkOnClick = () => {
+            const profileLinkOnClick = (): void => {
                 if (!dmPartnerRoomMember) {
                     // We were unable to fetch membership info for the other user in this DM. Do nothing.
                     return;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2202,7 +2202,7 @@
     "Downloading": "Downloading",
     "Decrypting": "Decrypting",
     "Some encryption parameters have been changed.": "Some encryption parameters have been changed.",
-    "Messages here are end-to-end encrypted. Verify %(displayName)s in their profile - tap on their profile picture.": "Messages here are end-to-end encrypted. Verify %(displayName)s in their profile - tap on their profile picture.",
+    "Messages here are end-to-end encrypted. Verify %(displayName)s in <a>their profile</a>.": "Messages here are end-to-end encrypted. Verify %(displayName)s in <a>their profile</a>.",
     "Messages in this chat will be end-to-end encrypted.": "Messages in this chat will be end-to-end encrypted.",
     "Messages in this room are end-to-end encrypted. When people join, you can verify them in their profile, just tap on their profile picture.": "Messages in this room are end-to-end encrypted. When people join, you can verify them in their profile, just tap on their profile picture.",
     "Ignored attempt to disable encryption": "Ignored attempt to disable encryption",

--- a/test/components/views/messages/EncryptionEvent-test.tsx
+++ b/test/components/views/messages/EncryptionEvent-test.tsx
@@ -16,11 +16,11 @@ limitations under the License.
 
 import React from "react";
 import { mocked } from "jest-mock";
-import { MatrixClient, MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { MatrixClient, MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
+
 import { Action } from "../../../../src/dispatcher/actions";
 import dispatcher from "../../../../src/dispatcher/dispatcher";
-
 import EncryptionEvent from "../../../../src/components/views/messages/EncryptionEvent";
 import { createTestClient, mkMessage } from "../../../test-utils";
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";

--- a/test/components/views/messages/EncryptionEvent-test.tsx
+++ b/test/components/views/messages/EncryptionEvent-test.tsx
@@ -136,7 +136,7 @@ describe("EncryptionEvent", () => {
             screen.getByText("Encryption enabled");
 
             // Check that the link to the user's profile in the subtitle exists.
-            let linkToProfile = screen.getByText("their profile", { exact: false });
+            const linkToProfile = screen.getByText("their profile", { exact: false });
 
             // Check that the non-linkified text in the subtitle is correct.
             // Then check that the link to the profile is contained within the card subtitle.

--- a/test/components/views/messages/EncryptionEvent-test.tsx
+++ b/test/components/views/messages/EncryptionEvent-test.tsx
@@ -114,6 +114,40 @@ describe("EncryptionEvent", () => {
         });
     });
 
+    describe("for an encrypted DM room", () => {
+        const otherUserId = "@alice:example.com";
+
+        beforeEach(() => {
+            event.event.content!.algorithm = algorithm;
+            mocked(client.isRoomEncrypted).mockReturnValue(true);
+
+            jest.spyOn(DMRoomMap, "shared").mockReturnValue({
+                getUserIdForRoomId: (_roomId: string) => otherUserId,
+            } as unknown as DMRoomMap);
+
+            const room = new Room(roomId, client, client.getUserId()!);
+            mocked(client.getRoom).mockReturnValue(room);
+        });
+
+        it("should show a link to the user's profile to verify them with", () => {
+            renderEncryptionEvent(client, event);
+
+            // Check that the expected title of the encrypted DM card exists and has the expected text.
+            screen.getByText("Encryption enabled");
+
+            // Check that the link to the user's profile in the subtitle exists.
+            let linkToProfile = screen.getByText("their profile", { exact: false });
+
+            // Check that the non-linkified text in the subtitle is correct.
+            // Then check that the link to the profile is contained within the card subtitle.
+            expect(
+                screen.getByText(`Messages here are end-to-end encrypted. Verify @alice:example.com in`, {
+                    exact: false,
+                }),
+            ).toContainElement(linkToProfile);
+        });
+    });
+
     describe("for an encrypted local room", () => {
         beforeEach(() => {
             event.event.content!.algorithm = algorithm;

--- a/test/components/views/messages/EncryptionEvent-test.tsx
+++ b/test/components/views/messages/EncryptionEvent-test.tsx
@@ -18,15 +18,14 @@ import React from "react";
 import { mocked } from "jest-mock";
 import { MatrixClient, MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { Action } from "../../../../src/dispatcher/actions";
+import dispatcher from "../../../../src/dispatcher/dispatcher";
 
 import EncryptionEvent from "../../../../src/components/views/messages/EncryptionEvent";
 import { createTestClient, mkMessage } from "../../../test-utils";
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import { LocalRoom } from "../../../../src/models/LocalRoom";
-import RightPanelStore from "../../../../src/stores/right-panel/RightPanelStore";
 import DMRoomMap from "../../../../src/utils/DMRoomMap";
-import { Action } from "matrix-react-sdk/src/dispatcher/actions";
-import dispatcher from "matrix-react-sdk/src/dispatcher/dispatcher";
 import MatrixClientContext from "../../../../src/contexts/MatrixClientContext";
 
 const renderEncryptionEvent = (client: MatrixClient, event: MatrixEvent) => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

## Description

This PR updates the subtitle of the "Encryption Enabled" card that appears at the top of end-to-end encrypted DMs to link directly to a user's profile, instead of asking the user to "tap" around to open it.

Old:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/1342360/b0bb073d-ea81-402b-ae85-82f93dced598)

New:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/1342360/9795e224-355a-403f-bd06-038f22681f7f)

## Changelog

Notes: Provide a link to a user's profile in the "Encryption Enabled" room card, instead of asking the user to navigate themselves

Type: enhancement

## Sign-off

```
Signed-off-by: Andrew Morgan <andrewm@matrix.org>
```

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Provide a link to a user's profile in the "Encryption Enabled" room card, instead of asking the user to navigate themselves ([\#11497](https://github.com/matrix-org/matrix-react-sdk/pull/11497)).<!-- CHANGELOG_PREVIEW_END -->