### PR TITLE
Enable tests fixed by https://github.com/matrix-org/matrix-js-sdk/pull/3817

### DIFF
--- a/cypress/e2e/read-receipts/editing-messages.spec.ts
+++ b/cypress/e2e/read-receipts/editing-messages.spec.ts
@@ -97,7 +97,6 @@ describe("Read receipts", () => {
 
     describe("editing messages", () => {
         describe("in the main timeline", () => {
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
             it("Editing a message leaves a room read", () => {
                 // Given I am not looking at the room
                 goTo(room1);
@@ -165,8 +164,7 @@ describe("Read receipts", () => {
                 // Then it remains read
                 assertStillRead(room2);
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Editing a reply after marking as read makes the room unread", () => {
+            it("Editing a reply after marking as read makes the room unread", () => {
                 // Given a reply is marked as read
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", replyTo("Msg1", "Reply1")]);
@@ -180,8 +178,7 @@ describe("Read receipts", () => {
                 // Then the room remains read
                 assertStillRead(room2);
             });
-            // https://github.com/vector-im/element-web/issues/26273
-            it.skip("A room with an edit is still read after restart", () => {
+            it("A room with an edit is still read after restart", () => {
                 // Given a message is marked as read
                 goTo(room2);
                 receiveMessages(room2, ["Msg1"]);
@@ -227,8 +224,7 @@ describe("Read receipts", () => {
         });
 
         describe("in threads", () => {
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("An edit of a threaded message makes the room unread", () => {
+            it("An edit of a threaded message makes the room unread", () => {
                 // Given we have read the thread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -247,8 +243,7 @@ describe("Read receipts", () => {
                 goTo(room2);
                 assertReadThread("Msg1");
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Reading an edit of a threaded message makes the room read", () => {
+            it("Reading an edit of a threaded message makes the room read", () => {
                 // Given an edited thread message appears after we read it
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -269,12 +264,12 @@ describe("Read receipts", () => {
                 assertStillRead(room2);
                 assertReadThread("Msg1");
             });
-            // XXX: fails because the room is still "bold" even though the notification counts all disappear
+            // XXX: fails because the unread dot remains after marking as read
             it.skip("Marking a room as read after an edit in a thread makes it read", () => {
                 // Given an edit in a thread is making the room unread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1"), editOf("Resp1", "Edit1")]);
-                assertUnread(room2, 3); // TODO: the edit counts as a message!
+                assertUnread(room2, 2);
 
                 // When I mark the room as read
                 markAsRead(room2);
@@ -312,8 +307,7 @@ describe("Read receipts", () => {
                 // Then is it still unread
                 assertRead(room2);
             });
-            // XXX: fails because it flakes, sometimes having 2 unread messages instead of 1
-            it.skip("A room where all threaded edits are read is still read after restart", () => {
+            it("A room where all threaded edits are read is still read after restart", () => {
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1"), editOf("Resp1", "Edit1")]);
                 assertUnread(room2, 1);
@@ -342,8 +336,7 @@ describe("Read receipts", () => {
         });
 
         describe("thread roots", () => {
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("An edit of a thread root leaves the room read", () => {
+            it("An edit of a thread root leaves the room read", () => {
                 // Given I have read a thread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -385,8 +378,7 @@ describe("Read receipts", () => {
                 goTo(room1);
                 assertStillRead(room2);
             });
-            // XXX: fails because it shows a dot instead of unread count
-            it.skip("Editing a thread root after reading leaves the room read", () => {
+            it("Editing a thread root after reading leaves the room read", () => {
                 // Given a fully-read thread exists
                 goTo(room2);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);
@@ -440,8 +432,7 @@ describe("Read receipts", () => {
                 goTo(room2);
                 assertReadThread("EditedReply");
             });
-            // XXX: fails because the room has an unread dot after I marked it as read
-            it.skip("Marking a room as read after an edit of a thread root that is a reply leaves it read", () => {
+            it("Marking a room as read after an edit of a thread root that is a reply leaves it read", () => {
                 // Given a thread based on a reply exists and the reply has been edited
                 goTo(room1);
                 receiveMessages(room2, ["Msg", replyTo("Msg", "Reply"), threadedOff("Reply", "InThread")]);

--- a/cypress/e2e/read-receipts/high-level.spec.ts
+++ b/cypress/e2e/read-receipts/high-level.spec.ts
@@ -246,8 +246,7 @@ describe("Read receipts", () => {
             assertReadThread("Root2");
             assertReadThread("Root3");
         });
-        // https://github.com/vector-im/element-web/issues/26294
-        it.skip("Paging up to find old threads that were never read keeps the room unread", () => {
+        it("Paging up to find old threads that were never read keeps the room unread", () => {
             // Given lots of messages in threads that are unread
             goTo(room1);
             receiveMessages(room2, [
@@ -284,8 +283,7 @@ describe("Read receipts", () => {
             assertUnreadThread("Root2");
             assertUnreadThread("Root3");
         });
-        // XXX: fails because flakes, sometimes finding 7 unread instead of 6
-        it.skip("Looking in thread view to find old threads that were never read makes the room unread", () => {
+        it("Looking in thread view to find old threads that were never read makes the room unread", () => {
             // Given lots of messages in threads that are unread
             goTo(room1);
             receiveMessages(room2, [

--- a/cypress/e2e/read-receipts/redactions.spec.ts
+++ b/cypress/e2e/read-receipts/redactions.spec.ts
@@ -170,8 +170,7 @@ describe("Read receipts", () => {
                 // Then it becomes read
                 assertRead(room2);
             });
-            // XXX: fails because it flakes with the room unread when it should be read
-            it.skip("Sending and redacting a message after marking the room as read makes it read", () => {
+            it("Sending and redacting a message after marking the room as read makes it read", () => {
                 // Given a room that is marked as read
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", "Msg2"]);
@@ -236,8 +235,7 @@ describe("Read receipts", () => {
                 // Then the unread count is still reduced
                 assertUnread(room2, 1);
             });
-            // XXX: fails because flakes with matrix-js-sdk#3798 (only when all other tests are enabled!)
-            it.skip("Redacting all unread messages makes the room read", () => {
+            it("Redacting all unread messages makes the room read", () => {
                 // Given an unread room
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", "Msg2"]);
@@ -266,8 +264,7 @@ describe("Read receipts", () => {
                 // Then the room is still read
                 assertRead(room2);
             });
-            // Flakes because sometimes the unread count stays at 2
-            it.skip("Reacting to a redacted message leaves the room read", () => {
+            it("Reacting to a redacted message leaves the room read", () => {
                 // Given a redacted message exists
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", "Msg2"]);


### PR DESCRIPTION
I have run all these tests 10 times locally with https://github.com/matrix-org/matrix-js-sdk/pull/3817 and they passed.

Fixes https://github.com/vector-im/element-web/issues/26273
Fixes https://github.com/vector-im/element-web/issues/26294

Might fix https://github.com/vector-im/element-web/issues/26341 @richvdh what should I do to check/undisable this test?


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->