### PR TITLE
Remove workaround for rust-SDK bug

### DIFF
--- a/cypress/support/bot.ts
+++ b/cypress/support/bot.ts
@@ -206,10 +206,6 @@ function setupBotClient(
             await cli.startClient();
 
             if (opts.bootstrapCrossSigning) {
-                // XXX: workaround https://github.com/matrix-org/matrix-rust-sdk/issues/2193
-                //   wait for out device list to be available, as a proxy for the device keys having been uploaded.
-                await cli.getCrypto()!.getUserDeviceInfo([credentials.userId]);
-
                 await cli.getCrypto()!.bootstrapCrossSigning({
                     authUploadDeviceSigningKeys: async (func) => {
                         await func({


### PR DESCRIPTION
Now that https://github.com/matrix-org/matrix-rust-sdk/issues/2193 is fixed, I believe we can remove this

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->