### PR TITLE
Fix sending call notify

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -850,13 +850,17 @@ export class ElementCall extends Call {
 
     protected async sendCallNotify(): Promise<void> {
         const room = this.room;
-        const existingRoomCallMembers = MatrixRTCSession.callMembershipsForRoom(room).filter(
+        const existingOtherRoomCallMembers = MatrixRTCSession.callMembershipsForRoom(room).filter(
             // filter all memberships where the application is m.call and the call_id is ""
-            (m) => m.application === "m.call" && m.callId === "",
+            (m) => {
+                const isRoomCallMember = m.application === "m.call" && m.callId === "";
+                const isThisDevice = m.deviceId === this.client.deviceId;
+                return isRoomCallMember && !isThisDevice;
+            },
         );
 
         const memberCount = getJoinedNonFunctionalMembers(room).length;
-        if (!isVideoRoom(room) && existingRoomCallMembers.length == 0) {
+        if (!isVideoRoom(room) && existingOtherRoomCallMembers.length === 0) {
             // send ringing event
             const content: ICallNotifyContent = {
                 "application": "m.call",


### PR DESCRIPTION
The call notify event is not sent anymore since we now wait until we joined the rtc session before even trying to sent the call notify event -> The current user is already part of the session -> we only sent notify events if there is no other user.

This fix ignores members from this device so that a notify is still sent.
Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

Changes in this project also generate changelogs in Element Web. To disable this, use the following:

element-web notes: none

or specify alternative text:

element-web notes: Add super cool feature

Changes to this project require tagging with the type of change. If you know the correct type, add the following:

Type: [enhancement/defect/task]

-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->