### PR TITLE
Add option to persist security key on platform

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -339,6 +339,33 @@ export default abstract class BasePlatform {
     }
 
     /**
+     * Get a previously stored generic secret.
+     * @param {string} key a unique identifier for this secret.
+     * @returns {string|null} the previously stored secret, or null if no such secret has been stored.
+     */
+    public async getPlatformSecret(key: string): Promise<string | null> {
+        return null;
+    }
+
+    /**
+     * Store a generic secret.
+     * @param {string} key a unique identifier for this secret.
+     * @param {string} value the secret to be stored.
+     * @returns {string|null} the stored secret, or null is could not be stored.
+     */
+    public async savePlatformSecret(key: string, value: string): Promise<string | null> {
+        return null;
+    }
+
+    /**
+     * Delete a generic secret from storage.
+     * @param {string} key a unique identifier for this secret.
+     */
+    public async destroyPlatformSecret(key: string): Promise<void> {
+        return;
+    }
+
+    /**
      * Get a previously stored pickle key.  The pickle key is used for
      * encrypting libolm objects.
      * @param {string} userId the user ID for the user that the pickle key is for.

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1431,6 +1431,7 @@
         "notifications": "Enable the notifications panel in the room header",
         "oidc_native_flow": "OIDC native authentication",
         "oidc_native_flow_description": "⚠ WARNING: Experimental. Use OIDC native authentication when supported by the server.",
+        "persist_ssss_key": "Save SSSS key on platform-dependent keychain",
         "pinning": "Message Pinning",
         "render_reaction_images": "Render custom images in reactions",
         "render_reaction_images_description": "Sometimes referred to as \"custom emojis\".",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1161,4 +1161,11 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         displayName: _td("settings|preferences|enable_hardware_acceleration"),
         default: true,
     },
+    "feature_persist_ssss_key": {
+        isFeature: true,
+        labsGroup: LabGroup.Encryption,
+        displayName: _td("labs|persist_ssss_key"),
+        supportedLevels: LEVELS_FEATURE,
+        default: false,
+    },
 };

--- a/src/utils/KeyPersistenceUtils.ts
+++ b/src/utils/KeyPersistenceUtils.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2019, 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "matrix-js-sdk/src/logger";
+import { SecretStorageKeyDescription } from "matrix-js-sdk/src/secret-storage";
+import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
+
+import { MatrixClientPeg } from "../MatrixClientPeg";
+import PlatformPeg from "../PlatformPeg";
+
+function platformSSSSKeyIdentifier(keyId: string): string {
+    const cli = MatrixClientPeg.safeGet();
+    return `${cli.getUserId()}|ssss|${keyId}`;
+}
+
+export async function storeSSSSKeyAsPlatformSecret(keyId: string, encodedPrivateKey: string): Promise<boolean> {
+    const identifier = platformSSSSKeyIdentifier(keyId);
+    const result = await PlatformPeg.get()?.savePlatformSecret(identifier, encodedPrivateKey);
+    if (result === encodedPrivateKey) {
+        logger.info(`PlatformSecret: persisted key ${identifier}`);
+        return true;
+    } else {
+        logger.warn(`PlatformSecret: Failed to persist key ${identifier}`);
+        return false;
+    }
+}
+
+export async function getSSSSKeyFromPlatformSecret(
+    keyId: string,
+    keyInfo: SecretStorageKeyDescription,
+): Promise<Uint8Array | null> {
+    const identifier = platformSSSSKeyIdentifier(keyId);
+    try {
+        logger.info(`PlatformSecret: fetching SSSS key ${identifier}`);
+        const cli = MatrixClientPeg.safeGet();
+        const encodedKey = await PlatformPeg.get()?.getPlatformSecret(platformSSSSKeyIdentifier(keyId));
+        if (encodedKey) {
+            const key = decodeRecoveryKey(encodedKey);
+            if (await cli.secretStorage.checkKey(key, keyInfo)) {
+                logger.info(`PlatformSecret: SSSS key ${identifier} is valid`);
+                return key;
+            } else {
+                logger.warn(`PlatformSecret: SSSS key ${identifier} is invalid`);
+            }
+        } else {
+            logger.info(`PlatformSecret: No such SSSS key: ${identifier}`);
+        }
+    } catch (e) {
+        logger.warn("PlatformSecret: Failed fetch key", e);
+    }
+    return null;
+}

--- a/test/components/views/dialogs/security/__snapshots__/CreateSecretStorageDialog-test.tsx.snap
+++ b/test/components/views/dialogs/security/__snapshots__/CreateSecretStorageDialog-test.tsx.snap
@@ -493,6 +493,457 @@ exports[`CreateSecretStorageDialog when canUploadKeysWithPasswordOnly when there
 </div>
 `;
 
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should finish successfully without user interaction 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog mx_SuccessDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Icon mx_Icon_circle-40 mx_Icon_accent mx_Icon_bg-accent-light"
+    />
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        Secure Backup successful
+      </h2>
+    </div>
+    <div>
+      <p
+        class="mx_Dialog_content"
+      >
+        Your keys are now being backed up from this device.
+      </p>
+      <div
+        class="mx_Dialog_buttons"
+      >
+        <span
+          class="mx_Dialog_buttons_row"
+        >
+          <button
+            class="mx_Dialog_primary"
+            data-testid="dialog-primary-button"
+            type="button"
+          >
+            Done
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should go back to start when crypto is not available 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title mx_CreateSecretStorageDialog_centeredTitle"
+        id="mx_BaseDialog_title"
+      >
+        Set up Secure Backup
+      </h2>
+    </div>
+    <div>
+      <div>
+        <p>
+          Unable to set up secret storage
+        </p>
+        <div
+          class="mx_Dialog_buttons"
+        >
+          <div
+            class="mx_Dialog_buttons"
+          >
+            <span
+              class="mx_Dialog_buttons_row"
+            >
+              <button
+                data-testid="dialog-cancel-button"
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                class="mx_Dialog_primary"
+                data-testid="dialog-primary-button"
+                type="button"
+              >
+                Retry
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should persist the secret strorage key 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog mx_SuccessDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Icon mx_Icon_circle-40 mx_Icon_accent mx_Icon_bg-accent-light"
+    />
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        Secure Backup successful
+      </h2>
+    </div>
+    <div>
+      <p
+        class="mx_Dialog_content"
+      >
+        Your keys are now being backed up from this device.
+      </p>
+      <div
+        class="mx_Dialog_buttons"
+      >
+        <span
+          class="mx_Dialog_buttons_row"
+        >
+          <button
+            class="mx_Dialog_primary"
+            data-testid="dialog-primary-button"
+            type="button"
+          >
+            Done
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should show generated key when default key does not match generated key 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title mx_CreateSecretStorageDialog_titleWithIcon mx_CreateSecretStorageDialog_secureBackupTitle"
+        id="mx_BaseDialog_title"
+      >
+        Save your Security Key
+      </h2>
+    </div>
+    <div>
+      <div>
+        <p>
+          Store your Security Key somewhere safe, like a password manager or a safe, as it's used to safeguard your encrypted data.
+        </p>
+        <div
+          class="mx_CreateSecretStorageDialog_primaryContainer mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer"
+        >
+          <div
+            class="mx_CreateSecretStorageDialog_recoveryKeyContainer"
+          >
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKey"
+            >
+              <code>
+                encoded test key
+              </code>
+            </div>
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKeyButtons"
+            >
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Download
+              </div>
+              <span>
+                 or 
+              </span>
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Copy
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mx_Dialog_buttons"
+        >
+          <span
+            class="mx_Dialog_buttons_row"
+          >
+            <button
+              class="mx_Dialog_primary"
+              data-testid="dialog-primary-button"
+              disabled=""
+              type="button"
+            >
+              Continue
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should show generated key when it cannot be stored 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title mx_CreateSecretStorageDialog_titleWithIcon mx_CreateSecretStorageDialog_secureBackupTitle"
+        id="mx_BaseDialog_title"
+      >
+        Save your Security Key
+      </h2>
+    </div>
+    <div>
+      <div>
+        <p>
+          Store your Security Key somewhere safe, like a password manager or a safe, as it's used to safeguard your encrypted data.
+        </p>
+        <div
+          class="mx_CreateSecretStorageDialog_primaryContainer mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer"
+        >
+          <div
+            class="mx_CreateSecretStorageDialog_recoveryKeyContainer"
+          >
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKey"
+            >
+              <code>
+                encoded test key
+              </code>
+            </div>
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKeyButtons"
+            >
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Download
+              </div>
+              <span>
+                 or 
+              </span>
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Copy
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mx_Dialog_buttons"
+        >
+          <span
+            class="mx_Dialog_buttons_row"
+          >
+            <button
+              class="mx_Dialog_primary"
+              data-testid="dialog-primary-button"
+              disabled=""
+              type="button"
+            >
+              Continue
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`CreateSecretStorageDialog when persist ssss key feature is enabled should show generated key when no default key is found 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_CreateSecretStorageDialog"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h2
+        class="mx_Heading_h3 mx_Dialog_title mx_CreateSecretStorageDialog_titleWithIcon mx_CreateSecretStorageDialog_secureBackupTitle"
+        id="mx_BaseDialog_title"
+      >
+        Save your Security Key
+      </h2>
+    </div>
+    <div>
+      <div>
+        <p>
+          Store your Security Key somewhere safe, like a password manager or a safe, as it's used to safeguard your encrypted data.
+        </p>
+        <div
+          class="mx_CreateSecretStorageDialog_primaryContainer mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer"
+        >
+          <div
+            class="mx_CreateSecretStorageDialog_recoveryKeyContainer"
+          >
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKey"
+            >
+              <code>
+                encoded test key
+              </code>
+            </div>
+            <div
+              class="mx_CreateSecretStorageDialog_recoveryKeyButtons"
+            >
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Download
+              </div>
+              <span>
+                 or 
+              </span>
+              <div
+                class="mx_AccessibleButton mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+                role="button"
+                tabindex="0"
+              >
+                Copy
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mx_Dialog_buttons"
+        >
+          <span
+            class="mx_Dialog_buttons_row"
+          >
+            <button
+              class="mx_Dialog_primary"
+              data-testid="dialog-primary-button"
+              disabled=""
+              type="button"
+            >
+              Continue
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
+`;
+
 exports[`CreateSecretStorageDialog when there is an error fetching the backup version shows an error 1`] = `
 <div>
   <div

--- a/test/utils/KeyPersistenceUtils-test.ts
+++ b/test/utils/KeyPersistenceUtils-test.ts
@@ -1,0 +1,169 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Mocked } from "jest-mock";
+import { GeneratedSecretStorageKey } from "matrix-js-sdk/src/crypto-api";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
+import { SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorageKeyDescription } from "matrix-js-sdk/src/secret-storage";
+
+import { MatrixClientPeg } from "../../src/MatrixClientPeg";
+import { getMockClientWithEventEmitter, mockPlatformPeg } from "../test-utils";
+import BasePlatform from "../../src/BasePlatform";
+import { getSSSSKeyFromPlatformSecret, storeSSSSKeyAsPlatformSecret } from "../../src/utils/KeyPersistenceUtils";
+
+describe("KeyPersistenceUtils", () => {
+    let mockClient: Mocked<MatrixClient>;
+    let mockPlatform: Mocked<BasePlatform>;
+
+    const aliceId = "@alice:server";
+
+    const fixtureKey: GeneratedSecretStorageKey = {
+        keyInfo: {
+            pubkey: "0bCJCAw2aO6aWjAW5DtWRaW28UWkqRLImcJxYS9ecVs",
+        },
+        encodedPrivateKey: "EsUB qAtc mFej v9sV NMTe ywCK NF7Y FfqA 6oa4 QXnA j3pK TvTE",
+        privateKey: new Uint8Array([
+            231, 199, 233, 255, 28, 12, 57, 168, 125, 66, 68, 80, 55, 134, 84, 196, 59, 217, 223, 40, 152, 139, 87, 158,
+            74, 89, 127, 171, 158, 208, 46, 42,
+        ]),
+    };
+    const fixtureKeyInfo = {
+        algorithm: SECRET_STORAGE_ALGORITHM_V1_AES,
+        iv: "5aXcYBI82fhueAGN51b0xA==",
+        mac: "AJfZkV0zMqI8G4TbQmGLeVRU9bxLBzOcAc/9wBUmOdI=",
+    } as SecretStorageKeyDescription;
+    const fixtureKeyId = "7u94zhoLfRKa3j0ePyvDOMAAq8hRTcJy";
+
+    beforeEach(async () => {
+        mockPlatform = mockPlatformPeg();
+        mockClient = getMockClientWithEventEmitter({
+            getUserId: jest.fn().mockReturnValue(aliceId),
+            secretStorage: {
+                checkKey: jest.fn(),
+                getKey: jest.fn(),
+            },
+        });
+        jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
+        jest.spyOn(MatrixClientPeg, "safeGet").mockReturnValue(mockClient);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("storeSSSSKeyAsPlatformSecret", () => {
+        let savePlatformSecretSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            savePlatformSecretSpy = jest.spyOn(mockPlatform, "savePlatformSecret");
+        });
+
+        it("should send the key to the platform", async () => {
+            await storeSSSSKeyAsPlatformSecret(fixtureKeyId, fixtureKey.encodedPrivateKey!);
+
+            expect(savePlatformSecretSpy).toHaveBeenCalled();
+            expect(savePlatformSecretSpy.mock.lastCall![0]).toContain(fixtureKeyId);
+            expect(savePlatformSecretSpy.mock.lastCall![1]).toBe(fixtureKey.encodedPrivateKey);
+        });
+
+        it("should return true when the key is saved correctly", async () => {
+            savePlatformSecretSpy.mockResolvedValue(fixtureKey.encodedPrivateKey!);
+
+            const result = await storeSSSSKeyAsPlatformSecret(fixtureKeyId, fixtureKey.encodedPrivateKey!);
+
+            expect(result).toBe(true);
+        });
+
+        it("should return false when no key can be saved", async () => {
+            savePlatformSecretSpy.mockResolvedValue(null);
+
+            const result = await storeSSSSKeyAsPlatformSecret(fixtureKeyId, fixtureKey.encodedPrivateKey!);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false when the key is not saved correctly", async () => {
+            savePlatformSecretSpy.mockResolvedValue(fixtureKey.encodedPrivateKey!.substring(1));
+
+            const result = await storeSSSSKeyAsPlatformSecret(fixtureKeyId, fixtureKey.encodedPrivateKey!);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("getSSSSKeyFromPlatformSecret", () => {
+        let checkKey: typeof mockClient.secretStorage.checkKey;
+        let getPlatformSecretSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            checkKey = mockClient.secretStorage.checkKey;
+            getPlatformSecretSpy = jest.spyOn(mockPlatform, "getPlatformSecret");
+        });
+
+        it("should get the key from the platform", async () => {
+            await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(getPlatformSecretSpy).toHaveBeenCalled();
+            expect(getPlatformSecretSpy.mock.lastCall![0]).toContain(fixtureKeyId);
+        });
+
+        it("should return the key when it is found", async () => {
+            getPlatformSecretSpy.mockResolvedValue(fixtureKey.encodedPrivateKey!);
+            checkKey.mockResolvedValue(true);
+
+            const result = await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(result).toEqual(fixtureKey.privateKey);
+            expect(checkKey).toHaveBeenCalledWith(fixtureKey.privateKey, fixtureKeyInfo);
+        });
+
+        it("should return null when no key is found", async () => {
+            getPlatformSecretSpy.mockResolvedValue(null);
+
+            const result = await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(result).toBe(null);
+        });
+
+        it("should return null when the key cannot be fetched", async () => {
+            getPlatformSecretSpy.mockRejectedValue(null);
+
+            const result = await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(result).toBe(null);
+        });
+
+        it("should return null when a corrupted key is found", async () => {
+            getPlatformSecretSpy.mockResolvedValue(fixtureKey.encodedPrivateKey!);
+            checkKey.mockResolvedValue(true);
+
+            const result = await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(result).toEqual(fixtureKey.privateKey);
+            expect(checkKey).toHaveBeenCalledWith(fixtureKey.privateKey, fixtureKeyInfo);
+        });
+
+        it("should return null when the found key does not match", async () => {
+            getPlatformSecretSpy.mockResolvedValue(fixtureKey.encodedPrivateKey!);
+            checkKey.mockResolvedValue(false);
+
+            const result = await getSSSSKeyFromPlatformSecret(fixtureKeyId, fixtureKeyInfo);
+
+            expect(result).toEqual(null);
+            expect(checkKey).toHaveBeenCalledWith(fixtureKey.privateKey, fixtureKeyInfo);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a `feature_persist_ssss_key` feature flag. When enabled, `element-desktop` tries to save any generated security key in the login keyring, similar to pickle keys. It automatically uses them for unlocking the backup. See also <https://github.com/vector-im/element-web/pull/26405> and <https://github.com/vector-im/element-desktop/pull/1286>.

## Goals

With this PR, we try to work towards user-friendly encryption key backups while preserving e2ee security. In our small/medium non-profit org, many members lack a technical background. Using element as-is without losing keys would be quite a challenge for them.

Since we might not be the only org struggling with secure backup/key management in practice (<https://github.com/vector-im/element-web/issues/20046>), we would like to contribute to Element.

This PR and the whole feature are experimental and we would love to receive comments or feedback.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: none
element-web notes: none
element-desktop notes: Add option to persist security key

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->