### PR TITLE
Allow adding extra icons to the room header

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@matrix-org/analytics-events": "^0.8.0",
         "@matrix-org/emojibase-bindings": "^1.1.2",
         "@matrix-org/matrix-wysiwyg": "2.4.1",
-        "@matrix-org/react-sdk-module-api": "^2.1.1",
+        "@matrix-org/react-sdk-module-api": "^2.2.0",
         "@matrix-org/spec": "^1.7.0",
         "@sentry/browser": "^7.0.0",
         "@sentry/tracing": "^7.0.0",

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -42,6 +42,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { CallState, MatrixCall } from "matrix-js-sdk/src/webrtc/call";
 import { throttle } from "lodash";
 import { CryptoEvent } from "matrix-js-sdk/src/crypto";
+import { ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 
 import shouldHideEvent from "../../shouldHideEvent";
 import { _t } from "../../languageHandler";
@@ -246,6 +247,8 @@ export interface IRoomState {
 
     canAskToJoin: boolean;
     promptAskToJoin: boolean;
+
+    viewRoomOpts: ViewRoomOpts;
 }
 
 interface LocalRoomViewProps {
@@ -458,6 +461,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             msc3946ProcessDynamicPredecessor: SettingsStore.getValue("feature_dynamic_room_predecessors"),
             canAskToJoin: this.askToJoinEnabled,
             promptAskToJoin: false,
+            viewRoomOpts: { buttons: [] },
         };
 
         this.dispatcherRef = dis.register(this.onAction);
@@ -663,6 +667,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 : false,
             activeCall: roomId ? CallStore.instance.getActiveCall(roomId) : null,
             promptAskToJoin: this.context.roomViewStore.promptAskToJoin(),
+            viewRoomOpts: this.context.roomViewStore.getViewRoomOpts(),
         };
 
         if (
@@ -1407,6 +1412,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             tombstone: this.getRoomTombstone(room),
             liveTimeline: room.getLiveTimeline(),
         });
