### PR TITLE
Hide the archived section

### DIFF
--- a/playwright/e2e/knock/knock-into-room.spec.ts
+++ b/playwright/e2e/knock/knock-into-room.spec.ts
@@ -227,8 +227,8 @@ test.describe("Knock Into Room", () => {
         await expect(roomPreviewBar.getByRole("button", { name: "Request access" })).toBeVisible();
 
         await expect(
-            page.getByRole("group", { name: "Historical" }).getByRole("treeitem", { name: "Cybersecurity" }),
-        ).toBeVisible();
+            page.getByRole("group", { name: "Rooms" }).getByRole("treeitem", { name: "Cybersecurity" }),
+        ).not.toBeVisible();
     });
 
     test("should knock into the room then knock is cancelled by another user and room is forgotten", async ({

--- a/playwright/e2e/one-to-one-chat/one-to-one-chat.spec.ts
+++ b/playwright/e2e/one-to-one-chat/one-to-one-chat.spec.ts
@@ -43,8 +43,8 @@ test.describe("1:1 chat room", () => {
 
         // wait till the room was left
         await expect(
-            page.getByRole("group", { name: "Historical" }).locator(".mx_RoomTile").getByText(user2.displayName),
-        ).toBeVisible();
+            page.getByRole("group", { name: "Rooms" }).locator(".mx_RoomTile").getByText(user2.displayName),
+        ).not.toBeVisible();
 
         // open new 1:1 chat room
         await page.goto(`/#/user/${user2.userId}?action=chat`);

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -87,7 +87,10 @@ export const TAG_ORDER: TagID[] = [
     DefaultTagID.LowPriority,
     DefaultTagID.ServerNotice,
     DefaultTagID.Suggested,
-    DefaultTagID.Archived,
+    // DefaultTagID.Archived isn't here any more: we don't show it at all.
+    // The section still exists in the code as a place for rooms that we know
+    // about but aren't joined. At some point it could be removed entirely
+    // but we'd have to make sure that rooms you weren't in were hidden.
 ];
 const ALWAYS_VISIBLE_TAGS: TagID[] = [DefaultTagID.DM, DefaultTagID.Untagged];
 

--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -483,6 +483,8 @@ export class Algorithm extends EventEmitter {
             // noinspection JSUnfilteredForInLoop
             newTags[tagId] = [];
         }
+        // We may not have had an archived section previously, so make sure its there.
+        newTags[DefaultTagID.Archived] = [];
 
         // If we can avoid doing work, do so.
         if (!rooms.length) {

--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -483,8 +483,6 @@ export class Algorithm extends EventEmitter {
             // noinspection JSUnfilteredForInLoop
             newTags[tagId] = [];
         }
-        // We may not have had an archived section previously, so make sure its there.
-        newTags[DefaultTagID.Archived] = [];
 
         // If we can avoid doing work, do so.
         if (!rooms.length) {
@@ -500,6 +498,8 @@ export class Algorithm extends EventEmitter {
             newTags[DefaultTagID.Invite].push(room);
         }
         for (const room of memberships[EffectiveMembership.Leave]) {
+            // We may not have had an archived section previously, so make sure its there.
+            if (newTags[DefaultTagID.Archived] === undefined) newTags[DefaultTagID.Archived] = [];
             newTags[DefaultTagID.Archived].push(room);
         }
 


### PR DESCRIPTION
This just hides the 'Archived' room list section, on the justification that it's somehow weird and a little buggy, and it's better for rooms to just go away once you leave them than hang around and be buggy, although of course it does mean you no longer have access to the history of those rooms.

This just leaves the Archives section in the code, but doesn't display it. A fix was needed in Algorithm because removing it from the order list meant that sometimes we ended up with no such section and Algorithm expects it to exist, so this was the simplest fix. I looked at stripping out the entire existence of the section, but the first problem was that it means that left rooms are just still displayed in the room list, so we'd need to find a way to not show them. Room visibility doesn't work for this because it doesn't expect visibility of a room to change.

Assuming this seems okay, I'll create a bug to remove the archived section entirely. We could also look at removing just the code for forgetting rooms.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md))
