### PR TITLE
Update open in other tab message

### DIFF
--- a/src/components/structures/auth/SessionLockStolenView.tsx
+++ b/src/components/structures/auth/SessionLockStolenView.tsx
@@ -28,7 +28,7 @@ export function SessionLockStolenView(): JSX.Element {
 
     return (
         <SplashPage className="mx_SessionLockStolenView">
-            <h1>{_t("common|error")}</h1>
+            <h1>{_t("error_app_open_in_another_tab_title", { brand })}</h1>
             <h2>{_t("error_app_open_in_another_tab", { brand })}</h2>
         </SplashPage>
     );

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1056,7 +1056,8 @@
         "unknown_error_code": "unknown error code",
         "update_power_level": "Failed to change power level"
     },
-    "error_app_open_in_another_tab": "%(brand)s has been opened in another tab.",
+    "error_app_open_in_another_tab": "Switch to the other tab to connect to %(brand)s. This tab can now be closed.",
+    "error_app_open_in_another_tab_title": "%(brand)s is connected in another tab",
     "error_app_opened_in_another_window": "%(brand)s is open in another window. Click \"%(label)s\" to use %(brand)s here and disconnect the other window.",
     "error_database_closed_description": "This may be caused by having the app open in multiple tabs or due to clearing browser data.",
     "error_database_closed_title": "Database unexpectedly closed",

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -1325,7 +1325,7 @@ describe("<MatrixChat />", () => {
                 await flushPromises();
 
                 // now we should see the error page
-                rendered.getByText("Test has been opened in another tab.");
+                rendered.getByText("Test is connected in another tab");
 
                 // let initCrypto complete, and check we don't get a modal
                 initCryptoCompleteDefer.resolve();

--- a/test/components/structures/__snapshots__/MatrixChat-test.tsx.snap
+++ b/test/components/structures/__snapshots__/MatrixChat-test.tsx.snap
@@ -6,10 +6,10 @@ exports[`<MatrixChat /> Multi-tab lockout shows the lockout page when a second t
     class="mx_SessionLockStolenView mx_SplashPage"
   >
     <h1>
-      Error
+      Test is connected in another tab
     </h1>
     <h2>
-      Test has been opened in another tab.
+      Switch to the other tab to connect to Test. This tab can now be closed.
     </h2>
   </main>
 </div>
@@ -22,10 +22,10 @@ exports[`<MatrixChat /> Multi-tab lockout shows the lockout page when a second t
       class="mx_SessionLockStolenView mx_SplashPage"
     >
       <h1>
-        Error
+        Test is connected in another tab
       </h1>
       <h2>
-        Test has been opened in another tab.
+        Switch to the other tab to connect to Test. This tab can now be closed.
       </h2>
     </main>
   </div>
@@ -38,10 +38,10 @@ exports[`<MatrixChat /> Multi-tab lockout shows the lockout page when a second t
     class="mx_SessionLockStolenView mx_SplashPage"
   >
     <h1>
-      Error
+      Test is connected in another tab
     </h1>
     <h2>
-      Test has been opened in another tab.
+      Switch to the other tab to connect to Test. This tab can now be closed.
     </h2>
   </main>
 </div>
@@ -53,10 +53,10 @@ exports[`<MatrixChat /> Multi-tab lockout shows the lockout page when a second t
     class="mx_SessionLockStolenView mx_SplashPage"
   >
     <h1>
-      Error
+      Test is connected in another tab
     </h1>
     <h2>
-      Test has been opened in another tab.
+      Switch to the other tab to connect to Test. This tab can now be closed.
     </h2>
   </main>
 </div>


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

New text comes from design, see comment [here](https://github.com/vector-im/element-web/issues/26537#issuecomment-1807973994)

| Before | After |
| --- | --- |
| ![tab-before](https://github.com/matrix-org/matrix-react-sdk/assets/6216686/f5327888-69a3-403b-a48d-52a55119cd20) | ![tab-after](https://github.com/matrix-org/matrix-react-sdk/assets/6216686/bac8f471-2627-4c2f-81b0-3a11080994d4) |

closes https://github.com/vector-im/element-web/issues/26537

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Notes: "is open in another tab" message is now more user-friendly

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: "is open in other tab" message is now more user-friendly

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * "is open in another tab" message is now more user-friendly ([\#11916](https://github.com/matrix-org/matrix-react-sdk/pull/11916)). Fixes vector-im/element-web#26537.<!-- CHANGELOG_PREVIEW_END -->