### PR TITLE
Remove Quote from MessageContextMenu as it is unsupported by WYSIWYG

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/src/components/views/context_menus/MessageContextMenu.tsx
@@ -49,7 +49,6 @@ import ViewSource from "../../structures/ViewSource";
 import { createRedactEventDialog } from "../dialogs/ConfirmRedactDialog";
 import ShareDialog from "../dialogs/ShareDialog";
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
-import { ComposerInsertPayload } from "../../../dispatcher/payloads/ComposerInsertPayload";
 import EndPollDialog from "../dialogs/EndPollDialog";
 import { isPollEnded } from "../messages/MPollBody";
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
@@ -286,15 +285,6 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
         this.closeMenu();
     };
 
-    private onQuoteClick = (): void => {
-        dis.dispatch<ComposerInsertPayload>({
-            action: Action.ComposerInsert,
-            event: this.props.mxEvent,
-            timelineRenderingType: this.context.timelineRenderingType,
-        });
-        this.closeMenu();
-    };
-
     private onShareClick = (e: ButtonEvent): void => {
         e.preventDefault();
         Modal.createDialog(ShareDialog, {
@@ -524,18 +514,6 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
             );
         }
 
-        let quoteButton: JSX.Element | undefined;
-        if (eventTileOps && canSendMessages) {
-            // this event is rendered using TextualBody
-            quoteButton = (
-                <IconizedContextMenuOption
-                    iconClassName="mx_MessageContextMenu_iconQuote"
-                    label={_t("action|quote")}
-                    onClick={this.onQuoteClick}
-                />
-            );
-        }
-
         // Bridges can provide a 'external_url' to link back to the source.
         let externalURLButton: JSX.Element | undefined;
         if (
@@ -709,7 +687,6 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
                 {viewInRoomButton}
                 {openInMapSiteButton}
                 {endPollButton}
-                {quoteButton}
                 {forwardButton}
                 {pinButton}
                 {permalinkButton}

--- a/src/dispatcher/payloads/ComposerInsertPayload.ts
+++ b/src/dispatcher/payloads/ComposerInsertPayload.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "matrix-js-sdk/src/matrix";
-
 import { ActionPayload } from "../payloads";
 import { Action } from "../actions";
 import { TimelineRenderingType } from "../../contexts/RoomContext";
@@ -35,15 +33,8 @@ interface IComposerInsertMentionPayload extends IBaseComposerInsertPayload {
     userId: string;
 }
 
-interface IComposerInsertQuotePayload extends IBaseComposerInsertPayload {
-    event: MatrixEvent;
-}
-
 interface IComposerInsertPlaintextPayload extends IBaseComposerInsertPayload {
     text: string;
 }
 
-export type ComposerInsertPayload =
-    | IComposerInsertMentionPayload
-    | IComposerInsertQuotePayload
-    | IComposerInsertPlaintextPayload;
+export type ComposerInsertPayload = IComposerInsertMentionPayload | IComposerInsertPlaintextPayload;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26296
Fixes https://github.com/vector-im/customer-retainer/issues/130

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Remove Quote from MessageContextMenu as it is unsupported by WYSIWYG ([\#11914](https://github.com/matrix-org/matrix-react-sdk/pull/11914)). Fixes vector-im/element-web#26296 and vector-im/customer-retainer#130.<!-- CHANGELOG_PREVIEW_END -->