### PR TITLE
Re-use doesRoomHaveUnreadThreads for useRoomThreadNotifications

### DIFF
--- a/src/hooks/room/useRoomThreadNotifications.ts
+++ b/src/hooks/room/useRoomThreadNotifications.ts
@@ -18,7 +18,7 @@ import { NotificationCountType, Room, RoomEvent, ThreadEvent } from "matrix-js-s
 import { useCallback, useEffect, useState } from "react";
 
 import { NotificationLevel } from "../../stores/notifications/NotificationLevel";
-import { doesRoomOrThreadHaveUnreadMessages } from "../../Unread";
+import { doesRoomHaveUnreadThreads } from "../../Unread";
 import { useEventEmitter } from "../useEventEmitter";
 
 /**
@@ -40,13 +40,7 @@ export const useRoomThreadNotifications = (room: Room): NotificationLevel => {
         }
         // We don't have any notified messages, but we might have unread messages. Let's
         // find out.
-        for (const thread of room!.getThreads()) {
-            // If the current thread has unread messages, we're done.
-            if (doesRoomOrThreadHaveUnreadMessages(thread)) {
-                setNotificationLevel(NotificationLevel.Activity);
-                break;
-            }
-        }
+        if (doesRoomHaveUnreadThreads(room)) setNotificationLevel(NotificationLevel.Activity);
     }, [room]);
 
     useEventEmitter(room, RoomEvent.UnreadNotifications, updateNotification);


### PR DESCRIPTION
This incorporates the logic of not showing unread dots if the room is muted

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Re-use doesRoomHaveUnreadThreads for useRoomThreadNotifications ([\#12195](https://github.com/matrix-org/matrix-react-sdk/pull/12195)).<!-- CHANGELOG_PREVIEW_END -->