### PR TITLE
added setting not to show indirect rooms of spaces in left sidebar

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1082,6 +1082,10 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         supportedLevels: [SettingLevel.ROOM_ACCOUNT],
         default: true,
     },
+    "Spaces.showIndirectRoomsInSpace": {
+        supportedLevels: LEVELS_ROOM_OR_ACCOUNT,
+        default: true,
+    },
     "developerMode": {
         displayName: _td("devtools|developer_mode"),
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,

--- a/src/stores/room-list/filters/SpaceFilterCondition.ts
+++ b/src/stores/room-list/filters/SpaceFilterCondition.ts
@@ -34,10 +34,11 @@ export class SpaceFilterCondition extends EventEmitter implements IFilterConditi
     private roomIds = new Set<string>();
     private userIds = new Set<string>();
     private showPeopleInSpace = true;
+    private showIndirectRoomsInSpace = true;
     private space: SpaceKey = MetaSpace.Home;
 
     public isVisible(room: Room): boolean {
-        return SpaceStore.instance.isRoomInSpace(this.space, room.roomId);
+        return SpaceStore.instance.isRoomInSpace(this.space, room.roomId, this.showIndirectRoomsInSpace);
     }
 
     private onStoreUpdate = async (forceUpdate = false): Promise<void> => {
@@ -53,9 +54,14 @@ export class SpaceFilterCondition extends EventEmitter implements IFilterConditi
         this.showPeopleInSpace =
             isMetaSpace(this.space[0]) || SettingsStore.getValue("Spaces.showPeopleInSpace", this.space);
 
+        const beforeShowIndirectRoomsInSpace = this.showIndirectRoomsInSpace;
+        this.showIndirectRoomsInSpace =
+            SettingsStore.getValue("Spaces.showIndirectRoomsInSpace", this.space);
+
         if (
             forceUpdate ||
             beforeShowPeopleInSpace !== this.showPeopleInSpace ||
+            beforeShowIndirectRoomsInSpace !== this.showIndirectRoomsInSpace ||
             setHasDiff(beforeRoomIds, this.roomIds) ||
             setHasDiff(beforeUserIds, this.userIds)
         ) {

--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -161,6 +161,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
         SettingsStore.monitorSetting("Spaces.allRoomsInHome", null);
         SettingsStore.monitorSetting("Spaces.enabledMetaSpaces", null);
         SettingsStore.monitorSetting("Spaces.showPeopleInSpace", null);
+        SettingsStore.monitorSetting("Spaces.showIndirectRoomsInSpace", null);
         SettingsStore.monitorSetting("feature_dynamic_room_predecessors", null);
     }
 
@@ -1304,6 +1305,11 @@ export class SpaceStoreClass extends AsyncStoreWithClient<IState> {
                                 this.updateNotificationStates([payload.roomId]);
                             }
                         }
+                        break;
+
+                    case "Spaces.showIndirectRoomsInSpace":
+                        // triggers SpaceFilterCondition onStoreUpdate
+                        this.emit(this.activeSpace);
                         break;
 
                     case "feature_dynamic_room_predecessors":

--- a/test/stores/SpaceStore-test.ts
+++ b/test/stores/SpaceStore-test.ts
@@ -129,6 +129,13 @@ describe("SpaceStore", () => {
         await emitProm;
     };
 
+    const setShowIndirectRoomsInSpace = async (value: boolean) => {
+        const emitProm = testUtils.emitPromise(store, store.activeSpace);
+        await SettingsStore.setValue("Spaces.showIndirectRoomsInSpace", null, SettingLevel.ACCOUNT, value);
+        jest.runOnlyPendingTimers(); // run async dispatch
+        await emitProm;
+    };
+
     beforeEach(async () => {
         jest.runOnlyPendingTimers(); // run async dispatch
         mocked(client).getVisibleRooms.mockReturnValue((rooms = []));
@@ -677,6 +684,14 @@ describe("SpaceStore", () => {
 
             it("does not honour m.space.parent if sender does not have permission in parent space", () => {
                 expect(store.isRoomInSpace(space3, room3)).toBeFalsy();
+            });
+
+            it("correctly emits events for SettingUpdate of Spaces.showIndirectRoomsInSpace", async () => {
+                const emitSpy = jest.spyOn(store, "emit");
+
+                setShowIndirectRoomsInSpace(false);
+
+                expect(emitSpy).toHaveBeenCalledWith(store.activeSpace);
             });
         });
     });

--- a/test/stores/room-list/filters/SpaceFilterCondition-test.ts
+++ b/test/stores/room-list/filters/SpaceFilterCondition-test.ts
@@ -70,11 +70,30 @@ describe("SpaceFilterCondition", () => {
 
     describe("isVisible", () => {
         const room1 = { roomId: room1Id } as unknown as Room;
-        it("calls isRoomInSpace correctly", () => {
+        it("calls isRoomInSpace correctly when showIndirectRoomsInSpace is true", () => {
+            // init filter with setting true for space1
+            SettingsStoreMock.getValue.mockImplementation(
+                makeMockGetValue({
+                    ["Spaces.showIndirectRoomsInSpace"]: { [space1]: true },
+                }),
+            );
             const filter = initFilter(space1);
 
             expect(filter.isVisible(room1)).toEqual(true);
-            expect(SpaceStoreInstanceMock.isRoomInSpace).toHaveBeenCalledWith(space1, room1Id);
+            expect(SpaceStoreInstanceMock.isRoomInSpace).toHaveBeenCalledWith(space1, room1Id, true);
+        });
+
+        it("calls isRoomInSpace correctly when showIndirectRoomsInSpace is false", () => {
+            // init filter with setting true for space1
+            SettingsStoreMock.getValue.mockImplementation(
+                makeMockGetValue({
+                    ["Spaces.showIndirectRoomsInSpace"]: { [space1]: false },
+                }),
+            );
+            const filter = initFilter(space1);
+
+            expect(filter.isVisible(room1)).toEqual(true);
+            expect(SpaceStoreInstanceMock.isRoomInSpace).toHaveBeenCalledWith(space1, room1Id, false);
         });
     });
 
@@ -120,6 +139,29 @@ describe("SpaceFilterCondition", () => {
                 const emitSpy = jest.spyOn(filter, "emit");
 
                 filter.updateSpace(MetaSpace.Home);
+                jest.runOnlyPendingTimers();
+                expect(emitSpy).toHaveBeenCalledWith(FILTER_CHANGED);
+            });
+        });
+
+        describe("showIndirectRoomsInSpace setting", () => {
+            it("emits filter changed event when setting changes", async () => {
+                // init filter with setting true for space1
+                SettingsStoreMock.getValue.mockImplementation(
+                    makeMockGetValue({
+                        ["Spaces.showIndirectRoomsInSpace"]: { [space1]: true },
+                    }),
+                );
+                const filter = initFilter(space1);
+                const emitSpy = jest.spyOn(filter, "emit");
+
+                SettingsStoreMock.getValue.mockClear().mockImplementation(
+                    makeMockGetValue({
+                        ["Spaces.showIndirectRoomsInSpace"]: { [space1]: false },
+                    }),
+                );
+
+                SpaceStoreInstanceMock.emit(space1);
                 jest.runOnlyPendingTimers();
                 expect(emitSpy).toHaveBeenCalledWith(FILTER_CHANGED);
             });


### PR DESCRIPTION
* Add Setting "Space.showIndirectRoomsInSpace" (#418)
* Changed SpaceFilterCondition and its tests to comply with new setting
* Changed SpaceStore to watch new setting and if updated emit event SpaceFilterCondition already listens for. Added a test for it.

Signed-off-by: Julius Schuchert <84525736+suiluj482@users.noreply.github.com>