### PR TITLE
Disable axe check which only fails in Chrome

### DIFF
--- a/cypress/e2e/spaces/spaces.spec.ts
+++ b/cypress/e2e/spaces/spaces.spec.ts
@@ -294,6 +294,11 @@ describe("Spaces", () => {
                 "nested-interactive": {
                     enabled: false,
                 },
+                // Disable this check as it wrongly triggers on the room list container which has
+                // roving tab index elements with automatic scrolling
+                "scrollable-region-focusable": {
+                    enabled: false,
+                },
             },
         };
         cy.checkA11y(undefined, axeOptions);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26607

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->