### PR TITLE
fix spoiler text-align

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -800,6 +800,7 @@ $left-gutter: 64px;
     font-size: inherit;
     font-family: inherit;
     line-height: inherit;
+    text-align: inherit;
 
     .mx_EventTile_spoiler_reason {
         color: $event-timestamp-color;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Long spoiler message text appear center aligned. This is because spoiler used `button` tag and user-agent sets it's `text-align: center` which was not cleared by app's css.

Before:
<img width="750" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/32841439/1ac54f5e-acd4-42cf-8174-43c1cc204540">
<img width="750" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/32841439/57a090eb-cd05-4afb-bd3e-a095e56ea0e5">

Now: 
<img width="750" alt="image" src="https://github.com/matrix-org/matrix-react-sdk/assets/32841439/5472e099-7984-480d-aa72-44240a623f01">


<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->
