### PR TITLE
Make micIcon display on primary

### DIFF
--- a/src/components/views/voip/VideoFeed.tsx
+++ b/src/components/views/voip/VideoFeed.tsx
@@ -193,7 +193,7 @@ export default class VideoFeed extends React.PureComponent<IProps, IState> {
         });
 
         let micIcon;
-        if (feed.purpose !== SDPStreamMetadataPurpose.Screenshare && !primary && !pipMode) {
+        if (feed.purpose !== SDPStreamMetadataPurpose.Screenshare && !pipMode) {
             micIcon = <div className={micIconClasses} />;
         }
 


### PR DESCRIPTION
## Checklist

-   [] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

This is a minor change fixing a small bug in the call window for element web and desktop. The mic status of the other participant in a 1:1 call is only shown on the secondary screen, but missing on the primary screen, causing confusion between parties. Proper status reflection was tested with calls between element-web / desktop. 
(Android client currently does not seem to send an event when muting / unmuting unlike the web variants. I'll have a look at that somewhen later as well)

Screenshot:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/5646760/2b67ec5c-dedc-4308-b46d-1d97ce0529a9)


No new test was written for this (very) small change.

Notes: Properly display mic icon on primary view in 1:1 call to see muted state of other participant

Type: [defect]

Signed-off-by: Kai Danielmeier <kai.danielmeier@gmail.com>
