### PR TITLE
Tooltip: close field tooltip when ESC is pressed

### DIFF
--- a/src/components/views/elements/Field.tsx
+++ b/src/components/views/elements/Field.tsx
@@ -27,6 +27,7 @@ import { debounce } from "lodash";
 
 import { IFieldState, IValidationResult } from "./Validation";
 import Tooltip from "./Tooltip";
+import { Key } from "../../../Keyboard";
 
 // Invoke validation from user input (when typing, etc.) at most once every N ms.
 const VALIDATION_THROTTLE_MS = 200;
@@ -242,7 +243,7 @@ export default class Field extends React.PureComponent<PropShapes, IState> {
     private onKeyDown = (evt: KeyboardEvent<HTMLDivElement>): void => {
         // If the tooltip is displayed to show a feedback and Escape is pressed
         // The tooltip is hided
-        if (this.state.feedbackVisible && evt.key === "Escape") {
+        if (this.state.feedbackVisible && evt.key === Key.ESCAPE) {
             evt.preventDefault();
             evt.stopPropagation();
             this.setState({

--- a/src/components/views/elements/Field.tsx
+++ b/src/components/views/elements/Field.tsx
@@ -14,7 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes, RefObject, createRef } from "react";
+import React, {
+    InputHTMLAttributes,
+    SelectHTMLAttributes,
+    TextareaHTMLAttributes,
+    RefObject,
+    createRef,
+    KeyboardEvent,
+} from "react";
 import classNames from "classnames";
 import { debounce } from "lodash";
 
@@ -232,6 +239,18 @@ export default class Field extends React.PureComponent<PropShapes, IState> {
         return this.props.inputRef ?? this._inputRef;
     }
 
+    private onKeyDown = (evt: KeyboardEvent<HTMLDivElement>): void => {
+        // If the tooltip is displayed to show a feedback and Escape is pressed
+        // The tooltip is hided
+        if (this.state.feedbackVisible && evt.key === "Escape") {
+            evt.preventDefault();
+            evt.stopPropagation();
+            this.setState({
+                feedbackVisible: false,
+            });
+        }
+    };
+
     public render(): React.ReactNode {
         /* eslint @typescript-eslint/no-unused-vars: ["error", { "ignoreRestSiblings": true }] */
         const {
@@ -318,7 +337,7 @@ export default class Field extends React.PureComponent<PropShapes, IState> {
         });
 
         return (
-            <div className={fieldClasses}>
+            <div className={fieldClasses} onKeyDown={this.onKeyDown}>
                 {prefixContainer}
                 {fieldInput}
                 <label htmlFor={this.id}>{this.props.label}</label>

--- a/test/components/views/elements/Field-test.tsx
+++ b/test/components/views/elements/Field-test.tsx
@@ -69,6 +69,10 @@ describe("Field", () => {
 
             // Expect 'alert' role
             expect(screen.queryByRole("alert")).toBeInTheDocument();
+
+            // Close the feedback is Escape is pressed
+            fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+            expect(screen.queryByRole("alert")).toBeNull();
         });
 
         it("Should mark the feedback as status if valid", async () => {
@@ -87,6 +91,10 @@ describe("Field", () => {
 
             // Expect 'status' role
             expect(screen.queryByRole("status")).toBeInTheDocument();
+
+            // Close the feedback is Escape is pressed
+            fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+            expect(screen.queryByRole("status")).toBeNull();
         });
 
         it("Should mark the feedback as tooltip if custom tooltip set", async () => {
@@ -106,6 +114,10 @@ describe("Field", () => {
 
             // Expect 'tooltip' role
             expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+
+            // Close the feedback is Escape is pressed
+            fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+            expect(screen.queryByRole("tooltip")).toBeNull();
         });
     });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Closes https://github.com/element-hq/customer-retainer/issues/157

When a field in a form needs to display an error message, we are displaying a tooltip. However we can't close it when we press `Escape`.