### PR TITLE
LogoutDialog: Remove usage of deprecated keybackup API

### DIFF
--- a/test/components/views/dialogs/LogoutDialog-test.tsx
+++ b/test/components/views/dialogs/LogoutDialog-test.tsx
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { mocked, MockedObject } from "jest-mock";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
+import { CryptoApi, KeyBackupInfo } from "matrix-js-sdk/src/crypto-api";
+import { render, RenderResult } from "@testing-library/react";
+
+import { filterConsole, getMockClientWithEventEmitter, mockClientMethodsCrypto } from "../../../test-utils";
+import LogoutDialog from "../../../../src/components/views/dialogs/LogoutDialog";
+
+describe("LogoutDialog", () => {
+    let mockClient: MockedObject<MatrixClient>;
+    let mockCrypto: MockedObject<CryptoApi>;
+
+    beforeEach(() => {
+        mockClient = getMockClientWithEventEmitter({
+            ...mockClientMethodsCrypto(),
+            getKeyBackupEnabled: jest.fn(),
+            getKeyBackupVersion: jest.fn(),
+        });
+
+        mockClient.isCryptoEnabled.mockReturnValue(true);
+        mockCrypto = mocked(mockClient.getCrypto()!);
+        Object.assign(mockCrypto, {});
+    });
+
+    function renderComponent(props: Partial<React.ComponentProps<typeof LogoutDialog>> = {}): RenderResult {
+        const onFinished = jest.fn();
+        return render(<LogoutDialog onFinished={onFinished} {...props} />);
+    }
+
+    it("shows a regular dialog when crypto is disabled", async () => {
+        mockClient.isCryptoEnabled.mockReturnValue(false);
+        const rendered = renderComponent();
+        await rendered.findByText("Are you sure you want to sign out?");
+        expect(rendered.container).toMatchSnapshot();
+    });
+
+    it("shows a regular dialog if backups are working", async () => {
+        mockClient.getKeyBackupEnabled.mockReturnValue(true);
+        const rendered = renderComponent();
+        await rendered.findByText("Are you sure you want to sign out?");
+    });
+
+    it("Prompts user to connect backup if there is a backup on the server", async () => {
+        mockClient.getKeyBackupVersion.mockResolvedValue({} as KeyBackupInfo);
+        const rendered = renderComponent();
+        await rendered.findByText("Connect this session to Key Backup");
+        expect(rendered.container).toMatchSnapshot();
+    });
+
+    it("Prompts user to set up backup if there is no backup on the server", async () => {
+        mockClient.getKeyBackupVersion.mockResolvedValue(null);
+        const rendered = renderComponent();
+        await rendered.findByText("Start using Key Backup");
+        expect(rendered.container).toMatchSnapshot();
+    });
+
+    describe("when there is an error fetching backups", () => {
+        filterConsole("Unable to fetch key backup status");
+        it("prompts user to set up backup", async () => {
+            mockClient.getKeyBackupVersion.mockImplementation(async () => {
+                throw new Error("beep");
+            });
+            const rendered = renderComponent();
+            await rendered.findByText("Start using Key Backup");
+        });
+    });
+});

