### PR TITLE
Set up key backup using non-deprecated APIs

### DIFF
--- a/playwright/e2e/crypto/backups.spec.ts
+++ b/playwright/e2e/crypto/backups.spec.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { test, expect } from "../../element-web-test";
+
+test.describe("Backups", () => {
+    test.use({
+        displayName: "Hanako",
+    });
+
+    test("Create, delete and recreate a keys backup", async ({ page, user, app }, workerInfo) => {
+        // skipIfLegacyCrypto
+        test.skip(
+            workerInfo.project.name === "Legacy Crypto",
+            "This test only works with Rust crypto. Deleting the backup seems to fail with legacy crypto.",
+        );
+
+        // Create a backup
+        const tab = await app.settings.openUserSettings("Security & Privacy");
+        await expect(tab.getByRole("heading", { name: "Secure Backup" })).toBeVisible();
+        await tab.getByRole("button", { name: "Set up", exact: true }).click();
+        const dialog = await app.getDialogByTitle("Set up Secure Backup", 60000);
+        await dialog.getByRole("button", { name: "Continue", exact: true }).click();
+        await expect(dialog.getByRole("heading", { name: "Save your Security Key" })).toBeVisible();
+        await dialog.getByRole("button", { name: "Copy", exact: true }).click();
+        const securityKey = await app.getClipboard();
+        await dialog.getByRole("button", { name: "Continue", exact: true }).click();
+        await expect(dialog.getByRole("heading", { name: "Secure Backup successful" })).toBeVisible();
+        await dialog.getByRole("button", { name: "Done", exact: true }).click();
+
+        // Delete it
+        await app.settings.openUserSettings("Security & Privacy");
+        await expect(tab.getByRole("heading", { name: "Secure Backup" })).toBeVisible();
+        await tab.getByRole("button", { name: "Delete Backup", exact: true }).click();
+        await dialog.getByTestId("dialog-primary-button").click(); // Click "Delete Backup"
+
+        // Create another
+        await tab.getByRole("button", { name: "Set up", exact: true }).click();
+        dialog.getByLabel("Security Key").fill(securityKey);
+        await dialog.getByRole("button", { name: "Continue", exact: true }).click();
+        await expect(dialog.getByRole("heading", { name: "Success!" })).toBeVisible();
+        await dialog.getByRole("button", { name: "OK", exact: true }).click();
+    });
+});

--- a/playwright/element-web-test.ts
+++ b/playwright/element-web-test.ts
@@ -238,3 +238,7 @@ export const expect = baseExpect.extend({
         return { pass: true, message: () => "", name: "toMatchScreenshot" };
     },
 });
+
+test.use({
+    permissions: ["clipboard-read"],
+});

--- a/playwright/pages/ElementAppPage.ts
+++ b/playwright/pages/ElementAppPage.ts
@@ -50,6 +50,19 @@ export class ElementAppPage {
         return this.settings.closeDialog();
     }
 
+    public async getClipboard(): Promise<string> {
+        return await this.page.evaluate(() => navigator.clipboard.readText());
+    }
+
+    /**
+     * Find an open dialog by its title
+     */
+    public async getDialogByTitle(title: string, timeout = 5000): Promise<Locator> {
+        const dialog = this.page.locator(".mx_Dialog");
+        await dialog.getByRole("heading", { name: title }).waitFor({ timeout });
+        return dialog;
+    }
+
     /**
      * Opens the given room by name. The room must be visible in the
      * room list, but the room list may be folded horizontally, and the

--- a/src/async-components/views/dialogs/security/CreateKeyBackupDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateKeyBackupDialog.tsx
@@ -17,7 +17,6 @@ limitations under the License.
 
 import React from "react";
 import { logger } from "matrix-js-sdk/src/logger";
-import { IKeyBackupInfo } from "matrix-js-sdk/src/crypto/keybackup";
 
 import { MatrixClientPeg } from "../../../../MatrixClientPeg";
 import { _t } from "../../../../languageHandler";
@@ -75,24 +74,25 @@ export default class CreateKeyBackupDialog extends React.PureComponent<IProps, I
         this.setState({
             error: undefined,
         });
-        let info: IKeyBackupInfo | undefined;
         const cli = MatrixClientPeg.safeGet();
         try {
-            await accessSecretStorage(async (): Promise<void> => {
-                // `accessSecretStorage` will have bootstrapped secret storage if necessary, so we can now
-                // set up key backup.
-                //
-                // XXX: `bootstrapSecretStorage` also sets up key backup as a side effect, so there is a 90% chance
-                // this is actually redundant.
-                //
-                // The only time it would *not* be redundant would be if, for some reason, we had working 4S but no
-                // working key backup. (For example, if the user clicked "Delete Backup".)
-                info = await cli.prepareKeyBackupVersion(null /* random key */, {
-                    secureSecretStorage: true,
-                });
-                info = await cli.createKeyBackupVersion(info);
-            });
-            await cli.scheduleAllGroupSessionsForBackup();
+            // We don't want accessSecretStorage to create a backup for us - we
+            // will create one ourselves in the closure we pass in by calling
+            // resetKeyBackup.
+            const setupNewKeyBackup = false;
+            const forceReset = false;
+
+            await accessSecretStorage(
+                async (): Promise<void> => {
+                    const crypto = cli.getCrypto();
+                    if (!crypto) {
+                        throw new Error("End-to-end encryption is disabled - unable to create backup.");
+                    }
+                    await crypto.resetKeyBackup();
+                },
+                forceReset,
+                setupNewKeyBackup,
+            );
             this.setState({
                 phase: Phase.Done,
             });
