### PR TITLE
Turn on Cypress debug logs to figure out why reports are not being created

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -214,6 +214,8 @@ jobs:
                   PERCY_PARALLEL_NONCE: ${{ needs.prepare.outputs.uuid }}
                   # We manually finalize the build in the report stage
                   PERCY_PARALLEL_TOTAL: -1
+                  # Temporarily turn on debug logs to figure out why reports are not being created
+                  DEBUG: "cypress:*"
 
             - name: Upload Artifact
               if: failure()


### PR DESCRIPTION
(This needs to be merged into develop before it is active.)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->