### PR TITLE
Deserialise spoilers back into slash command form

### DIFF
--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -247,6 +247,10 @@ function parseNode(n: Node, pc: PartCreator, opts: IParseOptions, mkListItem?: (
 
                         return pc.plainWithEmoji(`${delimLeft}${tex}${delimRight}`);
                     }
+                    // Spoilers are translated back into their slash command form
+                    else if ((n as Element).hasAttribute("data-mx-spoiler")) {
+                        return [pc.plain("/spoiler "), ...parseChildren(n, pc, opts)];
+                    }
             }
     }
 

--- a/test/editor/deserialize-test.ts
+++ b/test/editor/deserialize-test.ts
@@ -98,6 +98,11 @@ describe("editor/deserialize", function () {
             expect(parts.length).toBe(1);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/me says DON'T SHOUT!" });
         });
+        it("spoiler", function () {
+            const parts = normalize(parseEvent(textMessage("/spoiler broiler"), createPartCreator()));
+            expect(parts.length).toBe(1);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "/spoiler broiler" });
+        });
     });
     describe("html messages", function () {
         it("inline styling", function () {
@@ -294,6 +299,11 @@ describe("editor/deserialize", function () {
             const parts = normalize(parseEvent(htmlMessage(html, "m.emote"), createPartCreator()));
             expect(parts.length).toBe(1);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/me says _DON'T SHOUT_!" });
+        });
+        it("spoiler", function () {
+            const parts = normalize(parseEvent(htmlMessage("<span data-mx-spoiler>broiler</span>"), createPartCreator()));
+            expect(parts.length).toBe(1);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "/spoiler broiler" });
         });
         it("preserves nested quotes", () => {
             const html = "<blockquote>foo<blockquote>bar</blockquote></blockquote>";

--- a/test/editor/deserialize-test.ts
+++ b/test/editor/deserialize-test.ts
@@ -301,7 +301,9 @@ describe("editor/deserialize", function () {
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/me says _DON'T SHOUT_!" });
         });
         it("spoiler", function () {
-            const parts = normalize(parseEvent(htmlMessage("<span data-mx-spoiler>broiler</span>"), createPartCreator()));
+            const parts = normalize(
+                parseEvent(htmlMessage("<span data-mx-spoiler>broiler</span>"), createPartCreator()),
+            );
             expect(parts.length).toBe(1);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/spoiler broiler" });
         });


### PR DESCRIPTION
Fixes: vector-im/element-web#26344

### Before this change

1. Post `/spoiler broiler`
2. Start editing the message
3. Notice that the composer contains just `broiler` and that submitting it will un-spoiler the message

### After this change

1. Post `/spoiler broiler`
2. Start editing the message
3. Notice that the composer contains `/spoiler broiler` and that submitting it will retain the spoiler (unless you delete the slash command)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Deserialise spoilers back into slash command form ([\#11805](https://github.com/matrix-org/matrix-react-sdk/pull/11805)). Fixes vector-im/element-web#26344.<!-- CHANGELOG_PREVIEW_END -->