### PR TITLE
Fix broken Timeline panel jest test

### DIFF
--- a/test/components/structures/TimelinePanel-test.tsx
+++ b/test/components/structures/TimelinePanel-test.tsx
@@ -540,13 +540,13 @@ describe("TimelinePanel", () => {
                 type: "m.call.invite",
                 room_id: virtualRoom.roomId,
                 event_id: `virtualCallEvent1`,
-                origin_server_ts: 0,
+                origin_server_ts: 2,
             });
             const virtualCallMetaEvent = new MatrixEvent({
                 type: "org.matrix.call.sdp_stream_metadata_changed",
                 room_id: virtualRoom.roomId,
                 event_id: `virtualCallEvent2`,
-                origin_server_ts: 0,
+                origin_server_ts: 2,
             });
             const virtualEvents = [virtualCallInvite, ...mockEvents(virtualRoom), virtualCallMetaEvent];
             const { timelineSet: overlayTimelineSet } = getProps(virtualRoom, virtualEvents);


### PR DESCRIPTION
After https://github.com/matrix-org/matrix-js-sdk/pull/3839, the events are ordered on the basis of `origin_server_ts`.
We just need to give the call event  a larger `origin_server_ts` compared to the other events so that it appears in the same order as before i.e it appears last.
