### PR TITLE
Don't start key backups when opening settings

### DIFF
--- a/src/components/views/settings/SecureBackupPanel.tsx
+++ b/src/components/views/settings/SecureBackupPanel.tsx
@@ -67,7 +67,7 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
     }
 
     public componentDidMount(): void {
-        this.checkKeyBackupStatus();
+        this.loadBackupStatus();
 
         MatrixClientPeg.safeGet().on(CryptoEvent.KeyBackupStatus, this.onKeyBackupStatus);
         MatrixClientPeg.safeGet().on(CryptoEvent.KeyBackupSessionsRemaining, this.onKeyBackupSessionsRemaining);
@@ -96,28 +96,6 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
         // a re-check otherwise we risk causing infinite loops
         this.loadBackupStatus();
     };
-
-    private async checkKeyBackupStatus(): Promise<void> {
-        this.getUpdatedDiagnostics();
-        try {
-            const keyBackupResult = await MatrixClientPeg.safeGet().checkKeyBackup();
-            this.setState({
-                loading: false,
-                error: false,
-                backupInfo: keyBackupResult?.backupInfo ?? null,
-                backupSigStatus: keyBackupResult?.trustInfo ?? null,
-            });
-        } catch (e) {
-            logger.log("Unable to fetch check backup status", e);
-            if (this.unmounted) return;
-            this.setState({
-                loading: false,
-                error: true,
-                backupInfo: null,
-                backupSigStatus: null,
-            });
-        }
-    }
 
     private async loadBackupStatus(): Promise<void> {
         this.setState({ loading: true });

--- a/test/components/views/settings/__snapshots__/SecureBackupPanel-test.tsx.snap
+++ b/test/components/views/settings/__snapshots__/SecureBackupPanel-test.tsx.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<SecureBackupPanel /> handles error fetching backup 1`] = `
+<div>
+  <div
+    class="mx_SettingsSubsection_text"
+  >
+    Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Security Key.
+  </div>
+  <div
+    class="mx_SettingsSubsection_text"
+  >
+    Unable to load key backup status
+  </div>
+  <details>
+    <summary>
+      Advanced
+    </summary>
+    <table
+      class="mx_SecureBackupPanel_statusList"
+    >
+      <tr>
+        <th
+          scope="row"
+        >
+          Backup key stored:
+        </th>
+        <td>
+          not stored
+        </td>
+      </tr>
+      <tr>
+        <th
+          scope="row"
+        >
+          Backup key cached:
+        </th>
+        <td>
+          not found locally
+          
+        </td>
+      </tr>
+      <tr>
+        <th
+          scope="row"
+        >
+          Secret storage public key:
+        </th>
+        <td>
+          not found
+        </td>
+      </tr>
+      <tr>
+        <th
+          scope="row"
+        >
+          Secret storage:
+        </th>
+        <td>
+          not ready
+        </td>
+      </tr>
+    </table>
+  </details>
+</div>
+`;
+
 exports[`<SecureBackupPanel /> suggests connecting session to key backup when backup exists 1`] = `
 <div>
   <div

--- a/test/components/views/settings/tabs/user/SecurityUserSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/user/SecurityUserSettingsTab-test.tsx
@@ -41,6 +41,7 @@ describe("<SecurityUserSettingsTab />", () => {
         ...mockClientMethodsCrypto(),
         getRooms: jest.fn().mockReturnValue([]),
         getIgnoredUsers: jest.fn(),
+        getKeyBackupVersion: jest.fn(),
     });
 
     const getComponent = () => (

--- a/test/test-utils/client.ts
+++ b/test/test-utils/client.ts
@@ -152,7 +152,6 @@ export const mockClientMethodsCrypto = (): Partial<
     isKeyBackupKeyStored: jest.fn(),
     getCrossSigningCacheCallbacks: jest.fn().mockReturnValue({ getCrossSigningKeyCache: jest.fn() }),
     getStoredCrossSigningForUser: jest.fn(),
-    checkKeyBackup: jest.fn().mockReturnValue({}),
     secretStorage: { hasKey: jest.fn() },
     getCrypto: jest.fn().mockReturnValue({
         getUserDeviceInfo: jest.fn(),


### PR DESCRIPTION
Currently, the key backup settings panel will start key backups if they aren't already running. In my not-so-humble opinion, the mere act of opening a settings panel shouldn't change anything.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't start key backups when opening settings ([\#11640](https://github.com/matrix-org/matrix-react-sdk/pull/11640)).<!-- CHANGELOG_PREVIEW_END -->