### PR TITLE
Fix missing CrossSigningKeys upload with sso sign in and backup migration

### DIFF
--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -24,6 +24,7 @@ import {
 import { deriveKey } from "matrix-js-sdk/src/crypto/key_passphrase";
 import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
 import { logger } from "matrix-js-sdk/src/logger";
+import { GeneratedSecretStorageKey } from "matrix-js-sdk/src/crypto-api";
 
 import type CreateSecretStorageDialog from "./async-components/views/dialogs/security/CreateSecretStorageDialog";
 import Modal from "./Modal";
@@ -297,7 +298,7 @@ export async function promptForBackupPassphrase(): Promise<Uint8Array> {
         RestoreKeyBackupDialog,
         {
             showSummary: false,
-            keyCallback: (k: Uint8Array) => (key = k),
+            keyCallback: (k: Uint8Array, _: GeneratedSecretStorageKey) => (key = k),
         },
         undefined,
         /* priority = */ false,
@@ -430,7 +431,7 @@ async function doAccessSecretStorage(func: () => Promise<void>, forceReset: bool
         // inner operation completes.
         return await func();
     } catch (e) {
-        ModuleRunner.instance.extensions.cryptoSetup.catchAccessSecretStorageError(e as Error);
+        SecurityCustomisations.catchAccessSecretStorageError?.(e);
         logger.error(e);
         // Re-throw so that higher level logic can abort as needed
         throw e;

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -382,6 +382,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                 //     moment via token login)
                 await crypto.bootstrapCrossSigning({
                     authUploadDeviceSigningKeys: this.doBootstrapUIAuth,
+                    setupNewCrossSigning: true,
                 });
                 await crypto.bootstrapSecretStorage({
                     createSecretStorageKey: async () => this.recoveryKey!,

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -429,8 +429,9 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
     private restoreBackup = async (): Promise<void> => {
         // It's possible we'll need the backup key later on for bootstrapping,
         // so let's stash it here, rather than prompting for it twice.
-        const keyCallback = (k: Uint8Array): void => {
+        const keyCallback = (k: Uint8Array, recoveryKey: GeneratedSecretStorageKey): void => {
             this.backupKey = k;
+            this.recoveryKey = recoveryKey;
         };
 
         const { finished } = Modal.createDialog(

--- a/src/i18n/strings/de_DE.json
+++ b/src/i18n/strings/de_DE.json
@@ -2514,6 +2514,7 @@
                 "requires_password_confirmation": "Gib dein Kontopasswort ein, um die Aktualisierung zu bestätigen:",
                 "requires_server_authentication": "Du musst dich authentifizieren, um die Aktualisierung zu bestätigen.",
                 "secret_storage_query_failure": "Status des sicheren Speichers kann nicht gelesen werden",
+                "secret_storage_migration_failure": "Während des Backup-Migrationsprozesses ist ein Fehler aufgetreten. Wir können nicht auf deinen Wiederherstellungsschlüssel zugreifen. Bitte versuche es erneut.",
                 "security_key_safety_reminder": "Bewahre deinen Sicherheitsschlüssel sicher auf, etwa in einem Passwortmanager oder einem Safe, da er verwendet wird, um deine Daten zu sichern.",
                 "session_upgrade_description": "Aktualisiere diese Sitzung, um mit ihr andere Sitzungen verifizieren zu können, damit sie Zugang zu verschlüsselten Nachrichten erhalten und für andere als vertrauenswürdig markiert werden.",
                 "set_phrase_again": "Gehe zurück und setze es erneut.",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2547,6 +2547,7 @@
                 "requires_password_confirmation": "Enter your account password to confirm the upgrade:",
                 "requires_server_authentication": "You'll need to authenticate with the server to confirm the upgrade.",
                 "secret_storage_query_failure": "Unable to query secret storage status",
+                "secret_storage_migration_failure": "An error occurred during the backup migration process. We cannot access your recovery key. Please try it again.",
                 "security_key_safety_reminder": "Store your Security Key somewhere safe, like a password manager or a safe, as it's used to safeguard your encrypted data.",
                 "session_upgrade_description": "Upgrade this session to allow it to verify other sessions, granting them access to encrypted messages and marking them as trusted for other users.",
                 "set_phrase_again": "Go back to set it again.",


### PR DESCRIPTION
## General Description Case 1 - Key Backup vs 4s
When using key backups without 4s (secure secret storage and sharing) and signing in with the web-client then no migration is performed and the session cannot backup keys without any further user interaction (resetting cross signing (and key backup)).
This seems to be related to: [element-web PR 27100](https://github.com/element-hq/element-web/issues/27100)
**ToDo**: If the above is correct then a note for the Changelog will be added.

## Case 1 - Steps to reproduce 
* Sign in with a new account via SSO at the Android-Client
* Create a private room and send a message
* Open the "Security & Privacy" settings, click on "Encrypted Messages Recovery" / German: "Wiederherstellung verschlüsselter Nachrichten", then select "Start Using Key Backup" / German: "Richte Schlüsselsicherung ein" and complete the setup process.
* Sign out and sign in again with the android client.
* After restoring the history in the settings ("Restore From Backup") all messages are decrypted and nothing indicates that there are problems. (The 4S was not setup with this process on purpose.)
* Sign out
* Sign in with the web-client
* Click on ```Upgrade``` in the ```Encryption upgrade available``` dialog / modal. The ```Upgrade your encryption``` dialog opens
* Click on ```Restore``` and enter your passphrase / recovery key.
	=> The message is decrypted but the "Upgrade your encryption" dialog remains.
		The following tables have no "useful" entries (master, selfsignign, ..., defaultKey,...): account_data, e2e_cross_signing_keys, e2e_cross_signing_signatures.
		The Security & Privacy page shows ```Thsi session inot backing up your keys, [...]```, ```Cross-signing is ready but keys are not backed up.``` and the session is not trusted.
* Send a message.
* Try to sign out
	=> It is shown that this session is not backed up. So connect with the secure storage but this doesn't help. If you try to sign out it is shown again.
	Signing out and signing in show that the last message is not decrypted.
	
## General Description Case 2 - Missing CrossSigningKeys for SSO
Signing in with a new account via SSO leads to a session which is not verified and does not backup keys.
(The cross signing keys are not uploaded.)
This seems to be related to: [element-web PR 27253](https://github.com/element-hq/element-web/issues/27253), [element-web PR 26322](https://github.com/element-hq/element-web/issues/26322)
**ToDo**: If the above is correct then a note for the Changelog will be added.

**Case 2 - Steps to reproduce**
* Create new SSO-Account and sign in for the first time with the web-client
* Create a private room
* setup secret storage with creating a recovery key / without passphrase
* Send a message
	=> The message has a red shield. The security page in the settings shows that the session is connected with the secret storage and the cross signing is setup. The session page shows that this session is not trusted.
		There are no db entries at the server for the tables e2e_cross_signing_keys, e2e_cross_signing_signatures for this user.
   The following tables seem to have "normal" entries: 
   * account_data: m.cross_signing.master, m.cross_signing.user_signing, m.cross_signing.self_signing, m.megolm_backup.v1, m.secret_storage.default_key, m.secret_storage.key.<the Keyid> 
   * e2e_room_keys_versions: one version 1 entry with algorithm m.megolm_backup.v1.curve25519-aes-sha2, ...
   * e2e_room_keys: one version 1 entry
   * e2e_device_keys_json: one entry with device_id equals to the current device's id
   The following request can just be found one time (v1.11.61) / three times (v1.11.64) in the network tab of the developer tools of the browser. The request fails with a 401
   ```POST /_matrix/client/unstable/keys/device_signing/upload```
   The tab doesn't show any ```device_keys/upload``` request.
* Sign out and sign in again. The dialog for entering the recovery key appears several times but it doesnt help to decrypt the message.
* Endless many ```POST matrix/client/v3/keys/query``` requests with 200 Response. It stops when clicking on the "Upgrade" button in the ```Encryption upgrade available``` modal / dialog.
* In the security settings it is shown that the session "is not booking up your keys" in the secret storage.
* Connecting to the secret storage leads to an error dialog ```Unable to restore backup``` when having entered the correct recovery key. The console prints (v1.11.64): ```Error: the signing key is missing from the object that signed the message```
	
## Environment
The sign in is performed via **SSO**.
The above test was done for (at least) the settings:

**Setting 1**
| Repository name	| commit hash							   	| version 		|
|:---               |:---                                    	|:--			|
| element-web 		| ba2336ac5c952a2dea36f70fc8e727cf9fe1d6a4 	|	v1.11.61	|
| matrix-react-sdk	| f96606acebaeea99e98c3a827575c76a68f37a5c 	|	v3.95.0		|
| matrix-js-sdk		| 78d05942a35a764ca2ae0de153ae38adf1d7c934 	|	v31.5.0		|

**Setting 2**
| Repository name	| commit hash							   	| version 		|
|:---               |:---                                    	|:---			|
| element-web 		| 180a1a243bbcd22f5fd9b17ea49f4d63ec960cc5 	|	v1.11.64	|
| matrix-react-sdk	| adc805828da3a5cc1f2a9dccc05ce83430166ff8 	|	v3.97.0		|
| matrix-js-sdk		| e4937e62226a90428a66194cb2eb389c94fd848b 	|	v32.0.0		|

and the fix / workaround in this PR.
	
## Automatic Tests
No automatic tests where added (for now).

## Explanation of the changes
### Case 1
File: ```matrix-react-sdk: src\async-components\views\dialogs\security\CreateSecretStorageDialog.tsx```
Setting ```setupNewCrossSigning: true,``` is enough to handle new accounts and reactivated accounts. It was not investigated enough why it doesn't work when the parameter is not set, while in the past it was not required.
A similar implementation worked till version v1.11.57 (element-web) while it was enough just to invoke bootstrapSecretStorage.

### Case 2
The aim here is to setup 4s if the passphrase / recovery key is entered correctly and we have access to the backup. Furthermore the signature of the backup is updated to ensure that all clients accept this backup is trusted.
It is assumed that an update of the backup's signature is no problem in this case because this session is the first using 4s and "obviously" trusted.

* ```restoreBackup & checkForBackupMigrationAndApply```: Start migrating the key backup to 4s if it is observed, that the passphrase /recovery key was entered correctly (checked via ```backupTrustInfo?.matchesDecryptionKey```) but the user has no 4s. The start of the migration is introduced by invoking ```bootstrapSecretStorage```.
* ```keyCallback```: Before switching to the rust-crypto.ts the bootstrapSecretStorage got the same value for the "createSecretStorageKey" parameter, but just used it if
	```!storageExists && !keyBackupInfo```. The setting in this PR didn't cause this condition to become true before v1.11.57. Now the CreateSecretStorageDialog opens the RestoreBackupDialog, but does not delegate the recoveryKey to the CreateSecretStorageDialog. This is fixed via extending keyCallback.
* ```resignBackupIfRequired```: At the end the signature of the backup is updated using the cross signing keys introduced in this session. This step does NOT upload a new backup and does NOT change the version. The "PUT /room_keys/version/{version}" endpoint is used.

## What alternatives were considered
* It was tried to setup 4s without touching the backup. As result the backup was still not trusted and no active backup existed with all leading consequences.
* It was tried to create a new backup by resetting the backup (using the ```setupNewKeyBackup``` parameter which leads to ```rust-crypto.ts resetKeyBackup```). This led to a situation where a (quick sign out) caused all messages from the last backup being encrypted forever, because all old room keys where lost and not replaced by new.
* It was tried to create a new backup by posting a new backup. In this case the old messages could not be decrypted again when signing out and in again.

## How you know this is the right solution
I don't know it, but all tests indicate that the original problem does not appear with this. The following database entries where checked in many steps:
```account_data, e2e_room_keys_versions, e2e_room_keys, e2e_cross_signing_keys, e2e_cross_signing_signatures, e2e_device_keys_json```
The review of this PR should help clearing the question if these changes fix both described problems or give at least an acceptable workaround until proper fixes are done.



Signed-off-by: Michael Schrader michael.schrader@connext.de