### PR TITLE
Room header: do not collapse avatar or facepile

### DIFF
--- a/res/css/structures/_RightPanel.pcss
+++ b/res/css/structures/_RightPanel.pcss
@@ -25,6 +25,7 @@ limitations under the License.
     box-sizing: border-box;
     height: 100%;
     contain: strict;
+    background-color: var(--cpd-color-bg-canvas-default);
 
     .mx_RoomView_MessageList {
         padding: 14px 18px; /* top and bottom is 4px smaller to balance with the padding set above */

--- a/res/css/views/rooms/_RoomHeader.pcss
+++ b/res/css/views/rooms/_RoomHeader.pcss
@@ -83,6 +83,9 @@ limitations under the License.
     cursor: pointer;
     user-select: none;
 
+    /* RoomAvatar doesn't pass classes down to avatar
+    So set style here
+    using div because compound classes are not stable */
     > div {
         flex-shrink: 0;
     }

--- a/res/css/views/rooms/_RoomHeader.pcss
+++ b/res/css/views/rooms/_RoomHeader.pcss
@@ -83,8 +83,16 @@ limitations under the License.
     cursor: pointer;
     user-select: none;
 
+    > div {
+        flex-shrink: 0;
+    }
+
     &:hover {
         color: $primary-content;
         background: var(--cpd-color-bg-subtle-primary);
     }
+}
+
+.mx_RoomHeader .mx_BaseAvatar {
+    flex-shrink: 0;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/vector-im/element-web/issues/26571

https://github.com/matrix-org/matrix-react-sdk/assets/3055605/86f3e20a-e175-4d42-89ac-e96cb99d57d9

Doesn't fully solve room header display in a small viewport, but this behaviour is equivalent to the legacy room header.

🚨 auto merge enabled 

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Room header: do not collapse avatar or facepile ([\#11866](https://github.com/matrix-org/matrix-react-sdk/pull/11866)). Fixes vector-im/element-web#26571. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->