### PR TITLE
Ignore permalink_prefix when serializing Markdown

### DIFF
--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -37,7 +37,7 @@ export function mdSerialize(model: EditorModel): string {
             case Type.AtRoomPill:
                 return html + part.text;
             case Type.RoomPill: {
-                const url = makeGenericPermalink(part.resourceId);
+                const url = makeGenericPermalink(part.resourceId, true);
                 // Escape square brackets and backslashes
                 // Here we use the resourceId for compatibility with non-rich text clients
                 // See https://github.com/vector-im/element-web/issues/16660
@@ -45,7 +45,7 @@ export function mdSerialize(model: EditorModel): string {
                 return html + `[${title}](${url})`;
             }
             case Type.UserPill: {
-                const url = makeGenericPermalink(part.resourceId);
+                const url = makeGenericPermalink(part.resourceId, true);
                 // Escape square brackets and backslashes; convert newlines to HTML
                 const title = part.text.replace(/[[\\\]]/g, (c) => "\\" + c).replace(/\n/g, "<br>");
                 return html + `[${title}](${url})`;

--- a/src/utils/permalinks/ElementPermalinkConstructor.ts
+++ b/src/utils/permalinks/ElementPermalinkConstructor.ts
@@ -32,21 +32,21 @@ export default class ElementPermalinkConstructor extends PermalinkConstructor {
     }
 
     public forEvent(roomId: string, eventId: string, serverCandidates: string[], ispill = false): string {
-        if(ispill) {
+        if (ispill) {
             return `https://matrix.to/#/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
         }
         return `${this.elementUrl}/#/room/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
     public forRoom(roomIdOrAlias: string, serverCandidates?: string[], ispill = false): string {
-        if(ispill) {
+        if (ispill) {
             return `https://matrix.to/#/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
         }
         return `${this.elementUrl}/#/room/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
     public forUser(userId: string, ispill = false): string {
-        if(ispill) {
+        if (ispill) {
             return `https://matrix.to/#/${userId}`;
         }
         return `${this.elementUrl}/#/user/${userId}`;

--- a/src/utils/permalinks/ElementPermalinkConstructor.ts
+++ b/src/utils/permalinks/ElementPermalinkConstructor.ts
@@ -31,23 +31,32 @@ export default class ElementPermalinkConstructor extends PermalinkConstructor {
         }
     }
 
-    public forEvent(roomId: string, eventId: string, serverCandidates: string[]): string {
+    public forEvent(roomId: string, eventId: string, serverCandidates: string[], ispill = false): string {
+        if(ispill) {
+            return `https://matrix.to/#/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
+        }
         return `${this.elementUrl}/#/room/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
-    public forRoom(roomIdOrAlias: string, serverCandidates?: string[]): string {
+    public forRoom(roomIdOrAlias: string, serverCandidates?: string[], ispill = false): string {
+        if(ispill) {
+            return `https://matrix.to/#/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
+        }
         return `${this.elementUrl}/#/room/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
-    public forUser(userId: string): string {
+    public forUser(userId: string, ispill = false): string {
+        if(ispill) {
+            return `https://matrix.to/#/${userId}`;
+        }
         return `${this.elementUrl}/#/user/${userId}`;
     }
 
-    public forEntity(entityId: string): string {
+    public forEntity(entityId: string, ispill = false): string {
         if (entityId[0] === "!" || entityId[0] === "#") {
-            return this.forRoom(entityId);
+            return this.forRoom(entityId, [], ispill);
         } else if (entityId[0] === "@") {
-            return this.forUser(entityId);
+            return this.forUser(entityId, ispill);
         } else throw new Error("Unrecognized entity");
     }
 

--- a/src/utils/permalinks/PermalinkConstructor.ts
+++ b/src/utils/permalinks/PermalinkConstructor.ts
@@ -19,19 +19,19 @@ limitations under the License.
  * TODO: Convert this to a real TypeScript interface
  */
 export default class PermalinkConstructor {
-    public forEvent(roomId: string, eventId: string, serverCandidates: string[] = []): string {
+    public forEvent(roomId: string, eventId: string, serverCandidates: string[] = [], ispill = false): string {
         throw new Error("Not implemented");
     }
 
-    public forRoom(roomIdOrAlias: string, serverCandidates: string[] = []): string {
+    public forRoom(roomIdOrAlias: string, serverCandidates: string[] = [], ispill = false): string {
         throw new Error("Not implemented");
     }
 
-    public forUser(userId: string): string {
+    public forUser(userId: string, ispill = false): string {
         throw new Error("Not implemented");
     }
 
-    public forEntity(entityId: string): string {
+    public forEntity(entityId: string, ispill = false): string {
         throw new Error("Not implemented");
     }
 

--- a/src/utils/permalinks/Permalinks.ts
+++ b/src/utils/permalinks/Permalinks.ts
@@ -269,26 +269,26 @@ export class RoomPermalinkCreator {
     };
 }
 
-export function makeGenericPermalink(entityId: string): string {
-    return getPermalinkConstructor().forEntity(entityId);
+export function makeGenericPermalink(entityId: string, ispill = false): string {
+    return getPermalinkConstructor().forEntity(entityId, ispill);
 }
 
-export function makeUserPermalink(userId: string): string {
+export function makeUserPermalink(userId: string, ispill = false): string {
     return getPermalinkConstructor().forUser(userId);
 }
 
-export function makeRoomPermalink(matrixClient: MatrixClient, roomId: string): string {
+export function makeRoomPermalink(matrixClient: MatrixClient, roomId: string, ispill = false): string {
     if (!roomId) {
         throw new Error("can't permalink a falsy roomId");
     }
 
     // If the roomId isn't actually a room ID, don't try to list the servers.
     // Aliases are already routable, and don't need extra information.
-    if (roomId[0] !== "!") return getPermalinkConstructor().forRoom(roomId, []);
+    if (roomId[0] !== "!") return getPermalinkConstructor().forRoom(roomId, [], ispill);
 
     const room = matrixClient.getRoom(roomId);
     if (!room) {
-        return getPermalinkConstructor().forRoom(roomId, []);
+        return getPermalinkConstructor().forRoom(roomId, [], ispill);
     }
     const permalinkCreator = new RoomPermalinkCreator(room);
     permalinkCreator.load();

--- a/test/editor/serialize-test.ts
+++ b/test/editor/serialize-test.ts
@@ -19,6 +19,7 @@ import { mocked } from "jest-mock";
 import EditorModel from "../../src/editor/model";
 import { htmlSerializeIfNeeded } from "../../src/editor/serialize";
 import { createPartCreator } from "./mock";
+import { IConfigOptions } from "../../src/IConfigOptions";
 import SettingsStore from "../../src/settings/SettingsStore";
 import SdkConfig from "../../src/SdkConfig";
 
@@ -108,9 +109,9 @@ describe("editor/serialize", function () {
             expect(html).toBe('<ol start="2021">\n<li>foo</li>\n</ol>\n');
         });
         describe("with permalink_prefix set", function () {
-            const sdkConfigGet = SdkConfig.get
+            const sdkConfigGet = SdkConfig.get;
             beforeEach(() => {
-                jest.spyOn(SdkConfig, "get").mockImplementation((key: string, altCaseName?: string) => {
+                jest.spyOn(SdkConfig, "get").mockImplementation((key: keyof IConfigOptions, altCaseName?: string) => {
                     if (key === "permalink_prefix") {
                         return "https://element.fs.tld";
                     } else return sdkConfigGet(key, altCaseName);

--- a/test/editor/serialize-test.ts
+++ b/test/editor/serialize-test.ts
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { mocked } from "jest-mock";
+
 import EditorModel from "../../src/editor/model";
 import { htmlSerializeIfNeeded } from "../../src/editor/serialize";
 import { createPartCreator } from "./mock";
 import SettingsStore from "../../src/settings/SettingsStore";
+import SdkConfig from "../../src/SdkConfig";
 
 describe("editor/serialize", function () {
     describe("with markdown", function () {
@@ -103,6 +106,32 @@ describe("editor/serialize", function () {
             const model = new EditorModel([pc.plain("2021. foo")], pc);
             const html = htmlSerializeIfNeeded(model, {});
             expect(html).toBe('<ol start="2021">\n<li>foo</li>\n</ol>\n');
+        });
+        describe("with permalink_prefix set", function () {
+            const sdkConfigGet = SdkConfig.get
+            beforeEach(() => {
+                jest.spyOn(SdkConfig, "get").mockImplementation((key: string, altCaseName?: string) => {
+                    if (key === "permalink_prefix") {
+                        return "https://element.fs.tld";
+                    } else return sdkConfigGet(key, altCaseName);
+                });
+            });
+
+            it("user pill uses matrix.to", function () {
+                const pc = createPartCreator();
+                const model = new EditorModel([pc.userPill("Alice", "@alice:hs.tld")], pc);
+                const html = htmlSerializeIfNeeded(model, {});
+                expect(html).toBe('<a href="https://matrix.to/#/@alice:hs.tld">Alice</a>');
+            });
+            it("room pill uses matrix.to", function () {
+                const pc = createPartCreator();
+                const model = new EditorModel([pc.roomPill("#room:hs.tld")], pc);
+                const html = htmlSerializeIfNeeded(model, {});
+                expect(html).toBe('<a href="https://matrix.to/#/#room:hs.tld">#room:hs.tld</a>');
+            });
+            afterEach(() => {
+                mocked(SdkConfig.get).mockRestore();
+            });
         });
     });
 

--- a/test/utils/permalinks/Permalinks-test.ts
+++ b/test/utils/permalinks/Permalinks-test.ts
@@ -24,6 +24,7 @@ import {
     parsePermalink,
     RoomPermalinkCreator,
 } from "../../../src/utils/permalinks/Permalinks";
+import { IConfigOptions } from "../../../src/IConfigOptions";
 import SdkConfig from "../../../src/SdkConfig";
 import { getMockClientWithEventEmitter } from "../../test-utils";
 
@@ -392,8 +393,8 @@ describe("Permalinks", function () {
     });
 
     it("should use permalink_prefix for permalinks", function () {
-        const sdkConfigGet = SdkConfig.get
-        jest.spyOn(SdkConfig, "get").mockImplementation((key: string, altCaseName?: string) => {
+        const sdkConfigGet = SdkConfig.get;
+        jest.spyOn(SdkConfig, "get").mockImplementation((key: keyof IConfigOptions, altCaseName?: string) => {
             if (key === "permalink_prefix") {
                 return "https://element.fs.tld";
             } else return sdkConfigGet(key, altCaseName);

--- a/test/utils/permalinks/Permalinks-test.ts
+++ b/test/utils/permalinks/Permalinks-test.ts
@@ -24,6 +24,7 @@ import {
     parsePermalink,
     RoomPermalinkCreator,
 } from "../../../src/utils/permalinks/Permalinks";
+import SdkConfig from "../../../src/SdkConfig";
 import { getMockClientWithEventEmitter } from "../../test-utils";
 
 describe("Permalinks", function () {
@@ -388,6 +389,17 @@ describe("Permalinks", function () {
     it("should generate a user permalink", function () {
         const result = makeUserPermalink("@someone:example.org");
         expect(result).toBe("https://matrix.to/#/@someone:example.org");
+    });
+
+    it("should use permalink_prefix for permalinks", function () {
+        const sdkConfigGet = SdkConfig.get
+        jest.spyOn(SdkConfig, "get").mockImplementation((key: string, altCaseName?: string) => {
+            if (key === "permalink_prefix") {
+                return "https://element.fs.tld";
+            } else return sdkConfigGet(key, altCaseName);
+        });
+        const result = makeUserPermalink("@someone:example.org");
+        expect(result).toBe("https://element.fs.tld/#/user/@someone:example.org");
     });
 
     describe("parsePermalink", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [X] Tests written for new code (and old code if feasible)
-   [X] Linter and other CI checks pass
-   [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

fixes vector-im/element-web/issues/26002

During serialization of messages, pills were wrongfully serialized to a URL
starting with `permalink_prefix`. This is against the Spec (which mandates
https://matrix.to/#/ links) and the resulting pills were not recognized as
pills in other clients.

Spec-Appendix concerning matrix.to links: https://spec.matrix.org/v1.8/appendices/#matrixto-navigation

Signed-off-by: Lars Wickel <git@herkulessi.de>
<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->