### PR TITLE
Add feature flag for disabling encryption in Element Call

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1398,7 +1398,7 @@
         "element_call_video_rooms": "Element Call video rooms",
         "experimental_description": "Feeling experimental? Try out our latest ideas in development. These features are not finalised; they may be unstable, may change, or may be dropped altogether. <a>Learn more</a>.",
         "experimental_section": "Early previews",
-        "feature_disable_call_per_sender_encryption": "Disable per sender encryption for element call",
+        "feature_disable_call_per_sender_encryption": "Disable per-sender encryption for Element Call",
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",
         "group_developer": "Developer",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1398,6 +1398,7 @@
         "element_call_video_rooms": "Element Call video rooms",
         "experimental_description": "Feeling experimental? Try out our latest ideas in development. These features are not finalised; they may be unstable, may change, or may be dropped altogether. <a>Learn more</a>.",
         "experimental_section": "Early previews",
+        "feature_disable_call_per_sender_encryption": "Disable per sender encryption for element call",
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",
         "group_developer": "Developer",

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -661,7 +661,8 @@ export class ElementCall extends Call {
             analyticsID,
         });
 
-        if (client.isRoomEncrypted(roomId) && !SettingsStore.getValue("feature_disable_call_per_sender_encryption")) params.append("perParticipantE2EE", "");
+        if (client.isRoomEncrypted(roomId) && !SettingsStore.getValue("feature_disable_call_per_sender_encryption"))
+            params.append("perParticipantE2EE", "");
         if (SettingsStore.getValue("fallbackICEServerAllowed")) params.append("allowIceFallback", "");
         if (SettingsStore.getValue("feature_allow_screen_share_only_mode")) params.append("allowVoipWithNoMedia", "");
 

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -662,9 +662,10 @@ export class ElementCall extends Call {
         });
 
         if (client.isRoomEncrypted(roomId) && !SettingsStore.getValue("feature_disable_call_per_sender_encryption"))
-            params.append("perParticipantE2EE", "");
-        if (SettingsStore.getValue("fallbackICEServerAllowed")) params.append("allowIceFallback", "");
-        if (SettingsStore.getValue("feature_allow_screen_share_only_mode")) params.append("allowVoipWithNoMedia", "");
+            params.append("perParticipantE2EE", "true");
+        if (SettingsStore.getValue("fallbackICEServerAllowed")) params.append("allowIceFallback", "true");
+        if (SettingsStore.getValue("feature_allow_screen_share_only_mode"))
+            params.append("allowVoipWithNoMedia", "true");
 
         // Set custom fonts
         if (SettingsStore.getValue("useSystemFont")) {

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -661,7 +661,7 @@ export class ElementCall extends Call {
             analyticsID,
         });
 
-        if (client.isRoomEncrypted(roomId)) params.append("perParticipantE2EE", "");
+        if (client.isRoomEncrypted(roomId) && !SettingsStore.getValue("feature_disable_call_per_sender_encryption")) params.append("perParticipantE2EE", "");
         if (SettingsStore.getValue("fallbackICEServerAllowed")) params.append("allowIceFallback", "");
         if (SettingsStore.getValue("feature_allow_screen_share_only_mode")) params.append("allowVoipWithNoMedia", "");
 

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -404,6 +404,13 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         controller: new ReloadOnChangeController(),
         default: false,
     },
+    "feature_disable_call_per_sender_encryption": {
+        isFeature: true,
+        supportedLevels: LEVELS_FEATURE,
+        labsGroup: LabGroup.VoiceAndVideo,
+        displayName: _td("labs|feature_disable_call_per_sender_encryption"),
+        default: false,
+    },
     "feature_allow_screen_share_only_mode": {
         isFeature: true,
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,

--- a/test/models/Call-test.ts
+++ b/test/models/Call-test.ts
@@ -932,20 +932,20 @@ describe("ElementCall", () => {
             const addWidgetSpy = jest.spyOn(WidgetStore.instance, "addVirtualWidget");
             // If a room is not encrypted we will never add the perParticipantE2EE flag.
             client.isRoomEncrypted.mockReturnValue(true);
-            {
-                // should create call with perParticipantE2EE flag
-                ElementCall.create(room);
 
-                expect(addWidgetSpy.mock.calls[0][0].url).toContain("perParticipantE2EE=true");
-                ElementCall.get(room)?.destroy();
+            // should create call with perParticipantE2EE flag
+            ElementCall.create(room);
 
-                // should create call without perParticipantE2EE flag
-                enabledSettings.add("feature_disable_call_per_sender_encryption");
-                await ElementCall.create(room);
-                enabledSettings.delete("feature_disable_call_per_sender_encryption");
+            expect(addWidgetSpy.mock.calls[0][0].url).toContain("perParticipantE2EE=true");
+            ElementCall.get(room)?.destroy();
 
-                expect(addWidgetSpy.mock.calls[1][0].url).not.toContain("perParticipantE2EE=true");
-            }
+            // should create call without perParticipantE2EE flag
+            enabledSettings.add("feature_disable_call_per_sender_encryption");
+            await ElementCall.create(room);
+            enabledSettings.delete("feature_disable_call_per_sender_encryption");
+
+            expect(addWidgetSpy.mock.calls[1][0].url).not.toContain("perParticipantE2EE=true");
+
             client.isRoomEncrypted.mockClear();
             addWidgetSpy.mockRestore();
         });

--- a/test/models/Call-test.ts
+++ b/test/models/Call-test.ts
@@ -925,6 +925,30 @@ describe("ElementCall", () => {
             call.destroy();
             expect(destroyPersistentWidgetSpy).toHaveBeenCalled();
         });
+
+        it("the perParticipantE2EE url flag is used in encrypted rooms while respecting the feature_disable_call_per_sender_encryption flag", async () => {
+            // We destroy the call created in beforeEach because we test the call creation process.
+            call.destroy();
+            const addWidgetSpy = jest.spyOn(WidgetStore.instance, "addVirtualWidget");
+            // If a room is not encrypted we will never add the perParticipantE2EE flag.
+            client.isRoomEncrypted.mockReturnValue(true);
+            {
+                // should create call with perParticipantE2EE flag
+                ElementCall.create(room);
+
+                expect(addWidgetSpy.mock.calls[0][0].url).toContain("perParticipantE2EE=true");
+                ElementCall.get(room)?.destroy();
+
+                // should create call without perParticipantE2EE flag
+                enabledSettings.add("feature_disable_call_per_sender_encryption");
+                await ElementCall.create(room);
+                enabledSettings.delete("feature_disable_call_per_sender_encryption");
+
+                expect(addWidgetSpy.mock.calls[1][0].url).not.toContain("perParticipantE2EE=true");
+            }
+            client.isRoomEncrypted.mockClear();
+            addWidgetSpy.mockRestore();
+        });
     });
 
     describe("instance in a video room", () => {


### PR DESCRIPTION
We want an option to disable the call encryption while it is not supported on all platforms and for specific experiments/demos. This is a very easy way to make this configurable for the ones working on/with it and allows to simplify some experiments.

Should be merged with: https://github.com/vector-im/element-web/pull/26548
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add feature flag for disabling encryption in Element Call ([\#11837](https://github.com/matrix-org/matrix-react-sdk/pull/11837)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->