### PR TITLE
Re-enable previously-flaky cypress test

### DIFF
--- a/cypress/e2e/crypto/verification.spec.ts
+++ b/cypress/e2e/crypto/verification.spec.ts
@@ -20,7 +20,7 @@ import type { MatrixClient } from "matrix-js-sdk/src/matrix";
 import type { VerificationRequest, Verifier } from "matrix-js-sdk/src/crypto-api";
 import { CypressBot } from "../../support/bot";
 import { HomeserverInstance } from "../../plugins/utils/homeserver";
-import { emitPromise, skipIfRustCrypto } from "../../support/util";
+import { emitPromise } from "../../support/util";
 import {
     checkDeviceIsConnectedKeyBackup,
     checkDeviceIsCrossSigned,
@@ -317,10 +317,6 @@ describe("User verification", () => {
     });
 
     it("can receive a verification request when there is no existing DM", () => {
-        // Extremely flaky with rust crypto
-        // see https://github.com/vector-im/element-web/issues/26420
-        skipIfRustCrypto();
-
         cy.bootstrapCrossSigning(aliceCredentials);
 
         // the other user creates a DM


### PR DESCRIPTION
This should now be fixed, thanks to https://github.com/matrix-org/matrix-js-sdk/pull/3932.

Fixes https://github.com/vector-im/element-web/issues/26420

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->