### PR TITLE
Re-enable parallelisation via Cypress Cloud now that the cycle has renewed

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -118,8 +118,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Naive segmentation of tests
-                segment: ["a-i", "j-p", "q-s", "t-z"]
+                # Run 4 instances in Parallel
+                runner: [1, 2, 3, 4]
         steps:
             - uses: browser-actions/setup-chrome@c485fa3bab6be59dce18dbc18ef6ab7cbc8ff5f1
             - run: echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
@@ -172,11 +172,10 @@ jobs:
                   start: npx serve -p 8080 -L ../webapp
                   wait-on: "http://localhost:8080"
                   record: true
-                  parallel: false
+                  parallel: true
                   command-prefix: "yarn percy exec --parallel --"
                   config: '{"reporter":"cypress-multi-reporters", "reporterOptions": { "configFile": "cypress-ci-reporter-config.json" } }'
                   ci-build-id: ${{ needs.prepare.outputs.uuid }}
-                  spec: cypress/e2e/[${{ matrix.segment }}]*/**
               env:
                   # pass the Dashboard record key as an environment variable
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
Our subscription cycle should have reset by now which means we can start using the cloud parallelization again. Flipping this back and forth isn't a sustainable workflow. However, this at least allows us to benefit from the 2x speed-up in the short-term while we figure out the best long-term solution.

This reverts the changes from 3f21b9a61c05bd69567f262b94208f7514307ac2, 1498c51b7b55162287de140cf13415275a87f3c7 and 111210e117ad684e324be5ada7bcf120c6c6f60d.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->