### PR TITLE
Add menu for legacy and element call in 1:1 rooms

### DIFF
--- a/src/components/views/rooms/LegacyRoomHeader.tsx
+++ b/src/components/views/rooms/LegacyRoomHeader.tsx
@@ -126,7 +126,7 @@ interface VideoCallButtonProps {
     room: Room;
     busy: boolean;
     setBusy: (value: boolean) => void;
-    behavior: DisabledWithReason | "legacy_or_jitsi" | "element" | "jitsi_or_element";
+    behavior: DisabledWithReason | "legacy_or_jitsi" | "element" | "jitsi_or_element" | "legacy_or_element";
 }
 
 /**
@@ -178,7 +178,7 @@ const VideoCallButton: FC<VideoCallButtonProps> = ({ room, busy, setBusy, behavi
                 disabled: false,
             };
         } else {
-            // behavior === "jitsi_or_element"
+            // behavior === "jitsi_or_element" | "legacy_or_element"
             return {
                 onClick: async (ev: ButtonEvent): Promise<void> => {
                     ev.preventDefault();
@@ -215,7 +215,11 @@ const VideoCallButton: FC<VideoCallButtonProps> = ({ room, busy, setBusy, behavi
             <IconizedContextMenu {...aboveLeftOf(buttonRect)} onFinished={closeMenu}>
                 <IconizedContextMenuOptionList>
                     <IconizedContextMenuOption
-                        label={_t("room|header|video_call_button_jitsi")}
+                        label={
+                            behavior == "legacy_or_element"
+                                ? _t("room|header|video_call_button_legacy")
+                                : _t("room|header|video_call_button_jitsi")
+                        }
                         onClick={onJitsiClick}
                     />
                     <IconizedContextMenuOption
@@ -319,7 +323,7 @@ const CallButtons: FC<CallButtonsProps> = ({ room }) => {
             return (
                 <>
                     {makeVoiceCallButton("legacy_or_jitsi")}
-                    {makeVideoCallButton("legacy_or_jitsi")}
+                    {makeVideoCallButton("legacy_or_element")}
                 </>
             );
         } else if (mayEditWidgets) {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1933,6 +1933,7 @@
             "show_widgets_button": "Show Widgets",
             "video_call_button_ec": "Video call (%(brand)s)",
             "video_call_button_jitsi": "Video call (Jitsi)",
+            "video_call_button_legacy": "Legacy video call",
             "video_call_ec_change_layout": "Change layout",
             "video_call_ec_layout_freedom": "Freedom",
             "video_call_ec_layout_spotlight": "Spotlight",

--- a/test/components/views/rooms/LegacyRoomHeader-test.tsx
+++ b/test/components/views/rooms/LegacyRoomHeader-test.tsx
@@ -347,6 +347,8 @@ describe("LegacyRoomHeader", () => {
             placeCallSpy.mockClear();
             fireEvent.click(screen.getByRole("button", { name: "Video call" }));
             await act(() => Promise.resolve()); // Allow effects to settle
+            fireEvent.click(screen.getByRole("menuitem", { name: "Legacy video call" }));
+            await act(() => Promise.resolve()); // Allow effects to settle
             expect(placeCallSpy).toHaveBeenCalledWith(room.roomId, CallType.Video);
         },
     );


### PR DESCRIPTION
This allows to also initiate element call calls in 1:1 rooms.

Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add menu for legacy and element call in 1:1 rooms ([\#11910](https://github.com/matrix-org/matrix-react-sdk/pull/11910)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->