### PR TITLE
Fix widgets not being cleaned up correctly.

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -647,7 +647,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             case "logout":
                 LegacyCallHandler.instance.hangupAllCalls();
                 Promise.all([
-                    ...[...CallStore.instance.activeCalls].map((call) => call.disconnect()),
+                    ...[...CallStore.instance.connectedCalls].map((call) => call.disconnect()),
                     cleanUpBroadcasts(this.stores),
                 ]).finally(() => Lifecycle.logout(this.stores.oidcClientStore));
                 break;

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -490,7 +490,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         WidgetEchoStore.on(UPDATE_EVENT, this.onWidgetEchoStoreUpdate);
         context.widgetStore.on(UPDATE_EVENT, this.onWidgetStoreUpdate);
 
-        CallStore.instance.on(CallStoreEvent.ActiveCalls, this.onActiveCalls);
+        CallStore.instance.on(CallStoreEvent.ConnectedCalls, this.onConnectedCalls);
 
         this.props.resizeNotifier.on("isResizing", this.onIsResizing);
 
@@ -811,7 +811,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         }
     };
 
-    private onActiveCalls = (): void => {
+    private onConnectedCalls = (): void => {
         if (this.state.roomId === undefined) return;
         const activeCall = CallStore.instance.getActiveCall(this.state.roomId);
         if (activeCall === null) {
@@ -1052,7 +1052,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             );
         }
 
-        CallStore.instance.off(CallStoreEvent.ActiveCalls, this.onActiveCalls);
+        CallStore.instance.off(CallStoreEvent.ConnectedCalls, this.onConnectedCalls);
         this.context.legacyCallHandler.off(LegacyCallHandlerEvent.CallState, this.onCallState);
 
         // cancel any pending calls to the throttled updated

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -60,7 +60,7 @@ const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, skipLobby, 
     const disconnectAllOtherCalls: () => Promise<void> = useCallback(async () => {
         // The stickyPromise has to resolve before the widget actually becomes sticky.
         // We only let the widget become sticky after disconnecting all other active calls.
-        const calls = [...CallStore.instance.activeCalls].filter(
+        const calls = [...CallStore.instance.connectedCalls].filter(
             (call) => SdkContextClass.instance.roomViewStore.getRoomId() !== call.roomId,
         );
         await Promise.all(calls.map(async (call) => await call.disconnect()));

--- a/src/hooks/room/useRoomCall.ts
+++ b/src/hooks/room/useRoomCall.ts
@@ -176,13 +176,13 @@ export const useRoomCall = (
     // We only want to prompt to pin the widget if it's not element call based.
     const isECWidget = WidgetType.CALL.matches(widget?.type ?? "");
     const promptPinWidget = !isECWidget && canPinWidget && !widgetPinned;
-    const activeCalls = useEventEmitterState(CallStore.instance, CallStoreEvent.ActiveCalls, () =>
-        Array.from(CallStore.instance.activeCalls),
+    const connectedCalls = useEventEmitterState(CallStore.instance, CallStoreEvent.ConnectedCalls, () =>
+        Array.from(CallStore.instance.connectedCalls),
     );
     const { canInviteGuests } = useGuestAccessInformation(room);
 
     const state = useMemo((): State => {
-        if (activeCalls.find((call) => call.roomId != room.roomId)) {
+        if (connectedCalls.find((call) => call.roomId != room.roomId)) {
             return State.Ongoing;
         }
         if (hasGroupCall && (hasJitsiWidget || hasManagedHybridWidget)) {
@@ -200,7 +200,7 @@ export const useRoomCall = (
         }
         return State.NoCall;
     }, [
-        activeCalls,
+        connectedCalls,
         canInviteGuests,
         hasGroupCall,
         hasJitsiWidget,

--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -963,7 +963,7 @@ export class ElementCall extends Call {
 
     private onRTCSessionEnded = (roomId: string, session: MatrixRTCSession): void => {
         // Don't destroy the call on hangup for video call rooms.
-        if (roomId == this.roomId && !this.room.isCallRoom()) {
+        if (roomId === this.roomId && !this.room.isCallRoom()) {
             this.destroy();
         }
     };

--- a/src/stores/ActiveWidgetStore.ts
+++ b/src/stores/ActiveWidgetStore.ts
@@ -70,8 +70,12 @@ export default class ActiveWidgetStore extends EventEmitter {
 
     public destroyPersistentWidget(widgetId: string, roomId: string | null): void {
         if (!this.getWidgetPersistence(widgetId, roomId)) return;
-        WidgetMessagingStore.instance.stopMessagingByUid(WidgetUtils.calcWidgetUid(widgetId, roomId ?? undefined));
+        // We first need to set the widget persistence to false
         this.setWidgetPersistence(widgetId, roomId, false);
+        // Then we can stop the messaging. Stopping the messaging emits - we might move the widget out of sight.
+        // If we would do this before setting the persistence to false, it would stay in the DOM (hidden) because
+        // its still persistent. We need to avoid this.
+        WidgetMessagingStore.instance.stopMessagingByUid(WidgetUtils.calcWidgetUid(widgetId, roomId ?? undefined));
     }
 
     public setWidgetPersistence(widgetId: string, roomId: string | null, val: boolean): void {

--- a/src/stores/CallStore.ts
+++ b/src/stores/CallStore.ts
@@ -66,8 +66,7 @@ export class CallStore extends AsyncStoreWithClient<{}> {
         }
         this.matrixClient.on(GroupCallEventHandlerEvent.Incoming, this.onGroupCall);
         this.matrixClient.on(GroupCallEventHandlerEvent.Outgoing, this.onGroupCall);
-        this.matrixClient.matrixRTC.on(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSession);
-        this.matrixClient.matrixRTC.on(MatrixRTCSessionManagerEvents.SessionEnded, this.onRTCSession);
+        this.matrixClient.matrixRTC.on(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSessionStart);
         WidgetStore.instance.on(UPDATE_EVENT, this.onWidgets);
 
         // If the room ID of a previously connected call is still in settings at
@@ -101,8 +100,7 @@ export class CallStore extends AsyncStoreWithClient<{}> {
             this.matrixClient.off(GroupCallEventHandlerEvent.Incoming, this.onGroupCall);
             this.matrixClient.off(GroupCallEventHandlerEvent.Outgoing, this.onGroupCall);
             this.matrixClient.off(GroupCallEventHandlerEvent.Ended, this.onGroupCall);
-            this.matrixClient.matrixRTC.off(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSession);
-            this.matrixClient.matrixRTC.off(MatrixRTCSessionManagerEvents.SessionEnded, this.onRTCSession);
+            this.matrixClient.matrixRTC.off(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSessionStart);
         }
         WidgetStore.instance.off(UPDATE_EVENT, this.onWidgets);
     }
@@ -200,7 +198,7 @@ export class CallStore extends AsyncStoreWithClient<{}> {
     };
 
     private onGroupCall = (groupCall: GroupCall): void => this.updateRoom(groupCall.room);
-    private onRTCSession = (roomId: string, session: MatrixRTCSession): void => {
+    private onRTCSessionStart = (roomId: string, session: MatrixRTCSession): void => {
         this.updateRoom(session.room);
     };
 }

--- a/src/stores/room-list/algorithms/Algorithm.ts
+++ b/src/stores/room-list/algorithms/Algorithm.ts
@@ -85,11 +85,11 @@ export class Algorithm extends EventEmitter {
     public updatesInhibited = false;
 
     public start(): void {
-        CallStore.instance.on(CallStoreEvent.ActiveCalls, this.onActiveCalls);
+        CallStore.instance.on(CallStoreEvent.ConnectedCalls, this.onConnectedCalls);
     }
 
     public stop(): void {
-        CallStore.instance.off(CallStoreEvent.ActiveCalls, this.onActiveCalls);
+        CallStore.instance.off(CallStoreEvent.ConnectedCalls, this.onConnectedCalls);
     }
 
     public get stickyRoom(): Room | null {
@@ -302,7 +302,7 @@ export class Algorithm extends EventEmitter {
         return this._stickyRoom;
     }
 
-    private onActiveCalls = (): void => {
+    private onConnectedCalls = (): void => {
         // In case we're unsticking a room, sort it back into natural order
         this.recalculateStickyRoom();
 
@@ -396,12 +396,12 @@ export class Algorithm extends EventEmitter {
             return;
         }
 
-        if (CallStore.instance.activeCalls.size) {
+        if (CallStore.instance.connectedCalls.size) {
             // We operate on the sticky rooms map
             if (!this._cachedStickyRooms) this.initCachedStickyRooms();
             const rooms = this._cachedStickyRooms![updatedTag];
 
-            const activeRoomIds = new Set([...CallStore.instance.activeCalls].map((call) => call.roomId));
+            const activeRoomIds = new Set([...CallStore.instance.connectedCalls].map((call) => call.roomId));
             const activeRooms: Room[] = [];
             const inactiveRooms: Room[] = [];
 

--- a/src/stores/widgets/StopGapWidget.ts
+++ b/src/stores/widgets/StopGapWidget.ts
@@ -345,7 +345,6 @@ export class StopGapWidget extends EventEmitter {
             async (ev: CustomEvent<IStickyActionRequest>) => {
                 if (this.messaging?.hasCapability(MatrixCapabilities.AlwaysOnScreen)) {
                     ev.preventDefault();
-                    this.messaging.transport.reply(ev.detail, <IWidgetApiRequestEmptyData>{}); // ack
                     if (ev.detail.data.value) {
                         // If the widget wants to become sticky we wait for the stickyPromise to resolve
                         if (this.stickyPromise) await this.stickyPromise();
@@ -356,6 +355,8 @@ export class StopGapWidget extends EventEmitter {
                         this.roomId ?? null,
                         ev.detail.data.value,
                     );
+                    // Send the ack after the widget actually has become sticky.
+                    this.messaging.transport.reply(ev.detail, <IWidgetApiRequestEmptyData>{});
                 }
             },
         );

--- a/test/components/structures/MatrixChat-test.tsx
+++ b/test/components/structures/MatrixChat-test.tsx
@@ -769,7 +769,7 @@ describe("<MatrixChat />", () => {
                     jest.spyOn(PosthogAnalytics.instance, "logout").mockImplementation(() => {});
                     jest.spyOn(EventIndexPeg, "deleteEventIndex").mockImplementation(async () => {});
 
-                    jest.spyOn(CallStore.instance, "activeCalls", "get").mockReturnValue(new Set([call1, call2]));
+                    jest.spyOn(CallStore.instance, "connectedCalls", "get").mockReturnValue(new Set([call1, call2]));
 
                     mockPlatformPeg({
                         destroyPickleKey: jest.fn(),

--- a/test/components/views/rooms/RoomHeader-test.tsx
+++ b/test/components/views/rooms/RoomHeader-test.tsx
@@ -492,7 +492,7 @@ describe("RoomHeader", () => {
         it("buttons are disabled if there is an ongoing call", async () => {
             mockRoomMembers(room, 3);
 
-            jest.spyOn(CallStore.prototype, "activeCalls", "get").mockReturnValue(
+            jest.spyOn(CallStore.prototype, "connectedCalls", "get").mockReturnValue(
                 new Set([{ roomId: "some_other_room" } as Call]),
             );
             const { container } = render(<RoomHeader room={room} />, getWrapper());
@@ -514,7 +514,7 @@ describe("RoomHeader", () => {
         it("join button is disabled if there is an other ongoing call", async () => {
             mockRoomMembers(room, 3);
             jest.spyOn(UseCall, "useParticipantCount").mockReturnValue(3);
-            jest.spyOn(CallStore.prototype, "activeCalls", "get").mockReturnValue(
+            jest.spyOn(CallStore.prototype, "connectedCalls", "get").mockReturnValue(
                 new Set([{ roomId: "some_other_room" } as Call]),
             );
             const { container } = render(<RoomHeader room={room} />, getWrapper());

--- a/test/toasts/IncomingCallToast-test.tsx
+++ b/test/toasts/IncomingCallToast-test.tsx
@@ -20,10 +20,6 @@ import { mocked, Mocked } from "jest-mock";
 import { Room, RoomStateEvent, MatrixEvent, MatrixEventEvent, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { ClientWidgetApi, Widget } from "matrix-widget-api";
 // eslint-disable-next-line no-restricted-imports
-import { MatrixRTCSessionManagerEvents } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSessionManager";
-// eslint-disable-next-line no-restricted-imports
-import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
-// eslint-disable-next-line no-restricted-imports
 import { ICallNotifyContent } from "matrix-js-sdk/src/matrixrtc/types";
 
 import type { RoomMember } from "matrix-js-sdk/src/matrix";
@@ -82,6 +78,7 @@ describe("IncomingCallEvent", () => {
         client.getRoom.mockImplementation((roomId) => (roomId === room.roomId ? room : null));
         client.getRooms.mockReturnValue([room]);
         client.reEmitter.reEmit(room, [RoomStateEvent.Events]);
+        MockedCall.create(room, "1");
 
         await Promise.all(
             [CallStore.instance, WidgetMessagingStore.instance].map((store) =>
@@ -89,7 +86,6 @@ describe("IncomingCallEvent", () => {
             ),
         );
 
-        MockedCall.create(room, "1");
         const maybeCall = CallStore.instance.getCall(room.roomId);
         if (!(maybeCall instanceof MockedCall)) throw new Error("Failed to create call");
         call = maybeCall;
@@ -179,7 +175,7 @@ describe("IncomingCallEvent", () => {
 
         defaultDispatcher.unregister(dispatcherRef);
     });
-    it("skips lobby when using shift key click", async () => {
+    it("Dismiss toast if user starts call and skips lobby when using shift key click", async () => {
         renderToast();
 
         const dispatcherSpy = jest.fn();
@@ -250,11 +246,7 @@ describe("IncomingCallEvent", () => {
 
     it("closes toast when the matrixRTC session has ended", async () => {
         renderToast();
-
-        client.matrixRTC.emit(MatrixRTCSessionManagerEvents.SessionEnded, room.roomId, {
-            callId: notifyContent.call_id,
-            room: room,
-        } as unknown as MatrixRTCSession);
+        call.destroy();
 
         await waitFor(() =>
             expect(toastStore.dismissToast).toHaveBeenCalledWith(


### PR DESCRIPTION
Widgets could persist forever because they were still sticky when we end the messaging.
Ending the messaging emits an event to which we connect ui changes that move the widget out of the screen. It does not end up in a pip view however.

So we need to make sure the widget is not persistend anymore when we call `stopMessagingByUid` so that any dom changes that remove the AppTile happen when the widget is not persistend anymore and let it destroy.

This PR also makes the role for `MatrixRTCSessionManager` more strict. We do ONLY use it in `Call.ts` and `CallStore`  so that we dont end up in reaces where we updated the ui based on the session manager but not in sync with the call and callstore changes.

Rename activeCalls to connectedCalls. Active call can also be understood as a call where there are active participants but the user itself is not connected. Especially with the `hasActiveCallSession` field of the useRoomCall hook which is tracking active (not necassarly connected sessions)


It is split into two commits.

The first is the one with the actual changes. The second one is noisy with all the renaming.
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
