### PR TITLE
Expected UTDs: use a different message for UTDs sent before login

### DIFF
--- a/playwright/e2e/crypto/crypto.spec.ts
+++ b/playwright/e2e/crypto/crypto.spec.ts
@@ -15,14 +15,17 @@ limitations under the License.
 */
 
 import type { Page } from "@playwright/test";
-import { test, expect } from "../../element-web-test";
+import { expect, test } from "../../element-web-test";
 import {
+    copyAndContinue,
+    createRoom,
     createSharedRoomWithUser,
     doTwoWaySasVerification,
-    copyAndContinue,
     enableKeyBackup,
     logIntoElement,
     logOutOfElement,
+    sendMessageInCurrentRoom,
+    verifySession,
     waitForVerificationRequest,
 } from "./utils";
 import { Bot } from "../../pages/bot";
@@ -453,8 +456,8 @@ test.describe("Cryptography", function () {
             // no e2e icon
             await expect(lastTileE2eIcon).not.toBeVisible();
 
-            // It can take up to 10 seconds for the key to be backed up. We don't really have much option other than
-            // to wait :/
+            // Workaround for https://github.com/element-hq/element-web/issues/27267: it can take up to 10 seconds for
+            // the key to be backed up.
             await page.waitForTimeout(10000);
 
             /* log out, and back in */
@@ -530,6 +533,71 @@ test.describe("Cryptography", function () {
             await expect(
                 page.locator(".mx_EventTile", { hasText: "Hee!" }).locator(".mx_EventTile_e2eIcon_warning"),
             ).not.toBeVisible();
+        });
+    });
+
+    test.describe("decryption failure messages", () => {
+        test("should handle device-relative historical messages", async ({
+            homeserver,
+            page,
+            app,
+            credentials,
+            user,
+            cryptoBackend,
+        }) => {
+            test.skip(cryptoBackend === "legacy", "Not implemented for legacy crypto");
+            test.setTimeout(60000);
+
+            // Start with a logged-in session, without key backup, and send a message.
+            await createRoom(page, "Test room", true);
+            await sendMessageInCurrentRoom(page, "test test");
+
+            // Log out, discarding the key for the sent message.
+            await logOutOfElement(page, true);
+
+            // Log in again, and see how the message looks.
+            await logIntoElement(page, homeserver, credentials);
+            await app.viewRoomByName("Test room");
+            const lastTile = page.locator(".mx_EventTile").last();
+            await expect(lastTile).toContainText("Historical messages are not available on this device");
+            await expect(lastTile.locator(".mx_EventTile_e2eIcon_decryption_failure")).toBeVisible();
+
+            // Now, we set up key backup, and then send another message.
+            const secretStorageKey = await enableKeyBackup(app);
+            await app.viewRoomByName("Test room");
+            await sendMessageInCurrentRoom(page, "test2 test2");
+
+            // Workaround for https://github.com/element-hq/element-web/issues/27267: it can take up to 10 seconds for
+            // the key to be backed up.
+            await page.waitForTimeout(10000);
+
+            // Finally, log out again, and back in, skipping verification for now, and see what we see.
+            await logOutOfElement(page);
+            await logIntoElement(page, homeserver, credentials);
+            await page.locator(".mx_AuthPage").getByRole("button", { name: "Skip verification for now" }).click();
+            await page.locator(".mx_AuthPage").getByRole("button", { name: "I'll verify later" }).click();
+            await app.viewRoomByName("Test room");
+
+            // There should be two historical events in the timeline
+            const tiles = await page.locator(".mx_EventTile").all();
+            expect(tiles.length).toBeGreaterThanOrEqual(2);
+            // look at the last two tiles only
+            for (const tile of tiles.slice(-2)) {
+                await expect(tile).toContainText("You need to verify this device for access to historical messages");
+                await expect(tile.locator(".mx_EventTile_e2eIcon_decryption_failure")).toBeVisible();
+            }
+
+            // Now verify our device (setting up key backup), and check what happens
+            await verifySession(app, secretStorageKey);
+            const tilesAfterVerify = (await page.locator(".mx_EventTile").all()).slice(-2);
+
+            // The first message still cannot be decrypted, because it was never backed up. It's now a regular UTD though.
+            await expect(tilesAfterVerify[0]).toContainText("Unable to decrypt message");
+            await expect(tilesAfterVerify[0].locator(".mx_EventTile_e2eIcon_decryption_failure")).toBeVisible();
+
+            // The second message should now be decrypted, with a grey shield
+            await expect(tilesAfterVerify[1]).toContainText("test2 test2");
+            await expect(tilesAfterVerify[1].locator(".mx_EventTile_e2eIcon_normal")).toBeVisible();
         });
     });
 });

