### PR TITLE
Disable flaky test: `should set inline start padding to a hidden event line`

### DIFF
--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -552,7 +552,11 @@ test.describe("Timeline", () => {
             );
         });
 
-        test("should set inline start padding to a hidden event line", async ({ page, app, room }) => {
+        test("should set inline start padding to a hidden event line", async ({ page, app, room, cryptoBackend }) => {
+            test.skip(
+                cryptoBackend === "rust",
+                "Disabled due to screenshot test being flaky - https://github.com/element-hq/element-web/issues/26890",
+            );
             await sendEvent(app.client, room.roomId);
             await page.goto(`/#/room/${room.roomId}`);
             await app.settings.setValue("showHiddenEventsInTimeline", null, SettingLevel.DEVICE, true);


### PR DESCRIPTION
https://github.com/element-hq/element-web/issues/26890

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->