### PR TITLE
Downgrade Cypress to v12.

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -15,12 +15,11 @@ limitations under the License.
 */
 
 import { defineConfig } from "cypress";
-import * as fs from "node:fs";
 
 import registerPlugins from "./cypress/plugins";
 
 export default defineConfig({
-    video: true,
+    videoUploadOnPasses: false,
     projectId: "ppvnzg",
     experimentalInteractiveRunEvents: true,
     experimentalMemoryManagement: true,
@@ -28,18 +27,6 @@ export default defineConfig({
     chromeWebSecurity: false,
     e2e: {
         setupNodeEvents(on, config) {
-            // Delete videos of passing tests
-            on("after:spec", (spec, results) => {
-                if (results && results.video) {
-                    const failures = results.tests.some((test) =>
-                        test.attempts.some((attempt) => attempt.state === "failed"),
-                    );
-                    if (!failures) {
-                        fs.unlinkSync(results.video);
-                    }
-                }
-            });
-
             return registerPlugins(on, config);
         },
         baseUrl: "http://localhost:8080",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
         "babel-jest": "^29.0.0",
         "blob-polyfill": "^7.0.0",
         "chokidar": "^3.5.1",
-        "cypress": "^13.0.0",
+        "cypress": "^12.0.0",
         "cypress-axe": "^1.0.0",
         "cypress-cloud": "^2.0.0-beta.0",
         "cypress-multi-reporters": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,10 @@
     lazy-ass "1.6.0"
     ramda "0.26.1"
 
-"@cypress/request@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.0.tgz#7f58dfda087615ed4e6aab1b25fffe7630d6dd85"
-  integrity sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==
+"@cypress/request@^2.88.11":
+  version "2.88.12"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
+  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -4374,12 +4374,12 @@ cypress-terminal-report@^5.3.2:
     semver "^7.3.5"
     tv4 "^1.3.0"
 
-cypress@^13.0.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.1.0.tgz#18f268e66662cd91b1766db18bd1f63a66592205"
-  integrity sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==
+cypress@^12.0.0:
+  version "12.17.3"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.3.tgz#1e2b19037236fc60e4a4b3a14f0846be17a1fc0e"
+  integrity sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^2.88.11"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"
@@ -4414,7 +4414,6 @@ cypress@^13.0.0:
     minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
-    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
     semver "^7.5.3"
@@ -8543,11 +8542,6 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
(On the understanding that v12 will continue to allow us to use the sorry-cypress service for balancing test parallelisation.)

The upgrade PR to v13 contained config changes which I have attempted to revert, but the config has changed a little since then so this is worthy of close checking.

The upgrade PR also contained a fix to a spotlight test, which we think was needed anyway, and not related to upgrade. This PR does not revert that fix, and the tests appear to pass, so we think that's ok.

Reverts "Update dependency cypress to v13 (#11570)" This reverts commit 35a6595080af1ea249b4a45413ca28f8757c94fd.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->