### PR TITLE
Fix: Playback-worker didn't terminated on voice message body destroyed

### DIFF
--- a/src/WorkerManager.ts
+++ b/src/WorkerManager.ts
@@ -43,4 +43,8 @@ export class WorkerManager<Request extends {}, Response> {
         this.worker.postMessage({ seq, ...request });
         return deferred.promise;
     }
+
+    public terminate(): void {
+        this.worker.terminate()
+    }
 }

--- a/src/audio/Playback.ts
+++ b/src/audio/Playback.ts
@@ -145,6 +145,7 @@ export class Playback extends EventEmitter implements IDestroyable, PlaybackInte
         this.removeAllListeners();
         this.clock.destroy();
         this.waveformObservable.close();
+        this.worker.terminate();
         if (this.element) {
             URL.revokeObjectURL(this.element.src);
             this.element.remove();


### PR DESCRIPTION
To fix to many voice message reopen will be OOM
issuer [Element freezes or crashes when too many voice messages are in a chat #26239](https://github.com/element-hq/element-web/issues/26239)
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
