### PR TITLE
Disable cypress debug logs

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -214,8 +214,6 @@ jobs:
                   PERCY_PARALLEL_NONCE: ${{ needs.prepare.outputs.uuid }}
                   # We manually finalize the build in the report stage
                   PERCY_PARALLEL_TOTAL: -1
-                  # Temporarily turn on debug logs to figure out why reports are not being created
-                  DEBUG: "cypress:*"
 
             - name: Upload Artifact
               if: failure()


### PR DESCRIPTION
These are noisy and no longer needed.

This reverts commit 70d834c28e5a01ebe4b4e7e639386924eb5c107b / PR #11716.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->