### PR TITLE
Playwright: Ensure that master key is the expected one

### DIFF
--- a/playwright/e2e/crypto/utils.ts
+++ b/playwright/e2e/crypto/utils.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import { expect, JSHandle, type Page } from "@playwright/test";
-import { CryptoEvent } from "matrix-js-sdk/src/matrix";
 
 import type { ICreateRoomOpts, MatrixClient } from "matrix-js-sdk/src/matrix";
 import type {
@@ -94,7 +93,8 @@ export async function checkDeviceIsCrossSigned(app: ElementAppPage, expectedMast
                         resolve();
                     }
                 };
-                cli.on(CryptoEvent.UserTrustStatusChanged, onUserTrustStatusChanged);
+                // @ts-ignore
+                cli.on("userTrustStatusChanged", onUserTrustStatusChanged);
             });
         }
 

--- a/src/components/views/settings/SecureBackupPanel.tsx
+++ b/src/components/views/settings/SecureBackupPanel.tsx
@@ -96,6 +96,7 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
 
         MatrixClientPeg.safeGet().on(CryptoEvent.KeyBackupStatus, this.onKeyBackupStatus);
         MatrixClientPeg.safeGet().on(CryptoEvent.KeyBackupSessionsRemaining, this.onKeyBackupSessionsRemaining);
+        MatrixClientPeg.safeGet().on(CryptoEvent.KeyBackupDecryptionKeyCached, this.onKeyBackupDecryptionKeyCached);
     }
 
     public componentWillUnmount(): void {
@@ -107,6 +108,10 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
                 CryptoEvent.KeyBackupSessionsRemaining,
                 this.onKeyBackupSessionsRemaining,
             );
+            MatrixClientPeg.get()!.removeListener(
+                CryptoEvent.KeyBackupDecryptionKeyCached,
+                this.onKeyBackupDecryptionKeyCached,
+            );
         }
     }
 
@@ -114,6 +119,10 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
         this.setState({
             sessionsRemaining,
         });
+    };
+
+    private onKeyBackupDecryptionKeyCached = (): void => {
+        this.getUpdatedDiagnostics();
     };
 
     private onKeyBackupStatus = (): void => {


### PR DESCRIPTION
Quick improvements to the playwright verification test:
 - Ensure that the new session sees the correct cross signing key (protects against regression that would rotate the key on the new session)
 - Check also that the backup decryption key is correctly gossiped after interactive verification (only rust crypto as on legacy it's a bit flaky because the setting page doesn't refresh when secret is received; would have to close and re-open or wait before opening first time)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->