### PR TITLE
Target specific thread name to unflake redaction tests

### DIFF
--- a/cypress/e2e/read-receipts/read-receipts-utils.ts
+++ b/cypress/e2e/read-receipts/read-receipts-utils.ts
@@ -285,7 +285,9 @@ function findRoomByName(room: string): Chainable<Room> {
 export function openThread(rootMessage: string) {
     cy.log("Open thread", rootMessage);
     cy.get(".mx_RoomView_body", { log: false }).within(() => {
-        cy.contains(".mx_EventTile[data-scroll-tokens]", rootMessage, { log: false })
+        cy.findAllByText(rootMessage)
+            .filter(".mx_EventTile_body")
+            .parents(".mx_EventTile[data-scroll-tokens]")
             .realHover()
             .findByRole("button", { name: "Reply in thread", log: false })
             .click();

--- a/cypress/e2e/read-receipts/read-receipts-utils.ts
+++ b/cypress/e2e/read-receipts/read-receipts-utils.ts
@@ -285,8 +285,6 @@ function findRoomByName(room: string): Chainable<Room> {
 export function openThread(rootMessage: string) {
     cy.log("Open thread", rootMessage);
     cy.get(".mx_RoomView_body", { log: false }).within(() => {
-        // TODO: using "contains" here means we have to be careful on the names
-        // of our thread roots - would be better if we could match exact text
         cy.contains(".mx_EventTile[data-scroll-tokens]", rootMessage, { log: false })
             .realHover()
             .findByRole("button", { name: "Reply in thread", log: false })

--- a/cypress/e2e/read-receipts/read-receipts-utils.ts
+++ b/cypress/e2e/read-receipts/read-receipts-utils.ts
@@ -285,6 +285,8 @@ function findRoomByName(room: string): Chainable<Room> {
 export function openThread(rootMessage: string) {
     cy.log("Open thread", rootMessage);
     cy.get(".mx_RoomView_body", { log: false }).within(() => {
+        // TODO: using "contains" here means we have to be careful on the names
+        // of our thread roots - would be better if we could match exact text
         cy.contains(".mx_EventTile[data-scroll-tokens]", rootMessage, { log: false })
             .realHover()
             .findByRole("button", { name: "Reply in thread", log: false })

--- a/cypress/e2e/read-receipts/redactions.spec.ts
+++ b/cypress/e2e/read-receipts/redactions.spec.ts
@@ -380,8 +380,8 @@ describe("Read receipts", () => {
                     "Root",
                     threadedOff("Root", "ThreadMsg1"),
                     threadedOff("Root", "ThreadMsg2"),
-                    "Root2",
-                    threadedOff("Root2", "Root2->A"),
+                    "SecondRoot",
+                    threadedOff("SecondRoot", "SecondRoot->A"),
                 ]);
                 assertUnread(room2, 5);
 
@@ -390,7 +390,7 @@ describe("Read receipts", () => {
                 assertUnreadThread("Root");
                 openThread("Root");
                 assertUnreadLessThan(room2, 4);
-                openThread("Root2");
+                openThread("SecondRoot");
                 assertRead(room2);
                 closeThreadsPanel();
                 goTo(room1);
@@ -677,15 +677,15 @@ describe("Read receipts", () => {
                     "Root",
                     threadedOff("Root", "ThreadMsg1"),
                     threadedOff("Root", "ThreadMsg2"),
-                    "Root2",
-                    threadedOff("Root2", "Root2->A"),
+                    "SecondRoot",
+                    threadedOff("SecondRoot", "SecondRoot->A"),
                 ]);
                 assertUnread(room2, 5);
                 goTo(room2);
                 assertUnreadThread("Root");
                 openThread("Root");
                 assertUnreadLessThan(room2, 4);
-                openThread("Root2");
+                openThread("SecondRoot");
                 assertRead(room2);
                 closeThreadsPanel();
                 goTo(room1);

--- a/cypress/e2e/read-receipts/redactions.spec.ts
+++ b/cypress/e2e/read-receipts/redactions.spec.ts
@@ -380,8 +380,8 @@ describe("Read receipts", () => {
                     "Root",
                     threadedOff("Root", "ThreadMsg1"),
                     threadedOff("Root", "ThreadMsg2"),
-                    "SecondRoot",
-                    threadedOff("SecondRoot", "SecondRoot->A"),
+                    "Root2",
+                    threadedOff("Root2", "Root2->A"),
                 ]);
                 assertUnread(room2, 5);
 
@@ -390,7 +390,7 @@ describe("Read receipts", () => {
                 assertUnreadThread("Root");
                 openThread("Root");
                 assertUnreadLessThan(room2, 4);
-                openThread("SecondRoot");
+                openThread("Root2");
                 assertRead(room2);
                 closeThreadsPanel();
                 goTo(room1);
@@ -677,15 +677,15 @@ describe("Read receipts", () => {
                     "Root",
                     threadedOff("Root", "ThreadMsg1"),
                     threadedOff("Root", "ThreadMsg2"),
-                    "SecondRoot",
-                    threadedOff("SecondRoot", "SecondRoot->A"),
+                    "Root2",
+                    threadedOff("Root2", "Root2->A"),
                 ]);
                 assertUnread(room2, 5);
                 goTo(room2);
                 assertUnreadThread("Root");
                 openThread("Root");
                 assertUnreadLessThan(room2, 4);
-                openThread("SecondRoot");
+                openThread("Root2");
                 assertRead(room2);
                 closeThreadsPanel();
                 goTo(room1);


### PR DESCRIPTION
Ensure that when we ask to open a thread called "Root2", we don't accidentally open a thread called "Root" that has "2 unread replies" in it.

Part of https://github.com/vector-im/element-web/issues/25449

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->