### PR TITLE
Fix start_sso / start_cas URLs failing to redirect to a authentication prompt

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -395,7 +395,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             return;
         }
 
-        if (firstScreen === "login" || firstScreen === "register" || firstScreen === "forgot_password") {
+        // If the first screen is an auth screen, we don't want to wait for login.
+        if (firstScreen !== null && AUTH_SCREENS.includes(firstScreen)) {
             this.showScreenAfterLogin();
         }
     }

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -1154,6 +1154,19 @@ describe("<MatrixChat />", () => {
             expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
             expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
         });
+
+        it("should automatically setup and redirect to CAS login", async () => {
+            getComponent({
+                initialScreenAfterLogin: {
+                    screen: 'start_cas',
+                }
+            });
+            await flushPromises();
+            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'cas', undefined, undefined);
+            expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
+            expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
+            expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
+        });
     });
 
     describe("Multi-tab lockout", () => {

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -41,6 +41,7 @@ import {
     MockClientWithEventEmitter,
     mockPlatformPeg,
     resetJsDomAfterEach,
+    unmockClientPeg,
 } from "../../test-utils";
 import * as leaveRoomUtils from "../../../src/utils/leave-behaviour";
 import * as voiceBroadcastUtils from "../../../src/voice-broadcast/utils/cleanUpBroadcasts";
@@ -51,6 +52,7 @@ import { PosthogAnalytics } from "../../../src/PosthogAnalytics";
 import PlatformPeg from "../../../src/PlatformPeg";
 import EventIndexPeg from "../../../src/indexing/EventIndexPeg";
 import * as Lifecycle from "../../../src/Lifecycle";
+import { SSO_HOMESERVER_URL_KEY, SSO_ID_SERVER_URL_KEY } from "../../../src/BasePlatform";
 
 jest.mock("matrix-js-sdk/src/oidc/authorize", () => ({
     completeAuthorizationCodeGrant: jest.fn(),
@@ -69,6 +71,7 @@ describe("<MatrixChat />", () => {
         setCanResetTimelineCallback: jest.fn(),
         isInitialSyncComplete: jest.fn(),
         getSyncState: jest.fn(),
+        getSsoLoginUrl: jest.fn(), 
         getSyncStateData: jest.fn().mockReturnValue(null),
         getThirdpartyProtocols: jest.fn().mockResolvedValue({}),
         getClientWellKnown: jest.fn().mockReturnValue({}),
@@ -1104,6 +1107,52 @@ describe("<MatrixChat />", () => {
                 // check we get to logged in view
                 await waitForSyncAndLoad(loginClient, true);
             });
+        });
+    });
+
+    describe("automatic SSO selection", () => {
+        let ssoClient: ReturnType<typeof getMockClientWithEventEmitter>;
+        let hrefSetter: jest.Mock<void, [string]>;
+        beforeEach(() => {
+            ssoClient = getMockClientWithEventEmitter({
+                ...getMockClientMethods(),
+                getHomeserverUrl: jest.fn().mockReturnValue("matrix.example.com"),
+                getIdentityServerUrl: jest.fn().mockReturnValue("ident.example.com"),
+                getSsoLoginUrl: jest.fn().mockReturnValue("http://my-sso-url"),
+            });
+            // this is used to create a temporary client to cleanup after logout
+            jest.spyOn(MatrixJs, "createClient").mockClear().mockReturnValue(ssoClient);
+            mockPlatformPeg();
+            // Ensure we don't have a client peg as we aren't logged in.
+            unmockClientPeg();
+
+
+            hrefSetter = jest.fn();
+            const originalHref = window.location.href.toString();
+            Object.defineProperty(window, "location", {
+                value: {
+                    get href() {
+                        return originalHref;
+                    },
+                    set href(href) {
+                        hrefSetter(href);
+                    }
+                },
+                writable: true,
+            });
+        });
+
+        it("should automatically setup and redirect to SSO login", async () => {
+            getComponent({
+                initialScreenAfterLogin: {
+                    screen: 'start_sso',
+                }
+            });
+            await flushPromises();
+            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'sso', undefined, undefined);
+            expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
+            expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
+            expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
         });
     });
 

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -1152,7 +1152,7 @@ describe("<MatrixChat />", () => {
             expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'sso', undefined, undefined);
             expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
             expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
-            expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
+            expect(hrefSetter).toBeCalledWith("http://my-sso-url");
         });
     });
 

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -71,7 +71,7 @@ describe("<MatrixChat />", () => {
         setCanResetTimelineCallback: jest.fn(),
         isInitialSyncComplete: jest.fn(),
         getSyncState: jest.fn(),
-        getSsoLoginUrl: jest.fn(), 
+        getSsoLoginUrl: jest.fn(),
         getSyncStateData: jest.fn().mockReturnValue(null),
         getThirdpartyProtocols: jest.fn().mockResolvedValue({}),
         getClientWellKnown: jest.fn().mockReturnValue({}),
@@ -1126,7 +1126,6 @@ describe("<MatrixChat />", () => {
             // Ensure we don't have a client peg as we aren't logged in.
             unmockClientPeg();
 
-
             hrefSetter = jest.fn();
             const originalHref = window.location.href.toString();
             Object.defineProperty(window, "location", {
@@ -1136,7 +1135,7 @@ describe("<MatrixChat />", () => {
                     },
                     set href(href) {
                         hrefSetter(href);
-                    }
+                    },
                 },
                 writable: true,
             });
@@ -1145,11 +1144,11 @@ describe("<MatrixChat />", () => {
         it("should automatically setup and redirect to SSO login", async () => {
             getComponent({
                 initialScreenAfterLogin: {
-                    screen: 'start_sso',
-                }
+                    screen: "start_sso",
+                },
             });
             await flushPromises();
-            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'sso', undefined, undefined);
+            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith("http://localhost/", "sso", undefined, undefined);
             expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
             expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
             expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
@@ -1158,11 +1157,11 @@ describe("<MatrixChat />", () => {
         it("should automatically setup and redirect to CAS login", async () => {
             getComponent({
                 initialScreenAfterLogin: {
-                    screen: 'start_cas',
-                }
+                    screen: "start_cas",
+                },
             });
             await flushPromises();
-            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'cas', undefined, undefined);
+            expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith("http://localhost/", "cas", undefined, undefined);
             expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
             expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
             expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -1152,7 +1152,7 @@ describe("<MatrixChat />", () => {
             expect(ssoClient.getSsoLoginUrl).toHaveBeenCalledWith('http://localhost/', 'sso', undefined, undefined);
             expect(window.localStorage.getItem(SSO_HOMESERVER_URL_KEY)).toEqual("matrix.example.com");
             expect(window.localStorage.getItem(SSO_ID_SERVER_URL_KEY)).toEqual("ident.example.com");
-            expect(hrefSetter).toBeCalledWith("http://my-sso-url");
+            expect(hrefSetter).toHaveBeenCalledWith("http://my-sso-url");
         });
     });
 


### PR DESCRIPTION
We were finding that trying to direct to start_sso was no longer working and prompting users with the welcome page, which looks wrong. I'm not sure if this is a recent breakage or not, but in practice this change seems to do the right thing.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix start_sso / start_cas URLs failing to redirect to a authentication prompt ([\#11681](https://github.com/matrix-org/matrix-react-sdk/pull/11681)). Contributed by @Half-Shot.<!-- CHANGELOG_PREVIEW_END -->