### PR TITLE
Add data attribute to know what header is used

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2103,7 +2103,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 // Assume preview loading if we don't have a ready client or a room ID (still resolving the alias)
                 const previewLoading = !this.state.matrixClientIsReady || !this.state.roomId || this.state.peekLoading;
                 return (
-                    <div className="mx_RoomView">
+                    <div
+                        className="mx_RoomView"
+                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                    >
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 canPreview={false}
@@ -2128,7 +2131,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 // We've got to this room by following a link, possibly a third party invite.
                 const roomAlias = this.state.roomAlias;
                 return (
-                    <div className="mx_RoomView">
+                    <div
+                        className="mx_RoomView"
+                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                    >
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 onJoinClick={this.onJoinButtonClicked}
@@ -2201,7 +2207,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
                 // We have a regular invite for this room.
                 return (
-                    <div className="mx_RoomView">
+                    <div
+                        className="mx_RoomView"
+                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                    >
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 onJoinClick={this.onJoinButtonClicked}
@@ -2222,7 +2231,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         if (this.state.canAskToJoin && ["knock", "leave"].includes(myMembership)) {
             return (
-                <div className="mx_RoomView">
+                <div
+                    className="mx_RoomView"
+                    data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                >
                     <ErrorBoundary>
                         <RoomPreviewBar
                             room={this.state.room}
@@ -2326,7 +2338,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 />
             );
             if (!this.state.canPeek && !this.state.room?.isSpaceRoom()) {
-                return <div className="mx_RoomView">{previewBar}</div>;
+                return (
+                    <div
+                        className="mx_RoomView"
+                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                    >
+                        {previewBar}
+                    </div>
+                );
             }
         } else if (hiddenHighlightCount > 0) {
             aux = (
@@ -2571,7 +2590,12 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         return (
             <RoomContext.Provider value={this.state}>
-                <main className={mainClasses} ref={this.roomView} onKeyDown={this.onReactKeyDown}>
+                <main
+                    className={mainClasses}
+                    ref={this.roomView}
+                    onKeyDown={this.onReactKeyDown}
+                    data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                >
                     {showChatEffects && this.roomView.current && (
                         <EffectsOverlay roomWidth={this.roomView.current.offsetWidth} />
                     )}

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2097,16 +2097,15 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             }
         }
 
+        const roomHeaderType = SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy";
+
         if (!this.state.room) {
             const loading = !this.state.matrixClientIsReady || this.state.roomLoading || this.state.peekLoading;
             if (loading) {
                 // Assume preview loading if we don't have a ready client or a room ID (still resolving the alias)
                 const previewLoading = !this.state.matrixClientIsReady || !this.state.roomId || this.state.peekLoading;
                 return (
-                    <div
-                        className="mx_RoomView"
-                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
-                    >
+                    <div className="mx_RoomView" data-room-header={roomHeaderType}>
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 canPreview={false}
@@ -2131,10 +2130,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 // We've got to this room by following a link, possibly a third party invite.
                 const roomAlias = this.state.roomAlias;
                 return (
-                    <div
-                        className="mx_RoomView"
-                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
-                    >
+                    <div className="mx_RoomView" data-room-header={roomHeaderType}>
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 onJoinClick={this.onJoinButtonClicked}
@@ -2207,10 +2203,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
                 // We have a regular invite for this room.
                 return (
-                    <div
-                        className="mx_RoomView"
-                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
-                    >
+                    <div className="mx_RoomView" data-room-header={roomHeaderType}>
                         <ErrorBoundary>
                             <RoomPreviewBar
                                 onJoinClick={this.onJoinButtonClicked}
@@ -2231,10 +2224,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         if (this.state.canAskToJoin && ["knock", "leave"].includes(myMembership)) {
             return (
-                <div
-                    className="mx_RoomView"
-                    data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
-                >
+                <div className="mx_RoomView" data-room-header={roomHeaderType}>
                     <ErrorBoundary>
                         <RoomPreviewBar
                             room={this.state.room}
@@ -2339,10 +2329,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             );
             if (!this.state.canPeek && !this.state.room?.isSpaceRoom()) {
                 return (
-                    <div
-                        className="mx_RoomView"
-                        data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
-                    >
+                    <div className="mx_RoomView" data-room-header={roomHeaderType}>
                         {previewBar}
                     </div>
                 );
@@ -2594,7 +2581,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                     className={mainClasses}
                     ref={this.roomView}
                     onKeyDown={this.onReactKeyDown}
-                    data-room-header={SettingsStore.getValue("feature_new_room_decoration_ui") ? "new" : "legacy"}
+                    data-room-header={roomHeaderType}
                 >
                     {showChatEffects && this.roomView.current && (
                         <EffectsOverlay roomWidth={this.roomView.current.offsetWidth} />

--- a/test/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -736,6 +736,7 @@ exports[`RoomView should show error view if failed to look up room alias 1`] = `
 <DocumentFragment>
   <div
     class="mx_RoomView"
+    data-room-header="legacy"
   >
     <div
       class="mx_RoomPreviewBar dark-panel mx_RoomPreviewBar_RoomNotFound mx_RoomPreviewBar_dialog"


### PR DESCRIPTION
Related to https://github.com/vector-im/element-desktop/issues/1245
To review alongside with https://github.com/vector-im/element-desktop/pull/1272

Asking for a test exemption here. This is very temporary and only needed during the transition period.

Used to implement the negative space in electron.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->