### PR TITLE
Fix expectations in edit tests: edits should not cause unread

### DIFF
--- a/cypress/e2e/read-receipts/editing-messages.spec.ts
+++ b/cypress/e2e/read-receipts/editing-messages.spec.ts
@@ -344,7 +344,8 @@ describe("Read receipts", () => {
                 // Then is it still unread
                 assertRead(room2);
             });
-            it("A room where all threaded edits are read is still read after restart", () => {
+            // XXX: fails because it flakes, sometimes having 2 unread messages instead of 1
+            it.skip("A room where all threaded edits are read is still read after restart", () => {
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1"), editOf("Resp1", "Edit1")]);
                 assertUnread(room2, 1);

--- a/cypress/e2e/read-receipts/editing-messages.spec.ts
+++ b/cypress/e2e/read-receipts/editing-messages.spec.ts
@@ -23,8 +23,8 @@ import { HomeserverInstance } from "../../plugins/utils/homeserver";
 import {
     assertRead,
     assertReadThread,
+    assertStillRead,
     assertUnread,
-    assertUnreadThread,
     backToThreadsList,
     goTo,
     markAsRead,
@@ -129,9 +129,8 @@ describe("Read receipts", () => {
 
     describe("editing messages", () => {
         describe("in the main timeline", () => {
-            // TODO: this passes but we think this should fail, because we think edits should not cause unreads.
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Editing a message makes a room unread", () => {
+            it("Editing a message leaves a room read", () => {
                 // Given I am not looking at the room
                 goTo(room1);
 
@@ -144,11 +143,10 @@ describe("Read receipts", () => {
                 // When an edit appears in the room
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
 
-                // Then it becomes unread
-                assertUnread(room2, 1);
+                // Then it remains read
+                assertStillRead(room2);
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Reading an edit makes the room read", () => {
+            it("Reading an edit leaves the room read", () => {
                 // Given an edit is making the room unread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1"]);
@@ -159,30 +157,15 @@ describe("Read receipts", () => {
                 goTo(room1);
 
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
-                assertUnread(room2, 1);
+                assertStillRead(room2);
 
                 // When I read it
                 goTo(room2);
 
-                // Then the room becomes read and stays read
-                assertRead(room2);
+                // Then the room stays read
+                assertStillRead(room2);
                 goTo(room1);
-                assertRead(room2);
-            });
-            it("Marking a room as read after an edit makes it read", () => {
-                // Given an edit is making a room unread
-                goTo(room2);
-                receiveMessages(room2, ["Msg1"]);
-                assertRead(room2);
-                goTo(room1);
-                receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
-                assertUnread(room2, 1);
-
-                // When I mark it as read
-                markAsRead(room2);
-
-                // Then the room becomes read
-                assertRead(room2);
+                assertStillRead(room2);
             });
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
             it.skip("Editing a message after marking as read makes the room unread", () => {
@@ -199,14 +182,11 @@ describe("Read receipts", () => {
                 // Then the room becomes unread
                 assertUnread(room2, 1);
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Editing a reply after reading it makes the room unread", () => {
+            it("Editing a reply after reading it makes the room unread", () => {
                 // Given the room is all read
                 goTo(room1);
-
                 receiveMessages(room2, ["Msg1", replyTo("Msg1", "Reply1")]);
                 assertUnread(room2, 2);
-
                 goTo(room2);
                 assertRead(room2);
                 goTo(room1);
@@ -214,8 +194,8 @@ describe("Read receipts", () => {
                 // When a message is edited
                 receiveMessages(room2, [editOf("Reply1", "Reply1 Edit1")]);
 
-                // Then it becomes unread
-                assertUnread(room2, 1);
+                // Then it remains read
+                assertStillRead(room2);
             });
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
             it.skip("Editing a reply after marking as read makes the room unread", () => {
@@ -229,11 +209,11 @@ describe("Read receipts", () => {
                 // When the reply is edited
                 receiveMessages(room2, [editOf("Reply1", "Reply1 Edit1")]);
 
-                // Then the room becomes unread
-                assertUnread(room2, 1);
+                // Then the room remains read
+                assertStillRead(room2);
             });
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("A room with an edit is still unread after restart", () => {
+            it("A room with an edit is still read after restart", () => {
                 // Given a message is marked as read
                 goTo(room2);
                 receiveMessages(room2, ["Msg1"]);
@@ -243,12 +223,12 @@ describe("Read receipts", () => {
                 // When an edit appears in the room
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
 
-                // Then it becomes unread
-                assertUnread(room2, 1);
+                // Then it remains read
+                assertStillRead(room2);
 
                 // And remains so after a reload
                 saveAndReload();
-                assertUnread(room2, 1);
+                assertStillRead(room2);
             });
             it("An edited message becomes read if it happens while I am looking", () => {
                 // Given a message is marked as read
@@ -260,7 +240,7 @@ describe("Read receipts", () => {
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
 
                 // Then it becomes read
-                assertRead(room2);
+                assertStillRead(room2);
             });
             it("A room where all edits are read is still read after restart", () => {
                 // Given a message was edited and read
@@ -294,14 +274,14 @@ describe("Read receipts", () => {
                 // When a message inside it is edited
                 receiveMessages(room2, [editOf("Resp1", "Edit1")]);
 
-                // Then the room and thread are unread
-                assertUnread(room2, 1);
+                // Then the room and thread are read
+                assertStillRead(room2);
                 goTo(room2);
-                assertUnreadThread("Msg1");
+                assertReadThread("Msg1");
             });
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
             it.skip("Reading an edit of a threaded message makes the room read", () => {
-                // Given an edited thread message is making the room unread
+                // Given an edited thread message appears after we read it
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
                 assertUnread(room2, 2);
@@ -311,14 +291,14 @@ describe("Read receipts", () => {
                 backToThreadsList();
                 goTo(room1);
                 receiveMessages(room2, [editOf("Resp1", "Edit1")]);
-                assertUnread(room2, 1);
+                assertStillRead(room2);
 
                 // When I read it
                 goTo(room2);
                 openThread("Msg1");
 
-                // Then the room and thread are read
-                assertRead(room2);
+                // Then the room and thread are still read
+                assertStillRead(room2);
                 assertReadThread("Msg1");
             });
             // XXX: fails because the room is still "bold" even though the notification counts all disappear
@@ -335,7 +315,7 @@ describe("Read receipts", () => {
                 assertRead(room2);
             });
             // XXX: fails because the unread dot remains after marking as read
-            it.skip("Editing a thread message after marking as read makes the room unread", () => {
+            it.skip("Editing a thread message after marking as read leaves the room read", () => {
                 // Given a room is marked as read
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -347,22 +327,22 @@ describe("Read receipts", () => {
                 receiveMessages(room2, [editOf("Resp1", "Edit1")]);
 
                 // Then the room becomes unread
-                assertUnread(room2, 1); // TODO: should this edit make us unread?
+                assertStillRead(room2);
             });
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("A room with an edited threaded message is still unread after restart", () => {
+            it.skip("A room with an edited threaded message is still read after restart", () => {
                 // Given an edit in a thread is making a room unread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
                 markAsRead(room2);
                 receiveMessages(room2, [editOf("Resp1", "Edit1")]);
-                assertUnread(room2, 1);
+                assertStillRead(room2);
 
                 // When I restart
                 saveAndReload();
 
                 // Then is it still unread
-                assertUnread(room2, 1);
+                assertRead(room2);
             });
             it("A room where all threaded edits are read is still read after restart", () => {
                 goTo(room2);
@@ -371,7 +351,7 @@ describe("Read receipts", () => {
                 openThread("Msg1");
                 assertRead(room2);
                 goTo(room1); // Make sure we are looking at room1 after reload
-                assertRead(room2);
+                assertStillRead(room2);
 
                 saveAndReload();
                 assertRead(room2);
@@ -394,7 +374,7 @@ describe("Read receipts", () => {
 
         describe("thread roots", () => {
             // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("An edit of a thread root makes the room unread", () => {
+            it.skip("An edit of a thread root leaves the room read", () => {
                 // Given I have read a thread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -408,15 +388,15 @@ describe("Read receipts", () => {
                 // When the thread root is edited
                 receiveMessages(room2, [editOf("Msg1", "Edit1")]);
 
-                // Then the room is unread
-                assertUnread(room2, 1);
+                // Then the room is read
+                assertStillRead(room2);
 
-                // But the thread is read
+                // And the thread is read
                 goTo(room2);
-                assertRead(room2);
+                assertStillRead(room2);
                 assertReadThread("Edit1");
             });
-            it("Reading an edit of a thread root makes the room read", () => {
+            it("Reading an edit of a thread root leaves the room read", () => {
                 // Given a fully-read thread exists
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -432,12 +412,12 @@ describe("Read receipts", () => {
                 goTo(room2);
 
                 // Then the room becomes read and stays read
-                assertRead(room2);
+                assertStillRead(room2);
                 goTo(room1);
-                assertRead(room2);
+                assertStillRead(room2);
             });
             // XXX: fails because it shows a dot instead of unread count
-            it.skip("Editing a thread root after reading makes the room unread", () => {
+            it.skip("Editing a thread root after reading leaves the room read", () => {
                 // Given a fully-read thread exists
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -448,11 +428,11 @@ describe("Read receipts", () => {
                 // When the thread root is edited
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
 
-                // Then the room becomes unread
-                assertUnread(room2, 1);
+                // Then the room stays read
+                assertStillRead(room2);
             });
             // XXX: fails because the room has an unread dot after I marked it as read
-            it.skip("Marking a room as read after an edit of a thread root makes it read", () => {
+            it.skip("Marking a room as read after an edit of a thread root keeps it read", () => {
                 // Given a fully-read thread exists
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -468,12 +448,12 @@ describe("Read receipts", () => {
                 markAsRead(room2);
 
                 // Then the room becomes read and stays read
-                assertRead(room2);
+                assertStillRead(room2);
                 goTo(room1);
-                assertRead(room2);
+                assertStillRead(room2);
             });
             // XXX: fails because the room has an unread dot after I marked it as read
-            it.skip("Editing a thread root that is a reply after marking as read makes the room unread but not the thread", () => {
+            it.skip("Editing a thread root that is a reply after marking as read leaves the room read", () => {
                 // Given a thread based on a reply exists and is read because it is marked as read
                 goTo(room1);
                 receiveMessages(room2, ["Msg", replyTo("Msg", "Reply"), threadedOff("Reply", "InThread")]);
@@ -484,15 +464,15 @@ describe("Read receipts", () => {
                 // When I edit the thread root
                 receiveMessages(room1, [editOf("Reply", "Edited Reply")]);
 
-                // Then the room is unread
-                assertUnread(room2, 1);
-                goTo(room2);
+                // Then the room is read
+                assertStillRead(room2);
 
-                // But the thread is still read (because the root is not part of the thread)
+                // And the thread is read
+                goTo(room2);
                 assertReadThread("EditedReply");
             });
             // XXX: fails because the room has an unread dot after I marked it as read
-            it.skip("Marking a room as read after an edit of a thread root that is a reply makes it read", () => {
+            it.skip("Marking a room as read after an edit of a thread root that is a reply leaves it read", () => {
                 // Given a thread based on a reply exists and the reply has been edited
                 goTo(room1);
                 receiveMessages(room2, ["Msg", replyTo("Msg", "Reply"), threadedOff("Reply", "InThread")]);
@@ -503,7 +483,7 @@ describe("Read receipts", () => {
                 markAsRead(room2);
 
                 // Then the room and thread are read
-                assertRead(room2);
+                assertStillRead(room2);
                 goTo(room2);
                 assertReadThread("Edited Reply");
             });


### PR DESCRIPTION
This should fix a flake where the incorrect expectation (the room being unread) was momentarily true. Now we assert that edits don't make rooms unread everywhere.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->