### PR TITLE
Revert "Fix: Right panel keeps showing chat when unmaximizing widget. "

### DIFF
--- a/cypress/e2e/widgets/layout.spec.ts
+++ b/cypress/e2e/widgets/layout.spec.ts
@@ -129,20 +129,4 @@ describe("Widget Layout", () => {
 
         cy.get('iframe[title="widget"]').invoke("height").should("be.greaterThan", 400);
     });
-    it("open right panel with chat when maximizing widget", () => {
-        cy.get('iframe[title="widget"]').invoke("height").should("be.lessThan", 250);
-        cy.findByRole("button", { name: "Maximise" }).click();
-        cy.get(".mx_RightPanel").within(() => {
-            cy.get(".mx_BaseCard_header").should("contain", "Chat");
-        });
-    });
-    it("close right panel with chat when unmaximizing widget", () => {
-        cy.get('iframe[title="widget"]').invoke("height").should("be.lessThan", 250);
-        cy.findByRole("button", { name: "Maximise" }).click();
-        cy.get(".mx_RightPanel").within(() => {
-            cy.get(".mx_BaseCard_header").should("contain", "Chat");
-        });
-        cy.findByRole("button", { name: "Un-maximise" }).click();
-        cy.get(".mx_RightPanel").should("not.exist");
-    });
 });

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -539,9 +539,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         if (this.context.widgetLayoutStore.hasMaximisedWidget(this.state.room)) {
             // Show chat in right panel when a widget is maximised
             this.context.rightPanelStore.setCard({ phase: RightPanelPhases.Timeline });
-        } else {
-            // Close the chat in right panel when the widget is unmaximised
-            this.context.rightPanelStore.togglePanel(null);
         }
         this.checkWidgets(this.state.room);
     };


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#11697

Fixes https://github.com/vector-im/element-web/issues/26421
And maybe https://github.com/vector-im/element-web/issues/26427

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Fix: Right panel keeps showing chat when unmaximizing widget. " ([\#11786](https://github.com/matrix-org/matrix-react-sdk/pull/11786)). Fixes vector-im/element-web#26421. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->