### PR TITLE
Fix Stickerpicker layout crossing multiple CSS stacking contexts

### DIFF
--- a/res/css/views/rooms/_Stickers.pcss
+++ b/res/css/views/rooms/_Stickers.pcss
@@ -5,11 +5,9 @@
 .mx_Stickers_content_container {
     overflow: hidden;
     height: 300px;
-}
 
-#mx_persistedElement_stickerPicker {
     .mx_AppTileFullWidth {
-        height: unset;
+        height: 100%;
         box-sizing: border-box;
         border-left: none;
         border-right: none;

--- a/res/css/views/rooms/_Stickers.pcss
+++ b/res/css/views/rooms/_Stickers.pcss
@@ -5,9 +5,11 @@
 .mx_Stickers_content_container {
     overflow: hidden;
     height: 300px;
+}
 
+#mx_persistedElement_stickerPicker {
     .mx_AppTileFullWidth {
-        height: 100%;
+        height: unset;
         box-sizing: border-box;
         border-left: none;
         border-right: none;

--- a/src/components/views/rooms/Stickerpicker.tsx
+++ b/src/components/views/rooms/Stickerpicker.tsx
@@ -25,7 +25,6 @@ import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import dis from "../../../dispatcher/dispatcher";
 import AccessibleButton from "../elements/AccessibleButton";
 import WidgetUtils, { UserWidget } from "../../../utils/WidgetUtils";
-import PersistedElement from "../elements/PersistedElement";
 import { IntegrationManagers } from "../../../integrations/IntegrationManagers";
 import ContextMenu, { ChevronFace } from "../../structures/ContextMenu";
 import { WidgetType } from "../../../widgets/WidgetType";
@@ -39,9 +38,6 @@ import { UPDATE_EVENT } from "../../../stores/AsyncStore";
 // This should be below the dialog level (4000), but above the rest of the UI (1000-2000).
 // We sit in a context menu, so this should be given to the context menu.
 const STICKERPICKER_Z_INDEX = 3500;
-
-// Key to store the widget's AppTile under in PersistedElement
-const PERSISTED_ELEMENT_KEY = "stickerPicker";
 
 interface IProps {
     room: Room;
@@ -61,8 +57,6 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
     public static defaultProps: Partial<IProps> = {
         threadId: null,
     };
-
-    public static currentWidget?: UserWidget;
 
     private dispatcherRef?: string;
 
@@ -170,21 +164,10 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
     private updateWidget = (): void => {
         const stickerpickerWidget = WidgetUtils.getStickerpickerWidgets(this.props.room.client)[0];
         if (!stickerpickerWidget) {
-            Stickerpicker.currentWidget = undefined;
             this.setState({ stickerpickerWidget: null, widgetId: null });
             return;
         }
 
-        const currentWidget = Stickerpicker.currentWidget;
-        const currentUrl = currentWidget?.content?.url ?? null;
-        const newUrl = stickerpickerWidget?.content?.url ?? null;
-
-        if (newUrl !== currentUrl) {
-            // Destroy the existing frame so a new one can be created
-            PersistedElement.destroyElement(PERSISTED_ELEMENT_KEY);
-        }
-
-        Stickerpicker.currentWidget = stickerpickerWidget;
         this.setState({
             stickerpickerWidget,
             widgetId: stickerpickerWidget ? stickerpickerWidget.id : null,
@@ -284,27 +267,23 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
                             width: this.popoverWidth,
                         }}
                     >
-                        <PersistedElement persistKey={PERSISTED_ELEMENT_KEY} zIndex={STICKERPICKER_Z_INDEX}>
-                            <AppTile
-                                app={stickerApp}
-                                room={this.props.room}
-                                threadId={this.props.threadId}
-                                fullWidth={true}
-                                userId={MatrixClientPeg.safeGet().credentials.userId!}
-                                creatorUserId={
-                                    stickerpickerWidget.sender || MatrixClientPeg.safeGet().credentials.userId!
-                                }
-                                waitForIframeLoad={true}
-                                showMenubar={true}
-                                onEditClick={this.launchManageIntegrations}
-                                onDeleteClick={this.removeStickerpickerWidgets}
-                                showTitle={false}
-                                showPopout={false}
-                                handleMinimisePointerEvents={true}
-                                userWidget={true}
-                                showLayoutButtons={false}
-                            />
-                        </PersistedElement>
+                        <AppTile
+                            app={stickerApp}
+                            room={this.props.room}
+                            threadId={this.props.threadId}
+                            fullWidth={true}
+                            userId={MatrixClientPeg.safeGet().credentials.userId!}
+                            creatorUserId={stickerpickerWidget.sender || MatrixClientPeg.safeGet().credentials.userId!}
+                            waitForIframeLoad={true}
+                            showMenubar={true}
+                            onEditClick={this.launchManageIntegrations}
+                            onDeleteClick={this.removeStickerpickerWidgets}
+                            showTitle={false}
+                            showPopout={false}
+                            handleMinimisePointerEvents={true}
+                            userWidget={true}
+                            showLayoutButtons={false}
+                        />
                     </div>
                 </div>
             );


### PR DESCRIPTION
Regressed by https://github.com/element-hq/element-web/pull/26840 not having the e2e tests in the branch protections (remedied now)

~At some point historically we seem to have needed Stickerpicker to be in a PersistedElement so it can be re-parented, I believe around the time of RoomList widgets, this causes a mess with our context menu implementation in a CSS stacking context (Compound) world, so lets ditch it given RoomList widgets are long dead.~

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix Stickerpicker layout crossing multiple CSS stacking contexts ([\#12126](https://github.com/matrix-org/matrix-react-sdk/pull/12126)).<!-- CHANGELOG_PREVIEW_END -->