### PR TITLE
Convert tabbedview to functional component

### DIFF
--- a/src/components/structures/TabbedView.tsx
+++ b/src/components/structures/TabbedView.tsx
@@ -63,7 +63,11 @@ interface IProps<T extends string> {
 export default function TabbedView<T extends string>(props: IProps<T>): JSX.Element {
     const tabLocation = props.tabLocation ?? TabLocation.LEFT;
 
-    const [activeTabId, setActiveTabId] = React.useState<T>(props.initialTabId ?? props.tabs[0].id);
+    const [activeTabId, setActiveTabId] = React.useState<T>((): T => {
+        const initialTabIdIsValid = props.tabs.find((tab) => tab.id === props.initialTabId);
+        // unfortunately typescript doesn't infer the types coorectly if the null check is included above
+        return initialTabIdIsValid && props.initialTabId ? props.initialTabId : props.tabs[0].id;
+    });
 
     const getTabById = (id: T): Tab<T> | undefined => {
         return props.tabs.find((tab) => tab.id === id);

--- a/src/components/structures/TabbedView.tsx
+++ b/src/components/structures/TabbedView.tsx
@@ -56,9 +56,18 @@ interface ITabPanelProps<T extends string> {
     tab: Tab<T>;
 }
 
+function domIDForTabID(tabId: string): string {
+    return `mx_tabpanel_${tabId}`;
+}
+
 function TabPanel<T extends string>({ tab }: ITabPanelProps<T>): JSX.Element {
     return (
-        <div className="mx_TabbedView_tabPanel" key={tab.id} id={tab.id} aria-labelledby={`${tab.id}_label`}>
+        <div
+            className="mx_TabbedView_tabPanel"
+            key={tab.id}
+            id={domIDForTabID(tab.id)}
+            aria-labelledby={`${domIDForTabID(tab.id)}_label`}
+        >
             <AutoHideScrollbar className="mx_TabbedView_tabPanelContent">{tab.body}</AutoHideScrollbar>
         </div>
     );
@@ -80,7 +89,7 @@ function TabLabel<T extends string>({ tab, isActive, onClick }: ITabLabelProps<T
         tabIcon = <span className={`mx_TabbedView_maskedIcon ${tab.icon}`} />;
     }
 
-    const id = `mx_tabpanel_${tab.id}`;
+    const id = domIDForTabID(tab.id);
 
     const label = _t(tab.label);
     return (

--- a/src/components/structures/TabbedView.tsx
+++ b/src/components/structures/TabbedView.tsx
@@ -74,6 +74,7 @@ export default function TabbedView<T extends string>(props: IProps<T>): JSX.Elem
      * @param {Tab} tab the tab to show
      */
     const setActiveTab = (tab: Tab<T>): void => {
+        // make sure this tab is still in available tabs
         if (!!getTabById(tab.id)) {
             if (props.onChange) props.onChange(tab.id);
             setActiveTabId(tab.id);

--- a/src/components/structures/TabbedView.tsx
+++ b/src/components/structures/TabbedView.tsx
@@ -102,13 +102,22 @@ function TabLabel<T extends string>({ tab, isActive, onClick }: ITabLabelProps<T
 }
 
 interface IProps<T extends string> {
+    // An array of objects representign tabs that the tabbed view will display.
     tabs: NonEmptyArray<Tab<T>>;
+    // The ID of the tab to display initially.
     initialTabId?: T;
+    // The location of the tabs, dictating the layout of the TabbedView.
     tabLocation?: TabLocation;
+    // A callback that is called when the active tab changes.
     onChange?: (tabId: T) => void;
+    // The screen name to report to Posthog.
     screenName?: ScreenName;
 }
 
+/**
+ * A tabbed view component. Given objects representing content with titles, displays
+ * them in a tabbed view where the user can select which one of the items to view at once.
+ */
 export default function TabbedView<T extends string>(props: IProps<T>): JSX.Element {
     const tabLocation = props.tabLocation ?? TabLocation.LEFT;
 


### PR DESCRIPTION
The 'Tab' is still a class, so now it's a functional component that has a supporting class, which is maybe a bit... jarring, but I think is actually perfectly logical.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
