### PR TITLE
Element-R: Disable `After marking room as read, paging up to find old threads that were never read leaves the room read`

### DIFF
--- a/cypress/e2e/read-receipts/high-level.spec.ts
+++ b/cypress/e2e/read-receipts/high-level.spec.ts
@@ -43,6 +43,7 @@ import {
     saveAndReload,
     sendMessageAsClient,
 } from "./read-receipts-utils";
+import { skipIfRustCrypto } from "../../support/util";
 
 describe("Read receipts", () => {
     const roomAlpha = "Room Alpha";
@@ -321,6 +322,10 @@ describe("Read receipts", () => {
             assertUnreadThread("Root3");
         });
         it("After marking room as read, paging up to find old threads that were never read leaves the room read", () => {
+            // Flaky with rust crypto
+            // See https://github.com/vector-im/element-web/issues/26341
+            skipIfRustCrypto();
+
             // Given lots of messages in threads that are unread but I marked as read on a main timeline message
             goTo(room1);
             receiveMessages(room2, [


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

Related to https://github.com/vector-im/element-web/issues/26341


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->