--- a/test/components/views/dialogs/LogoutDialog-test.tsx
+++ b/test/components/views/dialogs/LogoutDialog-test.tsx
@@ -30,13 +30,13 @@ describe("LogoutDialog", () => {
     beforeEach(() => {
         mockClient = getMockClientWithEventEmitter({
             ...mockClientMethodsCrypto(),
-            getKeyBackupEnabled: jest.fn(),
             getKeyBackupVersion: jest.fn(),
         });
 
-        mockClient.isCryptoEnabled.mockReturnValue(true);
         mockCrypto = mocked(mockClient.getCrypto()!);
-        Object.assign(mockCrypto, {});
+        Object.assign(mockCrypto, {
+            getActiveSessionBackupVersion: jest.fn().mockResolvedValue(null),
+        });
     });
 
     function renderComponent(props: Partial<React.ComponentProps<typeof LogoutDialog>> = {}): RenderResult {
@@ -45,14 +45,14 @@ describe("LogoutDialog", () => {
     }
 
     it("shows a regular dialog when crypto is disabled", async () => {
-        mockClient.isCryptoEnabled.mockReturnValue(false);
+        mocked(mockClient.getCrypto).mockReturnValue(undefined);
         const rendered = renderComponent();
         await rendered.findByText("Are you sure you want to sign out?");
         expect(rendered.container).toMatchSnapshot();
     });
 
     it("shows a regular dialog if backups are working", async () => {
-        mockClient.getKeyBackupEnabled.mockReturnValue(true);
+        mockCrypto.getActiveSessionBackupVersion.mockResolvedValue("1");
         const rendered = renderComponent();
         await rendered.findByText("Are you sure you want to sign out?");
     });

--- a/test/components/views/dialogs/__snapshots__/LogoutDialog-test.tsx.snap
+++ b/test/components/views/dialogs/__snapshots__/LogoutDialog-test.tsx.snap
@@ -1,0 +1,237 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LogoutDialog Prompts user to connect backup if there is a backup on the server 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-describedby="mx_Dialog_content"
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header mx_Dialog_headerWithCancel"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        You'll lose access to your encrypted messages
+      </h2>
+      <div
+        aria-label="Close dialog"
+        class="mx_AccessibleButton mx_Dialog_cancelButton"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <div>
+      <div
+        class="mx_Dialog_content"
+        id="mx_Dialog_content"
+      >
+        <div>
+          <p>
+            Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.
+          </p>
+          <p>
+            When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.
+          </p>
+          <p>
+            Back up your keys before signing out to avoid losing them.
+          </p>
+        </div>
+      </div>
+      <div
+        class="mx_Dialog_buttons"
+      >
+        <span
+          class="mx_Dialog_buttons_row"
+        >
+          <button>
+            I don't want my encrypted messages
+          </button>
+          <button
+            class="mx_Dialog_primary"
+            data-testid="dialog-primary-button"
+            type="button"
+          >
+            Connect this session to Key Backup
+          </button>
+        </span>
+      </div>
+      <details>
+        <summary>
+          Advanced
+        </summary>
+        <p>
+          <button>
+            Manually export keys
+          </button>
+        </p>
+      </details>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`LogoutDialog Prompts user to set up backup if there is no backup on the server 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-describedby="mx_Dialog_content"
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header mx_Dialog_headerWithCancel"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        You'll lose access to your encrypted messages
+      </h2>
+      <div
+        aria-label="Close dialog"
+        class="mx_AccessibleButton mx_Dialog_cancelButton"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <div>
+      <div
+        class="mx_Dialog_content"
+        id="mx_Dialog_content"
+      >
+        <div>
+          <p>
+            Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.
+          </p>
+          <p>
+            When you sign out, these keys will be deleted from this device, which means you won't be able to read encrypted messages unless you have the keys for them on your other devices, or backed them up to the server.
+          </p>
+          <p>
+            Back up your keys before signing out to avoid losing them.
+          </p>
+        </div>
+      </div>
+      <div
+        class="mx_Dialog_buttons"
+      >
+        <span
+          class="mx_Dialog_buttons_row"
+        >
+          <button>
+            I don't want my encrypted messages
+          </button>
+          <button
+            class="mx_Dialog_primary"
+            data-testid="dialog-primary-button"
+            type="button"
+          >
+            Start using Key Backup
+          </button>
+        </span>
+      </div>
+      <details>
+        <summary>
+          Advanced
+        </summary>
+        <p>
+          <button>
+            Manually export keys
+          </button>
+        </p>
+      </details>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`LogoutDialog shows a regular dialog when crypto is disabled 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-describedby="mx_Dialog_content"
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_QuestionDialog mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header mx_Dialog_headerWithCancel"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        Sign out
+      </h2>
+      <div
+        aria-label="Close dialog"
+        class="mx_AccessibleButton mx_Dialog_cancelButton"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <div
+      class="mx_Dialog_content"
+      id="mx_Dialog_content"
+    >
+      Are you sure you want to sign out?
+    </div>
+    <div
+      class="mx_Dialog_buttons"
+    >
+      <span
+        class="mx_Dialog_buttons_row"
+      >
+        <button
+          data-testid="dialog-cancel-button"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="mx_Dialog_primary"
+          data-testid="dialog-primary-button"
+          type="button"
+        >
+          Sign out
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;


### PR DESCRIPTION
Part of https://github.com/vector-im/crypto-internal/issues/155

The first commit adds a test. The second updatest the dialog to use modern APIs.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->