### PR TITLE
Fix: Clicking on members pile does nothing (Alternate fix)

### DIFF
--- a/res/css/views/elements/_FacePile.pcss
+++ b/res/css/views/elements/_FacePile.pcss
@@ -21,6 +21,7 @@ limitations under the License.
     height: 30px;
     background-color: $spacePanel-bg-color;
     display: inline-block;
+    cursor: pointer;
 
     &::before {
         content: "";

--- a/src/components/views/elements/FacePile.tsx
+++ b/src/components/views/elements/FacePile.tsx
@@ -58,7 +58,7 @@ const FacePile: FC<IProps> = ({
     const pileContents = (
         <>
             {/* XXX: The margin-left is a workaround for Compound's styling excluding this element and being overly specific */}
-            {overflow ? <span className="mx_FacePile_more" style={{ marginLeft: `calc(${size} * -0.2)` }} /> : null}
+            {overflow ? <span onClick={props.onClick} className="mx_FacePile_more" style={{ marginLeft: `calc(${size} * -0.2)` }} /> : null}
             {faces}
         </>
     );

--- a/src/components/views/elements/FacePile.tsx
+++ b/src/components/views/elements/FacePile.tsx
@@ -42,7 +42,7 @@ const FacePile: FC<IProps> = ({
 }) => {
     const faces = members.map(
         tooltipLabel
-            ? (m) => <MemberAvatar key={m.userId} member={m} size={size} hideTitle />
+            ? (m) => <MemberAvatar key={m.userId} member={m} size={size} viewUserOnClick={viewUserOnClick} hideTitle />
             : (m) => (
                   <Tooltip key={m.userId} label={m.name} shortcut={tooltipShortcut}>
                       <MemberAvatar

--- a/src/components/views/elements/FacePile.tsx
+++ b/src/components/views/elements/FacePile.tsx
@@ -58,7 +58,13 @@ const FacePile: FC<IProps> = ({
     const pileContents = (
         <>
             {/* XXX: The margin-left is a workaround for Compound's styling excluding this element and being overly specific */}
-            {overflow ? <span onClick={props.onClick} className="mx_FacePile_more" style={{ marginLeft: `calc(${size} * -0.2)` }} /> : null}
+            {overflow ? (
+                <span
+                    onClick={props.onClick}
+                    className="mx_FacePile_more"
+                    style={{ marginLeft: `calc(${size} * -0.2)` }}
+                />
+            ) : null}
             {faces}
         </>
     );


### PR DESCRIPTION
## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Fixes https://github.com/vector-im/element-web/issues/26164
Signed-off-by: Manan Sadana manancodes.dev@gmail.com

Clicking on a particular person should open his/her profile and clicking on the ...(more) button should open the list.

This was the behaviour before the fix:

Clicking on ...(more) button does nothing.

https://github.com/matrix-org/matrix-react-sdk/assets/54790263/b348c319-d2e8-4bc0-98b3-8279986051fb

Clicking user profile button does nothing.

https://github.com/matrix-org/matrix-react-sdk/assets/54790263/587d5eff-7565-49f0-bad7-220059027900



And this is the behaviour after the fix:

Clicking on ...(more) button opens list of users.

https://github.com/matrix-org/matrix-react-sdk/assets/54790263/0ce9b64b-6292-48d8-8024-2726fe4dd719

Clicking user profile opens user profile.

https://github.com/matrix-org/matrix-react-sdk/assets/54790263/63b43bab-b207-4be5-a83d-e58aa594a9b0


Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: Clicking on members pile does nothing (Alternate fix) ([\#11656](https://github.com/matrix-org/matrix-react-sdk/pull/11656)). Fixes vector-im/element-web#26164. Contributed by @manancodes.<!-- CHANGELOG_PREVIEW_END -->