### PR TITLE
Make video rooms compatible with matrix RTC

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -706,7 +706,7 @@ export class ElementCall extends Call {
     }
 
     public static get(room: Room): ElementCall | null {
-        // Only supported in the new group call experience or in video rooms
+        // Only supported in the new group call experience or in video rooms.
         if (
             SettingsStore.getValue("feature_group_calls") ||
             (SettingsStore.getValue("feature_video_rooms") &&
@@ -718,7 +718,7 @@ export class ElementCall extends Call {
             const session = room.client.matrixRTC.getRoomSession(room);
 
             // A call is present if we
-            // - have a widget: This means the create function was called
+            // - have a widget: This means the create function was called.
             // - or there is a running session where we have not yet created a widget for.
             // - or this this is a call room. Then we also always want to show a call.
             if (hasEcWidget || session.memberships.length !== 0 || room.isCallRoom()) {

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -50,6 +50,7 @@ import ActiveWidgetStore, { ActiveWidgetStoreEvent } from "../stores/ActiveWidge
 import { getCurrentLanguage } from "../languageHandler";
 import { FontWatcher } from "../settings/watchers/FontWatcher";
 import { PosthogAnalytics } from "../PosthogAnalytics";
+import { UPDATE_EVENT } from "../stores/AsyncStore";
 
 const TIMEOUT_MS = 16000;
 
@@ -225,7 +226,7 @@ export abstract class Call extends TypedEventEmitter<CallEvent, CallEventHandler
         const messagingStore = WidgetMessagingStore.instance;
         this.messaging = messagingStore.getMessagingForUid(this.widgetUid) ?? null;
         if (!this.messaging) {
-            // The widget might still be initializing, so wait for it
+            // The widget might still be initializing, so wait for it.
             try {
                 await waitForEvent(
                     messagingStore,
@@ -632,12 +633,10 @@ export class ElementCall extends Call {
         this.emit(CallEvent.Layout, value);
     }
 
-    private static createCallWidget(roomId: string, client: MatrixClient): IApp {
+    private static createOrGetCallWidget(roomId: string, client: MatrixClient): IApp {
         const ecWidget = WidgetStore.instance.getApps(roomId).find((app) => WidgetType.CALL.matches(app.type));
         if (ecWidget) {
-            logger.log("There is already a widget in this room, so we recreate it");
-            ActiveWidgetStore.instance.destroyPersistentWidget(ecWidget.id, ecWidget.roomId);
-            WidgetStore.instance.removeVirtualWidget(ecWidget.id, ecWidget.roomId);
+            return ecWidget;
         }
         const accountAnalyticsData = client.getAccountData(PosthogAnalytics.ANALYTICS_EVENT_TYPE);
         // The analyticsID is passed directly to element call (EC) since this codepath is only for EC and no other widget.
@@ -715,15 +714,16 @@ export class ElementCall extends Call {
                 room.isCallRoom())
         ) {
             const apps = WidgetStore.instance.getApps(room.roomId);
-            const ecWidget = apps.find((app) => WidgetType.CALL.matches(app.type));
+            const hasEcWidget = apps.some((app) => WidgetType.CALL.matches(app.type));
             const session = room.client.matrixRTC.getRoomSession(room);
 
             // A call is present if we
             // - have a widget: This means the create function was called
             // - or there is a running session where we have not yet created a widget for.
-            if (ecWidget || session.memberships.length !== 0) {
+            // - or this this is a call room. Then we also always want to show a call.
+            if (hasEcWidget || session.memberships.length !== 0 || room.isCallRoom()) {
                 // create a widget for the case we are joining a running call and don't have on yet.
-                const availableOrCreatedWidget = ecWidget ?? ElementCall.createCallWidget(room.roomId, room.client);
+                const availableOrCreatedWidget = ElementCall.createOrGetCallWidget(room.roomId, room.client);
                 return new ElementCall(session, availableOrCreatedWidget, room.client);
             }
         }
@@ -738,7 +738,8 @@ export class ElementCall extends Call {
             room.isCallRoom();
 
         console.log("Intend is ", isVideoRoom ? "VideoRoom" : "Prompt", " TODO, handle intent appropriately");
-        ElementCall.createCallWidget(room.roomId, room.client);
+        ElementCall.createOrGetCallWidget(room.roomId, room.client);
+        WidgetStore.instance.emit(UPDATE_EVENT, null);
     }
 
     protected async performConnection(
@@ -790,7 +791,8 @@ export class ElementCall extends Call {
     }
 
     private onRTCSessionEnded = (roomId: string, session: MatrixRTCSession): void => {
-        if (roomId == this.roomId) {
+        // Don't destroy widget on hangup for video call rooms.
+        if (roomId == this.roomId && !this.room.isCallRoom()) {
             this.destroy();
         }
     };

--- a/src/stores/WidgetStore.ts
+++ b/src/stores/WidgetStore.ts
@@ -202,7 +202,6 @@ export default class WidgetStore extends AsyncStoreWithClient<IState> {
         const app = WidgetUtils.makeAppConfig(widget.id, widget, widget.creatorUserId, roomId, undefined);
         this.widgetMap.set(WidgetUtils.getWidgetUid(app), app);
         this.roomMap.get(roomId)!.widgets.push(app);
-        this.emit(UPDATE_EVENT, roomId);
         return app;
     }
 

--- a/test/models/Call-test.ts
+++ b/test/models/Call-test.ts
@@ -596,16 +596,19 @@ describe("ElementCall", () => {
         it("finds calls", async () => {
             await ElementCall.create(room);
             expect(Call.get(room)).toBeInstanceOf(ElementCall);
+            Call.get(room)?.destroy();
         });
 
         it("finds ongoing calls that are created by the session manager", async () => {
             // There is an existing session created by another user in this room.
             client.matrixRTC.getRoomSession.mockReturnValue({
                 on: (ev: any, fn: any) => {},
+                off: (ev: any, fn: any) => {},
                 memberships: [{ fakeVal: "fake membership" }],
             } as unknown as MatrixRTCSession);
             const call = Call.get(room);
             if (!(call instanceof ElementCall)) throw new Error("Failed to create call");
+            call.destroy();
         });
 
         it("passes font settings through widget URL", async () => {
@@ -642,6 +645,7 @@ describe("ElementCall", () => {
 
             const urlParams1 = new URLSearchParams(new URL(call1.widget.url).hash.slice(1));
             expect(urlParams1.has("allowIceFallback")).toBe(false);
+            call1.destroy();
 
             // Now test with the preference set to true
             const originalGetValue = SettingsStore.getValue;
@@ -654,13 +658,14 @@ describe("ElementCall", () => {
                 }
             };
 
-            await ElementCall.create(room);
+            ElementCall.create(room);
             const call2 = Call.get(room);
             if (!(call2 instanceof ElementCall)) throw new Error("Failed to create call");
 
             const urlParams2 = new URLSearchParams(new URL(call2.widget.url).hash.slice(1));
             expect(urlParams2.has("allowIceFallback")).toBe(true);
 
+            call2.destroy();
             SettingsStore.getValue = originalGetValue;
         });
 
@@ -677,6 +682,7 @@ describe("ElementCall", () => {
 
             const urlParams = new URLSearchParams(new URL(call.widget.url).hash.slice(1));
             expect(urlParams.get("analyticsID")).toBe("123456789987654321");
+            call.destroy();
         });
 
         it("does not pass analyticsID if `pseudonymousAnalyticsOptIn` set to false", async () => {


### PR DESCRIPTION
After a lot of trying I actually found a stepping store solution. 
It is possible to get it working with very minimal changes when beeing careful.

Its all slighly more fragile than I would want It to be.
Especially there need to be desitions made on when we add/remove the widget.

For video rooms the widget now always lives and never gets destroyed.
For normal rooms the widget is the indicator that the usere created a call. So we create the widget on call button press but only connect the widget once the lobby ends.
If the call ends we destroy the widget because it is our indicator that the user created a call so the ui would show a call after the hangup as long as the widget lives.

```
        ElementCall.createOrGetCallWidget(room.roomId, room.client);
        WidgetStore.instance.emit(UPDATE_EVENT, null);
```

Sadly we need to emit here from the outside. It would be nicer if createVirtualWidget would call the WidgetStore update automatically. But then `WidgetStore.instance.emit(UPDATE_EVENT, null);` also would be called during the `Call.get()` fn. But this is causing iussues in the CallStore.
```
private updateRoom(room: Room): void {

   if (!this.calls.has(room.roomId)) {
              const call = Call.get(room); // HERE

              if (call) {
                  const onConnectionState = (state: ConnectionState): void => {
```
If Call.get() calls `WidgetStore.instance.emit(UPDATE_EVENT, null);` we create two widgets since the second call at `HERE` also would call the updateRoom again and we end up with two widgets.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->