### PR TITLE
Tell the timeline window when an event is removed (fixes element-web/issues/26498)

### DIFF
--- a/cypress/e2e/read-receipts/reactions.spec.ts
+++ b/cypress/e2e/read-receipts/reactions.spec.ts
@@ -252,6 +252,38 @@ describe("Read receipts", () => {
                 assertReadThread("Msg1");
                 assertReadThread("Msg2");
             });
+            it("Can remove a reaction in a thread", () => {
+                // Note: this is not strictly a read receipt test, but it checks
+                // for a bug we caused when we were fixing unreads, so it's
+                // included here. The bug is:
+                // https://github.com/vector-im/element-web/issues/26498
+
+                // Given a thread exists
+                goTo(room1);
+                assertRead(room2);
+                receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Reply1a")]);
+                assertUnread(room2, 2);
+
+                // When I react to a thread message
+                goTo(room2);
+                openThread("Msg1");
+                cy.get(".mx_ThreadPanel").findByText("Reply1a").realHover();
+                cy.findByRole("button", { name: "React" }).click();
+                cy.get(".mx_EmojiPicker_body").findByText("😀").click();
+
+                // And cancel the reaction
+                cy.get(".mx_ThreadPanel").findByLabelText("Mae reacted with 😀", { timeout: 1000000 }).click();
+
+                // Then it disappears
+                cy.get(".mx_ThreadPanel").findByLabelText("Mae reacted with 😀").should("not.exist");
+
+                // And I can do it all again without an error
+                cy.get(".mx_ThreadPanel").findByText("Reply1a").realHover();
+                cy.findByRole("button", { name: "React" }).click();
+                cy.get(".mx_EmojiPicker_body").findAllByText("😀").first().click();
+                cy.get(".mx_ThreadPanel").findByLabelText("Mae reacted with 😀", { timeout: 1000000 }).click();
+                cy.get(".mx_ThreadPanel").findByLabelText("Mae reacted with 😀").should("not.exist");
+            });
         });
 
         describe("thread roots", () => {

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -735,6 +735,10 @@ class TimelinePanel extends React.Component<IProps, IState> {
             return;
         }
 
+        if (removed) {
+            this.timelineWindow?.removeEvent();
+        }
+
         if (!Thread.hasServerSideSupport && this.context.timelineRenderingType === TimelineRenderingType.Thread) {
             if (toStartOfTimeline && !this.state.canBackPaginate) {
                 this.setState({

--- a/test/components/structures/TimelinePanel-test.tsx
+++ b/test/components/structures/TimelinePanel-test.tsx
@@ -534,6 +534,34 @@ describe("TimelinePanel", () => {
 
             expect(paginateSpy).toHaveBeenCalledTimes(2);
         });
+
+        it("reduces window size when event is removed", async () => {
+            // Given a TimelinePanel with some events
+            const [client, room, events] = setupTestData();
+
+            const virtualRoom = mkRoom(client, "virtualRoomId");
+            const virtualEvents = mockEvents(virtualRoom);
+            const { timelineSet: overlayTimelineSet } = getProps(virtualRoom, virtualEvents);
+
+            const props = {
+                ...getProps(room, events),
+                overlayTimelineSet,
+            };
+
+            const removeEventSpy = jest.spyOn(TimelineWindow.prototype, "removeEvent").mockClear();
+
+            render(<TimelinePanel {...props} />);
+            await flushPromises();
+
+            // When an event is removed
+            const event = new MatrixEvent({ type: RoomEvent.Timeline, origin_server_ts: 0 });
+            const data = { timeline: props.timelineSet.getLiveTimeline(), liveEvent: true };
+            client.emit(RoomEvent.Timeline, event, room, false, true, data);
+            await flushPromises();
+
+            // Then we call removeEvent on the TimelineWindow
+            expect(removeEventSpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("with overlayTimeline", () => {


### PR DESCRIPTION
Prevents https://github.com/vector-im/element-web/issues/26498 (Can't remove a reaction from a thread) from happening, even when https://github.com/matrix-org/matrix-js-sdk/pull/3798 (Move deleted messages into main timeline) is applied.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Tell the timeline window when an event is removed (fixes element-web/issues/26498) ([\#11836](https://github.com/matrix-org/matrix-react-sdk/pull/11836)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->