### PR TITLE
improve invite tile color

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -151,7 +151,7 @@ limitations under the License.
     margin-inline-end: $spacing-8;
 
     .mx_InviteDialog_userTile_pill {
-        background-color: $username-variant1-color;
+        background-color: var(--cpd-color-blue-800);
         border-radius: 12px;
         display: inline-block;
         height: 24px;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -338,7 +338,7 @@ limitations under the License.
 
         .mx_InviteDialog_tile--room_selected {
             border-radius: 36px;
-            background-color: $username-variant1-color;
+            background-color: var(--cpd-color-blue-800);
 
             &::before {
                 content: "";


### PR DESCRIPTION
Signed-off-by: Gabriel Rodríguez <rgabriel@mit.edu>

Fixes [#26098](https://github.com/vector-im/element-web/issues/26098)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:



Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->
Notes: Fixes invite dialog pill color contrast

Dark theme (5.3 contrast ratio):

![image](https://github.com/matrix-org/matrix-react-sdk/assets/24363938/8d1a2656-0888-4baa-bfa4-58b9d51006af)

Light theme (3.5 contrast ratio):

![image](https://github.com/matrix-org/matrix-react-sdk/assets/24363938/06a5050e-3a89-464c-b11a-75bb15f7a583)

Let us know if we should make a new variable (and how to name it!) or use an existing variable, or if you disagree with the color choice. There was no existing more specific alias for `--cpd-color-blue-800`: the closest was

```css
--cpd-color-icon-info-primary: var(--cpd-color-blue-900);
```

but it does not seem to be enough contrast for dark theme.