### PR TITLE
Fix position & size of dot on the tac button

### DIFF
--- a/res/css/structures/_ThreadsActivityCentre.pcss
+++ b/res/css/structures/_ThreadsActivityCentre.pcss
@@ -43,12 +43,6 @@
         }
     }
 
-    & > .mx_ThreadsActivityCentreButton_IndicatorIcon {
-        height: 24px;
-        width: 24px;
-        padding: 4px;
-    }
-
     & .mx_ThreadsActivityCentreButton_Icon {
         color: $secondary-content;
     }

--- a/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentreButton.tsx
+++ b/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentreButton.tsx
@@ -56,6 +56,7 @@ export const ThreadsActivityCentreButton = forwardRef<HTMLDivElement, ThreadsAct
                 <IndicatorIcon
                     className="mx_ThreadsActivityCentreButton_IndicatorIcon"
                     indicator={notificationLevelToIndicator(notificationLevel)}
+                    size="24px"
                 >
                     <Icon className="mx_ThreadsActivityCentreButton_Icon" />
                 </IndicatorIcon>


### PR DESCRIPTION
IndicatorIcon doesn't like having the size of its icon adjusted and we probably shouldn't do it anyway: better to specify to the component what size we want it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix position & size of dot on the tac button ([\#12199](https://github.com/matrix-org/matrix-react-sdk/pull/12199)).<!-- CHANGELOG_PREVIEW_END -->