### PR TITLE
Remove room key history sharing

### DIFF
--- a/src/RoomInvite.tsx
+++ b/src/RoomInvite.tsx
@@ -40,7 +40,6 @@ export interface IInviteResult {
  *
  * @param {string} roomId The ID of the room to invite to
  * @param {string[]} addresses Array of strings of addresses to invite. May be matrix IDs or 3pids.
- * @param {boolean} sendSharedHistoryKeys whether to share e2ee keys with the invitees if applicable.
  * @param {function} progressCallback optional callback, fired after each invite.
  * @returns {Promise} Promise
  */
@@ -48,13 +47,10 @@ export function inviteMultipleToRoom(
     client: MatrixClient,
     roomId: string,
     addresses: string[],
-    sendSharedHistoryKeys = false,
     progressCallback?: () => void,
 ): Promise<IInviteResult> {
     const inviter = new MultiInviter(client, roomId, progressCallback);
-    return inviter
-        .invite(addresses, undefined, sendSharedHistoryKeys)
-        .then((states) => Promise.resolve({ states, inviter }));
+    return inviter.invite(addresses, undefined).then((states) => Promise.resolve({ states, inviter }));
 }
 
 export function showStartChatInviteDialog(initialText = ""): void {
@@ -105,10 +101,9 @@ export function inviteUsersToRoom(
     client: MatrixClient,
     roomId: string,
     userIds: string[],
-    sendSharedHistoryKeys = false,
     progressCallback?: () => void,
 ): Promise<void> {
-    return inviteMultipleToRoom(client, roomId, userIds, sendSharedHistoryKeys, progressCallback)
+    return inviteMultipleToRoom(client, roomId, userIds, progressCallback)
         .then((result) => {
             const room = client.getRoom(roomId)!;
             showAnyInviteErrors(result.states, room, result.inviter);

--- a/src/SlashCommands.tsx
+++ b/src/SlashCommands.tsx
@@ -420,7 +420,7 @@ export const Commands = [
                     return success(
                         prom
                             .then(() => {
-                                return inviter.invite([address], reason, true);
+                                return inviter.invite([address], reason);
                             })
                             .then(() => {
                                 if (inviter.getCompletionState(address) !== "invited") {

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -22,7 +22,6 @@ import { MatrixCall } from "matrix-js-sdk/src/webrtc/call";
 import { logger } from "matrix-js-sdk/src/logger";
 import { uniqBy } from "lodash";
 
-import { Icon as InfoIcon } from "../../../../res/img/element-icons/info.svg";
 import { Icon as EmailPillAvatarIcon } from "../../../../res/img/icon-email-pill-avatar.svg";
 import { _t, _td } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -624,7 +623,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         }
 
         try {
-            const result = await inviteMultipleToRoom(cli, this.props.roomId, targetIds, true);
+            const result = await inviteMultipleToRoom(cli, this.props.roomId, targetIds);
             if (!this.shouldAbortAfterInviteError(result, room)) {
                 // handles setting error message too
                 this.props.onFinished(true);
@@ -1279,7 +1278,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         let consultConnectSection;
         let extraSection;
         let footer;
-        let keySharingWarning = <span />;
 
         const identityServersEnabled = SettingsStore.getValue(UIFeature.IdentityServer);
 
@@ -1391,21 +1389,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
             buttonText = _t("action|invite");
             goButtonFn = this.inviteUsers;
-
-            if (cli.isRoomEncrypted(this.props.roomId)) {
-                const room = cli.getRoom(this.props.roomId)!;
-                const visibilityEvent = room.currentState.getStateEvents("m.room.history_visibility", "");
-                const visibility =
-                    visibilityEvent && visibilityEvent.getContent() && visibilityEvent.getContent().history_visibility;
-                if (visibility === "world_readable" || visibility === "shared") {
-                    keySharingWarning = (
-                        <p className="mx_InviteDialog_helpText">
-                            <InfoIcon height={14} width={14} />
-                            {" " + _t("invite|key_share_warning")}
-                        </p>
-                    );
-                }
-            }
         } else if (this.props.kind === InviteKind.CallTransfer) {
             title = _t("action|transfer");
 
@@ -1471,7 +1454,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                         {spinner}
                     </div>
                 </div>
-                {keySharingWarning}
                 {this.renderIdentityServerWarning()}
                 <div className="error">{this.state.errorText}</div>
                 {onlyOneThreepidNote}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1293,7 +1293,6 @@
         "failed_generic": "Operation failed",
         "failed_title": "Failed to invite",
         "invalid_address": "Unrecognised address",
-        "key_share_warning": "Invited people will be able to read old messages.",
         "name_email_mxid_share_room": "Invite someone using their name, email address, username (like <userId/>) or <a>share this room</a>.",
         "name_email_mxid_share_space": "Invite someone using their name, email address, username (like <userId/>) or <a>share this space</a>.",
         "name_mxid_share_room": "Invite someone using their name, username (like <userId/>) or <a>share this room</a>.",

--- a/src/utils/RoomUpgrade.ts
+++ b/src/utils/RoomUpgrade.ts
@@ -120,7 +120,7 @@ export async function upgradeRoom(
 
     if (toInvite.length > 0) {
         // Errors are handled internally to this function
-        await inviteUsersToRoom(cli, newRoomId, toInvite, false, () => {
+        await inviteUsersToRoom(cli, newRoomId, toInvite, () => {
             progress.inviteUsersProgress!++;
             progressCallback?.(progress);
         });


### PR DESCRIPTION
The Rust crypto implementation doesn't implement key history sharing, and it causes errors in the logs.  Since the Rust implementation is the default implementation, and all users will soon be migrated, remove key history sharing.

Also fixes https://github.com/element-hq/element-web/issues/27150

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
