### PR TITLE
Prevent Cypress typechecking react-sdk components without strict mode

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import "../src/@types/global";
-import "../src/@types/svg";
-import "../src/@types/raw-loader";
+import "../src/@types/react";
 // eslint-disable-next-line no-restricted-imports
 import "matrix-js-sdk/src/@types/global";
 import type {
@@ -31,20 +29,19 @@ import type {
     RoomMemberEvent,
     ICreateClientOpts,
 } from "matrix-js-sdk/src/matrix";
-import type { MatrixDispatcher } from "../src/dispatcher/dispatcher";
-import type PerformanceMonitor from "../src/performance";
-import type SettingsStore from "../src/settings/SettingsStore";
+import type { SettingLevel } from "../src/settings/SettingLevel";
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
         interface ApplicationWindow {
-            mxSettingsStore: typeof SettingsStore;
+            // XXX: Importing SettingsStore causes a bunch of type lint errors
+            mxSettingsStore: {
+                setValue(settingName: string, roomId: string | null, level: SettingLevel, value: any): Promise<void>;
+            };
             mxMatrixClientPeg: {
                 matrixClient?: MatrixClient;
             };
-            mxDispatcher: MatrixDispatcher;
-            mxPerformanceMonitor: PerformanceMonitor;
             beforeReload?: boolean; // for detecting reloads
             // Partial type for the matrix-js-sdk module, exported by browser-matrix
             matrixcs: {
@@ -60,14 +57,6 @@ declare global {
                 createClient(opts: ICreateClientOpts | string);
             };
         }
-    }
-
-    interface Window {
-        // to appease the MatrixDispatcher import
-        mxDispatcher: MatrixDispatcher;
-        // to appease the PerformanceMonitor import
-        mxPerformanceMonitor: PerformanceMonitor;
-        mxPerformanceEntryNames: any;
     }
 }
 

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import "../src/@types/react";
 // eslint-disable-next-line no-restricted-imports
 import "matrix-js-sdk/src/@types/global";
 import type {


### PR DESCRIPTION
For https://github.com/element-hq/customer-retainer/issues/157

This prevented us from switching to `forwardRef` in a bunch of places due to it behaving different with & without strict mode.



<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->