### PR TITLE
Fix display of room notification debug info

### DIFF
--- a/src/components/views/dialogs/devtools/RoomNotifications.tsx
+++ b/src/components/views/dialogs/devtools/RoomNotifications.tsx
@@ -77,26 +77,16 @@ export default function RoomNotifications({ onBack }: IDevtoolsProps): JSX.Eleme
                 <h2>{_t("devtools|room_status")}</h2>
                 <ul>
                     <li>
-                        {count > 0
-                            ? _t(
-                                  "devtools|room_unread_status_count",
-                                  {
-                                      status: humanReadableNotificationLevel(level),
-                                      count,
-                                  },
-                                  {
-                                      strong: (sub) => <strong>{sub}</strong>,
-                                  },
-                              )
-                            : _t(
-                                  "devtools|room_unread_status",
-                                  {
-                                      status: humanReadableNotificationLevel(level),
-                                  },
-                                  {
-                                      strong: (sub) => <strong>{sub}</strong>,
-                                  },
-                              )}
+                        {_t(
+                            "devtools|room_unread_status_count",
+                            {
+                                status: humanReadableNotificationLevel(level),
+                                count,
+                            },
+                            {
+                                strong: (sub) => <strong>{sub}</strong>,
+                            },
+                        )}
                     </li>
                     <li>
                         {_t(

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -765,8 +765,8 @@
         "room_notifications_total": "Total: ",
         "room_notifications_type": "Type: ",
         "room_status": "Room status",
-        "room_unread_status": "Room unread status: <strong>%(status)s</strong>",
         "room_unread_status_count": {
+            "one": "Room unread status: <strong>%(status)s</strong>, count: <strong>%(count)s</strong>",
             "other": "Room unread status: <strong>%(status)s</strong>, count: <strong>%(count)s</strong>"
         },
         "save_setting_values": "Save setting values",

--- a/test/components/views/dialogs/devtools/__snapshots__/RoomNotifications-test.tsx.snap
+++ b/test/components/views/dialogs/devtools/__snapshots__/RoomNotifications-test.tsx.snap
@@ -16,6 +16,10 @@ exports[`<RoomNotifications /> should render 1`] = `
             <strong>
               None
             </strong>
+            , count: 
+            <strong>
+              0
+            </strong>
           </span>
         </li>
         <li>


### PR DESCRIPTION
 * Add 'one' string because apprently it just displays nothing at all if that's missing, rather than erroring or falling back to use the 'other'.
 * Simplify and always display the count: it's debug info so it's best to be very explicit anyway, plus simpler code & one less string.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix display of room notification debug info ([\#12183](https://github.com/matrix-org/matrix-react-sdk/pull/12183)).<!-- CHANGELOG_PREVIEW_END -->