### PR TITLE
Use knock rooms sync to reflect the knock state

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -245,7 +245,6 @@ export interface IRoomState {
 
     canAskToJoin: boolean;
     promptAskToJoin: boolean;
-    knocked: boolean;
 }
 
 interface LocalRoomViewProps {
@@ -458,7 +457,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             msc3946ProcessDynamicPredecessor: SettingsStore.getValue("feature_dynamic_room_predecessors"),
             canAskToJoin: this.askToJoinEnabled,
             promptAskToJoin: false,
-            knocked: false,
         };
 
         this.dispatcherRef = dis.register(this.onAction);
@@ -664,7 +662,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 : false,
             activeCall: roomId ? CallStore.instance.getActiveCall(roomId) : null,
             promptAskToJoin: this.context.roomViewStore.promptAskToJoin(),
-            knocked: this.context.roomViewStore.knocked(),
         };
 
         if (
@@ -2118,7 +2115,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                                 signUrl={this.props.threepidInvite?.signUrl}
                                 roomId={this.state.roomId}
                                 promptAskToJoin={this.state.promptAskToJoin}
-                                knocked={this.state.knocked}
                                 onSubmitAskToJoin={this.onSubmitAskToJoin}
                                 onCancelAskToJoin={this.onCancelAskToJoin}
                             />
@@ -2202,7 +2198,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                         <RoomPreviewBar
                             room={this.state.room}
                             promptAskToJoin={myMembership === "leave" || this.state.promptAskToJoin}
-                            knocked={myMembership === "knock" || this.state.knocked}
+                            knocked={myMembership === "knock"}
                             onSubmitAskToJoin={this.onSubmitAskToJoin}
                             onCancelAskToJoin={this.onCancelAskToJoin}
                             onForgetClick={this.onForgetClick}

--- a/src/contexts/RoomContext.ts
+++ b/src/contexts/RoomContext.ts
@@ -73,7 +73,6 @@ const RoomContext = createContext<
     msc3946ProcessDynamicPredecessor: false,
     canAskToJoin: false,
     promptAskToJoin: false,
-    knocked: false,
 });
 RoomContext.displayName = "RoomContext";
 export default RoomContext;

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -85,7 +85,6 @@ describe("<SendMessageComposer/>", () => {
         msc3946ProcessDynamicPredecessor: false,
         canAskToJoin: false,
         promptAskToJoin: false,
-        knocked: false,
     };
     describe("createMessageContent", () => {
         const permalinkCreator = jest.fn() as any;

--- a/test/stores/RoomViewStore-test.ts
+++ b/test/stores/RoomViewStore-test.ts
@@ -507,39 +507,25 @@ describe("RoomViewStore", function () {
         });
     });
 
-    describe("knocked()", () => {
-        it("returns false", () => {
-            expect(roomViewStore.knocked()).toBe(false);
-        });
-
-        it("returns true", async () => {
-            jest.spyOn(mockClient, "knockRoom").mockResolvedValue({ room_id: roomId });
-            await dispatchSubmitAskToJoin(roomId);
-            expect(roomViewStore.knocked()).toBe(true);
-        });
-    });
-
     describe("Action.SubmitAskToJoin", () => {
         const reason = "some reason";
         beforeEach(async () => await dispatchPromptAskToJoin());
 
-        it("calls knockRoom(), sets askToJoin state to false and knocked state to true", async () => {
+        it("calls knockRoom() and sets promptAskToJoin state to false", async () => {
             jest.spyOn(mockClient, "knockRoom").mockResolvedValue({ room_id: roomId });
             await dispatchSubmitAskToJoin(roomId, reason);
 
             expect(mockClient.knockRoom).toHaveBeenCalledWith(roomId, { reason, viaServers: [] });
             expect(roomViewStore.promptAskToJoin()).toBe(false);
-            expect(roomViewStore.knocked()).toBe(true);
         });
 
-        it("calls knockRoom(), sets askToJoin to false, keeps knocked state false and shows an error dialog", async () => {
+        it("calls knockRoom(), sets promptAskToJoin state to false and shows an error dialog", async () => {
             const error = new MatrixError(undefined, 403);
             jest.spyOn(mockClient, "knockRoom").mockRejectedValue(error);
             await dispatchSubmitAskToJoin(roomId, reason);
 
             expect(mockClient.knockRoom).toHaveBeenCalledWith(roomId, { reason, viaServers: [] });
             expect(roomViewStore.promptAskToJoin()).toBe(false);
-            expect(roomViewStore.knocked()).toBe(false);
             expect(Modal.createDialog).toHaveBeenCalledWith(ErrorDialog, {
                 description: "You need an invite to access this room.",
                 title: "Failed to join",
@@ -550,6 +536,7 @@ describe("RoomViewStore", function () {
             const error = new MatrixError();
             jest.spyOn(mockClient, "knockRoom").mockRejectedValue(error);
             await dispatchSubmitAskToJoin(roomId);
+
             expect(Modal.createDialog).toHaveBeenCalledWith(ErrorDialog, {
                 description: error.message,
                 title: "Failed to join",
@@ -563,21 +550,19 @@ describe("RoomViewStore", function () {
             await dispatchSubmitAskToJoin(roomId);
         });
 
-        it("calls leave() and sets knocked state to false", async () => {
+        it("calls leave()", async () => {
             jest.spyOn(mockClient, "leave").mockResolvedValue({});
             await dispatchCancelAskToJoin(roomId);
 
             expect(mockClient.leave).toHaveBeenCalledWith(roomId);
-            expect(roomViewStore.knocked()).toBe(false);
         });
 
-        it("calls leave(), keeps knocked state true and shows an error dialog", async () => {
+        it("calls leave() and shows an error dialog", async () => {
             const error = new MatrixError();
             jest.spyOn(mockClient, "leave").mockRejectedValue(error);
             await dispatchCancelAskToJoin(roomId);
 
             expect(mockClient.leave).toHaveBeenCalledWith(roomId);
-            expect(roomViewStore.knocked()).toBe(true);
             expect(Modal.createDialog).toHaveBeenCalledWith(ErrorDialog, {
                 description: error.message,
                 title: "Failed to cancel",

--- a/test/test-utils/room.ts
+++ b/test/test-utils/room.ts
@@ -90,7 +90,6 @@ export function getRoomContext(room: Room, override: Partial<IRoomState>): IRoom
         msc3946ProcessDynamicPredecessor: false,
         canAskToJoin: false,
         promptAskToJoin: false,
-        knocked: false,
 
         ...override,
     };


### PR DESCRIPTION
This pull request makes use of the [knock room sync](https://github.com/matrix-org/matrix-js-sdk/pull/3703) to reflect the user's knock state for a room based on the knock membership.

Epic https://github.com/vector-im/element-web/issues/18655

Fixes https://github.com/vector-im/element-web/issues/26043
Fixes https://github.com/vector-im/element-web/issues/26044

### Video

**Hint:** The knock rooms UI and categorization in the left panel is addressed separately [here](https://github.com/matrix-org/matrix-react-sdk/pull/11573).

https://github.com/matrix-org/matrix-react-sdk/assets/1422657/d3028f8e-9854-4dce-a867-a9c3ba69e050

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use knock rooms sync to reflect the knock state ([\#11596](https://github.com/matrix-org/matrix-react-sdk/pull/11596)). Fixes vector-im/element-web#26043 and vector-im/element-web#26044. Contributed by @charlynguyen.<!-- CHANGELOG_PREVIEW_END -->