### PR TITLE
fix avatar stretched on 1:1 call

### DIFF
--- a/res/css/views/toasts/_IncomingLegacyCallToast.pcss
+++ b/res/css/views/toasts/_IncomingLegacyCallToast.pcss
@@ -18,6 +18,7 @@ limitations under the License.
 .mx_IncomingLegacyCallToast {
     display: flex;
     flex-direction: row;
+    align-items: flex-start;
     pointer-events: initial; /* restore pointer events so the user can accept/decline */
 
     .mx_IncomingLegacyCallToast_content {


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27427

In a 1:1 private conversation with another person, when receiving a call, the avatar icon is stretch :

As it is:
![2024-05-03_10-21](https://github.com/matrix-org/matrix-react-sdk/assets/91682618/f8fb4c0b-0487-45d1-9e3e-4689b959e627)

As it should be:
![2024-05-03_10-20](https://github.com/matrix-org/matrix-react-sdk/assets/91682618/fd7cefb0-3e76-4e1b-95db-825a926c3594)

The issue is due to the flex box of the parent element > mx_IncomingLegacyCallToast
As there is no align-item property, the elements can be strectched.

To test:
1. Call anybody in a 1:1 room

Signed-off-by: I-lander Ilan.varillon@gmail.com