### PR TITLE
Add flag for tests to avoid double-reporting check

### DIFF
--- a/src/DecryptionFailureTracker.ts
+++ b/src/DecryptionFailureTracker.ts
@@ -159,15 +159,15 @@ export class DecryptionFailureTracker {
      * @param {function} errorCodeMapFn The function used to map decryption failure reason  codes to the
      * `trackedErrorCode`.
      *
-     * @param {boolean} dontTrackReportedEvents Don't check if we have already reported
-     * an event. This is only used for tests, to avoid possible false positives from
-     * the Bloom filter. This should be set to `true` for all tests except for those
+     * @param {boolean} checkReportedEvents Check if we have already reported an event.
+     * Defaults to `true`. This is only used for tests, to avoid possible false positives from
+     * the Bloom filter. This should be set to `false` for all tests except for those
      * that specifically test the `reportedEvents` functionality.
      */
     private constructor(
         private readonly fn: TrackingFn,
         private readonly errorCodeMapFn: ErrCodeMapFn,
-        private readonly dontCheckReportedEvents: boolean = false,
+        private readonly checkReportedEvents: boolean = true,
     ) {
         if (!fn || typeof fn !== "function") {
             throw new Error("DecryptionFailureTracker requires tracking function");
@@ -220,7 +220,7 @@ export class DecryptionFailureTracker {
         const eventId = e.getId()!;
 
         // if it's already reported, we don't need to do anything
-        if (this.reportedEvents.has(eventId) && !this.dontCheckReportedEvents) {
+        if (this.reportedEvents.has(eventId) && this.checkReportedEvents) {
             return;
         }
 
@@ -246,7 +246,7 @@ export class DecryptionFailureTracker {
         const eventId = e.getId()!;
 
         // if it's already reported, we don't need to do anything
-        if (this.reportedEvents.has(eventId) && !this.dontCheckReportedEvents) {
+        if (this.reportedEvents.has(eventId) && this.checkReportedEvents) {
             return;
         }
 

--- a/src/DecryptionFailureTracker.ts
+++ b/src/DecryptionFailureTracker.ts
@@ -158,10 +158,16 @@ export class DecryptionFailureTracker {
      *
      * @param {function} errorCodeMapFn The function used to map decryption failure reason  codes to the
      * `trackedErrorCode`.
+     *
+     * @param {boolean} dontTrackReportedEvents Don't check if we have already reported
+     * an event. This is only used for tests, to avoid possible false positives from
+     * the Bloom filter. This should be set to `true` for all tests except for those
+     * that specifically test the `reportedEvents` functionality.
      */
     private constructor(
         private readonly fn: TrackingFn,
         private readonly errorCodeMapFn: ErrCodeMapFn,
+        private readonly dontCheckReportedEvents: boolean = false,
     ) {
         if (!fn || typeof fn !== "function") {
             throw new Error("DecryptionFailureTracker requires tracking function");
@@ -214,7 +220,7 @@ export class DecryptionFailureTracker {
         const eventId = e.getId()!;
 
         // if it's already reported, we don't need to do anything
-        if (this.reportedEvents.has(eventId)) {
+        if (this.reportedEvents.has(eventId) && !this.dontCheckReportedEvents) {
             return;
         }
 
@@ -240,7 +246,7 @@ export class DecryptionFailureTracker {
         const eventId = e.getId()!;
 
         // if it's already reported, we don't need to do anything
-        if (this.reportedEvents.has(eventId)) {
+        if (this.reportedEvents.has(eventId) && !this.dontCheckReportedEvents) {
             return;
         }
 

--- a/test/DecryptionFailureTracker-test.ts
+++ b/test/DecryptionFailureTracker-test.ts
@@ -52,7 +52,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
-            true,
+            false,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);
@@ -79,7 +79,7 @@ describe("DecryptionFailureTracker", function () {
                 reportedRawCode = rawCode;
             },
             () => "UnknownError",
-            true,
+            false,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);
@@ -103,7 +103,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
-            true,
+            false,
         );
 
         eventDecrypted(tracker, failedDecryptionEvent, Date.now());
@@ -124,7 +124,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
-            true,
+            false,
         );
 
         // use three different errors so that we can distinguish the reports
@@ -165,7 +165,7 @@ describe("DecryptionFailureTracker", function () {
                 expect(true).toBe(false);
             },
             () => "UnknownError",
-            true,
+            false,
         );
 
         tracker.addVisibleEvent(decryptedEvent);
@@ -194,7 +194,7 @@ describe("DecryptionFailureTracker", function () {
                     expect(true).toBe(false);
                 },
                 () => "UnknownError",
-                true,
+                false,
             );
 
             eventDecrypted(tracker, decryptedEvent, Date.now());
@@ -222,7 +222,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
-            true,
+            false,
         );
 
         tracker.addVisibleEvent(decryptedEvent);
@@ -386,7 +386,7 @@ describe("DecryptionFailureTracker", function () {
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (error: DecryptionFailureCode) =>
                 error === DecryptionFailureCode.UNKNOWN_ERROR ? "UnknownError" : "OlmKeysNotSentError",
-            true,
+            false,
         );
 
         const decryptedEvent1 = await createFailedDecryptionEvent({
@@ -424,7 +424,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (_errorCode: string) => "OlmUnspecifiedError",
-            true,
+            false,
         );
 
         const decryptedEvent1 = await createFailedDecryptionEvent({
@@ -459,7 +459,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (errorCode: string) => Array.from(errorCode).reverse().join(""),
-            true,
+            false,
         );
 
         const decryptedEvent = await createFailedDecryptionEvent({
@@ -485,7 +485,7 @@ describe("DecryptionFailureTracker", function () {
             },
             // @ts-ignore access to private member
             DecryptionFailureTracker.instance.errorCodeMapFn,
-            true,
+            false,
         );
 
         const now = Date.now();
@@ -554,7 +554,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
-            true,
+            false,
         );
 
         // use three different errors so that we can distinguish the reports
@@ -609,7 +609,7 @@ describe("DecryptionFailureTracker", function () {
                 errorCount++;
             },
             (error: string) => error,
-            true,
+            false,
         );
 
         // Calling .start will start some intervals.  This test shouldn't run
@@ -651,7 +651,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
-            true,
+            false,
         );
 
         // @ts-ignore access to private method
@@ -724,7 +724,7 @@ describe("DecryptionFailureTracker", function () {
                 failure = properties;
             },
             () => "UnknownError",
-            true,
+            false,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);

--- a/test/DecryptionFailureTracker-test.ts
+++ b/test/DecryptionFailureTracker-test.ts
@@ -52,6 +52,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
+            true,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);
@@ -78,6 +79,7 @@ describe("DecryptionFailureTracker", function () {
                 reportedRawCode = rawCode;
             },
             () => "UnknownError",
+            true,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);
@@ -101,6 +103,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
+            true,
         );
 
         eventDecrypted(tracker, failedDecryptionEvent, Date.now());
@@ -121,6 +124,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
+            true,
         );
 
         // use three different errors so that we can distinguish the reports
@@ -161,6 +165,7 @@ describe("DecryptionFailureTracker", function () {
                 expect(true).toBe(false);
             },
             () => "UnknownError",
+            true,
         );
 
         tracker.addVisibleEvent(decryptedEvent);
@@ -189,6 +194,7 @@ describe("DecryptionFailureTracker", function () {
                     expect(true).toBe(false);
                 },
                 () => "UnknownError",
+                true,
             );
 
             eventDecrypted(tracker, decryptedEvent, Date.now());
@@ -216,6 +222,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             () => count++,
             () => "UnknownError",
+            true,
         );
 
         tracker.addVisibleEvent(decryptedEvent);
@@ -379,6 +386,7 @@ describe("DecryptionFailureTracker", function () {
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (error: DecryptionFailureCode) =>
                 error === DecryptionFailureCode.UNKNOWN_ERROR ? "UnknownError" : "OlmKeysNotSentError",
+            true,
         );
 
         const decryptedEvent1 = await createFailedDecryptionEvent({
@@ -416,6 +424,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (_errorCode: string) => "OlmUnspecifiedError",
+            true,
         );
 
         const decryptedEvent1 = await createFailedDecryptionEvent({
@@ -450,6 +459,7 @@ describe("DecryptionFailureTracker", function () {
         const tracker = new DecryptionFailureTracker(
             (errorCode: string) => (counts[errorCode] = (counts[errorCode] || 0) + 1),
             (errorCode: string) => Array.from(errorCode).reverse().join(""),
+            true,
         );
 
         const decryptedEvent = await createFailedDecryptionEvent({
@@ -475,6 +485,7 @@ describe("DecryptionFailureTracker", function () {
             },
             // @ts-ignore access to private member
             DecryptionFailureTracker.instance.errorCodeMapFn,
+            true,
         );
 
         const now = Date.now();
@@ -543,6 +554,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
+            true,
         );
 
         // use three different errors so that we can distinguish the reports
@@ -597,6 +609,7 @@ describe("DecryptionFailureTracker", function () {
                 errorCount++;
             },
             (error: string) => error,
+            true,
         );
 
         // Calling .start will start some intervals.  This test shouldn't run
@@ -638,6 +651,7 @@ describe("DecryptionFailureTracker", function () {
                 propertiesByErrorCode[errorCode] = properties;
             },
             (error: string) => error,
+            true,
         );
 
         // @ts-ignore access to private method
@@ -710,6 +724,7 @@ describe("DecryptionFailureTracker", function () {
                 failure = properties;
             },
             () => "UnknownError",
+            true,
         );
 
         tracker.addVisibleEvent(failedDecryptionEvent);


### PR DESCRIPTION
Some of the tests were flaking.  Our best guess is that it's failing to track some events due to false positives in the Bloom filter used to guard against double-reporting.  So we add a flag to disable using that in tests (except for tests that test that functionality).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