--- a/playwright/e2e/crypto/crypto.spec.ts
+++ b/playwright/e2e/crypto/crypto.spec.ts
@@ -456,7 +456,7 @@ test.describe("Cryptography", function () {
             // no e2e icon
             await expect(lastTileE2eIcon).not.toBeVisible();
 
-            // Workaround for https://github.com/element-hq/element-web/issues/27267: it can take up to 10 seconds for
+            // Workaround for https://github.com/element-hq/element-web/issues/27267. It can take up to 10 seconds for
             // the key to be backed up.
             await page.waitForTimeout(10000);
 
@@ -567,7 +567,7 @@ test.describe("Cryptography", function () {
             await app.viewRoomByName("Test room");
             await sendMessageInCurrentRoom(page, "test2 test2");
 
-            // Workaround for https://github.com/element-hq/element-web/issues/27267: it can take up to 10 seconds for
+            // Workaround for https://github.com/element-hq/element-web/issues/27267. It can take up to 10 seconds for
             // the key to be backed up.
             await page.waitForTimeout(10000);
 

--- a/src/components/views/messages/DecryptionFailureBody.tsx
+++ b/src/components/views/messages/DecryptionFailureBody.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { forwardRef, ForwardRefExoticComponent } from "react";
+import React, { forwardRef, ForwardRefExoticComponent, useContext } from "react";
 import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { DecryptionFailureCode } from "matrix-js-sdk/src/crypto-api";
 
 import { _t } from "../../../languageHandler";
 import { IBodyProps } from "./IBodyProps";
+import { LocalDeviceVerificationStateContext } from "../../../contexts/LocalDeviceVerificationStateContext";
 
-function getErrorMessage(mxEvent?: MatrixEvent): string {
-    return mxEvent?.isEncryptedDisabledForUnverifiedDevices
-        ? _t("timeline|decryption_failure|blocked")
-        : _t("timeline|decryption_failure|unable_to_decrypt");
+function getErrorMessage(mxEvent: MatrixEvent, isVerified: boolean | undefined): string {
+    if (mxEvent.isEncryptedDisabledForUnverifiedDevices) return _t("timeline|decryption_failure|blocked");
+    switch (mxEvent.decryptionFailureReason) {
+        case DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP:
+            return _t("timeline|decryption_failure|historical_event_no_key_backup");
+
+        case DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED:
+        case DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP:
+            if (isVerified === false) {
+                return _t("timeline|decryption_failure|historical_event_unverified_device");
+            }
+            // otherwise, use the default.
+            break;
+    }
+    return _t("timeline|decryption_failure|unable_to_decrypt");
 }
 
 // A placeholder element for messages that could not be decrypted
-export const DecryptionFailureBody = forwardRef<HTMLDivElement, IBodyProps>(({ mxEvent }, ref): JSX.Element => {
+export const DecryptionFailureBody = forwardRef<HTMLDivElement, IBodyProps>(({ mxEvent }, ref): React.JSX.Element => {
+    const verificationState = useContext(LocalDeviceVerificationStateContext);
     return (
         <div className="mx_DecryptionFailureBody mx_EventTile_content" ref={ref}>
-            {getErrorMessage(mxEvent)}
+            {getErrorMessage(mxEvent, verificationState)}
         </div>
     );
 }) as ForwardRefExoticComponent<IBodyProps>;

--- a/src/components/views/messages/DecryptionFailureBody.tsx
+++ b/src/components/views/messages/DecryptionFailureBody.tsx
@@ -29,8 +29,9 @@ function getErrorMessage(mxEvent: MatrixEvent, isVerified: boolean | undefined):
             return _t("timeline|decryption_failure|historical_event_no_key_backup");
 
         case DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED:
-        case DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP:
             if (isVerified === false) {
+                // The user seems to have a key backup, so prompt them to verify in the hope that doing so will
+                // mean we can restore from backup and we'll get the key for this message.
                 return _t("timeline|decryption_failure|historical_event_unverified_device");
             }
             // otherwise, use the default.

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -3214,6 +3214,8 @@
         "creation_summary_room": "%(creator)s created and configured the room.",
         "decryption_failure": {
             "blocked": "The sender has blocked you from receiving this message",
+            "historical_event_no_key_backup": "Historical messages are not available on this device",
+            "historical_event_unverified_device": "You need to verify this device for access to historical messages",
             "unable_to_decrypt": "Unable to decrypt message"
         },
         "disambiguated_profile": "%(displayName)s (%(matrixId)s)",

--- a/test/components/views/messages/DecryptionFailureBody-test.tsx
+++ b/test/components/views/messages/DecryptionFailureBody-test.tsx
@@ -17,13 +17,20 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { mkDecryptionFailureMatrixEvent } from "matrix-js-sdk/src/testing";
+import { DecryptionFailureCode } from "matrix-js-sdk/src/crypto-api";
 
 import { mkEvent } from "../../../test-utils";
 import { DecryptionFailureBody } from "../../../../src/components/views/messages/DecryptionFailureBody";
+import { LocalDeviceVerificationStateContext } from "../../../../src/contexts/LocalDeviceVerificationStateContext";
 
 describe("DecryptionFailureBody", () => {
-    function customRender(event: MatrixEvent) {
-        return render(<DecryptionFailureBody mxEvent={event} />);
+    function customRender(event: MatrixEvent, localDeviceVerified: boolean = false) {
+        return render(
+            <LocalDeviceVerificationStateContext.Provider value={localDeviceVerified}>
+                <DecryptionFailureBody mxEvent={event} />
+            </LocalDeviceVerificationStateContext.Provider>,
+        );
     }
 
     it(`Should display "Unable to decrypt message"`, () => {
@@ -60,4 +67,42 @@ describe("DecryptionFailureBody", () => {
         // Then
         expect(container).toMatchSnapshot();
     });
+
+    it("should handle historical messages with no key backup", async () => {
+        // When
+        const event = await mkDecryptionFailureMatrixEvent({
+            code: DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP,
+            msg: "No backup",
+            roomId: "fakeroom",
+            sender: "fakesender",
+        });
+        const { container } = customRender(event);
+
+        // Then
+        expect(container).toHaveTextContent("Historical messages are not available on this device");
+    });
+
+    describe.each([true, false])(
+        "should handle historical messages when there is a backup and device verification is",
+        (verified) => {
+            it.each([
+                [DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED],
+                [DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP],
+            ])("Error code %s", async (code) => {
+                // When
+                const event = await mkDecryptionFailureMatrixEvent({
+                    code,
+                    msg: "Failure",
+                    roomId: "fakeroom",
+                    sender: "fakesender",
+                });
+                const { container } = customRender(event, verified);
+
+                // Then
+                expect(container).toHaveTextContent(
+                    verified ? "Unable to decrypt" : "You need to verify this device for access to historical messages",
+                );
+            });
+        },
+    );
 });

--- a/test/components/views/messages/DecryptionFailureBody-test.tsx
+++ b/test/components/views/messages/DecryptionFailureBody-test.tsx
@@ -82,27 +82,22 @@ describe("DecryptionFailureBody", () => {
         expect(container).toHaveTextContent("Historical messages are not available on this device");
     });
 
-    describe.each([true, false])(
-        "should handle historical messages when there is a backup and device verification is",
-        (verified) => {
-            it.each([
-                [DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED],
-                [DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP],
-            ])("Error code %s", async (code) => {
-                // When
-                const event = await mkDecryptionFailureMatrixEvent({
-                    code,
-                    msg: "Failure",
-                    roomId: "fakeroom",
-                    sender: "fakesender",
-                });
-                const { container } = customRender(event, verified);
-
-                // Then
-                expect(container).toHaveTextContent(
-                    verified ? "Unable to decrypt" : "You need to verify this device for access to historical messages",
-                );
+    it.each([true, false])(
+        "should handle historical messages when there is a backup and device verification is %s",
+        async (verified) => {
+            // When
+            const event = await mkDecryptionFailureMatrixEvent({
+                code: DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED,
+                msg: "Failure",
+                roomId: "fakeroom",
+                sender: "fakesender",
             });
+            const { container } = customRender(event, verified);
+
+            // Then
+            expect(container).toHaveTextContent(
+                verified ? "Unable to decrypt" : "You need to verify this device for access to historical messages",
+            );
         },
     );
 });


### PR DESCRIPTION
Requires matrix-org/matrix-js-sdk#4139. Part of element-hq/element-meta#2313.

~~Based on #12436.~~

## Screenshots

If there is no backup on the server, we display this message:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/1389908/63b06b56-648c-4d6e-bd8c-7275afa4dc0b)

If there *is* a backup, and we have not yet verified:

![image](https://github.com/matrix-org/matrix-react-sdk/assets/1389908/f3ecf20f-d225-41e2-8e6a-367e8e384329)
