### PR TITLE
Element-R: Use `MatrixClient.CryptoApi.getUserVerificationStatus` instead of `MatrixClient.checkUserTrust` in `MKeyVerificationConclusion.tsx`

### DIFF
--- a/src/components/views/messages/MKeyVerificationConclusion.tsx
+++ b/src/components/views/messages/MKeyVerificationConclusion.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
+import React, { useState } from "react";
 import classNames from "classnames";
 import { MatrixEvent, EventType } from "matrix-js-sdk/src/matrix";
 import { VerificationPhase, VerificationRequest, VerificationRequestEvent } from "matrix-js-sdk/src/crypto-api";
@@ -24,6 +24,8 @@ import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import { _t } from "../../../languageHandler";
 import { getNameForEventRoom, userLabelForEventRoom } from "../../../utils/KeyVerificationStateObserver";
 import EventTileBubble from "./EventTileBubble";
+import { useTypedEventEmitter } from "../../../hooks/useEventEmitter";
+import { useAsyncMemo } from "../../../hooks/useAsyncMemo";
 
 interface IProps {
     /* the MatrixEvent to show */
@@ -31,114 +33,103 @@ interface IProps {
     timestamp?: JSX.Element;
 }
 
-export default class MKeyVerificationConclusion extends React.Component<IProps> {
-    public constructor(props: IProps) {
-        super(props);
-    }
+export function MKeyVerificationConclusion({ mxEvent, timestamp }: IProps): JSX.Element | null {
+    const request = mxEvent.verificationRequest;
+    const client = MatrixClientPeg.safeGet();
 
-    public componentDidMount(): void {
-        const request = this.props.mxEvent.verificationRequest;
-        if (request) {
-            request.on(VerificationRequestEvent.Change, this.onRequestChanged);
-        }
-        MatrixClientPeg.safeGet().on(CryptoEvent.UserTrustStatusChanged, this.onTrustChanged);
-    }
-
-    public componentWillUnmount(): void {
-        const request = this.props.mxEvent.verificationRequest;
-        if (request) {
-            request.off(VerificationRequestEvent.Change, this.onRequestChanged);
-        }
-        const cli = MatrixClientPeg.get();
-        if (cli) {
-            cli.removeListener(CryptoEvent.UserTrustStatusChanged, this.onTrustChanged);
-        }
-    }
-
-    private onRequestChanged = (): void => {
-        this.forceUpdate();
-    };
-
-    private onTrustChanged = (userId: string): void => {
-        const { mxEvent } = this.props;
+    // key is used to trigger rerender when we received event
+    const [key, setKey] = useState(0);
+    useTypedEventEmitter(client, CryptoEvent.UserTrustStatusChanged, async (userId: string) => {
         const request = mxEvent.verificationRequest;
-        if (!request || request.otherUserId !== userId) {
-            return;
+
+        // rerender only for the current user
+        if (request?.otherUserId === userId) {
+            setKey((key) => ++key);
         }
-        this.forceUpdate();
-    };
+    });
+    useTypedEventEmitter(request, VerificationRequestEvent.Change, () => {
+        setKey((key) => ++key);
+    });
 
-    public static shouldRender(mxEvent: MatrixEvent, request?: VerificationRequest): boolean {
-        // normally should not happen
-        if (!request) {
-            return false;
-        }
-        // .cancel event that was sent after the verification finished, ignore
-        if (mxEvent.getType() === EventType.KeyVerificationCancel && request.phase !== VerificationPhase.Cancelled) {
-            return false;
-        }
-        // .done event that was sent after the verification cancelled, ignore
-        if (mxEvent.getType() === EventType.KeyVerificationDone && request.phase !== VerificationPhase.Done) {
-            return false;
-        }
+    // check at every received request event if the verification is still ongoing
+    const isDisplayed = useAsyncMemo(
+        () => isVerificationOngoing(mxEvent, mxEvent.verificationRequest),
+        [mxEvent, mxEvent.verificationRequest, key],
+        false,
+    );
 
-        // request hasn't concluded yet
-        if (request.pending) {
-            return false;
-        }
+    if (!isDisplayed || !request) return null;
 
-        // User isn't actually verified
-        if (!MatrixClientPeg.safeGet().checkUserTrust(request.otherUserId).isCrossSigningVerified()) {
-            return false;
-        }
+    const myUserId = client.getUserId();
+    let title: string | undefined;
 
-        return true;
-    }
-
-    public render(): JSX.Element | null {
-        const { mxEvent } = this.props;
-        const request = mxEvent.verificationRequest!;
-
-        if (!MKeyVerificationConclusion.shouldRender(mxEvent, request)) {
-            return null;
-        }
-
-        const client = MatrixClientPeg.safeGet();
-        const myUserId = client.getUserId();
-
-        let title: string | undefined;
-
-        if (request.phase === VerificationPhase.Done) {
-            title = _t("timeline|m.key.verification.done", {
+    if (request.phase === VerificationPhase.Done) {
+        title = _t("timeline|m.key.verification.done", {
+            name: getNameForEventRoom(client, request.otherUserId, mxEvent.getRoomId()!),
+        });
+    } else if (request.phase === VerificationPhase.Cancelled) {
+        const userId = request.cancellingUserId;
+        if (userId === myUserId) {
+            title = _t("timeline|m.key.verification.cancel|you_cancelled", {
                 name: getNameForEventRoom(client, request.otherUserId, mxEvent.getRoomId()!),
             });
-        } else if (request.phase === VerificationPhase.Cancelled) {
-            const userId = request.cancellingUserId;
-            if (userId === myUserId) {
-                title = _t("timeline|m.key.verification.cancel|you_cancelled", {
-                    name: getNameForEventRoom(client, request.otherUserId, mxEvent.getRoomId()!),
-                });
-            } else if (userId) {
-                title = _t("timeline|m.key.verification.cancel|user_cancelled", {
-                    name: getNameForEventRoom(client, userId, mxEvent.getRoomId()!),
-                });
-            }
-        }
-
-        if (title) {
-            const classes = classNames("mx_cryptoEvent mx_cryptoEvent_icon", {
-                mx_cryptoEvent_icon_verified: request.phase === VerificationPhase.Done,
+        } else if (userId) {
+            title = _t("timeline|m.key.verification.cancel|user_cancelled", {
+                name: getNameForEventRoom(client, userId, mxEvent.getRoomId()!),
             });
-            return (
-                <EventTileBubble
-                    className={classes}
-                    title={title}
-                    subtitle={userLabelForEventRoom(client, request.otherUserId, mxEvent.getRoomId()!)}
-                    timestamp={this.props.timestamp}
-                />
-            );
         }
-
-        return null;
     }
+
+    if (title) {
+        const classes = classNames("mx_cryptoEvent mx_cryptoEvent_icon", {
+            mx_cryptoEvent_icon_verified: request.phase === VerificationPhase.Done,
+        });
+        return (
+            <EventTileBubble
+                key={key}
+                className={classes}
+                title={title}
+                subtitle={userLabelForEventRoom(client, request.otherUserId, mxEvent.getRoomId()!)}
+                timestamp={timestamp}
+            />
+        );
+    }
+
+    return null;
+}
+
+/**
+ * Check the verification is not pending, the other user is verified,
+ * and we didn't receive a cancel or done event after the verification ending
+ * @param mxEvent matrixEvent related to the verification request
+ * @param request the verification request
+ */
+export async function isVerificationOngoing(mxEvent: MatrixEvent, request?: VerificationRequest): Promise<boolean> {
+    // normally should not happen
+    if (!request) {
+        return false;
+    }
+    // .cancel event that was sent after the verification finished, ignore
+    if (mxEvent.getType() === EventType.KeyVerificationCancel && request.phase !== VerificationPhase.Cancelled) {
+        return false;
+    }
+    // .done event that was sent after the verification cancelled, ignore
+    if (mxEvent.getType() === EventType.KeyVerificationDone && request.phase !== VerificationPhase.Done) {
+        return false;
+    }
+
+    // request hasn't concluded yet
+    if (request.pending) {
+        return false;
+    }
+
+    // User isn't actually verified
+    const userVerificationStatus = await MatrixClientPeg.safeGet()
+        .getCrypto()
+        ?.getUserVerificationStatus(request.otherUserId);
+    if (!userVerificationStatus?.isVerified()) {
+        return false;
+    }
+
+    return true;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->
