### PR TITLE
Fix Emoji font on Safari 17

### DIFF
--- a/src/utils/FontManager.ts
+++ b/src/utils/FontManager.ts
@@ -31,10 +31,11 @@ function safariVersionCheck(ua: string): boolean {
             const safariVersionStr = safariVersionMatch[2];
             const macOSVersion = macOSVersionStr.split("_").map((n) => parseInt(n, 10));
             const safariVersion = safariVersionStr.split(".").map((n) => parseInt(n, 10));
-            const colrFontSupported = macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12;
-            // https://www.colorfonts.wtf/ states safari supports COLR fonts from this version on
+            const colrFontSupported =
+                macOSVersion[0] >= 10 && macOSVersion[1] >= 14 && safariVersion[0] >= 12 && safariVersion[0] < 17;
+            // https://www.colorfonts.wtf/ states Safari supports COLR fonts from this version on but Safari 17 breaks it
             logger.log(
-                `COLR support on Safari requires macOS 10.14 and Safari 12, ` +
+                `COLR support on Safari requires macOS 10.14 and Safari 12-16, ` +
                     `detected Safari ${safariVersionStr} on macOS ${macOSVersionStr}, ` +
                     `COLR supported: ${colrFontSupported}`,
             );


### PR DESCRIPTION
Safari 17:
![image](https://github.com/matrix-org/matrix-react-sdk/assets/2403652/fa6cac29-6fce-4570-a2a5-ef7e23b49bfd)

Safari 16:
![image](https://github.com/matrix-org/matrix-react-sdk/assets/2403652/3423a2bf-b1bf-4f5d-b86c-8c83eb556cec)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix Emoji font on Safari 17 ([\#11673](https://github.com/matrix-org/matrix-react-sdk/pull/11673)).<!-- CHANGELOG_PREVIEW_END -->