### PR TITLE
Fix alignment and poor contrast on user pills in invite dialog

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -151,7 +151,7 @@ limitations under the License.
     margin-inline-end: $spacing-8;
 
     .mx_InviteDialog_userTile_pill {
-        background-color: $username-variant1-color;
+        background-color: var(--cpd-color-blue-800);
         border-radius: 12px;
         display: inline-block;
         height: 24px;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -151,14 +151,14 @@ limitations under the License.
     margin-inline-end: $spacing-8;
 
     .mx_InviteDialog_userTile_pill {
-        background-color: var(--cpd-color-text-info-primary);
+        background-color: var(--cpd-color-bg-success-subtle);
         border-radius: 12px;
         display: inline-block;
         height: 24px;
         line-height: $font-24px;
         padding-inline: $spacing-8;
         vertical-align: middle;
-        color: #ffffff; /* this is fine without a var because it's for both themes */
+        color: $primary-content;
 
         .mx_SearchResultAvatar {
             border-radius: 20px;
@@ -340,7 +340,7 @@ limitations under the License.
 
         .mx_InviteDialog_tile--room_selected {
             border-radius: 36px;
-            background-color: var(--cpd-color-text-info-primary);
+            background-color: var(--cpd-color-bg-success-subtle);
 
             &::before {
                 content: "";
@@ -354,7 +354,7 @@ limitations under the License.
                 position: absolute;
                 top: 6px; /* 50% */
                 left: 6px; /* 50% */
-                background-color: #ffffff; /* this is fine without a var because it's for both themes */
+                background-color: $primary-content;
             }
         }
 

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -157,6 +157,7 @@ limitations under the License.
         height: 24px;
         line-height: $font-24px;
         padding-inline: $spacing-8;
+        vertical-align: middle;
         color: #ffffff; /* this is fine without a var because it's for both themes */
 
         .mx_SearchResultAvatar {
@@ -182,6 +183,7 @@ limitations under the License.
     .mx_InviteDialog_userTile_remove {
         display: inline-block;
         margin-inline-start: $spacing-4;
+        vertical-align: middle;
     }
 }
 

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -338,7 +338,7 @@ limitations under the License.
 
         .mx_InviteDialog_tile--room_selected {
             border-radius: 36px;
-            background-color: $username-variant1-color;
+            background-color: var(--cpd-color-blue-800);
 
             &::before {
                 content: "";

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -151,7 +151,7 @@ limitations under the License.
     margin-inline-end: $spacing-8;
 
     .mx_InviteDialog_userTile_pill {
-        background-color: var(--cpd-color-blue-800);
+        background-color: var(--cpd-color-text-info-primary);
         border-radius: 12px;
         display: inline-block;
         height: 24px;
@@ -338,7 +338,7 @@ limitations under the License.
 
         .mx_InviteDialog_tile--room_selected {
             border-radius: 36px;
-            background-color: var(--cpd-color-blue-800);
+            background-color: var(--cpd-color-text-info-primary);
 
             &::before {
                 content: "";


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Signed-off-by: Gabriel Rodríguez <rgabriel@mit.edu>

Fixes [#26098](https://github.com/vector-im/element-web/issues/26098)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Fixes invite dialog pill alignment and color contrast

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

Notes: Fixes invite dialog alignment and pill color contrast

## Before screenshots

![image](https://github.com/vector-im/element-web/assets/24363938/b2588938-2848-48c4-a60f-448266007108)

![image](https://github.com/matrix-org/matrix-react-sdk/assets/24363938/cc65b28e-6c47-4fcc-a3dc-3eea2b81378a)

## After screenshots

Dark theme (5.3 contrast ratio):

![image](https://github.com/matrix-org/matrix-react-sdk/assets/24363938/8d1a2656-0888-4baa-bfa4-58b9d51006af)

Light theme (3.5 contrast ratio):

![image](https://github.com/matrix-org/matrix-react-sdk/assets/24363938/06a5050e-3a89-464c-b11a-75bb15f7a583)

Let us know if we should make a new variable (and how to name it! This would be helpful to improve the contrast for light theme without worsening for dark theme) or use an existing variable, or if you disagree with the color choice. There was no existing more specific alias for `--cpd-color-blue-800`: the closest was

```css
--cpd-color-icon-info-primary: var(--cpd-color-blue-900);
```

but it does not seem to be enough contrast for dark theme.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fixes invite dialog alignment and pill color contrast ([\#11722](https://github.com/matrix-org/matrix-react-sdk/pull/11722)). Contributed by @gabrc52.<!-- CHANGELOG_PREVIEW_END -->