### PR TITLE
Don't show 'saved' on display name save error

### DIFF
--- a/src/components/views/settings/UserProfileSettings.tsx
+++ b/src/components/views/settings/UserProfileSettings.tsx
@@ -131,6 +131,7 @@ const UserProfileSettings: React.FC = () => {
             setInitialDisplayName(displayName);
         } catch (e) {
             setDisplayNameError(true);
+            throw e;
         }
     }, [displayName, client]);
 

--- a/test/components/views/settings/UserProfileSettings-test.tsx
+++ b/test/components/views/settings/UserProfileSettings-test.tsx
@@ -167,6 +167,25 @@ describe("ProfileSettings", () => {
         expect(client.setDisplayName).toHaveBeenCalledWith("The Value");
     });
 
+    it("displays error if changing display name fails", async () => {
+        jest.spyOn(OwnProfileStore.instance, "displayName", "get").mockReturnValue("Alice");
+        mocked(client).setDisplayName.mockRejectedValue(new Error("Failed to set display name"));
+
+        renderProfileSettings(toastRack, client);
+
+        expect(editInPlaceOnSave).toBeDefined();
+
+        act(() => {
+            editInPlaceOnChange({
+                target: { value: "Not Alice any more" } as HTMLInputElement,
+            } as ChangeEvent<HTMLInputElement>);
+        });
+
+        await act(async () => {
+            await expect(editInPlaceOnSave()).rejects.toEqual(expect.any(Error));
+        });
+    });
+
     it("resets on cancel", async () => {
         jest.spyOn(OwnProfileStore.instance, "displayName", "get").mockReturnValue("Alice");
 


### PR DESCRIPTION
The save callback nees to throw on an error so the EditInPlace component knows it's not been successful.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
