### PR TITLE
Fix incorrect type annotation on `cacheSecretStorageKey`

### DIFF
--- a/cypress/support/bot.ts
+++ b/cypress/support/bot.ts
@@ -20,7 +20,7 @@ import * as loglevel from "loglevel";
 
 import type { ISendEventResponse, MatrixClient, Room } from "matrix-js-sdk/src/matrix";
 import type { GeneratedSecretStorageKey } from "matrix-js-sdk/src/crypto-api";
-import type { AddSecretStorageKeyOpts } from "matrix-js-sdk/src/secret-storage";
+import type { SecretStorageKeyDescription } from "matrix-js-sdk/src/secret-storage";
 import { HomeserverInstance } from "../plugins/utils/homeserver";
 import { Credentials } from "./homeserver";
 import { collapseLastLogGroup } from "./log";
@@ -157,7 +157,7 @@ function setupBotClient(
 
             // Store the cached secret storage key and return it when `getSecretStorageKey` is called
             let cachedKey: { keyId: string; key: Uint8Array };
-            const cacheSecretStorageKey = (keyId: string, keyInfo: AddSecretStorageKeyOpts, key: Uint8Array) => {
+            const cacheSecretStorageKey = (keyId: string, keyInfo: SecretStorageKeyDescription, key: Uint8Array) => {
                 cachedKey = {
                     keyId,
                     key,


### PR DESCRIPTION
`cacheSecretStorageKey` is passed a `SecretStorageKeyDescription` (aka a `ISecretStorageKeyInfo`), and has done ever since https://github.com/matrix-org/matrix-js-sdk/pull/1502. `AddSecretStorageKeyOpts`is something else, though until recently some of the properties on `AddSecretStorageKeyOpts` were incorrectly marked as optional, so this went unnoticed since it was broken by https://github.com/matrix-org/matrix-react-sdk/pull/11217.