### PR TITLE
Expand a thread reply test to be more explicit

### DIFF
--- a/cypress/e2e/read-receipts/high-level.spec.ts
+++ b/cypress/e2e/read-receipts/high-level.spec.ts
@@ -670,9 +670,18 @@ describe("Read receipts", () => {
             });
             it.skip("Reading a thread root within the thread view marks it as read in the main timeline", () => {});
             it("Creating a new thread based on a reply makes the room unread", () => {
+                // Given a message and reply exist and are read
                 goTo(room1);
-                receiveMessages(room2, ["Msg1", replyTo("Msg1", "Reply1"), threadedOff("Reply1", "Resp1")]);
-                assertUnread(room2, 3);
+                receiveMessages(room2, ["Msg1", replyTo("Msg1", "Reply1")]);
+                goTo(room2);
+                goTo(room1);
+                assertRead(room2);
+
+                // When I receive a thread message created on the reply
+                receiveMessages(room2, [threadedOff("Reply1", "Resp1")]);
+
+                // Then the room is unread
+                assertUnread(room2, 1);
             });
             it("Reading a thread whose root is a reply makes the room read", () => {
                 goTo(room1);


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/25449
<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->