### PR TITLE
Recovery: Fix backup change detection not working in rust

### DIFF
--- a/playwright/e2e/crypto/backups.spec.ts
+++ b/playwright/e2e/crypto/backups.spec.ts
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 import { type Page } from "@playwright/test";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { test, expect } from "../../element-web-test";
 import { Bot } from "../../pages/bot";
-import { MatrixClient } from "../../../../matrix-js-sdk";
 import { Credentials, HomeserverInstance } from "../../plugins/homeserver";
 
 async function expectBackupVersionToBe(page: Page, version: string) {

--- a/src/async-components/views/dialogs/security/NewRecoveryMethodDialog.tsx
+++ b/src/async-components/views/dialogs/security/NewRecoveryMethodDialog.tsx
@@ -16,18 +16,14 @@ limitations under the License.
 */
 
 import React from "react";
-import { IKeyBackupInfo } from "matrix-js-sdk/src/crypto/keybackup";
 
 import dis from "../../../../dispatcher/dispatcher";
 import { _t } from "../../../../languageHandler";
-import Modal from "../../../../Modal";
-import RestoreKeyBackupDialog from "../../../../components/views/dialogs/security/RestoreKeyBackupDialog";
 import { Action } from "../../../../dispatcher/actions";
 import DialogButtons from "../../../../components/views/elements/DialogButtons";
 import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
 
 interface IProps {
-    newVersionInfo: IKeyBackupInfo;
     onFinished(): void;
 }
 
@@ -41,18 +37,6 @@ export default class NewRecoveryMethodDialog extends React.PureComponent<IProps>
         dis.fire(Action.ViewUserSettings);
     };
 
-    private onSetupClick = async (): Promise<void> => {
-        Modal.createDialog(
-            RestoreKeyBackupDialog,
-            {
-                onFinished: this.props.onFinished,
-            },
-            undefined,
-            /* priority = */ false,
-            /* static = */ true,
-        );
-    };
-
     public render(): React.ReactNode {
         const title = (
             <span className="mx_KeyBackupFailedDialog_title">
@@ -64,35 +48,19 @@ export default class NewRecoveryMethodDialog extends React.PureComponent<IProps>
 
         const hackWarning = <p className="warning">{_t("encryption|new_recovery_method_detected|warning")}</p>;
 
-        let content: JSX.Element | undefined;
-        if (this.props.newVersionInfo) {
-            content = (
-                <div>
-                    {newMethodDetected}
-                    <p>{_t("encryption|new_recovery_method_detected|description_2")}</p>
-                    {hackWarning}
-                    <DialogButtons
-                        primaryButton={_t("action|ok")}
-                        onPrimaryButtonClick={this.onOkClick}
-                        cancelButton={_t("common|go_to_settings")}
-                        onCancel={this.onGoToSettingsClick}
-                    />
-                </div>
-            );
-        } else {
-            content = (
-                <div>
-                    {newMethodDetected}
-                    {hackWarning}
-                    <DialogButtons
-                        primaryButton={_t("common|setup_secure_messages")}
-                        onPrimaryButtonClick={this.onSetupClick}
-                        cancelButton={_t("common|go_to_settings")}
-                        onCancel={this.onGoToSettingsClick}
-                    />
-                </div>
-            );
-        }
+        const content = (
+            <div>
+                {newMethodDetected}
+                <p>{_t("encryption|new_recovery_method_detected|description_2")}</p>
+                {hackWarning}
+                <DialogButtons
+                    primaryButton={_t("action|ok")}
+                    onPrimaryButtonClick={this.onOkClick}
+                    cancelButton={_t("common|go_to_settings")}
+                    onCancel={this.onGoToSettingsClick}
+                />
+            </div>
+        );
 
         return (
             <BaseDialog className="mx_KeyBackupFailedDialog" onFinished={this.props.onFinished} title={title}>

--- a/src/async-components/views/dialogs/security/NewRecoveryMethodDialog.tsx
+++ b/src/async-components/views/dialogs/security/NewRecoveryMethodDialog.tsx
@@ -18,7 +18,6 @@ limitations under the License.
 import React from "react";
 import { IKeyBackupInfo } from "matrix-js-sdk/src/crypto/keybackup";
 
-import { MatrixClientPeg } from "../../../../MatrixClientPeg";
 import dis from "../../../../dispatcher/dispatcher";
 import { _t } from "../../../../languageHandler";
 import Modal from "../../../../Modal";
@@ -66,7 +65,7 @@ export default class NewRecoveryMethodDialog extends React.PureComponent<IProps>
         const hackWarning = <p className="warning">{_t("encryption|new_recovery_method_detected|warning")}</p>;
 
         let content: JSX.Element | undefined;
-        if (MatrixClientPeg.safeGet().getKeyBackupEnabled()) {
+        if (this.props.newVersionInfo) {
             content = (
                 <div>
                     {newMethodDetected}

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1675,7 +1675,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             let haveNewVersion: boolean | undefined;
             let newVersionInfo: IKeyBackupInfo | null = null;
             // if key backup is still enabled, there must be a new backup in place
-            if (cli.getKeyBackupEnabled()) {
+            const backupEnabled = (await cli.getCrypto()!.getActiveSessionBackupVersion()) !== null;
+            if (backupEnabled) {
                 haveNewVersion = true;
             } else {
                 // otherwise check the server to see if there's a new one


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/element-hq/element-web/issues/26792

React sdk was still making usage of  `client#getKeyBackupEnabled()` that is deprecated and failing in rust stack.
That would cause the following dialog to not show up:

- When the backup is deleted from another session
![image](https://github.com/matrix-org/matrix-react-sdk/assets/9841565/9a95d135-cf72-4b63-b72d-71b7a861992f)

- When backup is reset from another session
![image](https://github.com/matrix-org/matrix-react-sdk/assets/9841565/d7a3793b-27c4-4094-a90b-35e754e771a0)


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Recovery: Fix backup change detection not working in rust ([\#12160](https://github.com/matrix-org/matrix-react-sdk/pull/12160)). Fixes element-hq/element-web#26792.<!-- CHANGELOG_PREVIEW_END -->