### PR TITLE
Update Element Call URL generation to match new parameter semantics

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -642,9 +642,10 @@ export class ElementCall extends Call {
 
         // Splice together the Element Call URL for this call
         const params = new URLSearchParams({
-            embed: "",
-            preload: "",
-            hideHeader: "",
+            embed: "true", // We're embedding EC within another application
+            preload: "true", // We want it to load in the background
+            skipLobby: "true", // Skip the lobby since we show a lobby component of our own
+            hideHeader: "true", // Hide the header since our room header is enough
             userId: client.getUserId()!,
             deviceId: client.getDeviceId()!,
             roomId: groupCall.room.roomId,


### PR DESCRIPTION
The semantics of the `preload` parameter are changing as detailed here, meaning we now have to additionally specify `skipLobby` to get the desired behavior out of Element Call: https://github.com/vector-im/element-call/pull/1730

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->