### PR TITLE
Move two runners from Cypress to Playwright to rebalance runtime

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -94,8 +94,8 @@ jobs:
             matrix:
                 # Run tests using both crypto stacks
                 crypto: [legacy, rust]
-                ci_node_total: [4]
-                ci_node_index: [0, 1, 2, 3]
+                ci_node_total: [3]
+                ci_node_index: [0, 1, 2]
         steps:
             # The version of chrome shipped by default may not be consistent across runners
             # so we explicitly use a specific version of chrome here.

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -48,8 +48,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Run 4 instances in Parallel
-                runner: [1, 2, 3, 4]
+                # Run multiple instances in parallel to speed up the tests
+                runner: [1, 2, 3, 4, 5, 6]
         steps:
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:


### PR DESCRIPTION
For https://github.com/vector-im/wat-internal/issues/37

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->