### PR TITLE
SettingsStore: Change feature_rust_crypto to default true

### DIFF
--- a/playwright/e2e/crypto/staged-rollout.spec.ts
+++ b/playwright/e2e/crypto/staged-rollout.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { test, expect } from "../../element-web-test";
 import { logIntoElement } from "./utils";
 
-test.describe("Migration of existing logins", () => {
+test.describe("Adoption of rust stack", () => {
     test("Test migration of existing logins when rollout is 100%", async ({
         page,
         context,
@@ -25,22 +25,35 @@ test.describe("Migration of existing logins", () => {
         credentials,
         homeserver,
     }, workerInfo) => {
-        test.skip(workerInfo.project.name === "Rust Crypto", "This test only works with Rust crypto.");
+        test.skip(
+            workerInfo.project.name === "Rust Crypto",
+            "No need to test this on Rust Crypto as we override the config manually",
+        );
         await page.goto("/#/login");
 
         let featureRustCrypto = false;
         let stagedRolloutPercent = 0;
 
         await context.route(`http://localhost:8080/config.json*`, async (route) => {
-            const json = {};
+            const json = {
+                default_server_config: {
+                    "m.homeserver": {
+                        base_url: "https://server.invalid",
+                    },
+                },
+            };
             json["features"] = {
                 feature_rust_crypto: featureRustCrypto,
             };
             json["setting_defaults"] = {
+                "language": "en-GB",
                 "RustCrypto.staged_rollout_percent": stagedRolloutPercent,
             };
             await route.fulfill({ json });
         });
+
+        // reload to ensure we read the config
+        await page.reload();
 
         await logIntoElement(page, homeserver, credentials);
 
@@ -60,5 +73,81 @@ test.describe("Migration of existing logins", () => {
 
         await app.settings.openUserSettings("Help & About");
         await expect(page.getByText("Crypto version: Rust SDK")).toBeVisible();
+    });
+
+    test("Test new logins by default on rust stack", async ({
+        page,
+        context,
+        app,
+        credentials,
+        homeserver,
+    }, workerInfo) => {
+        test.skip(
+            workerInfo.project.name === "Rust Crypto",
+            "No need to test this on Rust Crypto as we override the config manually",
+        );
+        await page.goto("/#/login");
+
+        await context.route(`http://localhost:8080/config.json*`, async (route) => {
+            const json = {
+                default_server_config: {
+                    "m.homeserver": {
+                        base_url: "https://server.invalid",
+                    },
+                },
+            };
+            // we only want to test the default
+            json["features"] = {};
+            json["setting_defaults"] = {
+                language: "en-GB",
+            };
+            await route.fulfill({ json });
+        });
+
+        // reload to get the new config
+        await page.reload();
+        await logIntoElement(page, homeserver, credentials);
+
+        await app.settings.openUserSettings("Help & About");
+        await expect(page.getByText("Crypto version: Rust SDK")).toBeVisible();
+    });
+
+    test("Test default is to not rollout existing logins", async ({
+        page,
+        context,
+        app,
+        credentials,
+        homeserver,
+    }, workerInfo) => {
+        test.skip(
+            workerInfo.project.name === "Rust Crypto",
+            "No need to test this on Rust Crypto as we override the config manually",
+        );
+
+        await page.goto("/#/login");
+
+        // In the project.name = "Legacy crypto" it will be olm crypto
+        await logIntoElement(page, homeserver, credentials);
+
+        await app.settings.openUserSettings("Help & About");
+        await expect(page.getByText("Crypto version: Olm")).toBeVisible();
+
+        // Now simulate a refresh with `feature_rust_crypto` enabled but ensure we use the default rollout
+        await context.route(`http://localhost:8080/config.json*`, async (route) => {
+            const json = {};
+            json["features"] = {
+                feature_rust_crypto: true,
+            };
+            json["setting_defaults"] = {
+                // We want to test the default so we don't set this
+                // "RustCrypto.staged_rollout_percent": 0,
+            };
+            await route.fulfill({ json });
+        });
+
+        await page.reload();
+
+        await app.settings.openUserSettings("Help & About");
+        await expect(page.getByText("Crypto version: Olm")).toBeVisible();
     });
 });

--- a/playwright/element-web-test.ts
+++ b/playwright/element-web-test.ts
@@ -111,8 +111,9 @@ export const test = base.extend<
                     return obj;
                 }, {}),
             };
-            if (cryptoBackend === "rust") {
-                json.features.feature_rust_crypto = true;
+            // the default is to use rust now, so set to `false` if on legacy backend
+            if (cryptoBackend === "legacy") {
+                json.features.feature_rust_crypto = false;
             }
             await route.fulfill({ json });
         });

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -501,7 +501,7 @@ export const SETTINGS: { [setting: string]: ISetting } = {
             }
         },
         shouldWarn: true,
-        default: false,
+        default: true,
         controller: new RustCryptoSdkController(),
     },
     // Must be set under `setting_defaults` in config.json.

--- a/test/components/views/settings/tabs/user/LabsUserSettingsTab-test.tsx
+++ b/test/components/views/settings/tabs/user/LabsUserSettingsTab-test.tsx
@@ -71,6 +71,25 @@ describe("<LabsUserSettingsTab />", () => {
         });
 
         describe("Not enabled in config", () => {
+            // these tests only works if the feature is not enabled in the config by default?
+            const copyOfGetValueAt = SettingsStore.getValueAt;
+
+            beforeEach(() => {
+                SettingsStore.getValueAt = (
+                    level: SettingLevel,
+                    name: string,
+                    roomId?: string,
+                    isExplicit?: boolean,
+                ) => {
+                    if (level == SettingLevel.CONFIG && name === "feature_rust_crypto") return false;
+                    return copyOfGetValueAt(level, name, roomId, isExplicit);
+                };
+            });
+
+            afterEach(() => {
+                SettingsStore.getValueAt = copyOfGetValueAt;
+            });
+
             it("can be turned on if not already", async () => {
                 // By the time the settings panel is shown, `MatrixClientPeg.initClientCrypto` has saved the current
                 // value to the settings store.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/element-hq/element-web/issues/26931

Some old upstream tests are not working with rust crypto by default.
These tests are running in a strange setup with no indexeddb support and with crypto disabled, not sure how to support that with the rust stack.
What I can propose is to only run these tests on the legacy stack https://github.com/element-hq/element-web/pull/26954

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->