### PR TITLE
TAC: Fix accessibility issue when the Release announcement is displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@sentry/browser": "^7.0.0",
         "@testing-library/react-hooks": "^8.0.1",
         "@vector-im/compound-design-tokens": "^1.2.0",
-        "@vector-im/compound-web": "^4.1.0",
+        "@vector-im/compound-web": "^4.1.1",
         "@zxcvbn-ts/core": "^3.0.4",
         "@zxcvbn-ts/language-common": "^3.0.4",
         "@zxcvbn-ts/language-en": "^3.0.2",

--- a/test/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
+++ b/test/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
@@ -230,6 +230,7 @@ exports[`<SpacePanel /> should show all activated MetaSpaces in the correct orde
     >
       <button
         aria-controls="floating-ui-7"
+        aria-describedby="floating-ui-7"
         aria-expanded="true"
         aria-haspopup="dialog"
         aria-label="Threads"

--- a/test/components/views/spaces/__snapshots__/ThreadsActivityCentre-test.tsx.snap
+++ b/test/components/views/spaces/__snapshots__/ThreadsActivityCentre-test.tsx.snap
@@ -433,6 +433,7 @@ exports[`ThreadsActivityCentre should render the release announcement 1`] = `
     >
       <button
         aria-controls="floating-ui-6"
+        aria-describedby="floating-ui-6"
         aria-expanded="true"
         aria-haspopup="dialog"
         aria-label="Threads"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3097,10 +3097,10 @@
   dependencies:
     svg2vectordrawable "^2.9.1"
 
-"@vector-im/compound-web@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@vector-im/compound-web/-/compound-web-4.1.0.tgz#45fa22e4e91b5fd4c2f535e040072990d5a33712"
-  integrity sha512-FQSJK7PaJ3dR1c1Q3TYVSShJBl9TwlrhKadnTWsPIX6xE+rvCAeujE50QbcEWdDlWeaJ9Hi0bVPlEssJ+eRwtQ==
+"@vector-im/compound-web@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@vector-im/compound-web/-/compound-web-4.1.1.tgz#7a3c7deb8be2ca7f13f151a51434759d64687ad9"
+  integrity sha512-vFJ6dyn712taz0TAt/ZwfwiD86ZbKyP9ePLcqCCeJ2M0dzvzrr0lCl702g6mbdiUKVqYwKHrqDhOUgsqb6TNoQ==
   dependencies:
     "@floating-ui/react" "^0.26.9"
     "@floating-ui/react-dom" "^2.0.8"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Closes https://github.com/element-hq/element-web/issues/27412

Needs https://github.com/element-hq/compound-web/pull/163
Update compound to fix the missing `aria-labelledby` attribute. 
