### PR TITLE
Fix avatars of knock members for people tab of room settings

### DIFF
--- a/res/css/views/settings/tabs/room/_PeopleRoomSettingsTab.pcss
+++ b/res/css/views/settings/tabs/room/_PeopleRoomSettingsTab.pcss
@@ -24,6 +24,11 @@ limitations under the License.
     margin: 0 var(--cpd-space-4x);
 }
 
+.mx_PeopleRoomSettingsTab_avatar {
+    align-self: flex-start;
+    flex-shrink: 0;
+}
+
 .mx_PeopleRoomSettingsTab_name {
     font-weight: var(--cpd-font-weight-semibold);
 }

--- a/src/components/views/settings/tabs/room/PeopleRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/PeopleRoomSettingsTab.tsx
@@ -82,7 +82,7 @@ const Knock: VFC<{
 
     return (
         <div className="mx_PeopleRoomSettingsTab_knock">
-            <MemberAvatar member={roomMember} size="42px" />
+            <MemberAvatar className="mx_PeopleRoomSettingsTab_avatar" member={roomMember} size="42px" />
             <div className="mx_PeopleRoomSettingsTab_content">
                 <span className="mx_PeopleRoomSettingsTab_name">{roomMember.name}</span>
                 <Timestamp roomMember={roomMember} />

--- a/test/components/views/settings/tabs/room/__snapshots__/PeopleRoomSettingsTab-test.tsx.snap
+++ b/test/components/views/settings/tabs/room/__snapshots__/PeopleRoomSettingsTab-test.tsx.snap
@@ -17,7 +17,7 @@ exports[`PeopleRoomSettingsTab with requests to join renders requests fully 1`] 
     >
       <span
         aria-label="Profile picture"
-        class="_avatar_2lhia_17 mx_BaseAvatar"
+        class="_avatar_2lhia_17 mx_BaseAvatar mx_PeopleRoomSettingsTab_avatar"
         data-color="4"
         data-testid="avatar-img"
         data-type="round"
@@ -111,7 +111,7 @@ exports[`PeopleRoomSettingsTab with requests to join renders requests reduced 1`
       class="mx_PeopleRoomSettingsTab_knock"
     >
       <span
-        class="_avatar_2lhia_17 mx_BaseAvatar _avatar-imageless_2lhia_56"
+        class="_avatar_2lhia_17 mx_BaseAvatar mx_PeopleRoomSettingsTab_avatar _avatar-imageless_2lhia_56"
         data-color="4"
         data-testid="avatar-img"
         data-type="round"


### PR DESCRIPTION
This pull request fixes avatars of knock members for people tab of room settings.

Epic: https://github.com/vector-im/element-web/issues/18655

Fixes: https://github.com/vector-im/element-web/issues/26083

### Screens

#### Before

![before](https://github.com/matrix-org/matrix-react-sdk/assets/1422657/4ada3467-3fbd-4c7e-a7bb-deac16467431)

#### After

![after](https://github.com/matrix-org/matrix-react-sdk/assets/1422657/7abe5e59-b780-4a18-a24b-d3350faeb1db)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix avatars of knock members for people tab of room settings ([\#11506](https://github.com/matrix-org/matrix-react-sdk/pull/11506)). Fixes vector-im/element-web#26083. Contributed by @charlynguyen.<!-- CHANGELOG_PREVIEW_END -->