### PR TITLE
Use the non-deprecated exportRoomKeys method on CryptoApi

### DIFF
--- a/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+++ b/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
@@ -109,7 +109,7 @@ export default class ExportE2eKeysDialog extends React.Component<IProps, IState>
         // asynchronous ones.
         Promise.resolve()
             .then(() => {
-                return this.props.matrixClient.exportRoomKeys();
+                return this.props.matrixClient.getCrypto()!.exportRoomKeys();
             })
             .then((k) => {
                 return MegolmExportEncryption.encryptMegolmKeyFile(JSON.stringify(k), passphrase);


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/26681

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->