### PR TITLE
Fix video rooms not showing share link button

### DIFF
--- a/src/hooks/room/useRoomCall.ts
+++ b/src/hooks/room/useRoomCall.ts
@@ -41,6 +41,7 @@ import { ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload";
 import { Action } from "../../dispatcher/actions";
 import { CallStore, CallStoreEvent } from "../../stores/CallStore";
 import { calculateRoomVia } from "../../utils/permalinks/Permalinks";
+import { isVideoRoom } from "../../utils/video-rooms";
 
 export enum PlatformCallType {
     ElementCall,
@@ -113,8 +114,10 @@ export const useRoomCall = (
     const isConnectedToCall = useConnectionState(groupCall) === ConnectionState.Connected;
     const hasGroupCall = groupCall !== null;
     const hasActiveCallSession = useParticipantCount(groupCall) > 0;
-    const isViewingCall = useEventEmitterState(SdkContextClass.instance.roomViewStore, UPDATE_EVENT, () =>
-        SdkContextClass.instance.roomViewStore.isViewingCall(),
+    const isViewingCall = useEventEmitterState(
+        SdkContextClass.instance.roomViewStore,
+        UPDATE_EVENT,
+        () => SdkContextClass.instance.roomViewStore.isViewingCall() || isVideoRoom(room),
     );
 
     // room


### PR DESCRIPTION
Video rooms are not marked as `isViewingCall() === true`.
So they did not show the share link button.
changed the logic to:
`isViewingCall() || isVideoRoom(room)`

Should we consider changing isViewingCall to already do the check if the room is a video room?
Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
