### PR TITLE
Make threads activity centre labs flag split out unread counts

### DIFF
--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -81,9 +81,12 @@ export function setRoomNotifsState(client: MatrixClient, roomId: string, newStat
 }
 
 export function getUnreadNotificationCount(room: Room, type: NotificationCountType, threadId?: string): number {
-    let notificationCount = !!threadId
-        ? room.getThreadUnreadNotificationCount(threadId, type)
-        : room.getUnreadNotificationCount(type);
+    const countShownForRoom = (): number =>
+        SettingsStore.getValue("threadsActivityCentre")
+            ? room.getRoomUnreadNotificationCount(type)
+            : room.getUnreadNotificationCount(type);
+
+    let notificationCount = !!threadId ? room.getThreadUnreadNotificationCount(threadId, type) : countShownForRoom();
 
     // Check notification counts in the old room just in case there's some lost
     // there. We only go one level down to avoid performance issues, and theory

--- a/src/Unread.ts
+++ b/src/Unread.ts
@@ -57,7 +57,12 @@ export function doesRoomHaveUnreadMessages(room: Room): boolean {
         return false;
     }
 
-    for (const withTimeline of [room, ...room.getThreads()]) {
+    const toCheck: Array<Room | Thread> = [room];
+    if (!SettingsStore.getValue("threadsActivityCentre")) {
+        toCheck.push(...room.getThreads());
+    }
+
+    for (const withTimeline of toCheck) {
         if (doesTimelineHaveUnreadMessages(room, withTimeline.timeline)) {
             // We found an unread, so the room is unread
             return true;

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1109,6 +1109,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
     "threadsActivityCentre": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         labsGroup: LabGroup.Threads,
+        controller: new ReloadOnChangeController(),
         displayName: _td("labs|threads_activity_centre"),
         default: false,
         isFeature: true,

--- a/test/components/views/rooms/LegacyRoomHeader-test.tsx
+++ b/test/components/views/rooms/LegacyRoomHeader-test.tsx
@@ -792,8 +792,17 @@ function createRoom(info: IRoomCreationInfo) {
     const userId = client.getUserId()!;
     if (info.isDm) {
         client.getAccountData = (eventType) => {
-            expect(eventType).toEqual("m.direct");
-            return mkDirectEvent(roomId, userId, info.userIds);
+            if (eventType === "m.direct") {
+                return mkDirectEvent(roomId, userId, info.userIds);
+            } else if (eventType === "im.vector.web.settings") {
+                return mkEvent({
+                    event: true,
+                    type: "im.vector.web.settings",
+                    room: roomId,
+                    user: userId,
+                    content: {},
+                });
+            }
         };
     }
 

--- a/test/components/views/rooms/LegacyRoomHeader-test.tsx
+++ b/test/components/views/rooms/LegacyRoomHeader-test.tsx
@@ -794,14 +794,8 @@ function createRoom(info: IRoomCreationInfo) {
         client.getAccountData = (eventType) => {
             if (eventType === "m.direct") {
                 return mkDirectEvent(roomId, userId, info.userIds);
-            } else if (eventType === "im.vector.web.settings") {
-                return mkEvent({
-                    event: true,
-                    type: "im.vector.web.settings",
-                    room: roomId,
-                    user: userId,
-                    content: {},
-                });
+            } else {
+                return undefined;
             }
         };
     }

--- a/test/stores/RoomNotificationStateStore-test.ts
+++ b/test/stores/RoomNotificationStateStore-test.ts
@@ -125,6 +125,7 @@ describe("RoomNotificationStateStore", function () {
         ret.getPendingEvents = jest.fn().mockReturnValue([]);
         ret.isSpaceRoom = jest.fn().mockReturnValue(false);
         ret.getUnreadNotificationCount = jest.fn().mockReturnValue(numUnreads);
+        ret.getRoomUnreadNotificationCount = jest.fn().mockReturnValue(numUnreads);
         return ret;
     }
 });


### PR DESCRIPTION
Just shows notif & unread counts for main thread if the TAC is enabled.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make threads activity centre labs flag split out unread counts ([\#12156](https://github.com/matrix-org/matrix-react-sdk/pull/12156)).<!-- CHANGELOG_PREVIEW_END -->