### PR TITLE
Load audioWorklet in a Webpack 5 compatible way

### DIFF
--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -28,7 +28,6 @@ import { UPDATE_EVENT } from "../stores/AsyncStore";
 import { createAudioContext } from "./compat";
 import { FixedRollingArray } from "../utils/FixedRollingArray";
 import { clamp } from "../utils/numbers";
-import mxRecorderWorkletPath from "./RecorderWorklet";
 
 const CHANNELS = 1; // stereo isn't important
 export const SAMPLE_RATE = 48000; // 48khz is what WebRTC uses. 12khz is where we lose quality.
@@ -129,7 +128,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
             if (this.recorderContext.audioWorklet) {
                 // Set up our worklet. We use this for timing information and waveform analysis: the
                 // web audio API prefers this be done async to avoid holding the main thread with math.
-                await this.recorderContext.audioWorklet.addModule(mxRecorderWorkletPath);
+                await this.recorderContext.audioWorklet.addModule("./RecorderWorklet");
                 this.recorderWorklet = new AudioWorkletNode(this.recorderContext, WORKLET_NAME);
                 this.recorderSource.connect(this.recorderWorklet);
                 this.recorderWorklet.connect(this.recorderContext.destination);

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -133,7 +133,8 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
             if (this.recorderContext.audioWorklet) {
                 // Set up our worklet. We use this for timing information and waveform analysis: the
                 // web audio API prefers this be done async to avoid holding the main thread with math.
-                await this.recorderContext.audioWorklet.addModule("./RecorderWorklet");
+                const audioWorklet = this.recorderContext.audioWorklet;
+                await audioWorklet.addModule(new URL("./RecorderWorklet", import.meta.url));
                 this.recorderWorklet = new AudioWorkletNode(this.recorderContext, WORKLET_NAME);
                 this.recorderSource.connect(this.recorderWorklet);
                 this.recorderWorklet.connect(this.recorderContext.destination);

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -28,6 +28,11 @@ import { UPDATE_EVENT } from "../stores/AsyncStore";
 import { createAudioContext } from "./compat";
 import { FixedRollingArray } from "../utils/FixedRollingArray";
 import { clamp } from "../utils/numbers";
+// This import is needed for dead code analysis but not actually used because the
+// built-in worker / worklet handling in Webpack 5 only supports static paths
+// @ts-ignore no-unused-locals
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import mxRecorderWorkletPath from "./RecorderWorklet";
 
 const CHANNELS = 1; // stereo isn't important
 export const SAMPLE_RATE = 48000; // 48khz is what WebRTC uses. 12khz is where we lose quality.

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -133,8 +133,13 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
             if (this.recorderContext.audioWorklet) {
                 // Set up our worklet. We use this for timing information and waveform analysis: the
                 // web audio API prefers this be done async to avoid holding the main thread with math.
+
+                // The audioWorklet.addModule syntax is required for Webpack 5 to correctly recognise
+                // this as a worklet rather than an asset. This also requires the parser.javascript.worker
+                // configuration described in https://github.com/webpack/webpack.js.org/issues/6869.
                 const audioWorklet = this.recorderContext.audioWorklet;
-                await audioWorklet.addModule(new URL("./RecorderWorklet", import.meta.url));
+                await audioWorklet.addModule(new URL("./RecorderWorklet.ts", import.meta.url));
+
                 this.recorderWorklet = new AudioWorkletNode(this.recorderContext, WORKLET_NAME);
                 this.recorderSource.connect(this.recorderWorklet);
                 this.recorderWorklet.connect(this.recorderContext.destination);


### PR DESCRIPTION
For: https://github.com/vector-im/element-web/pull/26229

We currently use worklet-loader but it isn't designed to work with Webpack 5. The [built-in](https://github.com/webpack/webpack.js.org/issues/6869) worklet support in Webpack 5 requires the use of URLs in the `addModule` call alongside special configuration.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->