### PR TITLE
Use the correct video call icon variant

### DIFF
--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useEffect, useMemo, useState } from "react";
 import { Body as BodyText, IconButton, Tooltip } from "@vector-im/compound-web";
-import { Icon as VideoCallIcon } from "@vector-im/compound-design-tokens/icons/video-call.svg";
+import { Icon as VideoCallIcon } from "@vector-im/compound-design-tokens/icons/video-call-solid.svg";
 import { Icon as VoiceCallIcon } from "@vector-im/compound-design-tokens/icons/voice-call.svg";
 import { Icon as ThreadsIcon } from "@vector-im/compound-design-tokens/icons/threads-solid.svg";
 import { Icon as NotificationsIcon } from "@vector-im/compound-design-tokens/icons/notifications-solid.svg";


### PR DESCRIPTION
This regression happened because of breaking changes in the most recent compound-design-tokens release.

Closes https://github.com/vector-im/element-web/issues/26536

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use the correct video call icon variant ([\#11859](https://github.com/matrix-org/matrix-react-sdk/pull/11859)). Fixes vector-im/element-web#26536.<!-- CHANGELOG_PREVIEW_END -->