### PR TITLE
Fix tabbedview breakpoint width

### DIFF
--- a/res/css/structures/_TabbedView.pcss
+++ b/res/css/structures/_TabbedView.pcss
@@ -167,7 +167,7 @@ limitations under the License.
 }
 
 /* Hide the labels on tabs, showing only the icons, on narrow viewports. */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     .mx_TabbedView_tabsOnLeft.mx_TabbedView_responsive {
         .mx_TabbedView_tabLabel_text {
             display: none;


### PR DESCRIPTION
Which should be 1024 according to the designs, not 768

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
