### PR TITLE
Prevent beeping when we run the receipt tests locally

### DIFF
--- a/cypress/e2e/read-receipts/high-level.spec.ts
+++ b/cypress/e2e/read-receipts/high-level.spec.ts
@@ -77,6 +77,9 @@ describe("Read receipts", () => {
                 cy.viewRoomById(betaRoomId);
                 cy.findByText(botName + " joined the room").should("exist");
             });
+
+        // Ensure we don't make annoying beeps when we receive messages
+        cy.window().then((w) => (w.mxNotifier.playAudioNotification = async () => {}));
     });
 
     after(() => {


### PR DESCRIPTION
Not sure whether this is the best way to do this, and/or whether we want to do it for all tests, but I couldn't find a better way to quieten the beeps, which have been driving me over the edge this week...

Relevant Cypress issue is: https://github.com/cypress-io/cypress/issues/27148 - looks like they are not interested in fixing this in Cypress.

It's hard to do it in a more general way with this approach, because the test needs to be underway before we can overwrite the `playAudioNotification` method, because before the test starts it doesn't exist yet.

Part of https://github.com/vector-im/element-web/issues/25449

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->