### PR TITLE
Fix bug which prevented correct clean up of rageshake store

### DIFF
--- a/src/rageshake/rageshake.ts
+++ b/src/rageshake/rageshake.ts
@@ -474,6 +474,14 @@ export function tryInitStorage(): Promise<void> {
     if (indexedDB) {
         global.mx_rage_store = new IndexedDBLogStore(indexedDB, global.mx_rage_logger);
         global.mx_rage_initStoragePromise = global.mx_rage_store.connect();
+
+        // Fire off a task in the background which will clean up old logs in the store
+        global.mx_rage_initStoragePromise.then(() => {
+            global.mx_rage_store.consume().catch((e) => {
+                logger.error("Error cleaning up rageshake store", e);
+            });
+        });
+
         return global.mx_rage_initStoragePromise;
     }
     global.mx_rage_initStoragePromise = Promise.resolve();
@@ -489,6 +497,10 @@ export function flush(): void {
 
 /**
  * Clean up old logs.
+ *
+ * @deprecated There is no need to call this explicitly: it will be done as a side-effect of {@link tryInitStorage},
+ * or {@link init} with `setUpPersistence: true`.
+ *
  * @return {Promise} Resolves if cleaned logs.
  */
 export async function cleanup(): Promise<void> {


### PR DESCRIPTION
Currently, Element-web calls `rageshake.cleanup` at startup, after `rageshake.init` (https://github.com/vector-im/element-web/blob/v1.11.51/src/vector/rageshakesetup.ts#L51).

However, at that point, the indexeddb store has not yet been set up (since `init` is called with `setUpPersistence: false`). So, the `cleanup` call doesn't actually do anything.

To save the application having to get this right, let's just do the `cleanup` work as a side-effect of `tryInitStorage`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix bug which prevented correct clean up of rageshake store ([\#12002](https://github.com/matrix-org/matrix-react-sdk/pull/12002)).<!-- CHANGELOG_PREVIEW_END -->