### PR TITLE
Fix OIDC end to end test which failed since Synapse updated authlib

### DIFF
--- a/playwright/plugins/homeserver/synapse/templates/default/homeserver.yaml
+++ b/playwright/plugins/homeserver/synapse/templates/default/homeserver.yaml
@@ -89,6 +89,7 @@ oidc_providers:
       discover: false
       scopes: ["profile"]
       skip_verification: true
+      client_auth_method: none
       user_mapping_provider:
           config:
               display_name_template: "{{ user.name }}"


### PR DESCRIPTION
Omitting the field has always been incorrect according to https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#oidc_providers but authlib 1.3.0 started erroring instead of treating it as `"None"`.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->