### PR TITLE
Adjust tooltip side for DecoratedRoomAvatar to not obscure room name

### DIFF
--- a/src/components/views/avatars/DecoratedRoomAvatar.tsx
+++ b/src/components/views/avatars/DecoratedRoomAvatar.tsx
@@ -209,7 +209,11 @@ export default class DecoratedRoomAvatar extends React.PureComponent<IProps, ISt
                     oobData={this.props.oobData}
                     viewAvatarOnClick={this.props.viewAvatarOnClick}
                 />
-                {icon && <Tooltip label={tooltipText(this.state.icon)!}>{icon}</Tooltip>}
+                {icon && (
+                    <Tooltip label={tooltipText(this.state.icon)!} side="bottom">
+                        {icon}
+                    </Tooltip>
+                )}
                 {badge}
             </div>
         );


### PR DESCRIPTION
For https://github.com/element-hq/customer-retainer/issues/157#issuecomment-1816321573

![image](https://github.com/element-hq/customer-retainer/assets/2403652/72fdebc6-d990-437b-8c09-46de795dee61)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Adjust tooltip side for DecoratedRoomAvatar to not obscure room name ([\#12079](https://github.com/matrix-org/matrix-react-sdk/pull/12079)).<!-- CHANGELOG_PREVIEW_END -->