### PR TITLE
Add extra attribute to `AccessibleButton`

### DIFF
--- a/src/components/views/elements/AccessibleButton.tsx
+++ b/src/components/views/elements/AccessibleButton.tsx
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-import React, { forwardRef, FunctionComponent, HTMLAttributes, InputHTMLAttributes, Ref } from "react";
+import React, { ComponentProps, forwardRef, FunctionComponent, HTMLAttributes, InputHTMLAttributes, Ref } from "react";
 import classnames from "classnames";
 import { Tooltip } from "@vector-im/compound-web";
 
@@ -61,6 +61,8 @@ type DynamicElementProps<T extends keyof JSX.IntrinsicElements> = Partial<
 > &
     Omit<InputHTMLAttributes<Element>, "onClick">;
 
+type TooltipProps = ComponentProps<typeof Tooltip>;
+
 /**
  * Type of props accepted by {@link AccessibleButton}.
  *
@@ -96,6 +98,14 @@ type Props<T extends keyof JSX.IntrinsicElements> = DynamicHtmlElementProps<T> &
      * Only valid when used in conjunction with `title`.
      */
     caption?: string;
+    /**
+     * The placement of the tooltip.
+     */
+    placement?: TooltipProps["placement"];
+    /**
+     * Callback for when the tooltip is opened or closed.
+     */
+    onTooltipOpenChange?: TooltipProps["onOpenChange"];
 };
 
 /**
@@ -128,6 +138,8 @@ const AccessibleButton = forwardRef(function <T extends keyof JSX.IntrinsicEleme
         triggerOnMouseDown,
         title,
         caption,
+        placement,
+        onTooltipOpenChange,
         ...restProps
     }: Props<T>,
     ref: Ref<HTMLElement>,
@@ -199,7 +211,13 @@ const AccessibleButton = forwardRef(function <T extends keyof JSX.IntrinsicEleme
 
     if (title) {
         return (
-            <Tooltip label={title} caption={caption} isTriggerInteractive={!disabled}>
+            <Tooltip
+                label={title}
+                caption={caption}
+                isTriggerInteractive={true}
+                placement={placement}
+                onOpenChange={onTooltipOpenChange}
+            >
                 {button}
             </Tooltip>
         );

--- a/test/components/views/settings/devices/__snapshots__/CurrentDeviceSection-test.tsx.snap
+++ b/test/components/views/settings/devices/__snapshots__/CurrentDeviceSection-test.tsx.snap
@@ -135,26 +135,22 @@ exports[`<CurrentDeviceSection /> handles when device is falsy 1`] = `
       >
         Current session
       </h3>
-      <span
+      <div
+        aria-disabled="true"
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-label="Options"
+        class="mx_AccessibleButton mx_AccessibleButton_disabled"
         data-state="closed"
+        data-testid="current-session-menu"
+        disabled=""
+        role="button"
         tabindex="0"
       >
         <div
-          aria-disabled="true"
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Options"
-          class="mx_AccessibleButton mx_AccessibleButton_disabled"
-          data-testid="current-session-menu"
-          disabled=""
-          role="button"
-          tabindex="0"
-        >
-          <div
-            class="mx_KebabContextMenu_icon"
-          />
-        </div>
-      </span>
+          class="mx_KebabContextMenu_icon"
+        />
+      </div>
     </div>
     <div
       class="mx_SettingsSubsection_content"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Part of https://github.com/element-hq/element-web/issues/26762

Prepare work for https://github.com/matrix-org/matrix-react-sdk/pull/12448 (it will be splitted in many PRs)
I will need this extra attributes for `AccessibleButton` for the migration from `AccessibleTooltipButton`.

TLDR: Add new attribute to prepare the incoming migration to  from `AccessibleTooltipButton` to `AccessibleButton`

Also, the `triggerInteractive` creates unwanted extra span in the dom. 
