### PR TITLE
Fix link modal not shown after access upgrade

### DIFF
--- a/src/components/views/rooms/RoomHeader/CallGuestLinkButton.tsx
+++ b/src/components/views/rooms/RoomHeader/CallGuestLinkButton.tsx
@@ -79,7 +79,6 @@ export const CallGuestLinkButton: React.FC<{ room: Room }> = ({ room }) => {
                 // If the user cannot invite the Knocking is not given as an option.
                 canInvite,
             }).finished.then(() => {
-                // we need to use the function here because the callback got called before the state was updated.
                 if (isRoomJoinable()) showLinkModal();
             });
         }

--- a/src/hooks/room/useGuestAccessInformation.ts
+++ b/src/hooks/room/useGuestAccessInformation.ts
@@ -53,8 +53,8 @@ export const useGuestAccessInformation = (room: Room): GuestAccessInformation =>
     );
 
     const isRoomJoinableFunction = (): boolean => {
-        const joinRule = room.getJoinRule();
-        return joinRule === JoinRule.Public || (joinRule === JoinRule.Knock && room.canInvite(room.myUserId));
+        const join = room.getJoinRule();
+        return join === JoinRule.Public || (join === JoinRule.Knock && room.canInvite(room.myUserId));
     };
 
     return { canInviteGuests, guestSpaUrl, isRoomJoinable: isRoomJoinableFunction, canInvite };

--- a/src/hooks/room/useGuestAccessInformation.ts
+++ b/src/hooks/room/useGuestAccessInformation.ts
@@ -52,7 +52,10 @@ export const useGuestAccessInformation = (room: Room): GuestAccessInformation =>
         [canChangeJoinRule, isRoomJoinable, guestSpaUrl],
     );
 
-    const isRoomJoinableFunction = (): boolean =>
-        room.getJoinRule() === JoinRule.Public || (joinRule === JoinRule.Knock && room.canInvite(room.myUserId));
+    const isRoomJoinableFunction = (): boolean => {
+        const joinRule = room.getJoinRule();
+        return joinRule === JoinRule.Public || (joinRule === JoinRule.Knock && room.canInvite(room.myUserId));
+    };
+
     return { canInviteGuests, guestSpaUrl, isRoomJoinable: isRoomJoinableFunction, canInvite };
 };


### PR DESCRIPTION
We dont show the modal since there was a mistake in the isRoomJoinable function. It used a state variable instead of reacomputing the join rule with room.getJoinRule() The state is a captured variable that from before the link share click -> does not update at that time.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
