### PR TITLE
Fix cypress bot logger causing test to fail with `TypeError: logger.getChild is not a function`

### DIFF
--- a/cypress/support/bot.ts
+++ b/cypress/support/bot.ts
@@ -331,8 +331,8 @@ function getLogger(win: Cypress.AUTWindow, loggerName: string): Logger {
     const logger = loglevel.getLogger(loggerName);
 
     // If this is the first time this logger has been returned, turn it into a `Logger` and set the default level
-    if (!("extend" in logger)) {
-        logger["extend"] = (namespace: string) => getLogger(win, loggerName + ":" + namespace);
+    if (!("getChild" in logger)) {
+        logger["getChild"] = (namespace: string) => getLogger(win, loggerName + ":" + namespace);
         logger.methodFactory = makeLogMethodFactory(win);
         logger.setLevel(loglevel.levels.DEBUG);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Looks like the bot.ts is incorrectly modifying the Logger before downcasting it to js-sdk Logger interface.

Causing CI failing to merge js-sdk PRs: https://github.com/matrix-org/matrix-js-sdk/actions/runs/7132244930/job/19422411955

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->