### PR TITLE
Allow popping out a Jitsi widget to respect Desktop `web_base_url` config

### DIFF
--- a/src/utils/WidgetUtils.ts
+++ b/src/utils/WidgetUtils.ts
@@ -521,7 +521,7 @@ export default class WidgetUtils {
             // safe to send.
             // We'll end up using a local render URL when we see a Jitsi widget anyways, so this is
             // really just for backwards compatibility and to appease the spec.
-            baseUrl = "https://app.element.io/";
+            baseUrl = PlatformPeg.get()!.baseUrl;
         }
         const url = new URL("jitsi.html#" + queryString, baseUrl); // this strips hash fragment from baseUrl
         return url.href;

--- a/test/utils/WidgetUtils-test.ts
+++ b/test/utils/WidgetUtils-test.ts
@@ -19,6 +19,15 @@ import WidgetUtils from "../../src/utils/WidgetUtils";
 import { mockPlatformPeg } from "../test-utils";
 
 describe("getLocalJitsiWrapperUrl", () => {
+    beforeEach(() => {
+        Object.defineProperty(window, "location", {
+            value: {
+                origin: "https://app.element.io",
+                pathname: "",
+            },
+        });
+    });
+
     it("should generate jitsi URL (for defaults)", () => {
         mockPlatformPeg();
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/1586