### PR TITLE
Decrypt events in reverse order without copying the array

### DIFF
--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -54,7 +54,6 @@ import dis from "../../dispatcher/dispatcher";
 import { Action } from "../../dispatcher/actions";
 import Timer from "../../utils/Timer";
 import shouldHideEvent from "../../shouldHideEvent";
-import { arrayFastClone } from "../../utils/arrays";
 import MessagePanel from "./MessagePanel";
 import { IScrollState } from "./ScrollPanel";
 import { ActionPayload } from "../../dispatcher/payloads";
@@ -1754,15 +1753,11 @@ class TimelinePanel extends React.Component<IProps, IState> {
             [...mainEvents],
         );
 
-        // `arrayFastClone` performs a shallow copy of the array
-        // we want the last event to be decrypted first but displayed last
-        // `reverse` is destructive and unfortunately mutates the "events" array
-        arrayFastClone(events)
-            .reverse()
-            .forEach((event) => {
-                const client = MatrixClientPeg.safeGet();
-                client.decryptEventIfNeeded(event);
-            });
+        // We want the last event to be decrypted first
+        const client = MatrixClientPeg.safeGet();
+        for (let i = events.length - 1; i >= 0; --i) {
+            client.decryptEventIfNeeded(events[i]);
+        }
 
         const firstVisibleEventIndex = this.checkForPreJoinUISI(events);
 


### PR DESCRIPTION
This is largely hygiene but I think the convenience of using `reverse` and `forEach` is ruined by having to explain why a copy of the array is needed. Performance-wise there's an 8x difference on my laptop but the loop overhead is still negligible unless you're dealing with millions of events.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
