### PR TITLE
Skip flaky cypress test on rust crypto

### DIFF
--- a/cypress/e2e/crypto/verification.spec.ts
+++ b/cypress/e2e/crypto/verification.spec.ts
@@ -20,7 +20,7 @@ import type { MatrixClient } from "matrix-js-sdk/src/matrix";
 import type { VerificationRequest, Verifier } from "matrix-js-sdk/src/crypto-api";
 import { CypressBot } from "../../support/bot";
 import { HomeserverInstance } from "../../plugins/utils/homeserver";
-import { emitPromise } from "../../support/util";
+import { emitPromise, skipIfRustCrypto } from "../../support/util";
 import {
     checkDeviceIsConnectedKeyBackup,
     checkDeviceIsCrossSigned,
@@ -123,6 +123,7 @@ describe("Device verification", () => {
     });
 
     it("Verify device during login with QR code", () => {
+        skipIfRustCrypto(); // https://github.com/vector-im/element-web/issues/26293
         logIntoElement(homeserver.baseUrl, aliceBotClient.getUserId(), aliceBotClient.__cypress_password);
 
         // Launch the verification request between alice and the bot


### PR DESCRIPTION
cf https://github.com/vector-im/element-web/issues/26293: this seems to have started being flaky, possibly dud to the extra check added in https://github.com/matrix-org/matrix-react-sdk/pull/11686

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->