### PR TITLE
Change 'type' prop on badges to 'forceDot'

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1311,7 +1311,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             <UnreadNotificationBadge
                                 room={room || undefined}
                                 threadId={this.props.mxEvent.getId()}
-                                type="dot"
+                                forceDot={true}
                             />
                         </div>
                         {isRenderingNotification && room ? (

--- a/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
@@ -70,16 +70,6 @@ export const StatelessNotificationBadge = forwardRef<HTMLDivElement, XOR<Props, 
             symbol = formatCount(count);
         }
 
-        // We show a dot if either:
-        // * The props force us to, or
-        // * It's just an activity-level notification or (in theory) lower and the room isn't knocked
-        const badgeType =
-            forceDot || (level <= NotificationLevel.Activity && !knocked)
-                ? "dot"
-                : !symbol || symbol.length < 3
-                  ? "badge_2char"
-                  : "badge_3char";
-
         const classes = classNames({
             mx_NotificationBadge: true,
             mx_NotificationBadge_visible: isEmptyBadge || knocked ? true : hasUnreadCount,
@@ -88,9 +78,9 @@ export const StatelessNotificationBadge = forwardRef<HTMLDivElement, XOR<Props, 
             mx_NotificationBadge_knocked: knocked,
 
             // Exactly one of mx_NotificationBadge_dot, mx_NotificationBadge_2char, mx_NotificationBadge_3char
-            mx_NotificationBadge_dot: badgeType === "dot",
-            mx_NotificationBadge_2char: badgeType === "badge_2char",
-            mx_NotificationBadge_3char: badgeType === "badge_3char",
+            mx_NotificationBadge_dot: (isEmptyBadge && !knocked) || forceDot,
+            mx_NotificationBadge_2char: !forceDot && symbol && symbol.length > 0 && symbol.length < 3,
+            mx_NotificationBadge_3char: !forceDot && symbol && symbol.length > 2,
         });
 
         if (props.onClick) {

--- a/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
@@ -29,8 +29,8 @@ interface Props {
     level: NotificationLevel;
     knocked?: boolean;
     /**
-     * If true, where we would normally show a badge, we instead show a dot. Count will
-     * not be displayed (but may affect whether the the dot is displayed). See class doc
+     * If true, where we would normally show a badge, we instead show a dot. No numeric count will
+     * be displayed (but may affect whether the the dot is displayed). See class doc
      * for the difference between the two.
      */
     forceDot?: boolean;
@@ -48,7 +48,7 @@ interface ClickableProps extends Props {
  * A notification indicator that conveys what activity / notifications the user has in whatever
  * context it is being used.
  *
- * Can either be a 'badge': a small circle with a number in it, or a 'dot': a smaller, empty circle.
+ * Can either be a 'badge': a small circle with a number in it (the 'count'), or a 'dot': a smaller, empty circle.
  * The two can be used to convey the same meaning but in different contexts, for example: for unread
  * notifications in the room list, it may have a green badge with the number of unread notifications,
  * but somewhere else it may just have a green dot as a more compact representation of the same information.

--- a/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
@@ -77,7 +77,7 @@ export const StatelessNotificationBadge = forwardRef<HTMLDivElement, XOR<Props, 
             mx_NotificationBadge_level_highlight: level >= NotificationLevel.Highlight,
             mx_NotificationBadge_knocked: knocked,
 
-            // Exactly one of mx_NotificationBadge_dot, mx_NotificationBadge_2char, mx_NotificationBadge_3char
+            // At most one of mx_NotificationBadge_dot, mx_NotificationBadge_2char, mx_NotificationBadge_3char
             mx_NotificationBadge_dot: (isEmptyBadge && !knocked) || forceDot,
             mx_NotificationBadge_2char: !forceDot && symbol && symbol.length > 0 && symbol.length < 3,
             mx_NotificationBadge_3char: !forceDot && symbol && symbol.length > 2,

--- a/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx
@@ -29,7 +29,9 @@ interface Props {
     level: NotificationLevel;
     knocked?: boolean;
     /**
-     * If true, the badge will always be displayed as a dot. Count will be ignored.
+     * If true, where we would normally show a badge, we instead show a dot. Count will
+     * not be displayed (but may affect whether the the dot is displayed). See class doc
+     * for the difference between the two.
      */
     forceDot?: boolean;
 }
@@ -42,6 +44,15 @@ interface ClickableProps extends Props {
     tabIndex?: number;
 }
 
+/**
+ * A notification indicator that conveys what activity / notifications the user has in whatever
+ * context it is being used.
+ *
+ * Can either be a 'badge': a small circle with a number in it, or a 'dot': a smaller, empty circle.
+ * The two can be used to convey the same meaning but in different contexts, for example: for unread
+ * notifications in the room list, it may have a green badge with the number of unread notifications,
+ * but somewhere else it may just have a green dot as a more compact representation of the same information.
+ */
 export const StatelessNotificationBadge = forwardRef<HTMLDivElement, XOR<Props, ClickableProps>>(
     ({ symbol, count, level, knocked, forceDot = false, ...props }, ref) => {
         const hideBold = useSettingValue("feature_hidebold");

--- a/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
@@ -24,7 +24,8 @@ interface Props {
     room?: Room;
     threadId?: string;
     /**
-     * If true, the badge will always be displayed as a dot.
+     * If true, where we would normally show a badge, we instead show a dot. No numeric count will
+     * be displayed.
      */
     forceDot?: boolean;
 }

--- a/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
@@ -24,7 +24,7 @@ interface Props {
     room?: Room;
     threadId?: string;
     /**
-     * If true, the badge will always be displayed as a dot. Count will be ignored.
+     * If true, the badge will always be displayed as a dot.
      */
     forceDot?: boolean;
 }

--- a/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
+++ b/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx
@@ -23,11 +23,14 @@ import { StatelessNotificationBadge } from "./StatelessNotificationBadge";
 interface Props {
     room?: Room;
     threadId?: string;
-    type?: "badge" | "dot";
+    /**
+     * If true, the badge will always be displayed as a dot. Count will be ignored.
+     */
+    forceDot?: boolean;
 }
 
-export function UnreadNotificationBadge({ room, threadId, type }: Props): JSX.Element {
+export function UnreadNotificationBadge({ room, threadId, forceDot }: Props): JSX.Element {
     const { symbol, count, level } = useUnreadNotifications(room, threadId);
 
-    return <StatelessNotificationBadge symbol={symbol} count={count} level={level} type={type} />;
+    return <StatelessNotificationBadge symbol={symbol} count={count} level={level} forceDot={forceDot} />;
 }

--- a/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentre.tsx
+++ b/src/components/views/spaces/threads-activity-centre/ThreadsActivityCentre.tsx
@@ -130,7 +130,7 @@ function ThreadsActivityRow({ room, onClick, notificationLevel }: ThreadsActivit
             label={room.name}
             Icon={<DecoratedRoomAvatar room={room} size="32px" />}
         >
-            <StatelessNotificationBadge level={notificationLevel} count={0} symbol={null} type="dot" />
+            <StatelessNotificationBadge level={notificationLevel} count={0} symbol={null} forceDot={true} />
         </MenuItem>
     );
 }

--- a/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
+++ b/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
@@ -36,13 +36,6 @@ describe("StatelessNotificationBadge", () => {
         expect(container.querySelector(".mx_NotificationBadge_knocked")).toBeInTheDocument();
     });
 
-    it("has dot style for activity", () => {
-        const { container } = render(
-            <StatelessNotificationBadge symbol={null} count={3} level={NotificationLevel.Activity} />,
-        );
-        expect(container.querySelector(".mx_NotificationBadge_dot")).toBeInTheDocument();
-    });
-
     it("has badge style for notification", () => {
         const { container } = render(
             <StatelessNotificationBadge symbol={null} count={3} level={NotificationLevel.Notification} />,

--- a/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
+++ b/test/components/views/rooms/NotificationBadge/StatelessNotificationBadge-test.tsx
@@ -35,4 +35,30 @@ describe("StatelessNotificationBadge", () => {
         expect(container.querySelector(".mx_NotificationBadge_dot")).not.toBeInTheDocument();
         expect(container.querySelector(".mx_NotificationBadge_knocked")).toBeInTheDocument();
     });
+
+    it("has dot style for activity", () => {
+        const { container } = render(
+            <StatelessNotificationBadge symbol={null} count={3} level={NotificationLevel.Activity} />,
+        );
+        expect(container.querySelector(".mx_NotificationBadge_dot")).toBeInTheDocument();
+    });
+
+    it("has badge style for notification", () => {
+        const { container } = render(
+            <StatelessNotificationBadge symbol={null} count={3} level={NotificationLevel.Notification} />,
+        );
+        expect(container.querySelector(".mx_NotificationBadge_dot")).not.toBeInTheDocument();
+    });
+
+    it("has dot style for notification when forced", () => {
+        const { container } = render(
+            <StatelessNotificationBadge
+                symbol={null}
+                count={3}
+                level={NotificationLevel.Notification}
+                forceDot={true}
+            />,
+        );
+        expect(container.querySelector(".mx_NotificationBadge_dot")).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
Which, hopefully, better represents what it actually does. Tidies up some of the logic. Also adds some tests.

Split out from https://github.com/matrix-org/matrix-react-sdk/pull/12254

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
