### PR TITLE
Use RoomStateEvent.Update for knocks

### DIFF
--- a/src/components/views/rooms/RoomKnocksBar.tsx
+++ b/src/components/views/rooms/RoomKnocksBar.tsx
@@ -33,7 +33,7 @@ export const RoomKnocksBar: VFC<{ room: Room }> = ({ room }) => {
     const [disabled, setDisabled] = useState(false);
     const knockMembers = useTypedEventEmitterState(
         room,
-        RoomStateEvent.Members,
+        RoomStateEvent.Update,
         useCallback(() => room.getMembersWithMembership("knock"), [room]),
     );
     const knockMembersCount = knockMembers.length;

--- a/src/components/views/settings/tabs/room/PeopleRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/PeopleRoomSettingsTab.tsx
@@ -144,7 +144,7 @@ export const PeopleRoomSettingsTab: VFC<{ room: Room }> = ({ room }) => {
 
     const knockMembers = useTypedEventEmitterState(
         room,
-        RoomStateEvent.Members,
+        RoomStateEvent.Update,
         useCallback(() => room.getMembersWithMembership("knock"), [room]),
     );
 

--- a/test/components/views/rooms/RoomKnocksBar-test.tsx
+++ b/test/components/views/rooms/RoomKnocksBar-test.tsx
@@ -141,7 +141,7 @@ describe("RoomKnocksBar", () => {
             expect(container.firstChild).toBeNull();
             jest.spyOn(room, "getMembersWithMembership").mockReturnValue([bob]);
             act(() => {
-                room.emit(RoomStateEvent.Members, new MatrixEvent(), state, bob);
+                room.emit(RoomStateEvent.Update, state);
             });
             expect(container.firstChild).not.toBeNull();
         });
@@ -151,7 +151,7 @@ describe("RoomKnocksBar", () => {
             expect(screen.getByRole("heading")).toHaveTextContent("Asking to join");
             jest.spyOn(room, "getMembersWithMembership").mockReturnValue([bob, jane]);
             act(() => {
-                room.emit(RoomStateEvent.Members, new MatrixEvent(), state, jane);
+                room.emit(RoomStateEvent.Update, state);
             });
             expect(screen.getByRole("heading")).toHaveTextContent("2 people asking to join");
         });

--- a/test/components/views/settings/tabs/room/PeopleRoomSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/room/PeopleRoomSettingsTab-test.tsx
@@ -176,7 +176,7 @@ describe("PeopleRoomSettingsTab", () => {
             jest.spyOn(room, "getMembersWithMembership").mockReturnValue([]);
             getComponent(room);
             act(() => {
-                room.emit(RoomStateEvent.Members, new MatrixEvent(), state, knockMember);
+                room.emit(RoomStateEvent.Update, state);
             });
             expect(getParagraph()).toHaveTextContent("No requests");
         });
@@ -209,7 +209,7 @@ describe("PeopleRoomSettingsTab", () => {
             jest.spyOn(room, "getMembersWithMembership").mockReturnValue([]);
             getComponent(room);
             act(() => {
-                room.emit(RoomStateEvent.Members, new MatrixEvent(), state, knockMember);
+                room.emit(RoomStateEvent.Update, state);
             });
             expect(getParagraph()).toHaveTextContent("No requests");
         });


### PR DESCRIPTION
This pull request makes use of RoomStateEvent.Update instead of RoomStateEvent.Members for knocks.

Epic: https://github.com/vector-im/element-web/issues/18655

Relates to: https://github.com/vector-im/element-web/issues/26090

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use RoomStateEvent.Update for knocks ([\#11516](https://github.com/matrix-org/matrix-react-sdk/pull/11516)). Contributed by @charlynguyen.<!-- CHANGELOG_PREVIEW_END -->