### PR TITLE
Increase the timeout for the bot to enter the room

### DIFF
--- a/cypress/e2e/read-receipts/read-receipts-utils.ts
+++ b/cypress/e2e/read-receipts/read-receipts-utils.ts
@@ -66,12 +66,12 @@ export class ReadReceiptSetup {
                 cy.inviteUser(this.alphaRoomId, this.bot.getUserId());
                 cy.viewRoomById(this.alphaRoomId);
                 cy.get(".mx_LegacyRoomHeader").within(() => cy.findByTitle(roomAlpha).should("exist"));
-                cy.findByText(botName + " joined the room").should("exist");
+                cy.findByText(botName + " joined the room", { timeout: 20000 }).should("exist");
 
                 cy.inviteUser(this.betaRoomId, this.bot.getUserId());
                 cy.viewRoomById(this.betaRoomId);
                 cy.get(".mx_LegacyRoomHeader").within(() => cy.findByTitle(roomBeta).should("exist"));
-                cy.findByText(botName + " joined the room").should("exist");
+                cy.findByText(botName + " joined the room", { timeout: 20000 }).should("exist");
             });
     }
 }


### PR DESCRIPTION
in an attempt to fix flakes like:

* https://github.com/vector-im/element-web/issues/26298
* https://github.com/vector-im/element-web/issues/26341

which appear to fail when using Rust crypto, possibly because the client takes a while to start up.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->