### PR TITLE
Fix threaded reply playwright tests

### DIFF
--- a/playwright/e2e/read-receipts/index.ts
+++ b/playwright/e2e/read-receipts/index.ts
@@ -155,10 +155,19 @@ export class MessageBuilder {
             public async getContent(room: JSHandle<Room>): Promise<Record<string, unknown>> {
                 const ev = await this.messageFinder.getMessage(room, targetMessage, true);
                 return ev.evaluate((ev, newMessage) => {
+                    const threadRel =
+                        ev.getRelation()?.rel_type === "m.thread"
+                            ? {
+                                  rel_type: "m.thread",
+                                  event_id: ev.getRelation().event_id,
+                              }
+                            : {};
+
                     return {
                         "msgtype": "m.text",
                         "body": newMessage,
                         "m.relates_to": {
+                            ...threadRel,
                             "m.in_reply_to": {
                                 event_id: ev.getId(),
                             },

--- a/playwright/e2e/read-receipts/redactions.spec.ts
+++ b/playwright/e2e/read-receipts/redactions.spec.ts
@@ -642,8 +642,7 @@ test.describe("Read receipts", () => {
                 await util.assertRead(room2);
                 await util.assertReadThread("Root");
             });
-            // XXX: fails because the read count drops to 1 but not to zero (this is a genuine stuck unread case)
-            test.skip("Reading a reply to a redacted message marks the thread as read", async ({
+            test("Reading a reply to a redacted message marks the thread as read", async ({
                 roomAlpha: room1,
                 roomBeta: room2,
                 util,
@@ -760,8 +759,7 @@ test.describe("Read receipts", () => {
                 // Then the room is still read
                 await util.assertRead(room2);
             });
-            // XXX: fails for the same reason as "Reading a reply to a redacted message marks the thread as read"
-            test.skip("A thread with an unread reply to a redacted message is still unread after restart", async ({
+            test("A thread with an unread reply to a redacted message is still unread after restart", async ({
                 roomAlpha: room1,
                 roomBeta: room2,
                 util,
@@ -791,8 +789,7 @@ test.describe("Read receipts", () => {
                 await util.assertRead(room2);
                 await util.assertReadThread("Root");
             });
-            // XXX: fails for the same reason as "Reading a reply to a redacted message marks the thread as read
-            test.skip("A thread with a read reply to a redacted message is still read after restart", async ({
+            test("A thread with a read reply to a redacted message is still read after restart", async ({
                 roomAlpha: room1,
                 roomBeta: room2,
                 util,


### PR DESCRIPTION
It appears the bug with these tests was just that the MessageBuilder wasn't setting the thread relation on the reply messages as this didn't happen trying to repro it manually, so fix the builder and re-enable the tests.

The flip side of this is that it implies buggy clients that don't set thread relations properly will cause stuck notifs in Element Web. I've filed this as https://github.com/element-hq/element-web/issues/26787

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix threaded reply playwright tests ([\#12070](https://github.com/matrix-org/matrix-react-sdk/pull/12070)).<!-- CHANGELOG_PREVIEW_END -->