### PR TITLE
Make invitation dialog scrollable when infos are too long

### DIFF
--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -193,7 +193,7 @@ limitations under the License.
     flex-direction: column;
     height: 600px;
     overflow: hidden;
-    
+
     h2 {
         display: -webkit-box;
         -webkit-line-clamp: 2;

--- a/res/css/views/dialogs/_InviteDialog.pcss
+++ b/res/css/views/dialogs/_InviteDialog.pcss
@@ -193,6 +193,14 @@ limitations under the License.
     flex-direction: column;
     height: 600px;
     overflow: hidden;
+    
+    h2 {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        white-space: pre-wrap;
+        overflow: hidden;
+    }
 
     .mx_InviteDialog_addressBar {
         margin-inline-end: 0;

--- a/res/css/views/rooms/_RoomPreviewBar.pcss
+++ b/res/css/views/rooms/_RoomPreviewBar.pcss
@@ -140,6 +140,11 @@ limitations under the License.
         }
     }
 }
+.mx_RoomPreviewBar_Invite {
+    max-height: 100vh;
+    overflow-y: auto;
+    justify-content: flex-start;
+}
 
 .mx_RoomPreviewBar_inviter {
     font-weight: var(--cpd-font-weight-semibold);

--- a/res/css/views/rooms/_RoomPreviewBar.pcss
+++ b/res/css/views/rooms/_RoomPreviewBar.pcss
@@ -146,6 +146,14 @@ limitations under the License.
     justify-content: flex-start;
 }
 
+.mx_RoomPreviewBar_Invite h3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    white-space: pre-wrap;
+    overflow: hidden;
+}
+
 .mx_RoomPreviewBar_inviter {
     font-weight: var(--cpd-font-weight-semibold);
 }


### PR DESCRIPTION
when the room name is too long or there is a meeting series, with all the information provided in the invitation dialog. the dialog gets too big and not functionable, since the actions buttons are hidden. 
therefore we added more styling to the invitation dialog so it would be scrollable.

screenshots:
before:
![Screenshot 2023-10-16 at 12 46 07](https://github.com/matrix-org/matrix-react-sdk/assets/34133773/7f69d11a-9dac-4da0-a3ff-239cba3bad82)

after:
![Screenshot 2023-10-16 at 12 47 21](https://github.com/matrix-org/matrix-react-sdk/assets/34133773/7ce163c5-403b-4818-98e3-82a5e69cec33)

![Screenshot 2023-10-16 at 12 47 39](https://github.com/matrix-org/matrix-react-sdk/assets/34133773/4bcae5e4-3305-467d-ad81-a99a777e0991)

note: this should not change the behaviour of how a normal envitation will look like this even after the changes:
![Screenshot 2023-10-16 at 13 29 40](https://github.com/matrix-org/matrix-react-sdk/assets/34133773/126af3f4-29eb-4de8-9687-28f2227048a3)



## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: enhancement

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make invitation dialog scrollable when infos are too long ([\#11753](https://github.com/matrix-org/matrix-react-sdk/pull/11753)). Contributed by @nurjinjafar.<!-- CHANGELOG_PREVIEW_END -->