### PR TITLE
Ensure backup settings in playwright

### DIFF
--- a/playwright/e2e/crypto/utils.ts
+++ b/playwright/e2e/crypto/utils.ts
@@ -103,33 +103,28 @@ export async function checkDeviceIsCrossSigned(app: ElementAppPage): Promise<voi
 }
 
 /**
- * Check that the current device is connected to the key backup.
+ * Check that the current device is connected to the expected key backup.
+ * Also checks that the decryption key is known and cached locally.
+ *
+ * @param page - the page to check
+ * @param expectedBackupVersion - the version of the backup we expect to be connected to.
  */
-export async function checkDeviceIsConnectedKeyBackup(page: Page) {
+export async function checkDeviceIsConnectedKeyBackup(page: Page, expectedBackupVersion: string): Promise<void> {
     await page.getByRole("button", { name: "User menu" }).click();
     await page.locator(".mx_UserMenu_contextMenu").getByRole("menuitem", { name: "Security & Privacy" }).click();
     await expect(page.locator(".mx_Dialog").getByRole("button", { name: "Restore from Backup" })).toBeVisible();
 
     // expand the advanced section to see the active version in the reports
-    const summary = page.locator(".mx_Dialog .mx_SettingsSubsection_content details .mx_SecureBackupPanel_advanced");
+    const summary = page.locator(".mx_SecureBackupPanel_advanced");
     await summary.locator("..").click();
 
-    const decryptionKeyCached = await page
-        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(2) td")
-        .textContent();
-    expect(decryptionKeyCached.trim()).toBe("cached locally, well formed");
+    const cacheDecryptionKeyStatusElement = page.locator(".mx_SecureBackupPanel_statusList tr:nth-child(2) td");
+    await expect(cacheDecryptionKeyStatusElement).toHaveText("cached locally, well formed");
 
-    // when initially setting up the key backup, the server version is 1,
-    // it should not change after that unless explicitly reset
-    const expectedBackupVersion = "1";
-    const serverVersion = await page
-        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(5) td")
-        .textContent();
+    const serverVersion = await page.locator(".mx_SecureBackupPanel_statusList tr:nth-child(5) td").textContent();
     expect(serverVersion.trim()).toBe(expectedBackupVersion + " (Algorithm: m.megolm_backup.v1.curve25519-aes-sha2)");
 
-    const activeVersion = await page
-        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(6) td")
-        .textContent();
+    const activeVersion = await page.locator(".mx_SecureBackupPanel_statusList tr:nth-child(6) td").textContent();
     expect(activeVersion.trim()).toBe(expectedBackupVersion);
 }
 

--- a/playwright/e2e/crypto/utils.ts
+++ b/playwright/e2e/crypto/utils.ts
@@ -109,6 +109,28 @@ export async function checkDeviceIsConnectedKeyBackup(page: Page) {
     await page.getByRole("button", { name: "User menu" }).click();
     await page.locator(".mx_UserMenu_contextMenu").getByRole("menuitem", { name: "Security & Privacy" }).click();
     await expect(page.locator(".mx_Dialog").getByRole("button", { name: "Restore from Backup" })).toBeVisible();
+
+    // expand the advanced section to see the active version in the reports
+    const summary = page.locator(".mx_Dialog .mx_SettingsSubsection_content details .mx_SecureBackupPanel_advanced");
+    await summary.locator("..").click();
+
+    const decryptionKeyCached = await page
+        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(2) td")
+        .textContent();
+    expect(decryptionKeyCached.trim()).toBe("cached locally, well formed");
+
+    // when initially setting up the key backup, the server version is 1,
+    // it should not change after that unless explicitly reset
+    const expectedBackupVersion = "1";
+    const serverVersion = await page
+        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(5) td")
+        .textContent();
+    expect(serverVersion.trim()).toBe(expectedBackupVersion + " (Algorithm: m.megolm_backup.v1.curve25519-aes-sha2)");
+
+    const activeVersion = await page
+        .locator(".mx_Dialog .mx_SecureBackupPanel_statusList tr:nth-child(6) td")
+        .textContent();
+    expect(activeVersion.trim()).toBe(expectedBackupVersion);
 }
 
 /**

--- a/playwright/e2e/crypto/verification.spec.ts
+++ b/playwright/e2e/crypto/verification.spec.ts
@@ -32,6 +32,7 @@ import { Bot } from "../../pages/bot";
 
 test.describe("Device verification", () => {
     let aliceBotClient: Bot;
+    let expectedBackupVersion: string;
 
     test.beforeEach(async ({ page, homeserver, credentials }) => {
         // Visit the login page of the app, to load the matrix sdk
@@ -49,7 +50,10 @@ test.describe("Device verification", () => {
             bootstrapSecretStorage: true,
         });
         aliceBotClient.setCredentials(credentials);
-        await aliceBotClient.prepareClient();
+        const mxClientHandle = await aliceBotClient.prepareClient();
+        expectedBackupVersion = await mxClientHandle.evaluate(async (mxClient) => {
+            return await mxClient.getCrypto()!.getActiveSessionBackupVersion();
+        });
 
         await page.waitForTimeout(20000);
     });
@@ -83,15 +87,11 @@ test.describe("Device verification", () => {
         await infoDialog.getByRole("button", { name: "They match" }).click();
         await infoDialog.getByRole("button", { name: "Got it" }).click();
 
-        // After the verification, the new device will request the secret to the existing device
-        // give some time for the request to be sent and received.
-        await page.waitForTimeout(1000);
-
         // Check that our device is now cross-signed
         await checkDeviceIsCrossSigned(app);
 
         // Check that the current device is connected to key backup
-        await checkDeviceIsConnectedKeyBackup(page);
+        await checkDeviceIsConnectedKeyBackup(page, expectedBackupVersion);
     });
 
     test("Verify device with QR code during login", async ({ page, app, credentials, homeserver }) => {
@@ -134,7 +134,7 @@ test.describe("Device verification", () => {
         await checkDeviceIsCrossSigned(app);
 
         // Check that the current device is connected to key backup
-        await checkDeviceIsConnectedKeyBackup(page);
+        await checkDeviceIsConnectedKeyBackup(page, expectedBackupVersion);
     });
 
     test("Verify device with Security Phrase during login", async ({ page, app, credentials, homeserver }) => {
@@ -154,7 +154,7 @@ test.describe("Device verification", () => {
         await checkDeviceIsCrossSigned(app);
 
         // Check that the current device is connected to key backup
-        await checkDeviceIsConnectedKeyBackup(page);
+        await checkDeviceIsConnectedKeyBackup(page, expectedBackupVersion);
     });
 
     test("Verify device with Security Key during login", async ({ page, app, credentials, homeserver }) => {
@@ -176,7 +176,7 @@ test.describe("Device verification", () => {
         await checkDeviceIsCrossSigned(app);
 
         // Check that the current device is connected to key backup
-        await checkDeviceIsConnectedKeyBackup(page);
+        await checkDeviceIsConnectedKeyBackup(page, expectedBackupVersion);
     });
 
     test("Handle incoming verification request with SAS", async ({ page, credentials, homeserver, toasts }) => {

--- a/playwright/e2e/crypto/verification.spec.ts
+++ b/playwright/e2e/crypto/verification.spec.ts
@@ -83,6 +83,10 @@ test.describe("Device verification", () => {
         await infoDialog.getByRole("button", { name: "They match" }).click();
         await infoDialog.getByRole("button", { name: "Got it" }).click();
 
+        // After the verification, the new device will request the secret to the existing device
+        // give some time for the request to be sent and received.
+        await page.waitForTimeout(1000);
+
         // Check that our device is now cross-signed
         await checkDeviceIsCrossSigned(app);
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

Improve the e2e crypto test and ensure that the backup is correctly configured after verification.
It will ensure that the backup version is as expected, and that the backup can be used to import keys (active), and to export (decryption key known)

The test will fail when verifying with passphrase/key until this [react PR](https://github.com/matrix-org/matrix-react-sdk/pull/12005) is reverted


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->