### PR TITLE
Fix / workaround for the failing upload of cross signing keys

### DIFF
--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -382,6 +382,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                 //     moment via token login)
                 await crypto.bootstrapCrossSigning({
                     authUploadDeviceSigningKeys: this.doBootstrapUIAuth,
+                    setupNewCrossSigning: true,
                 });
                 await crypto.bootstrapSecretStorage({
                     createSecretStorageKey: async () => this.recoveryKey!,


### PR DESCRIPTION
Signing in with a new account via SSO leads to a session which is not verified and does not backup keys.
(The cross signing keys are not uploaded.)
This is related to the issue [element-web issue 27382](https://github.com/element-hq/element-web/issues/27382)
This to be related to: [element-web issue 27253](https://github.com/element-hq/element-web/issues/27253), [element-web issue 26322](https://github.com/element-hq/element-web/issues/26322)
**ToDo**: If the above is correct then a note for the Changelog will be added.

Setting ```setupNewCrossSigning: true,``` is enough to handle new accounts and reactivated accounts. It was not investigated enough why it doesn't work when the parameter is not set, while in the past it was not required.
The described behaviour could not be observed in version v1.11.57.

## What alternatives were considered
No alternatives were considered.

## How you know this is the right solution
I don't know it, but all tests indicate that the original problem does not appear with this. The following database entries where checked in many steps:
```account_data, e2e_room_keys_versions, e2e_room_keys, e2e_cross_signing_keys, e2e_cross_signing_signatures, e2e_device_keys_json```
The review of this PR should help clearing the question if these changes fix both described problems or give at least an acceptable workaround until proper fixes are done.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).


Signed-off-by: Michael Schrader michael.schrader@connext.de