### PR TITLE
Hopefully deflake the login overwriting test

### DIFF
--- a/playwright/e2e/login/overwrite_login.spec.ts
+++ b/playwright/e2e/login/overwrite_login.spec.ts
@@ -47,7 +47,12 @@ test.describe("Overwrite login action", () => {
         }, clientCredentials);
 
         // It should be now another user!!
-        const newUserMenu = await app.openUserMenu();
-        await expect(newUserMenu.getByText(bobRegister.userId)).toBeVisible();
+        await expect
+            .poll(async () => {
+                const newUserMenu = await app.openUserMenu();
+                return newUserMenu.locator(".mx_UserMenu_contextMenu_userId").innerText();
+                //return await newUserMenu.getByText(bobRegister.userId)).toBeVisible();
+            })
+            .toBe(bobRegister.userId);
     });
 });

--- a/playwright/e2e/login/overwrite_login.spec.ts
+++ b/playwright/e2e/login/overwrite_login.spec.ts
@@ -52,9 +52,13 @@ test.describe("Overwrite login action", () => {
         // It should be now another user!!
         await expect
             .poll(async () => {
-                const newUserMenu = await app.openUserMenu();
-                return newUserMenu.locator(".mx_UserMenu_contextMenu_userId").innerText();
-                //return await newUserMenu.getByText(bobRegister.userId)).toBeVisible();
+                try {
+                    const newUserMenu = await app.openUserMenu();
+                    return newUserMenu.locator(".mx_UserMenu_contextMenu_userId").innerText();
+                } finally {
+                    page.keyboard.press("Escape");
+                    await expect(userMenu.getByText(credentials.userId)).not.toBeVisible();
+                }
             })
             .toBe(bobRegister.userId);
     });

--- a/playwright/e2e/login/overwrite_login.spec.ts
+++ b/playwright/e2e/login/overwrite_login.spec.ts
@@ -23,6 +23,9 @@ test.describe("Overwrite login action", () => {
 
         const userMenu = await app.openUserMenu();
         await expect(userMenu.getByText(credentials.userId)).toBeVisible();
+        // close it again, so we know it's closed when we come to open it again later
+        page.keyboard.press("Escape");
+        await expect(userMenu.getByText(credentials.userId)).not.toBeVisible();
 
         const bobRegister = await homeserver.registerUser("BobOverwrite", "p@ssword1!", "BOB");
 


### PR DESCRIPTION
Overwriting the login is async but it didn't wait before opening the user menu, so occasionally it just raced.

Fixes https://github.com/element-hq/element-web/issues/27363

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
