### PR TITLE
Update widget tile if the url should change

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -273,7 +273,8 @@ export default class AppTile extends React.Component<IProps, IState> {
                 !newProps.userWidget,
                 newProps.onDeleteClick,
             ),
-            widgetUrl: this.sgWidget?.embedUrl,
+            // Explicitly do not set until startWidget() has run
+            widgetUrl: undefined,
         };
     }
 
@@ -365,7 +366,6 @@ export default class AppTile extends React.Component<IProps, IState> {
         this.sgWidget?.on("error:preparing", this.updateRequiresClient);
         // emits when the capabilities have been set up or changed
         this.sgWidget?.on("capabilitiesNotified", this.updateRequiresClient);
-        this.sgWidget?.on("urlChanged", this.updateWidgetUrl);
     }
 
     private stopSgListeners(): void {
@@ -375,7 +375,6 @@ export default class AppTile extends React.Component<IProps, IState> {
         this.sgWidget?.off("ready", this.onWidgetReady);
         this.sgWidget.off("error:preparing", this.updateRequiresClient);
         this.sgWidget.off("capabilitiesNotified", this.updateRequiresClient);
-        this.sgWidget?.off("urlChanged", this.updateWidgetUrl);
     }
 
     private resetWidget(newProps: IProps): void {
@@ -393,10 +392,11 @@ export default class AppTile extends React.Component<IProps, IState> {
     }
 
     private startWidget(): void {
-        this.sgWidget?.prepare().then(() => {
+        const widget = this.sgWidget;
+        widget?.prepare().then(() => {
             if (this.unmounted) return;
             if (!this.state.initialising) return;
-            this.setState({ initialising: false });
+            this.setState({ initialising: false, widgetUrl: widget.embedUrl });
         });
     }
 
@@ -479,12 +479,6 @@ export default class AppTile extends React.Component<IProps, IState> {
 
         // TODO: This is a stop gap solution to responsively update the theme of the widget.
         // A new action should be introduced and the widget driver should be called here, so it informs the widget. (or connect to this by itself)
-    };
-
-    private updateWidgetUrl = (): void => {
-        this.setState({
-            widgetUrl: this.sgWidget?.embedUrl,
-        });
     };
 
     private onAction = (payload: ActionPayload): void => {

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -365,6 +365,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         this.sgWidget?.on("error:preparing", this.updateRequiresClient);
         // emits when the capabilities have been set up or changed
         this.sgWidget?.on("capabilitiesNotified", this.updateRequiresClient);
+        this.sgWidget?.on("urlChanged", this.updateWidgetUrl);
     }
 
     private stopSgListeners(): void {
@@ -374,6 +375,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         this.sgWidget?.off("ready", this.onWidgetReady);
         this.sgWidget.off("error:preparing", this.updateRequiresClient);
         this.sgWidget.off("capabilitiesNotified", this.updateRequiresClient);
+        this.sgWidget?.off("urlChanged", this.updateWidgetUrl);
     }
 
     private resetWidget(newProps: IProps): void {
@@ -477,6 +479,12 @@ export default class AppTile extends React.Component<IProps, IState> {
 
         // TODO: This is a stop gap solution to responsively update the theme of the widget.
         // A new action should be introduced and the widget driver should be called here, so it informs the widget. (or connect to this by itself)
+    };
+
+    private updateWidgetUrl = (): void => {
+        this.setState({
+            widgetUrl: this.sgWidget?.embedUrl,
+        });
     };
 
     private onAction = (payload: ActionPayload): void => {

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -445,8 +445,6 @@ export class StopGapWidget extends EventEmitter {
                     if (defaultManager && WidgetUtils.isScalarUrl(defaultManager.apiUrl)) {
                         const scalar = defaultManager.getScalarClient();
                         this.scalarToken = await scalar.getScalarToken();
-                        // The URL will have changed as a result of this.
-                        this.emit('urlChanged');
                     }
                 }
             }

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -445,6 +445,8 @@ export class StopGapWidget extends EventEmitter {
                     if (defaultManager && WidgetUtils.isScalarUrl(defaultManager.apiUrl)) {
                         const scalar = defaultManager.getScalarClient();
                         this.scalarToken = await scalar.getScalarToken();
+                        // The URL will have changed as a result of this.
+                        this.emit('urlChanged');
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-integration-manager/issues/116

The scalar token can arrive async after we've rendered a widget, which means we may need to change the URL of the app tile after this has happened. It felt reasonable to me to raise an event from the widget to the tile when this happens.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).