+
+        dis.dispatch<ActionPayload>({ action: Action.RoomLoaded });
     };
 
     private onRoomTimelineReset = (room?: Room): void => {
@@ -2601,7 +2608,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                                 data-layout={this.state.layout}
                             >
                                 {SettingsStore.getValue("feature_new_room_decoration_ui") ? (
-                                    <RoomHeader room={this.state.room} />
+                                    <RoomHeader
+                                        room={this.state.room}
+                                        additionalButtons={this.state.viewRoomOpts.buttons}
+                                    />
                                 ) : (
                                     <LegacyRoomHeader
                                         room={this.state.room}
@@ -2619,6 +2629,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                                         enableRoomOptionsMenu={!this.viewsLocalRoom}
                                         viewingCall={viewingCall}
                                         activeCall={this.state.activeCall}
+                                        additionalButtons={this.state.viewRoomOpts.buttons}
                                     />
                                 )}
                                 {mainSplitBody}

--- a/src/components/views/rooms/LegacyRoomHeader.tsx
+++ b/src/components/views/rooms/LegacyRoomHeader.tsx
@@ -20,6 +20,8 @@ import classNames from "classnames";
 import { throttle } from "lodash";
 import { RoomStateEvent, ISearchResults } from "matrix-js-sdk/src/matrix";
 import { CallType } from "matrix-js-sdk/src/webrtc/call";
+import { IconButton, Tooltip } from "@vector-im/compound-web";
+import { ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 
 import type { MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 import { _t } from "../../../languageHandler";
@@ -476,6 +478,7 @@ export interface IProps {
     enableRoomOptionsMenu?: boolean;
     viewingCall: boolean;
     activeCall: Call | null;
+    additionalButtons?: ViewRoomOpts["buttons"];
 }
 
 interface IState {
@@ -669,6 +672,19 @@ export default class RoomHeader extends React.Component<IProps, IState> {
 
         return (
             <>
+                {this.props.additionalButtons?.map(({ icon, id, label, onClick }) => (
+                    <Tooltip label={label()} key={id}>
+                        <IconButton
+                            onClick={() => {
+                                onClick();
+                                this.forceUpdate();
+                            }}
+                            title={label()}
+                        >
+                            {icon}
+                        </IconButton>
+                    </Tooltip>
+                ))}
                 {startButtons}
                 <RoomHeaderButtons
                     room={this.props.room}

--- a/src/components/views/rooms/LegacyRoomHeader.tsx
+++ b/src/components/views/rooms/LegacyRoomHeader.tsx
@@ -672,19 +672,23 @@ export default class RoomHeader extends React.Component<IProps, IState> {
 
         return (
             <>
-                {this.props.additionalButtons?.map(({ icon, id, label, onClick }) => (
-                    <Tooltip label={label()} key={id}>
-                        <IconButton
-                            onClick={() => {
-                                onClick();
-                                this.forceUpdate();
-                            }}
-                            title={label()}
-                        >
-                            {icon}
-                        </IconButton>
-                    </Tooltip>
-                ))}
+                {this.props.additionalButtons?.map((props) => {
+                    const label = props.label();
+
+                    return (
+                        <Tooltip label={label} key={props.id}>
+                            <IconButton
+                                onClick={() => {
+                                    props.onClick();
+                                    this.forceUpdate();
+                                }}
+                                title={label}
+                            >
+                                {props.icon}
+                            </IconButton>
+                        </Tooltip>
+                    );
+                })}
                 {startButtons}
                 <RoomHeaderButtons
                     room={this.props.room}

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -69,7 +69,7 @@ export default function RoomHeader({
     additionalButtons,
 }: {
     room: Room;
-    additionalButtons: ViewRoomOpts["buttons"];
+    additionalButtons?: ViewRoomOpts["buttons"];
 }): JSX.Element {
     const client = useMatrixClientContext();
 

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -67,10 +67,10 @@ function notificationColorToIndicator(color: NotificationColor): React.Component
 export default function RoomHeader({
     room,
     additionalButtons,
-}: Readonly<{
+}: {
     room: Room;
     additionalButtons: ViewRoomOpts["buttons"];
-}>): JSX.Element {
+}): JSX.Element {
     const client = useMatrixClientContext();
 
     const roomName = useRoomName(room);

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -176,19 +176,23 @@ export default function RoomHeader({
                 )}
             </Box>
             <Flex as="nav" align="center" gap="var(--cpd-space-2x)">
-                {additionalButtons?.map(({ icon, id, label, onClick }) => (
-                    <Tooltip label={label()} key={id}>
-                        <IconButton
-                            aria-label={label()}
-                            onClick={(event) => {
-                                event.stopPropagation();
-                                onClick();
-                            }}
-                        >
-                            {icon}
-                        </IconButton>
-                    </Tooltip>
-                ))}
+                {additionalButtons?.map((props) => {
+                    const label = props.label();
+
+                    return (
+                        <Tooltip label={label} key={props.id}>
+                            <IconButton
+                                aria-label={label}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    props.onClick();
+                                }}
+                            >
+                                {props.icon}
+                            </IconButton>
+                        </Tooltip>
+                    );
+                })}
                 {!useElementCallExclusively && (
                     <Tooltip label={!voiceCallDisabledReason ? _t("voip|voice_call") : voiceCallDisabledReason!}>
                         <IconButton

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -69,7 +69,7 @@ export default function RoomHeader({
     additionalButtons,
 }: {
     room: Room;
-    additionalButtons?: ViewRoomOpts["buttons"];
+    additionalButtons?: Readonly<ViewRoomOpts["buttons"]>;
 }): JSX.Element {
     const client = useMatrixClientContext();
 

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -67,10 +67,10 @@ function notificationColorToIndicator(color: NotificationColor): React.Component
 export default function RoomHeader({
     room,
     additionalButtons,
-}: {
+}: Readonly<{
     room: Room;
-    additionalButtons?: Readonly<ViewRoomOpts["buttons"]>;
-}): JSX.Element {
+    additionalButtons: ViewRoomOpts["buttons"];
+}>): JSX.Element {
     const client = useMatrixClientContext();
 
     const roomName = useRoomName(room);

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -24,6 +24,7 @@ import { Icon as VerifiedIcon } from "@vector-im/compound-design-tokens/icons/ve
 import { Icon as ErrorIcon } from "@vector-im/compound-design-tokens/icons/error.svg";
 import { Icon as PublicIcon } from "@vector-im/compound-design-tokens/icons/public.svg";
 import { EventType, JoinRule, type Room } from "matrix-js-sdk/src/matrix";
+import { ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 
 import { useRoomName } from "../../../hooks/useRoomName";
 import { RightPanelPhases } from "../../../stores/right-panel/RightPanelStorePhases";
@@ -63,7 +64,13 @@ function notificationColorToIndicator(color: NotificationColor): React.Component
     }
 }
 
-export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+export default function RoomHeader({
+    room,
+    additionalButtons,
+}: {
+    room: Room;
+    additionalButtons?: ViewRoomOpts["buttons"];
+}): JSX.Element {
     const client = useMatrixClientContext();
 
     const roomName = useRoomName(room);
@@ -169,6 +176,19 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                 )}
             </Box>
             <Flex as="nav" align="center" gap="var(--cpd-space-2x)">
+                {additionalButtons?.map(({ icon, id, label, onClick }) => (
+                    <Tooltip label={label()} key={id}>
+                        <IconButton
+                            aria-label={label()}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                onClick();
+                            }}
+                        >
+                            {icon}
+                        </IconButton>
+                    </Tooltip>
+                ))}
                 {!useElementCallExclusively && (
                     <Tooltip label={!voiceCallDisabledReason ? _t("voip|voice_call") : voiceCallDisabledReason!}>
                         <IconButton

--- a/src/contexts/RoomContext.ts
+++ b/src/contexts/RoomContext.ts
@@ -73,6 +73,7 @@ const RoomContext = createContext<
     msc3946ProcessDynamicPredecessor: false,
     canAskToJoin: false,
     promptAskToJoin: false,
+    viewRoomOpts: { buttons: [] },
 });
 RoomContext.displayName = "RoomContext";
 export default RoomContext;

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -371,4 +371,9 @@ export enum Action {
      * Fired when we want to open spotlight search. Use with a OpenSpotlightPayload.
      */
     OpenSpotlight = "open_spotlight",
+
+    /**
+     * Fired when the room loaded.
+     */
+    RoomLoaded = "room_loaded",
 }

--- a/test/components/structures/RoomView-test.tsx
+++ b/test/components/structures/RoomView-test.tsx
@@ -585,4 +585,10 @@ describe("RoomView", () => {
             expect(dis.dispatch).toHaveBeenCalledWith({ action: "cancel_ask_to_join", roomId: room.roomId });
         });
     });
+
+    it("fires Action.RoomLoaded", async () => {
+        jest.spyOn(dis, "dispatch");
+        await mountRoomView();
+        expect(dis.dispatch).toHaveBeenCalledWith({ action: Action.RoomLoaded });
+    });
 });

--- a/test/components/views/rooms/LegacyRoomHeader-test.tsx
+++ b/test/components/views/rooms/LegacyRoomHeader-test.tsx
@@ -752,6 +752,21 @@ describe("LegacyRoomHeader", () => {
         renderHeader({ additionalButtons });
         expect(screen.getByRole("button", { name: "test-icon" })).toBeInTheDocument();
     });
+
+    it("calls onClick-callback on additionalButtons", () => {
+        const callback = jest.fn();
+        const additionalButtons: ViewRoomOpts["buttons"] = [
+            {
+                icon: <>test-icon</>,
+                id: "test-id",
+                label: () => "test-label",
+                onClick: callback,
+            },
+        ];
+        renderHeader({ additionalButtons });
+        fireEvent.click(screen.getByRole("button", { name: "test-icon" }));
+        expect(callback).toHaveBeenCalled();
+    });
 });
 
 interface IRoomCreationInfo {

--- a/test/components/views/rooms/LegacyRoomHeader-test.tsx
+++ b/test/components/views/rooms/LegacyRoomHeader-test.tsx
@@ -29,6 +29,7 @@ import { CallType } from "matrix-js-sdk/src/webrtc/call";
 import { ClientWidgetApi, Widget } from "matrix-widget-api";
 import EventEmitter from "events";
 import { setupJestCanvasMock } from "jest-canvas-mock";
+import { ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 
 import type { MatrixClient, MatrixEvent, RoomMember } from "matrix-js-sdk/src/matrix";
 import type { MatrixCall } from "matrix-js-sdk/src/webrtc/call";
@@ -738,6 +739,19 @@ describe("LegacyRoomHeader", () => {
             expect(wrapper.container.querySelector(".mx_LegacyRoomHeader_name.mx_AccessibleButton")).toBeFalsy();
         },
     );
+
+    it("renders additionalButtons", async () => {
+        const additionalButtons: ViewRoomOpts["buttons"] = [
+            {
+                icon: <>test-icon</>,
+                id: "test-id",
+                label: () => "test-label",
+                onClick: () => {},
+            },
+        ];
+        renderHeader({ additionalButtons });
+        expect(screen.getByRole("button", { name: "test-icon" })).toBeInTheDocument();
+    });
 });
 
 interface IRoomCreationInfo {

--- a/test/components/views/rooms/RoomHeader-test.tsx
+++ b/test/components/views/rooms/RoomHeader-test.tsx
@@ -27,6 +27,7 @@ import {
     screen,
     waitFor,
 } from "@testing-library/react";
+import { ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 
 import { filterConsole, mkEvent, stubClient, withClientContextRenderOptions } from "../../../test-utils";
 import RoomHeader from "../../../../src/components/views/rooms/RoomHeader";
@@ -515,6 +516,22 @@ describe("RoomHeader", () => {
 
             await waitFor(() => expect(getByLabelText(container, expectedLabel)).toBeInTheDocument());
         });
+    });
+
+    it("renders additionalButtons", async () => {
+        const additionalButtons: ViewRoomOpts["buttons"] = [
+            {
+                icon: <>test-icon</>,
+                id: "test-id",
+                label: () => "test-label",
+                onClick: () => {},
+            },
+        ];
+        render(
+            <RoomHeader room={room} additionalButtons={additionalButtons} />,
+            withClientContextRenderOptions(MatrixClientPeg.get()!),
+        );
+        expect(screen.getByRole("button", { name: "test-label" })).toBeInTheDocument();
     });
 });
 

