### PR TITLE
Avoid `MatrixEvent.toJSON` in event indexer

### DIFF
--- a/src/indexing/EventIndex.ts
+++ b/src/indexing/EventIndex.ts
@@ -309,8 +309,7 @@ export default class EventIndex extends EventEmitter {
     }
 
     private eventToJson(ev: MatrixEvent): IEventWithRoomId {
-        const jsonEvent: any = ev.toJSON();
-        const e = ev.isEncrypted() ? jsonEvent.decrypted : jsonEvent;
+        const e = ev.getEffectiveEvent() as any;
 
         if (ev.isEncrypted()) {
             // Let us store some additional data so we can re-verify the event.


### PR DESCRIPTION
Part of the solution to https://github.com/vector-im/element-web/issues/26380:
`toJSON` is dangerous, and I'd like to kill it off. There is no need for it
here; it is simpler to call `getEffectiveEvent` directly.