### PR TITLE
Fix a test that was expecting an edit to be considered unread

### DIFF
--- a/cypress/e2e/read-receipts/editing-messages.spec.ts
+++ b/cypress/e2e/read-receipts/editing-messages.spec.ts
@@ -134,8 +134,7 @@ describe("Read receipts", () => {
                 goTo(room1);
                 assertStillRead(room2);
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("Editing a message after marking as read makes the room unread", () => {
+            it("Editing a message after marking as read makes the room unread", () => {
                 // Given the room is marked as read
                 goTo(room1);
                 receiveMessages(room2, ["Msg1"]);
@@ -146,8 +145,8 @@ describe("Read receipts", () => {
                 // When a message is edited
                 receiveMessages(room2, [editOf("Msg1", "Msg1 Edit1")]);
 
-                // Then the room becomes unread
-                assertUnread(room2, 1);
+                // Then the room remains unread
+                assertStillRead(room2);
             });
             it("Editing a reply after reading it makes the room unread", () => {
                 // Given the room is all read


### PR DESCRIPTION
This test contained the wrong assumption that an edit causes a room to be unread. It got missed when we changed our minds on what the correct behaviour should be.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->