--- a/test/components/views/rooms/RoomHeader-test.tsx
+++ b/test/components/views/rooms/RoomHeader-test.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { CallType, MatrixCall } from "matrix-js-sdk/src/webrtc/call";
 import { EventType, JoinRule, MatrixClient, MatrixEvent, PendingEventOrdering, Room } from "matrix-js-sdk/src/matrix";
 import {
+    createEvent,
     fireEvent,
     getAllByLabelText,
     getByLabelText,
@@ -532,6 +533,31 @@ describe("RoomHeader", () => {
             withClientContextRenderOptions(MatrixClientPeg.get()!),
         );
         expect(screen.getByRole("button", { name: "test-label" })).toBeInTheDocument();
+    });
+
+    it("calls onClick-callback on additionalButtons", () => {
+        const callback = jest.fn();
+        const additionalButtons: ViewRoomOpts["buttons"] = [
+            {
+                icon: <>test-icon</>,
+                id: "test-id",
+                label: () => "test-label",
+                onClick: callback,
+            },
+        ];
+
+        render(
+            <RoomHeader room={room} additionalButtons={additionalButtons} />,
+            withClientContextRenderOptions(MatrixClientPeg.get()!),
+        );
+
+        const button = screen.getByRole("button", { name: "test-label" });
+        const event = createEvent.click(button);
+        event.stopPropagation = jest.fn();
+        fireEvent(button, event);
+
+        expect(callback).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
     });
 });
 

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -84,6 +84,7 @@ describe("<SendMessageComposer/>", () => {
         msc3946ProcessDynamicPredecessor: false,
         canAskToJoin: false,
         promptAskToJoin: false,
+        viewRoomOpts: { buttons: [] },
     };
     describe("createMessageContent", () => {
         const permalinkCreator = jest.fn() as any;

--- a/test/test-utils/room.ts
+++ b/test/test-utils/room.ts
@@ -90,6 +90,7 @@ export function getRoomContext(room: Room, override: Partial<IRoomState>): IRoom
         msc3946ProcessDynamicPredecessor: false,
         canAskToJoin: false,
         promptAskToJoin: false,
+        viewRoomOpts: { buttons: [] },
 
         ...override,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,10 +1828,10 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/olm/-/olm-3.2.15.tgz#55f3c1b70a21bbee3f9195cecd6846b1083451ec"
   integrity sha512-S7lOrndAK9/8qOtaTq/WhttJC/o4GAzdfK0MUPpo8ApzsJEC0QjtwrkC3KBXdFP1cD1MXi/mlKR7aaoVMKgs6Q==
 
-"@matrix-org/react-sdk-module-api@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-2.1.1.tgz#54e8617c15185010d608c0325ecaec8d1574d12b"
-  integrity sha512-dYPY3aXtNwPrg2aEmFeWddMdohus/Ha17XES2QH+WMCawt+hH+uq28jH1EmW1RUOOzxVcdY36lRGOwqRtAJbhA==
+"@matrix-org/react-sdk-module-api@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-2.2.0.tgz#cb284601a82448dc23fac31949c466eb34ec64b4"
+  integrity sha512-HSicxLdagZRbQp35d3t2SeDFTiT4GmEQDQGih8dWSKRHXK4krVQjb6Kf1NkwweiFDAeU0qgbz2pP4RZqbv0XIg==
   dependencies:
     "@babel/runtime" "^7.17.9"
 


### PR DESCRIPTION
This PR allows to add extra icons to the room header.

Related issue: https://github.com/vector-im/element-web/issues/26028
Blocked by: https://github.com/matrix-org/matrix-react-sdk-module-api/pull/22

### Screens

#### Legacy Room Header
![legacy-room-header](https://github.com/matrix-org/matrix-react-sdk-module-api/assets/1422657/223b9bfd-956f-4fde-93f3-05edc488700a)

#### New Room Header
![new-room-header](https://github.com/matrix-org/matrix-react-sdk-module-api/assets/1422657/80cd2a8b-7fc6-43ea-9cb2-3d19b89f7a59)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow adding extra icons to the room header ([\#11799](https://github.com/matrix-org/matrix-react-sdk/pull/11799)). Contributed by @charlynguyen.<!-- CHANGELOG_PREVIEW_END -->