### PR TITLE
Add waits in Spotlight Cypress tests, hoping this unflakes them

### DIFF
--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -226,6 +226,7 @@ describe("Spotlight", () => {
             cy.get(".mx_SpotlightDialog_filter").should("contain", "Public spaces");
             cy.spotlightSearch().type("{backspace}");
             cy.get(".mx_SpotlightDialog_filter").should("not.exist");
+            cy.wait(200); // Again, wait to settle so keypresses arrive correctly
 
             cy.spotlightSearch().type("{downArrow}");
             cy.get("#mx_SpotlightDialog_button_explorePublicRooms").should("have.attr", "aria-selected", "true");
@@ -239,6 +240,7 @@ describe("Spotlight", () => {
     it("should find joined rooms", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightSearch().clear().type(room1Name);
                 cy.spotlightResults().should("have.length", 1);
                 cy.spotlightResults().eq(0).should("contain", room1Name);
@@ -253,6 +255,7 @@ describe("Spotlight", () => {
     it("should find known public rooms", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room1Name);
                 cy.spotlightResults().should("have.length", 1);
@@ -269,6 +272,7 @@ describe("Spotlight", () => {
     it("should find unknown public rooms", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room2Name);
                 cy.spotlightResults().should("have.length", 1);
@@ -286,6 +290,7 @@ describe("Spotlight", () => {
     it("should find unknown public world readable rooms", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room3Name);
                 cy.spotlightResults().should("have.length", 1);
@@ -305,6 +310,7 @@ describe("Spotlight", () => {
     it.skip("should find unknown public rooms on other homeservers", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.PublicRooms);
                 cy.spotlightSearch().clear().type(room3Name);
                 cy.get("[aria-haspopup=true][role=button]").click();
@@ -317,6 +323,7 @@ describe("Spotlight", () => {
             })
             .then(() =>
                 cy.spotlightDialog().within(() => {
+                    cy.wait(500); // Wait for dialog to settle
                     cy.spotlightResults().should("have.length", 1);
                     cy.spotlightResults().eq(0).should("contain", room3Name);
                     cy.spotlightResults().eq(0).should("contain", room3Id);
@@ -327,6 +334,7 @@ describe("Spotlight", () => {
     it("should find known people", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.People);
                 cy.spotlightSearch().clear().type(bot1Name);
                 cy.spotlightResults().should("have.length", 1);
@@ -341,6 +349,7 @@ describe("Spotlight", () => {
     it("should find unknown people", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.People);
                 cy.spotlightSearch().clear().type(bot2Name);
                 cy.spotlightResults().should("have.length", 1);
@@ -358,6 +367,7 @@ describe("Spotlight", () => {
 
         // Starting a DM with ByteBot (will be turned into a group dm later)
         cy.openSpotlightDialog().within(() => {
+            cy.wait(500); // Wait for dialog to settle
             cy.spotlightFilter(Filter.People);
             cy.spotlightSearch().clear().type(bot2Name);
             cy.spotlightResults().should("have.length", 1);
@@ -413,6 +423,7 @@ describe("Spotlight", () => {
     // Test against https://github.com/vector-im/element-web/issues/22851
     it("should show each person result only once", () => {
         cy.openSpotlightDialog().within(() => {
+            cy.wait(500); // Wait for dialog to settle
             cy.spotlightFilter(Filter.People);
 
             // 2 rounds of search to simulate the bug conditions. Specifically, the first search
@@ -433,6 +444,7 @@ describe("Spotlight", () => {
     it("should allow opening group chat dialog", () => {
         cy.openSpotlightDialog()
             .within(() => {
+                cy.wait(500); // Wait for dialog to settle
                 cy.spotlightFilter(Filter.People);
                 cy.spotlightSearch().clear().type(bot2Name);
                 cy.wait(3000); // wait for the dialog code to settle
@@ -456,6 +468,7 @@ describe("Spotlight", () => {
         cy.visit("/#/home");
 
         cy.openSpotlightDialog().within(() => {
+            cy.wait(500); // Wait for dialog to settle
             cy.spotlightFilter(Filter.People);
             cy.spotlightSearch().clear().type(bot1Name);
             cy.wait(3000); // wait for the dialog code to settle
@@ -466,6 +479,7 @@ describe("Spotlight", () => {
 
     it("should be able to navigate results via keyboard", () => {
         cy.openSpotlightDialog().within(() => {
+            cy.wait(500); // Wait for dialog to settle
             cy.spotlightFilter(Filter.People);
             cy.spotlightSearch().clear().type("b");
             // our debouncing logic only starts the search after a short timeout,
@@ -474,6 +488,7 @@ describe("Spotlight", () => {
             cy.get(".mx_Spinner")
                 .should("not.exist")
                 .then(() => {
+                    cy.wait(500); // Wait to settle again
                     cy.spotlightResults()
                         .should("have.length", 2)
                         .then(() => {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26053
Fixes https://github.com/vector-im/element-web/issues/26140
Fixes https://github.com/vector-im/element-web/issues/26139
Fixes https://github.com/vector-im/element-web/issues/26138

I ran this for several hours repeating the spotlight tests over and over and they passed with this change.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add waits in Spotlight Cypress tests, hoping this unflakes them ([\#11590](https://github.com/matrix-org/matrix-react-sdk/pull/11590)). Fixes vector-im/element-web#26053, vector-im/element-web#26140 vector-im/element-web#26139 and vector-im/element-web#26138. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->