### PR TITLE
Cypress: Enable `editing-messages.spec.ts` > `A room with an edited threaded message is still read after restart`

### DIFF
--- a/cypress/e2e/read-receipts/editing-messages.spec.ts
+++ b/cypress/e2e/read-receipts/editing-messages.spec.ts
@@ -292,8 +292,7 @@ describe("Read receipts", () => {
                 // Then the room becomes unread
                 assertStillRead(room2);
             });
-            // XXX: fails because we see a dot instead of an unread number - probably the server and client disagree
-            it.skip("A room with an edited threaded message is still read after restart", () => {
+            it("A room with an edited threaded message is still read after restart", () => {
                 // Given an edit in a thread is making a room unread
                 goTo(room1);
                 receiveMessages(room2, ["Msg1", threadedOff("Msg1", "Resp1")]);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->