### PR TITLE
Open thread panel when thread clicked in Threads Activity Centre

### DIFF
--- a/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentre.tsx
+++ b/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentre.tsx
@@ -24,11 +24,12 @@ import { ThreadsActivityCentreButton } from "./ThreadsActivityCentreButton";
 import { _t } from "../../../../languageHandler";
 import RoomListStore from "../../../../stores/room-list/RoomListStore";
 import DecoratedRoomAvatar from "../../avatars/DecoratedRoomAvatar";
-import { showThreadPanel } from "../../../../dispatcher/dispatch-actions/threads";
 import { Action } from "../../../../dispatcher/actions";
 import defaultDispatcher from "../../../../dispatcher/dispatcher";
 import { ViewRoomPayload } from "../../../../dispatcher/payloads/ViewRoomPayload";
 import { ThreadsActivityCentreBadge } from "./ThreadsActivityCentreBadge";
+import RightPanelStore from "../../../../stores/right-panel/RightPanelStore";
+import { RightPanelPhases } from "../../../../stores/right-panel/RightPanelStorePhases";
 
 interface ThreadsActivityCentreProps {
     /**
@@ -85,6 +86,10 @@ function ThreadsActivityRow({ room, onClick }: ThreadsActivityRow): JSX.Element 
             onSelect={(event: Event) => {
                 onClick();
 
+                // Set the right panel card for that room so the threads panel is open before we dispatch,
+                // so it will open once the room appears.
+                RightPanelStore.instance.setCard({ phase: RightPanelPhases.ThreadPanel }, true, room.roomId);
+
                 // Display the selected room in the timeline
                 defaultDispatcher.dispatch<ViewRoomPayload>({
                     action: Action.ViewRoom,
@@ -93,13 +98,6 @@ function ThreadsActivityRow({ room, onClick }: ThreadsActivityRow): JSX.Element 
                     metricsTrigger: "RoomList",
                     metricsViaKeyboard: event.type !== "click",
                 });
-
-                //RightPanelStore.instance.setCard({ phase: RightPanelPhases.ThreadPanel });
-                // TODO find a way to open the thread panel after the room is displayed
-                setTimeout(() => {
-                    showThreadPanel();
-                    //RightPanelStore.instance.togglePanel(room.roomId);
-                }, 1000);
             }}
             label={room.name}
             Icon={<DecoratedRoomAvatar room={room} size="32px" />}


### PR DESCRIPTION
Hopefully this is a sensible enough way. The panel will stay open of course (ie. if you go to a different room & come back), but that's the nature of the right panel.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Open thread panel when thread clicked in Threads Activity Centre ([\#12161](https://github.com/matrix-org/matrix-react-sdk/pull/12161)).<!-- CHANGELOG_PREVIEW_END -->