### PR TITLE
Fix: Emoji cause topics being cut off in new room header

### DIFF
--- a/res/css/views/rooms/_RoomHeader.pcss
+++ b/res/css/views/rooms/_RoomHeader.pcss
@@ -55,6 +55,11 @@ limitations under the License.
     height: 0;
     opacity: 0;
     transition: all var(--transition-standard) ease 0.1s;
+    /* Emojis are rendered a bit bigger than text in the timeline
+        Make them compact/the same size as text here */
+    .mx_Emoji {
+        font-size: inherit;
+    }
 }
 
 .mx_RoomHeader:hover .mx_RoomHeader_topic {

--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -193,6 +193,15 @@ export default function RoomHeader({
                         </Tooltip>
                     );
                 })}
+                <Tooltip label={!videoCallDisabledReason ? _t("voip|video_call") : videoCallDisabledReason!}>
+                    <IconButton
+                        disabled={!!videoCallDisabledReason}
+                        aria-label={!videoCallDisabledReason ? _t("voip|video_call") : videoCallDisabledReason!}
+                        onClick={videoCallClick}
+                    >
+                        <VideoCallIcon />
+                    </IconButton>
+                </Tooltip>
                 {!useElementCallExclusively && (
                     <Tooltip label={!voiceCallDisabledReason ? _t("voip|voice_call") : voiceCallDisabledReason!}>
                         <IconButton
@@ -204,15 +213,7 @@ export default function RoomHeader({
                         </IconButton>
                     </Tooltip>
                 )}
-                <Tooltip label={!videoCallDisabledReason ? _t("voip|video_call") : videoCallDisabledReason!}>
-                    <IconButton
-                        disabled={!!videoCallDisabledReason}
-                        aria-label={!videoCallDisabledReason ? _t("voip|video_call") : videoCallDisabledReason!}
-                        onClick={videoCallClick}
-                    >
-                        <VideoCallIcon />
-                    </IconButton>
-                </Tooltip>
+
                 <Tooltip label={_t("common|threads")}>
                     <IconButton
                         indicator={notificationColorToIndicator(threadNotifications)}


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/vector-im/element-web/issues/26326
Fixes https://github.com/vector-im/element-web/issues/26568
Fixes https://github.com/vector-im/element-web/issues/26569

Makes emojis the same size as the rest of the room topic so they fit in the compact space of the header.
Also fixes the ordering or voice and video call buttons

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: Emoji cause topics being cut off in new room header ([\#11865](https://github.com/matrix-org/matrix-react-sdk/pull/11865)). Fixes vector-im/element-web#26326 vector-im/element-web#26568 and vector-im/element-web#26569. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->