### PR TITLE
Saner releases: rebuild release automation to provide better introspection

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,7 +33,7 @@ on:
 concurrency: ${{ github.workflow }}
 jobs:
     draft:
-        uses: matrix-org/matrix-js-sdk/.github/workflows/release-drafter-action.yml@develop
+        uses: matrix-org/matrix-js-sdk/.github/workflows/release-drafter-workflow.yml@develop
         secrets: inherit
         with:
             version-bump: ${{ inputs.version-bump }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,21 +1,44 @@
 name: Release Drafter
 on:
-    push:
-        branches: [staging]
     workflow_dispatch:
         inputs:
+            version-bump:
+                description: The scale of the version bump required for semver compatibility
+                required: true
+                default: automatic
+                type: choice
+                options:
+                    - automatic
+                    - patch
+                    - minor
+                    - major
+            type:
+                description: The type of release to make
+                required: true
+                default: release-candidate
+                type: choice
+                options:
+                    - release-candidate
+                    - release
+                    - hotfix
             previous-version:
-                description: What release to use as a base for release note purposes
+                description: What release to use as a base for release note purposes, defaults to the latest stable release.
                 required: false
+                type: string
+            matrix-js-sdk:
+                description: JS SDK version to use (current|X.Y.Z)
+                required: false
+                default: current
                 type: string
 concurrency: ${{ github.workflow }}
 jobs:
     draft:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: release-drafter/release-drafter@e64b19c4c46173209ed9f2e5a2f4ca7de89a0e86 # v5
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  disable-autolabeler: true
-                  previous-version: ${{ inputs.previous-version }}
+        uses: matrix-org/matrix-js-sdk/.github/workflows/release-drafter-action.yml@develop
+        secrets: inherit
+        with:
+            version-bump: ${{ inputs.version-bump }}
+            previous-version: ${{ inputs.previous-version }}
+            final: ${{ inputs.type != 'release-candidate' }}
+            yarn-pack: true
+            dependencies: |
+                matrix-js-sdk=${{ inputs.matrix-js-sdk }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,17 @@
-name: Release Process
+name: Post Release Process
 on:
-    workflow_dispatch:
-        inputs:
-            mode:
-                description: What type of release
-                required: true
-                default: rc
-                type: choice
-                options:
-                    - rc
-                    - final
-            matrix-js-sdk:
-                description: JS SDK version to use (current|X.Y.Z)
-                required: false
-                default: current
-                type: string
-            npm:
-                description: Publish to npm
-                required: true
-                type: boolean
-                default: true
+    release:
+        types: [published]
 concurrency: ${{ github.workflow }}
 jobs:
     release:
-        uses: matrix-org/matrix-js-sdk/.github/workflows/release-make.yml@develop
-        secrets: inherit
-        with:
-            final: ${{ inputs.mode == 'final' }}
-            npm: ${{ inputs.npm }}
-            dependencies: |
-                matrix-js-sdk=${{ inputs.matrix-js-sdk }}
+        uses: matrix-org/matrix-js-sdk/.github/workflows/release-action.yml@develop
+        secrets:
+            ELEMENT_BOT_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+    npm:
+        name: Publish to npm
+        needs: release
+        uses: matrix-org/matrix-js-sdk/.github/workflows/release-npm.yml@develop
+        secrets:
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 concurrency: ${{ github.workflow }}
 jobs:
     release:
-        uses: matrix-org/matrix-js-sdk/.github/workflows/release-action.yml@develop
+        uses: matrix-org/matrix-js-sdk/.github/workflows/release-workflow.yml@develop
         secrets:
             ELEMENT_BOT_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "UserFriendlyError"
     ],
     "scripts": {
-        "prepublishOnly": "yarn build",
+        "prepack": "yarn build",
         "i18n": "matrix-gen-i18n && yarn i18n:sort && yarn i18n:lint",
         "i18n:sort": "jq --sort-keys '.' src/i18n/strings/en_EN.json > src/i18n/strings/en_EN.json.tmp && mv src/i18n/strings/en_EN.json.tmp src/i18n/strings/en_EN.json",
         "i18n:lint": "matrix-i18n-lint && prettier --log-level=silent --write src/i18n/strings/ --ignore-path /dev/null",


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/4040

Flow

1. Draft releases are triggered by the release person
2. Draft releases are inspected & tested along with their artifacts & notes
3. Draft releases are published when ready and this kicks off any deploys e.g. npm, docs, etc

Switches to prepack hook to better dry-run release steps in drafting

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->