### PR TITLE
Tests for paging up to find old messages

### DIFF
--- a/cypress/e2e/read-receipts/new-messages.spec.ts
+++ b/cypress/e2e/read-receipts/new-messages.spec.ts
@@ -176,7 +176,7 @@ describe("Read receipts", () => {
                 assertUnread(room2, 30);
 
                 // When I jump to one of the older messages
-                jumpTo(room2, "Msg1");
+                jumpTo(room2, "Msg0001");
 
                 // Then the room is still unread, but some messages were read
                 assertUnreadLessThan(room2, 30);
@@ -321,7 +321,7 @@ describe("Read receipts", () => {
                 assertUnread(room2, 21);
 
                 // When I read an older message in the thread
-                jumpTo(room2, "InThread1", true);
+                jumpTo(room2, "InThread0001", true);
                 assertUnreadLessThan(room2, 21);
                 // TODO: for some reason, we can't find the first message
                 // "InThread0", so I am using the second here. Also, they appear
@@ -488,7 +488,7 @@ describe("Read receipts", () => {
                 assertUnread(room2, 62); // Sanity
 
                 // When I jump to an old message and read the thread
-                jumpTo(room2, "beforeThread0");
+                jumpTo(room2, "beforeThread0000");
                 openThread("ThreadRoot");
 
                 // Then the thread root is marked as read in the main timeline,

--- a/cypress/e2e/read-receipts/read-receipts-utils.ts
+++ b/cypress/e2e/read-receipts/read-receipts-utils.ts
@@ -372,7 +372,7 @@ export function pageUp() {
  * @param howMany the number of strings to generate
  */
 export function many(prefix: string, howMany: number): Array<string> {
-    return Array.from(Array(howMany).keys()).map((i) => prefix + i.toFixed());
+    return Array.from(Array(howMany).keys()).map((i) => prefix + i.toString().padStart(4, "0"));
 }
 
 /**


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/25449

Rebased on top of https://github.com/matrix-org/matrix-react-sdk/pull/11649 since the CI was effectively broken by there being too many tests.

Functionally identical to the PR @weeman1337 already reviewed (sorry for the re-do).

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->