### PR TITLE
Use latest LTS Node in CI

### DIFF
--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -55,6 +55,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Fetch layered build
@@ -119,6 +120,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
                   cache-dependency-path: matrix-react-sdk/yarn.lock
 
@@ -173,6 +175,7 @@ jobs:
             - uses: actions/setup-node@v4
               if: inputs.skip != true
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Install dependencies

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -24,6 +24,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Install Deps
@@ -82,6 +83,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             # Does not need branch matching as only analyses this layer
@@ -99,6 +101,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             # Does not need branch matching as only analyses this layer
@@ -116,6 +119,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             # Does not need branch matching as only analyses this layer
@@ -133,6 +137,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Install Deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
             - name: Yarn cache
               uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Install Deps
@@ -114,6 +115,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
+                  node-version: lts/* # Latest LTS
                   cache: "yarn"
 
             - name: Run tests


### PR DESCRIPTION
The README says we require the latest LTS version of Node, but actions/setup-node with ubuntu-latest appears to default to a version earlier than that. I'd like to make use of [a feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) available only since Node 20, which happens to be the latest LTS. So, let's get CI on the right version.