### PR TITLE
Element-R: fix repeated requests to enter 4S key during cross-signing reset

### DIFF
--- a/playwright/e2e/crypto/crypto.spec.ts
+++ b/playwright/e2e/crypto/crypto.spec.ts
@@ -212,6 +212,43 @@ test.describe("Cryptography", function () {
         });
     }
 
+    test("Can reset cross-signing keys", async ({ page, app, user: aliceCredentials }) => {
+        const secretStorageKey = await enableKeyBackup(app);
+
+        // Fetch the current cross-signing keys
+        async function fetchMasterKey() {
+            return await test.step("Fetch master key from server", async () => {
+                const k = await app.client.evaluate(async (cli) => {
+                    const userId = cli.getUserId();
+                    const keys = await cli.downloadKeysForUsers([userId]);
+                    return Object.values(keys.master_keys[userId].keys)[0];
+                });
+                console.log(`fetchMasterKey: ${k}`);
+                return k;
+            });
+        }
+        const masterKey1 = await fetchMasterKey();
+
+        // Find the "reset cross signing" button, and click it
+        await app.settings.openUserSettings("Security & Privacy");
+        await page.locator("div.mx_CrossSigningPanel_buttonRow").getByRole("button", { name: "Reset" }).click();
+
+        // Confirm
+        await page.getByRole("button", { name: "Clear cross-signing keys" }).click();
+
+        // Enter the 4S key
+        await page.getByPlaceholder("Security Key").fill(secretStorageKey);
+        await page.getByRole("button", { name: "Continue" }).click();
+
+        await expect(async () => {
+            const masterKey2 = await fetchMasterKey();
+            expect(masterKey1).not.toEqual(masterKey2);
+        }).toPass();
+
+        // The dialog should have gone away
+        await expect(page.locator(".mx_Dialog")).toHaveCount(1);
+    });
+
     test("creating a DM should work, being e2e-encrypted / user verification", async ({
         page,
         app,

--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -300,6 +300,28 @@ export async function promptForBackupPassphrase(): Promise<Uint8Array> {
 }
 
 /**
+ * Carry out an operation that may require multiple accesses to secret storage, caching the key.
+ *
+ * Use this helper to wrap an operation that may require multiple accesses to secret storage; the user will be prompted
+ * to enter the 4S key or passphrase on the first access, and the key will be cached for the rest of the operation.
+ *
+ * @param func - The operation to be wrapped.
+ */
+export async function withSecretStorageKeyCache<T>(func: () => Promise<T>): Promise<T> {
+    secretStorageBeingAccessed = true;
+    try {
+        return await func();
+    } finally {
+        // Clear secret storage key cache now that work is complete
+        secretStorageBeingAccessed = false;
+        if (!isCachingAllowed()) {
+            secretStorageKeys = {};
+            secretStorageKeyInfo = {};
+        }
+    }
+}
+
+/**
  * This helper should be used whenever you need to access secret storage. It
  * ensures that secret storage (and also cross-signing since they each depend on
  * each other in a cycle of sorts) have been bootstrapped before running the
@@ -326,7 +348,15 @@ export async function accessSecretStorage(
     forceReset = false,
     setupNewKeyBackup = true,
 ): Promise<void> {
-    secretStorageBeingAccessed = true;
+    await withSecretStorageKeyCache(() => doAccessSecretStorage(func, forceReset, setupNewKeyBackup));
+}
+
+/** Helper for {@link #accessSecretStorage} */
+async function doAccessSecretStorage(
+    func: () => Promise<void>,
+    forceReset: boolean,
+    setupNewKeyBackup: boolean,
+): Promise<void> {
     try {
         const cli = MatrixClientPeg.safeGet();
         if (!(await cli.hasSecretStorageKey()) || forceReset) {
@@ -403,13 +433,6 @@ export async function accessSecretStorage(
         logger.error(e);
         // Re-throw so that higher level logic can abort as needed
         throw e;
-    } finally {
-        // Clear secret storage key cache now that work is complete
-        secretStorageBeingAccessed = false;
-        if (!isCachingAllowed()) {
-            secretStorageKeys = {};
-            secretStorageKeyInfo = {};
-        }
     }
 }
 

--- a/src/components/views/settings/CrossSigningPanel.tsx
+++ b/src/components/views/settings/CrossSigningPanel.tsx
@@ -261,54 +261,56 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
                 <details>
                     <summary className="mx_CrossSigningPanel_advanced">{_t("common|advanced")}</summary>
                     <table className="mx_CrossSigningPanel_statusList">
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_public_keys")}</th>
-                            <td>
-                                {crossSigningPublicKeysOnDevice
-                                    ? _t("settings|security|cross_signing_in_memory")
-                                    : _t("settings|security|cross_signing_not_found")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_private_keys")}</th>
-                            <td>
-                                {crossSigningPrivateKeysInStorage
-                                    ? _t("settings|security|cross_signing_in_4s")
-                                    : _t("settings|security|cross_signing_not_in_4s")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_master_private_Key")}</th>
-                            <td>
-                                {masterPrivateKeyCached
-                                    ? _t("settings|security|cross_signing_cached")
-                                    : _t("settings|security|cross_signing_not_cached")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_self_signing_private_key")}</th>
-                            <td>
-                                {selfSigningPrivateKeyCached
-                                    ? _t("settings|security|cross_signing_cached")
-                                    : _t("settings|security|cross_signing_not_cached")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_user_signing_private_key")}</th>
-                            <td>
-                                {userSigningPrivateKeyCached
-                                    ? _t("settings|security|cross_signing_cached")
-                                    : _t("settings|security|cross_signing_not_cached")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">{_t("settings|security|cross_signing_homeserver_support")}</th>
-                            <td>
-                                {homeserverSupportsCrossSigning
-                                    ? _t("settings|security|cross_signing_homeserver_support_exists")
-                                    : _t("settings|security|cross_signing_not_found")}
-                            </td>
-                        </tr>
+                        <tbody>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_public_keys")}</th>
+                                <td>
+                                    {crossSigningPublicKeysOnDevice
+                                        ? _t("settings|security|cross_signing_in_memory")
+                                        : _t("settings|security|cross_signing_not_found")}
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_private_keys")}</th>
+                                <td>
+                                    {crossSigningPrivateKeysInStorage
+                                        ? _t("settings|security|cross_signing_in_4s")
+                                        : _t("settings|security|cross_signing_not_in_4s")}
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_master_private_Key")}</th>
+                                <td>
+                                    {masterPrivateKeyCached
+                                        ? _t("settings|security|cross_signing_cached")
+                                        : _t("settings|security|cross_signing_not_cached")}
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_self_signing_private_key")}</th>
+                                <td>
+                                    {selfSigningPrivateKeyCached
+                                        ? _t("settings|security|cross_signing_cached")
+                                        : _t("settings|security|cross_signing_not_cached")}
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_user_signing_private_key")}</th>
+                                <td>
+                                    {userSigningPrivateKeyCached
+                                        ? _t("settings|security|cross_signing_cached")
+                                        : _t("settings|security|cross_signing_not_cached")}
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{_t("settings|security|cross_signing_homeserver_support")}</th>
+                                <td>
+                                    {homeserverSupportsCrossSigning
+                                        ? _t("settings|security|cross_signing_homeserver_support_exists")
+                                        : _t("settings|security|cross_signing_not_found")}
+                                </td>
+                            </tr>
+                        </tbody>
                     </table>
                 </details>
                 {errorSection}

--- a/test/components/views/settings/tabs/user/__snapshots__/SecurityUserSettingsTab-test.tsx.snap
+++ b/test/components/views/settings/tabs/user/__snapshots__/SecurityUserSettingsTab-test.tsx.snap
@@ -175,66 +175,68 @@ exports[`<SecurityUserSettingsTab /> renders security section 1`] = `
                 <table
                   class="mx_CrossSigningPanel_statusList"
                 >
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      Cross-signing public keys:
-                    </th>
-                    <td>
-                      not found
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      Cross-signing private keys:
-                    </th>
-                    <td>
-                      not found in storage
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      Master private key:
-                    </th>
-                    <td>
-                      not found locally
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      Self signing private key:
-                    </th>
-                    <td>
-                      not found locally
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      User signing private key:
-                    </th>
-                    <td>
-                      not found locally
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      scope="row"
-                    >
-                      Homeserver feature support:
-                    </th>
-                    <td>
-                      not found
-                    </td>
-                  </tr>
+                  <tbody>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        Cross-signing public keys:
+                      </th>
+                      <td>
+                        not found
+                      </td>
+                    </tr>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        Cross-signing private keys:
+                      </th>
+                      <td>
+                        not found in storage
+                      </td>
+                    </tr>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        Master private key:
+                      </th>
+                      <td>
+                        not found locally
+                      </td>
+                    </tr>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        Self signing private key:
+                      </th>
+                      <td>
+                        not found locally
+                      </td>
+                    </tr>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        User signing private key:
+                      </th>
+                      <td>
+                        not found locally
+                      </td>
+                    </tr>
+                    <tr>
+                      <th
+                        scope="row"
+                      >
+                        Homeserver feature support:
+                      </th>
+                      <td>
+                        not found
+                      </td>
+                    </tr>
+                  </tbody>
                 </table>
               </details>
             </div>


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/26321. Also adds a playwright test for this flow.

As the issue says: this works in legacy crypto, because legacy crypto has its own caching layer for 4S keys in addition to the application-level one. That seems like one caching layer too many so rather than replicate it for rust crypto I've just changed things to use the app-level caching layer for this flow.

Suggest review commit-by-commit.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Element-R: fix repeated requests to enter 4S key during cross-signing reset ([\#12059](https://github.com/matrix-org/matrix-react-sdk/pull/12059)). Fixes element-hq/element-web#26321.<!-- CHANGELOG_PREVIEW_END -->