### PR TITLE
Disable test 'Paging up to find old threads' on Rust due to flakes

### DIFF
--- a/cypress/e2e/read-receipts/high-level.spec.ts
+++ b/cypress/e2e/read-receipts/high-level.spec.ts
@@ -263,6 +263,10 @@ describe("Read receipts", () => {
             assertReadThread("Root3");
         });
         it("Paging up to find old threads that were never read keeps the room unread", () => {
+            // Flaky with rust crypto
+            // See https://github.com/vector-im/element-web/issues/26539
+            skipIfRustCrypto();
+
             // Given lots of messages in threads that are unread
             goTo(room1);
             receiveMessages(room2, [


### PR DESCRIPTION
See https://github.com/vector-im/element-web/issues/26539

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->