### PR TITLE
Fix a test that would otherwise be broken by matrix-js-sdk#3817

### DIFF
--- a/test/components/structures/TimelinePanel-test.tsx
+++ b/test/components/structures/TimelinePanel-test.tsx
@@ -291,6 +291,10 @@ describe("TimelinePanel", () => {
 
                     it("and forgetting the read markers, should send the stored marker again", async () => {
                         timelineSet.addLiveEvent(ev2, {});
+                        // Add the event to the room as well as the timeline, so we can find it when we
+                        // call findEventById in getEventReadUpTo. This is odd because in our test
+                        // setup, timelineSet is not actually the timelineSet of the room.
+                        await room.addLiveEvents([ev2], {});
                         room.addEphemeralEvents([newReceipt(ev2.getId()!, userId, 222, 200)]);
                         await timelinePanel.forgetReadMarker();
                         expect(client.setRoomReadMarkers).toHaveBeenCalledWith(roomId, ev2.getId());


### PR DESCRIPTION
Ensure this test sets up the room correctly, so that when we call `findEventById` in our changes in https://github.com/matrix-org/matrix-js-sdk/pull/3817 it works correctly.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->