@@ -102,9 +102,6 @@ export default class CreateKeyBackupDialog extends React.PureComponent<IProps, I
             // delete the version, disable backup, or do nothing?  If we just
             // disable without deleting, we'll enable on next app reload since
             // it is trusted.
-            if (info?.version) {
-                cli.deleteKeyBackupVersion(info.version);
-            }
             this.setState({
                 error: true,
             });

--- a/test/SecurityManager-test.ts
+++ b/test/SecurityManager-test.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { mocked } from "jest-mock";
+import { CryptoApi } from "matrix-js-sdk/src/crypto-api";
+
+import { accessSecretStorage } from "../src/SecurityManager";
+import { filterConsole, stubClient } from "./test-utils";
+
+describe("SecurityManager", () => {
+    describe("accessSecretStorage", () => {
+        filterConsole("Not setting dehydration key: no SSSS key found");
+
+        it("runs the function passed in", async () => {
+            // Given a client
+            const crypto = {
+                bootstrapCrossSigning: () => {},
+                bootstrapSecretStorage: () => {},
+            } as unknown as CryptoApi;
+            const client = stubClient();
+            mocked(client.hasSecretStorageKey).mockResolvedValue(true);
+            mocked(client.getCrypto).mockReturnValue(crypto);
+
+            // When I run accessSecretStorage
+            const func = jest.fn();
+            await accessSecretStorage(func);
+
+            // Then we call the passed-in function
+            expect(func).toHaveBeenCalledTimes(1);
+        });
+
+        describe("expecting errors", () => {
+            filterConsole("End-to-end encryption is disabled - unable to access secret storage");
+
+            it("throws if crypto is unavailable", async () => {
+                // Given a client with no crypto
+                const client = stubClient();
+                mocked(client.hasSecretStorageKey).mockResolvedValue(true);
+                mocked(client.getCrypto).mockReturnValue(undefined);
+
+                // When I run accessSecretStorage
+                // Then we throw an error
+                await expect(async () => {
+                    await accessSecretStorage(jest.fn());
+                }).rejects.toThrow("End-to-end encryption is disabled - unable to access secret storage");
+            });
+        });
+    });
+});

--- a/test/components/views/dialogs/security/__snapshots__/CreateKeyBackupDialog-test.tsx.snap
+++ b/test/components/views/dialogs/security/__snapshots__/CreateKeyBackupDialog-test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CreateKeyBackupDialog should display the error message when backup creation failed 1`] = `
+exports[`CreateKeyBackupDialog expecting failure should display an error message when backup creation failed 1`] = `
 <DocumentFragment>
   <div
     data-focus-guard="true"

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -132,6 +132,7 @@ export function createTestClient(): MatrixClient {
             getUserDeviceInfo: jest.fn(),
             getUserVerificationStatus: jest.fn(),
             getDeviceVerificationStatus: jest.fn(),
+            resetKeyBackup: jest.fn(),
         }),
 
         getPushActionsForEvent: jest.fn(),


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/3935

Fixes https://github.com/vector-im/element-web/issues/26323

Replace use of deprecated APIs to set up the key backup, meaning it works for the Rust crypto implementation as well as the legacy one.

This change:

* Adds a new Playwright test for creating, deleting, and re-creating a backup. This test reproduces the symptoms of [the bug](https://github.com/vector-im/element-web/issues/26323) without the rest of this PR.
* Disables the Playwright test for legacy crypto, since it doesn't work quite the same there. The backup fails to delete, possibly because it has no keys inside it, or because we are deleting it too quickly after it was created. Since this bug only affects Rust crypto, I thought it would be OK only to run the test for Rust crypto.
* Adds a `getClipboard` method, and requests `clipboard-read` permission in the Playwright setup, so we can copy the security key to use later in the test.
* Adds a new optional argument, `setupNewKeyBackup` to `accessSecretStorage` so that we can pass in `false` in our case. We will set up the backup manually once we have access to the secret storage, so we don't want it set up automatically just because we are asking for access.
* Uses `getCrypto` to get hold of the crypto backend instead of the deprecated `.crypto` pattern.
* Uses `resetKeyBackup` to create a backup instead of the deprecated two-step `prepareKeyBackupVersion` + `createKeyBackupVersion`
* Expects `scheduleAllGroupSessionsForBackup` to be called inside `resetKeyBackup` because of https://github.com/matrix-org/matrix-js-sdk/pull/3935
* Doesn't call `deleteKeyBackupVersion` any more when an unknown error is encountered. As per the comment in that section of the code, it is not clear what we should do in this situation, and we don't have the required information to perform the delete, so I've left it out.
* Fixes up the unit tests for `CreateKeyBackupDialog` to ensure we do call the code passed in to `accessSecretStorage` so that we can allow an error to leak out of them in the failure case.
* Wraps the error case unit test in a describe block so we can filter its error messages from the console without suppressing any legitimate errors from the other tests.
* Adds very basic unit tests for the previously-untested `SecurityManager.accessSecretStorage`

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set up key backup using non-deprecated APIs ([\#12005](https://github.com/matrix-org/matrix-react-sdk/pull/12005)). Fixes vector-im/element-web#26323. Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->