### PR TITLE
Load web workers and worklets in a way that Webpack 5 can bundle them

### DIFF
--- a/__mocks__/workerFactoryMock.js
+++ b/__mocks__/workerFactoryMock.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default function workerFactory(options) {
+  return jest.fn;
+}

--- a/__mocks__/workerFactoryMock.js
+++ b/__mocks__/workerFactoryMock.js
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function workerFactory(options) {
-  return jest.fn;
+    return jest.fn;
 }

--- a/__mocks__/workerMock.js
+++ b/__mocks__/workerMock.js
@@ -1,1 +1,0 @@
-module.exports = jest.fn();

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -7,7 +7,7 @@
         "resolveJsonModule": true,
         "esModuleInterop": true,
         "moduleResolution": "node",
-        "module": "commonjs"
+        "module": "es2022"
     },
     "include": ["**/*.ts"]
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,7 +33,7 @@ const config: Config = {
         "waveWorker\\.min\\.js": "<rootDir>/__mocks__/empty.js",
         "workers/(.+)Factory": "<rootDir>/__mocks__/workerFactoryMock.js",
         "^!!raw-loader!.*": "jest-raw-loader",
-        "RecorderWorklet": "<rootDir>/__mocks__/empty.js",
+        "recorderWorkletFactory": "<rootDir>/__mocks__/empty.js",
     },
     transformIgnorePatterns: ["/node_modules/(?!matrix-js-sdk).+$"],
     collectCoverageFrom: [

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,7 @@ const config: Config = {
         "decoderWorker\\.min\\.js": "<rootDir>/__mocks__/empty.js",
         "decoderWorker\\.min\\.wasm": "<rootDir>/__mocks__/empty.js",
         "waveWorker\\.min\\.js": "<rootDir>/__mocks__/empty.js",
-        "workers/(.+)\\.worker\\.ts": "<rootDir>/__mocks__/workerMock.js",
+        "workers/(.+)Factory": "<rootDir>/__mocks__/workerFactoryMock.js",
         "^!!raw-loader!.*": "jest-raw-loader",
         "RecorderWorklet": "<rootDir>/__mocks__/empty.js",
     },

--- a/src/BlurhashEncoder.ts
+++ b/src/BlurhashEncoder.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // @ts-ignore - `.ts` is needed here to make TS happy
-import BlurhashWorker, { Request, Response } from "./workers/blurhash.worker.ts";
+import { Request, Response } from "./workers/blurhash.worker.ts";
 import { WorkerManager } from "./WorkerManager";
 
 export class BlurhashEncoder {
@@ -25,7 +25,9 @@ export class BlurhashEncoder {
         return BlurhashEncoder.internalInstance;
     }
 
-    private readonly worker = new WorkerManager<Request, Response>(BlurhashWorker);
+    private readonly worker = new WorkerManager<Request, Response>(
+        new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url)),
+    );
 
     public getBlurhash(imageData: ImageData): Promise<string> {
         return this.worker.call({ imageData }).then((resp) => resp.blurhash);

--- a/src/BlurhashEncoder.ts
+++ b/src/BlurhashEncoder.ts
@@ -17,6 +17,7 @@ limitations under the License.
 // @ts-ignore - `.ts` is needed here to make TS happy
 import { Request, Response } from "./workers/blurhash.worker.ts";
 import { WorkerManager } from "./WorkerManager";
+import blurhashWorkerFactory from "./workers/blurhashWorkerFactory.js";
 
 export class BlurhashEncoder {
     private static internalInstance = new BlurhashEncoder();
@@ -25,9 +26,7 @@ export class BlurhashEncoder {
         return BlurhashEncoder.internalInstance;
     }
 
-    private readonly worker = new WorkerManager<Request, Response>(
-        new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url)),
-    );
+    private readonly worker = new WorkerManager<Request, Response>(blurhashWorkerFactory());
 
     public getBlurhash(imageData: ImageData): Promise<string> {
         return this.worker.call({ imageData }).then((resp) => resp.blurhash);

--- a/src/BlurhashEncoder.ts
+++ b/src/BlurhashEncoder.ts
@@ -17,7 +17,7 @@ limitations under the License.
 // @ts-ignore - `.ts` is needed here to make TS happy
 import { Request, Response } from "./workers/blurhash.worker.ts";
 import { WorkerManager } from "./WorkerManager";
-import blurhashWorkerFactory from "./workers/blurhashWorkerFactory.js";
+import blurhashWorkerFactory from "./workers/blurhashWorkerFactory";
 
 export class BlurhashEncoder {
     private static internalInstance = new BlurhashEncoder();

--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -23,8 +23,8 @@ export class WorkerManager<Request extends {}, Response> {
     private seq = 0;
     private pendingDeferredMap = new Map<number, IDeferred<Response>>();
 
-    public constructor(WorkerConstructor: { new (): Worker }) {
-        this.worker = new WorkerConstructor();
+    public constructor(worker: Worker) {
+        this.worker = worker;
         this.worker.onmessage = this.onMessage;
     }
 

--- a/src/audio/Playback.ts
+++ b/src/audio/Playback.ts
@@ -20,7 +20,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { defer } from "matrix-js-sdk/src/utils";
 
 // @ts-ignore - `.ts` is needed here to make TS happy
-import PlaybackWorker, { Request, Response } from "../workers/playback.worker.ts";
+import { Request, Response } from "../workers/playback.worker.ts";
 import { UPDATE_EVENT } from "../stores/AsyncStore";
 import { arrayFastResample } from "../utils/arrays";
 import { IDestroyable } from "../utils/IDestroyable";
@@ -63,7 +63,9 @@ export class Playback extends EventEmitter implements IDestroyable, PlaybackInte
     private waveformObservable = new SimpleObservable<number[]>();
     private readonly clock: PlaybackClock;
     private readonly fileSize: number;
-    private readonly worker = new WorkerManager<Request, Response>(PlaybackWorker);
+    private readonly worker = new WorkerManager<Request, Response>(
+        new Worker(new URL("../workers/playback.worker.ts", import.meta.url)),
+    );
 
     /**
      * Creates a new playback instance from a buffer.

--- a/src/audio/Playback.ts
+++ b/src/audio/Playback.ts
@@ -29,6 +29,7 @@ import { createAudioContext, decodeOgg } from "./compat";
 import { clamp } from "../utils/numbers";
 import { WorkerManager } from "../WorkerManager";
 import { DEFAULT_WAVEFORM, PLAYBACK_WAVEFORM_SAMPLES } from "./consts";
+import playbackWorkerFactory from "../workers/playbackWorkerFactory.js";
 
 export enum PlaybackState {
     Decoding = "decoding",
@@ -63,9 +64,7 @@ export class Playback extends EventEmitter implements IDestroyable, PlaybackInte
     private waveformObservable = new SimpleObservable<number[]>();
     private readonly clock: PlaybackClock;
     private readonly fileSize: number;
-    private readonly worker = new WorkerManager<Request, Response>(
-        new Worker(new URL("../workers/playback.worker.ts", import.meta.url)),
-    );
+    private readonly worker = new WorkerManager<Request, Response>(playbackWorkerFactory());
 
     /**
      * Creates a new playback instance from a buffer.

--- a/src/audio/Playback.ts
+++ b/src/audio/Playback.ts
@@ -29,7 +29,7 @@ import { createAudioContext, decodeOgg } from "./compat";
 import { clamp } from "../utils/numbers";
 import { WorkerManager } from "../WorkerManager";
 import { DEFAULT_WAVEFORM, PLAYBACK_WAVEFORM_SAMPLES } from "./consts";
-import playbackWorkerFactory from "../workers/playbackWorkerFactory.js";
+import playbackWorkerFactory from "../workers/playbackWorkerFactory";
 
 export enum PlaybackState {
     Decoding = "decoding",

--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -28,11 +28,7 @@ import { UPDATE_EVENT } from "../stores/AsyncStore";
 import { createAudioContext } from "./compat";
 import { FixedRollingArray } from "../utils/FixedRollingArray";
 import { clamp } from "../utils/numbers";
-// This import is needed for dead code analysis but not actually used because the
-// built-in worker / worklet handling in Webpack 5 only supports static paths
-// @ts-ignore no-unused-locals
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import mxRecorderWorkletPath from "./RecorderWorklet";
+import recorderWorkletFactory from "./recorderWorkletFactory";
 
 const CHANNELS = 1; // stereo isn't important
 export const SAMPLE_RATE = 48000; // 48khz is what WebRTC uses. 12khz is where we lose quality.
@@ -133,12 +129,7 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
             if (this.recorderContext.audioWorklet) {
                 // Set up our worklet. We use this for timing information and waveform analysis: the
                 // web audio API prefers this be done async to avoid holding the main thread with math.
-
-                // The audioWorklet.addModule syntax is required for Webpack 5 to correctly recognise
-                // this as a worklet rather than an asset. This also requires the parser.javascript.worker
-                // configuration described in https://github.com/webpack/webpack.js.org/issues/6869.
-                const audioWorklet = this.recorderContext.audioWorklet;
-                await audioWorklet.addModule(new URL("./RecorderWorklet.ts", import.meta.url));
+                await recorderWorkletFactory(this.recorderContext);
 
                 this.recorderWorklet = new AudioWorkletNode(this.recorderContext, WORKLET_NAME);
                 this.recorderSource.connect(this.recorderWorklet);

--- a/src/audio/recorderWorkletFactory.ts
+++ b/src/audio/recorderWorkletFactory.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This import is needed for dead code analysis but not actually used because the
+// built-in worker / worklet handling in Webpack 5 only supports static paths
+// @ts-ignore no-unused-locals
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import mxRecorderWorkletPath from "./RecorderWorklet";
+
+export default function recorderWorkletFactory(context: AudioContext): Promise<void> {
+  // The context.audioWorklet.addModule syntax is required for Webpack 5 to correctly recognise
+  // this as a worklet rather than an asset. This also requires the parser.javascript.worker
+  // configuration described in https://github.com/webpack/webpack.js.org/issues/6869.
+  return context.audioWorklet.addModule(new URL("./RecorderWorklet.ts", import.meta.url));
+}

--- a/src/audio/recorderWorkletFactory.ts
+++ b/src/audio/recorderWorkletFactory.ts
@@ -21,8 +21,8 @@ limitations under the License.
 import mxRecorderWorkletPath from "./RecorderWorklet";
 
 export default function recorderWorkletFactory(context: AudioContext): Promise<void> {
-  // The context.audioWorklet.addModule syntax is required for Webpack 5 to correctly recognise
-  // this as a worklet rather than an asset. This also requires the parser.javascript.worker
-  // configuration described in https://github.com/webpack/webpack.js.org/issues/6869.
-  return context.audioWorklet.addModule(new URL("./RecorderWorklet.ts", import.meta.url));
+    // The context.audioWorklet.addModule syntax is required for Webpack 5 to correctly recognise
+    // this as a worklet rather than an asset. This also requires the parser.javascript.worker
+    // configuration described in https://github.com/webpack/webpack.js.org/issues/6869.
+    return context.audioWorklet.addModule(new URL("./RecorderWorklet.ts", import.meta.url));
 }

--- a/src/utils/createMatrixClient.ts
+++ b/src/utils/createMatrixClient.ts
@@ -24,9 +24,6 @@ import {
     LocalStorageCryptoStore,
 } from "matrix-js-sdk/src/matrix";
 
-// @ts-ignore - `.ts` is needed here to make TS happy
-import IndexedDBWorker from "../workers/indexeddb.worker.ts";
-
 const localStorage = window.localStorage;
 
 // just *accessing* indexedDB throws an exception in firefox with
@@ -55,7 +52,7 @@ export default function createMatrixClient(opts: ICreateClientOpts): MatrixClien
             indexedDB: indexedDB,
             dbName: "riot-web-sync",
             localStorage,
-            workerFactory: () => new IndexedDBWorker(),
+            workerFactory: () => new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url)),
         });
     } else if (localStorage) {
         storeOpts.store = new MemoryStore({ localStorage });

--- a/src/utils/createMatrixClient.ts
+++ b/src/utils/createMatrixClient.ts
@@ -23,6 +23,7 @@ import {
     IndexedDBStore,
     LocalStorageCryptoStore,
 } from "matrix-js-sdk/src/matrix";
+import indexeddbWorkerFactory from "../workers/indexeddbWorkerFactory";
 
 const localStorage = window.localStorage;
 
@@ -52,7 +53,7 @@ export default function createMatrixClient(opts: ICreateClientOpts): MatrixClien
             indexedDB: indexedDB,
             dbName: "riot-web-sync",
             localStorage,
-            workerFactory: () => new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url)),
+            workerFactory: indexeddbWorkerFactory,
         });
     } else if (localStorage) {
         storeOpts.store = new MemoryStore({ localStorage });

--- a/src/utils/createMatrixClient.ts
+++ b/src/utils/createMatrixClient.ts
@@ -23,6 +23,7 @@ import {
     IndexedDBStore,
     LocalStorageCryptoStore,
 } from "matrix-js-sdk/src/matrix";
+
 import indexeddbWorkerFactory from "../workers/indexeddbWorkerFactory";
 
 const localStorage = window.localStorage;

--- a/src/workers/blurhashWorkerFactory.ts
+++ b/src/workers/blurhashWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-    return new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url), options);
+    return new Worker(new URL("./blurhash.worker.ts", import.meta.url), options);
 }

--- a/src/workers/blurhashWorkerFactory.ts
+++ b/src/workers/blurhashWorkerFactory.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
+  return new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url), options);
+}

--- a/src/workers/blurhashWorkerFactory.ts
+++ b/src/workers/blurhashWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-  return new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url), options);
+    return new Worker(new URL("./workers/blurhash.worker.ts", import.meta.url), options);
 }

--- a/src/workers/indexeddbWorkerFactory.ts
+++ b/src/workers/indexeddbWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-    return new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url), options);
+    return new Worker(new URL("./indexeddb.worker.ts", import.meta.url), options);
 }

--- a/src/workers/indexeddbWorkerFactory.ts
+++ b/src/workers/indexeddbWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-  return new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url), options)
+    return new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url), options);
 }

--- a/src/workers/indexeddbWorkerFactory.ts
+++ b/src/workers/indexeddbWorkerFactory.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
+  return new Worker(new URL("../workers/indexeddb.worker.ts", import.meta.url), options)
+}

--- a/src/workers/playbackWorkerFactory.ts
+++ b/src/workers/playbackWorkerFactory.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
+  return new Worker(new URL("../workers/playback.worker.ts", import.meta.url), options)
+}

--- a/src/workers/playbackWorkerFactory.ts
+++ b/src/workers/playbackWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-    return new Worker(new URL("../workers/playback.worker.ts", import.meta.url), options);
+    return new Worker(new URL("./playback.worker.ts", import.meta.url), options);
 }

--- a/src/workers/playbackWorkerFactory.ts
+++ b/src/workers/playbackWorkerFactory.ts
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 export default function blurhashWorkerFactory(options?: WorkerOptions | undefined): Worker {
-  return new Worker(new URL("../workers/playback.worker.ts", import.meta.url), options)
+    return new Worker(new URL("../workers/playback.worker.ts", import.meta.url), options);
 }

--- a/test/WorkerManager-test.ts
+++ b/test/WorkerManager-test.ts
@@ -19,7 +19,7 @@ import { WorkerManager } from "../src/WorkerManager";
 describe("WorkerManager", () => {
     it("should generate consecutive sequence numbers for each call", () => {
         const postMessage = jest.fn();
-        const manager = new WorkerManager(jest.fn(() => ({ postMessage } as unknown as Worker)));
+        const manager = new WorkerManager({ postMessage } as unknown as Worker);
 
         manager.call({ data: "One" });
         manager.call({ data: "Two" });
@@ -37,7 +37,7 @@ describe("WorkerManager", () => {
     it("should support resolving out of order", async () => {
         const postMessage = jest.fn();
         const worker = { postMessage } as unknown as Worker;
-        const manager = new WorkerManager(jest.fn(() => worker));
+        const manager = new WorkerManager(worker);
 
         const oneProm = manager.call({ data: "One" });
         const twoProm = manager.call({ data: "Two" });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "emitDecoratorMetadata": false,
         "resolveJsonModule": true,
         "esModuleInterop": true,
-        "module": "commonjs",
+        "module": "es2022",
         "moduleResolution": "node",
         "target": "es2016",
         "noUnusedLocals": true,


### PR DESCRIPTION
For: https://github.com/vector-im/element-web/pull/26229

This changes the way web workers and worklets are loaded to be compatible with Webpack 5's built-in support for [workers](https://webpack.js.org/guides/web-workers/) and [worklets](https://github.com/webpack/webpack.js.org/issues/6869). This in turn allows us to get rid of worker-loader and worklet-loader.

Remaining issues:

- [x] `import.meta.url` causes an IDE warning: `The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.ts(1343)`
- [x] Most unit tests fail (likely because the [worker mock](https://github.com/matrix-org/matrix-react-sdk/blob/johannes/worklet-path/jest.config.ts#L34) isn't applied anymore now that we load via URLs)
- [ ] Some integration tests fail with the same error 

Requires: https://github.com/vector-im/element-web/pull/26551

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->