### PR TITLE
Broaden support for matrix spec versions

### DIFF
--- a/test/Lifecycle-test.ts
+++ b/test/Lifecycle-test.ts
@@ -453,10 +453,7 @@ describe("Lifecycle", () => {
 
             it("should show a toast if the matrix server version is unsupported", async () => {
                 const toastSpy = jest.spyOn(ToastStore.sharedInstance(), "addOrReplaceToast");
-                mockClient.getVersions.mockResolvedValue({
-                    versions: ["r0.6.0"],
-                    unstable_features: {},
-                });
+                mockClient.isVersionSupported.mockImplementation(async (version) => version == "r0.6.0");
                 initLocalStorageMock({ ...localStorageSession });
 
                 expect(await restoreFromLocalStorage()).toEqual(true);


### PR DESCRIPTION
Something of a compainion to https://github.com/matrix-org/matrix-js-sdk/pull/4014, but also covering the issues discussed at https://github.com/matrix-org/matrix-js-sdk/issues/3915#issuecomment-1865221366.

In short: we should not reject servers which only implement recent versions of the spec. Doing so holds back the Matrix ecosystem by requiring all new servers to implement features that nobody actually uses any more.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Broaden support for matrix spec versions ([\#12154](https://github.com/matrix-org/matrix-react-sdk/pull/12154)).<!-- CHANGELOG_PREVIEW_END -->