### PR TITLE
Invite dialog: display MXID on its own line

### DIFF
--- a/res/css/views/rooms/_RoomPreviewBar.pcss
+++ b/res/css/views/rooms/_RoomPreviewBar.pcss
@@ -163,6 +163,10 @@ a.mx_RoomPreviewBar_inviter {
     cursor: pointer;
 }
 
+.mx_RoomPreviewBar_inviter_mxid {
+    color: var(--cpd-color-text-secondary);
+}
+
 .mx_RoomPreviewBar_icon {
     margin-right: 8px;
     vertical-align: text-top;

--- a/src/components/views/rooms/RoomPreviewBar.tsx
+++ b/src/components/views/rooms/RoomPreviewBar.tsx
@@ -510,19 +510,16 @@ export default class RoomPreviewBar extends React.Component<IProps, IState> {
                 const avatar = <RoomAvatar room={this.props.room} oobData={this.props.oobData} />;
 
                 const inviteMember = this.getInviteMember();
+                const userName = (
+                    <span className="mx_RoomPreviewBar_inviter">
+                        {inviteMember?.rawDisplayName ?? this.props.inviterName}
+                    </span>
+                );
                 const inviterElement = (
                     <>
-                        {_t(
-                            isDM ? "room|dm_invite_subtitle" : "room|invite_subtitle",
-                            {},
-                            {
-                                userName: () => (
-                                    <span className="mx_RoomPreviewBar_inviter">
-                                        {inviteMember?.rawDisplayName ?? this.props.inviterName}
-                                    </span>
-                                ),
-                            },
-                        )}
+                        {isDM
+                            ? _t("room|dm_invite_subtitle", {}, { userName })
+                            : _t("room|invite_subtitle", {}, { userName })}
                         {inviteMember && (
                             <>
                                 <br />

--- a/src/components/views/rooms/RoomPreviewBar.tsx
+++ b/src/components/views/rooms/RoomPreviewBar.tsx
@@ -506,33 +506,42 @@ export default class RoomPreviewBar extends React.Component<IProps, IState> {
                 break;
             }
             case MessageCase.Invite: {
+                const isDM = this.isDMInvite();
                 const avatar = <RoomAvatar room={this.props.room} oobData={this.props.oobData} />;
 
                 const inviteMember = this.getInviteMember();
-                let inviterElement: JSX.Element;
-                if (inviteMember) {
-                    inviterElement = (
-                        <span>
-                            <span className="mx_RoomPreviewBar_inviter">{inviteMember.rawDisplayName}</span> (
-                            {inviteMember.userId})
-                        </span>
-                    );
-                } else {
-                    inviterElement = <span className="mx_RoomPreviewBar_inviter">{this.props.inviterName}</span>;
-                }
+                const inviterElement = (
+                    <>
+                        {_t(
+                            isDM ? "room|dm_invite_subtitle" : "room|invite_subtitle",
+                            {},
+                            {
+                                userName: () => (
+                                    <span className="mx_RoomPreviewBar_inviter">
+                                        {inviteMember?.rawDisplayName ?? this.props.inviterName}
+                                    </span>
+                                ),
+                            },
+                        )}
+                        {inviteMember && (
+                            <>
+                                <br />
+                                <span className="mx_RoomPreviewBar_inviter_mxid">{inviteMember.userId}</span>
+                            </>
+                        )}
+                    </>
+                );
 
-                const isDM = this.isDMInvite();
                 if (isDM) {
                     title = _t("room|dm_invite_title", {
                         user: inviteMember?.name ?? this.props.inviterName,
                     });
-                    subTitle = [avatar, _t("room|dm_invite_subtitle", {}, { userName: () => inviterElement })];
                     primaryActionLabel = _t("room|dm_invite_action");
                 } else {
                     title = _t("room|invite_title", { roomName });
-                    subTitle = [avatar, _t("room|invite_subtitle", {}, { userName: () => inviterElement })];
                     primaryActionLabel = _t("action|accept");
                 }
+                subTitle = [avatar, inviterElement];
 
                 const myUserId = MatrixClientPeg.safeGet().getSafeUserId();
                 const member = this.props.room?.currentState.getMember(myUserId);

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1991,7 +1991,7 @@
         "invite_reject_ignore": "Reject & Ignore user",
         "invite_sent_to_email": "This invite was sent to %(email)s",
         "invite_sent_to_email_room": "This invite to %(roomName)s was sent to %(email)s",
-        "invite_subtitle": "<userName/> invited you",
+        "invite_subtitle": "Invited by <userName/>",
         "invite_this_room": "Invite to this room",
         "invite_title": "Do you want to join %(roomName)s?",
         "inviter_unknown": "Unknown",

--- a/test/components/views/rooms/__snapshots__/RoomPreviewBar-test.tsx.snap
+++ b/test/components/views/rooms/__snapshots__/RoomPreviewBar-test.tsx.snap
@@ -264,12 +264,12 @@ exports[`<RoomPreviewBar /> with an invite with an invited email when client has
   </p>
   <p>
     <span>
+      Invited by 
       <span
         class="mx_RoomPreviewBar_inviter"
       >
         @inviter:test.com
       </span>
-       invited you
     </span>
   </p>
 </div>
@@ -322,17 +322,18 @@ exports[`<RoomPreviewBar /> with an invite without an invited email for a dm roo
   </p>
   <p>
     <span>
-      <span>
-        <span
-          class="mx_RoomPreviewBar_inviter"
-        >
-          @inviter:test.com name
-        </span>
-         (
-        @inviter:test.com
-        )
+      <span
+        class="mx_RoomPreviewBar_inviter"
+      >
+        @inviter:test.com name
       </span>
        wants to chat
+    </span>
+    <br />
+    <span
+      class="mx_RoomPreviewBar_inviter_mxid"
+    >
+      @inviter:test.com
     </span>
   </p>
 </div>
@@ -387,17 +388,18 @@ exports[`<RoomPreviewBar /> with an invite without an invited email for a non-dm
   </p>
   <p>
     <span>
-      <span>
-        <span
-          class="mx_RoomPreviewBar_inviter"
-        >
-          @inviter:test.com name
-        </span>
-         (
-        @inviter:test.com
-        )
+      Invited by 
+      <span
+        class="mx_RoomPreviewBar_inviter"
+      >
+        @inviter:test.com name
       </span>
-       invited you
+    </span>
+    <br />
+    <span
+      class="mx_RoomPreviewBar_inviter_mxid"
+    >
+      @inviter:test.com
     </span>
   </p>
 </div>


### PR DESCRIPTION
The reason for doing this is to make the invite dialog more readable when the inviter's MXID is very long, which tends to be the case when the inviter is a bridged user with a machine-generated MXID.

## Screenshots

### DM invite

#### Before
![image](https://github.com/matrix-org/matrix-react-sdk/assets/3271094/d575222b-1763-4a22-824d-cbf43e302414)

#### After
![image](https://github.com/matrix-org/matrix-react-sdk/assets/3271094/376ee464-cca0-4598-845a-d29059322a0f)

### Room invite

#### Before
![image](https://github.com/matrix-org/matrix-react-sdk/assets/3271094/f93fe566-3061-4610-bb5e-61bd96eaa9ed)

#### After
![image](https://github.com/matrix-org/matrix-react-sdk/assets/3271094/2b9b7552-8cfd-4497-9c4f-356451d884af)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Invite dialog: display MXID on its own line ([\#11756](https://github.com/matrix-org/matrix-react-sdk/pull/11756)). Contributed by @AndrewFerr.<!-- CHANGELOG_PREVIEW_END -->