### PR TITLE
Allow passing knapsack token as secret in workflow

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,7 +17,9 @@ on:
                 required: true
                 description: "The name of the github repository to check out and build."
         secrets:
-            CYPRESS_RECORD_KEY:
+            KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS_RUST:
+                required: true
+            KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS_LEGACY:
                 required: true
             TCMS_USERNAME:
                 required: true


### PR DESCRIPTION
This is needed before we can fix broken cypress tests in `matrix-js-sdk` CI

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->