### PR TITLE
Playwright: Disable failing read-receipts test

### DIFF
--- a/playwright/e2e/read-receipts/read-receipts.spec.ts
+++ b/playwright/e2e/read-receipts/read-receipts.spec.ts
@@ -107,7 +107,12 @@ test.describe("Read receipts", () => {
         await page.goto(`/#/room/${selectedRoomId}`);
     });
 
-    test("With sync accumulator, considers main thread and unthreaded receipts #24629", async ({ page, app, bot }) => {
+    // Disabled due to flakiness: https://github.com/element-hq/element-web/issues/26895
+    test.skip("With sync accumulator, considers main thread and unthreaded receipts #24629", async ({
+        page,
+        app,
+        bot,
+    }) => {
         // Details are in https://github.com/vector-im/element-web/issues/24629
         // This proves we've fixed one of the "stuck unreads" issues.
 


### PR DESCRIPTION
This is the first test in the file, so it's possible that the failure will move to the next test. But let's give it a try.

Related: https://github.com/element-hq/element-web/issues/26895

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->