### PR TITLE
Disable upgraderoom command without developer mode enabled

### DIFF
--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -149,7 +149,7 @@ export const Commands = [
         command: "upgraderoom",
         args: "<new_version>",
         description: _td("slash_command|upgraderoom"),
-        isEnabled: (cli) => !isCurrentLocalRoom(cli),
+        isEnabled: (cli) => !isCurrentLocalRoom(cli) && SettingsStore.getValue("developerMode"),
         runFn: function (cli, roomId, threadId, args) {
             if (args) {
                 const room = cli.getRoom(roomId);

--- a/test/SlashCommands-test.tsx
+++ b/test/SlashCommands-test.tsx
@@ -28,6 +28,7 @@ import WidgetUtils from "../src/utils/WidgetUtils";
 import { WidgetType } from "../src/widgets/WidgetType";
 import { warnSelfDemote } from "../src/components/views/right_panel/UserInfo";
 import dispatcher from "../src/dispatcher/dispatcher";
+import { SettingLevel } from "../src/settings/SettingLevel";
 
 jest.mock("../src/components/views/right_panel/UserInfo");
 
@@ -88,7 +89,6 @@ describe("SlashCommands", () => {
     });
 
     describe.each([
-        ["upgraderoom"],
         ["myroomnick"],
         ["roomavatar"],
         ["myroomavatar"],
@@ -123,6 +123,22 @@ describe("SlashCommands", () => {
                 setCurrentLocalRoom();
                 expect(command.isEnabled(client)).toBe(false);
             });
+        });
+    });
+
+    describe("/upgraderoom", () => {
+        beforeEach(() => {
+            command = findCommand("upgraderoom")!;
+            setCurrentRoom();
+        });
+
+        it("should be disabled by default", () => {
+            expect(command.isEnabled(client)).toBe(false);
+        });
+
+        it("should be enabled for developerMode", () => {
+            SettingsStore.setValue("developerMode", null, SettingLevel.DEVICE, true);
+            expect(command.isEnabled(client)).toBe(true);
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17620

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Disable upgraderoom command without developer mode enabled ([\#11744](https://github.com/matrix-org/matrix-react-sdk/pull/11744)). Fixes vector-im/element-web#17620.<!-- CHANGELOG_PREVIEW_END -->