### PR TITLE
Disable spotlight unknown people test

### DIFF
--- a/cypress/e2e/spotlight/spotlight.spec.ts
+++ b/cypress/e2e/spotlight/spotlight.spec.ts
@@ -346,7 +346,14 @@ describe("Spotlight", () => {
             });
     });
 
-    it("should find unknown people", () => {
+    /**
+     * Search sends the correct query to Synapse.
+     * Synapse doesn't return the user in the result list.
+     * Waiting for the profile to be available via APIs before the tests didn't help.
+     *
+     * https://github.com/matrix-org/synapse/issues/16472
+     */
+    it.skip("should find unknown people", () => {
         cy.openSpotlightDialog()
             .within(() => {
                 cy.wait(500); // Wait for dialog to settle


### PR DESCRIPTION
Relates to https://github.com/vector-im/element-web/issues/26138

This is probably a Synapse issue:
https://github.com/matrix-org/synapse/issues/16472 

aiting for the profile to be available via API before the tests didn't help.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->