### PR TITLE
Use h tag for widget title instead of b tag

### DIFF
--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -216,6 +216,10 @@ limitations under the License.
             margin-right: 12px;
         }
 
+        h3 {
+            font-size: inherit;
+        }
+
         > :last-child {
             margin-left: 9px;
             display: flex;

--- a/res/css/views/rooms/_AppsDrawer.pcss
+++ b/res/css/views/rooms/_AppsDrawer.pcss
@@ -218,6 +218,7 @@ limitations under the License.
 
         h3 {
             font-size: inherit;
+            margin: 0;
         }
 
         > :last-child {

--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -537,7 +537,7 @@ export default class AppTile extends React.Component<IProps, IState> {
         return (
             <span>
                 <WidgetAvatar app={this.props.app} size="20px" />
-                <b>{name}</b>
+                <h3>{name}</h3>
                 <span>
                     {title ? titleSpacer : ""}
                     {title}

--- a/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
+++ b/test/components/views/elements/__snapshots__/AppTile-test.tsx.snap
@@ -125,9 +125,9 @@ exports[`AppTile for a pinned widget should render 1`] = `
               width="20px"
             />
           </span>
-          <b>
+          <h3>
             Example 1
-          </b>
+          </h3>
           <span />
         </span>
       </span>
@@ -211,9 +211,9 @@ exports[`AppTile for a pinned widget should render permission request 1`] = `
               width="20px"
             />
           </span>
-          <b>
+          <h3>
             Example 1
-          </b>
+          </h3>
           <span />
         </span>
       </span>
@@ -364,9 +364,9 @@ exports[`AppTile preserves non-persisted widget on container move 1`] = `
                     width="20px"
                   />
                 </span>
-                <b>
+                <h3>
                   Example 1
-                </b>
+                </h3>
                 <span />
               </span>
             </span>


### PR DESCRIPTION
Part of https://github.com/element-hq/wat-internal/issues/182

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
