### PR TITLE
Always use cypress-multi-reporters XML report, not just in CI

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -174,7 +174,6 @@ jobs:
                   record: true
                   parallel: true
                   command: "yarn percy exec --parallel -- npx cypress-cloud run"
-                  config: '{"reporter":"cypress-multi-reporters", "reporterOptions": { "configFile": "cypress-ci-reporter-config.json" } }'
                   ci-build-id: ${{ needs.prepare.outputs.uuid }}
               env:
                   # pass the Dashboard record key as an environment variable

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -45,4 +45,10 @@ export default defineConfig({
     // disable logging of HTTP requests made to the Cypress server. They are noisy and not very helpful.
     // @ts-ignore https://github.com/cypress-io/cypress/issues/26284
     morgan: false,
+
+    // Create XML result files
+    reporter: "cypress-multi-reporters",
+    reporterOptions: {
+        configFile: "cypress-ci-reporter-config.json",
+    },
 });


### PR DESCRIPTION
This seems harmless or even useful because it just means we create an XML report of the test results whenever we run Cypress.

I am hoping that it also fixes a problem we have at the moment, where the XML report is not getting created when we run the Cypress tests in CI: https://github.com/vector-im/element-web/issues/26348

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->