### PR TITLE
Call the AsJson forms of import and exportRoomKeys

### DIFF
--- a/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+++ b/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
@@ -109,10 +109,10 @@ export default class ExportE2eKeysDialog extends React.Component<IProps, IState>
         // asynchronous ones.
         Promise.resolve()
             .then(() => {
-                return this.props.matrixClient.getCrypto()!.exportRoomKeys();
+                return this.props.matrixClient.getCrypto()!.exportRoomKeysAsJson();
             })
             .then((k) => {
-                return MegolmExportEncryption.encryptMegolmKeyFile(JSON.stringify(k), passphrase);
+                return MegolmExportEncryption.encryptMegolmKeyFile(k, passphrase);
             })
             .then((f) => {
                 const blob = new Blob([f], {

--- a/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
+++ b/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
@@ -108,7 +108,7 @@ export default class ImportE2eKeysDialog extends React.Component<IProps, IState>
                 return MegolmExportEncryption.decryptMegolmKeyFile(arrayBuffer, passphrase);
             })
             .then((keys) => {
-                return this.props.matrixClient.getCrypto()!.importRoomKeys(JSON.parse(keys));
+                return this.props.matrixClient.getCrypto()!.importRoomKeysAsJson(keys);
             })
             .then(() => {
                 // TODO: it would probably be nice to give some feedback about what we've imported here.

--- a/test/components/views/dialogs/security/ExportE2eKeysDialog-test.tsx
+++ b/test/components/views/dialogs/security/ExportE2eKeysDialog-test.tsx
@@ -66,10 +66,10 @@ describe("ExportE2eKeysDialog", () => {
         const cli = createTestClient();
         const keys: IMegolmSessionData[] = [];
         const passphrase = "ThisIsAMoreSecurePW123$$";
-        const exportRoomKeys = jest.fn().mockResolvedValue(keys);
+        const exportRoomKeysAsJson = jest.fn().mockResolvedValue(JSON.stringify(keys));
         cli.getCrypto = () => {
             return {
-                exportRoomKeys,
+                exportRoomKeysAsJson,
             } as unknown as CryptoApi;
         };
 
@@ -85,7 +85,7 @@ describe("ExportE2eKeysDialog", () => {
         fireEvent.click(container.querySelector("[type=submit]")!);
 
         // Then it exports keys and encrypts them
-        await waitFor(() => expect(exportRoomKeys).toHaveBeenCalled());
+        await waitFor(() => expect(exportRoomKeysAsJson).toHaveBeenCalled());
         await waitFor(() =>
             expect(MegolmExportEncryption.encryptMegolmKeyFile).toHaveBeenCalledWith(JSON.stringify(keys), passphrase),
         );

--- a/test/components/views/dialogs/security/ImportE2eKeysDialog-test.tsx
+++ b/test/components/views/dialogs/security/ImportE2eKeysDialog-test.tsx
@@ -71,10 +71,10 @@ describe("ImportE2eKeysDialog", () => {
         const cli = createTestClient();
         const onFinished = jest.fn();
         const file = new File(["test"], "file.txt", { type: "text/plain" });
-        const importRoomKeys = jest.fn();
+        const importRoomKeysAsJson = jest.fn();
         cli.getCrypto = () => {
             return {
-                importRoomKeys,
+                importRoomKeysAsJson,
             } as unknown as CryptoApi;
         };
 
@@ -90,6 +90,6 @@ describe("ImportE2eKeysDialog", () => {
         await userEvent.paste("passphrase");
         fireEvent.click(container.querySelector("[type=submit]")!);
 
-        await waitFor(() => expect(importRoomKeys).toHaveBeenCalled());
+        await waitFor(() => expect(importRoomKeysAsJson).toHaveBeenCalled());
     });
 });


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/26681

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/4057

Improve export and import memory usage and performance by using the new `AsJson` forms of the import and export room keys methods, meaning that when we are using Rust crypto we avoid deserialising and reserialising the keys as JSON.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Call the AsJson forms of import and exportRoomKeys ([\#12233](https://github.com/matrix-org/matrix-react-sdk/pull/12233)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->