### PR TITLE
Hide voice call button when redundant

### DIFF
--- a/src/components/views/rooms/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader.tsx
@@ -82,6 +82,7 @@ export default function RoomHeader({
         isConnectedToCall,
         hasActiveCallSession,
         callOptions,
+        showVoiceCallButton,
     } = useRoomCall(room);
 
     const groupCallsEnabled = useFeatureEnabled("feature_group_calls");
@@ -199,20 +200,25 @@ export default function RoomHeader({
             )}
         </>
     );
-    const voiceCallButton = (
-        <Tooltip label={voiceCallDisabledReason ?? _t("voip|voice_call")}>
-            <IconButton
-                // We need both: isViewingCall and isConnectedToCall
-                //  - in the Lobby we are viewing a call but are not connected to it.
-                //  - in pip view we are connected to the call but not viewing it.
-                disabled={!!voiceCallDisabledReason || isViewingCall || isConnectedToCall}
-                aria-label={voiceCallDisabledReason ?? _t("voip|voice_call")}
-                onClick={(ev) => voiceCallClick(ev, callOptions[0])}
-            >
-                <VoiceCallIcon />
-            </IconButton>
-        </Tooltip>
-    );
+
+    let voiceCallButton: JSX.Element | undefined;
+    if (showVoiceCallButton) {
+        voiceCallButton = (
+            <Tooltip label={voiceCallDisabledReason ?? _t("voip|voice_call")}>
+                <IconButton
+                    // We need both: isViewingCall and isConnectedToCall
+                    //  - in the Lobby we are viewing a call but are not connected to it.
+                    //  - in pip view we are connected to the call but not viewing it.
+                    disabled={!!voiceCallDisabledReason || isViewingCall || isConnectedToCall}
+                    aria-label={voiceCallDisabledReason ?? _t("voip|voice_call")}
+                    onClick={(ev) => voiceCallClick(ev, callOptions[0])}
+                >
+                    <VoiceCallIcon />
+                </IconButton>
+            </Tooltip>
+        );
+    }
+
     const closeLobbyButton = (
         <Tooltip label={_t("voip|close_lobby")}>
             <IconButton onClick={toggleCall} aria-label={_t("voip|close_lobby")}>

--- a/src/hooks/room/useRoomCall.ts
+++ b/src/hooks/room/useRoomCall.ts
@@ -31,7 +31,7 @@ import { placeCall } from "../../utils/room/placeCall";
 import { Container, WidgetLayoutStore } from "../../stores/widgets/WidgetLayoutStore";
 import { useRoomState } from "../useRoomState";
 import { _t } from "../../languageHandler";
-import { isManagedHybridWidget } from "../../widgets/ManagedHybrid";
+import { isManagedHybridWidget, isManagedHybridWidgetEnabled } from "../../widgets/ManagedHybrid";
 import { IApp } from "../../stores/WidgetStore";
 import { SdkContextClass } from "../../contexts/SDKContext";
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
@@ -83,6 +83,7 @@ export const useRoomCall = (
     isConnectedToCall: boolean;
     hasActiveCallSession: boolean;
     callOptions: PlatformCallType[];
+    showVoiceCallButton: boolean;
 } => {
     // settings
     const groupCallsEnabled = useFeatureEnabled("feature_group_calls");
@@ -124,7 +125,7 @@ export const useRoomCall = (
     // The options provided to the RoomHeader.
     // If there are multiple options, the user will be prompted to choose.
     const callOptions = useMemo((): PlatformCallType[] => {
-        const options = [];
+        const options: PlatformCallType[] = [];
         if (memberCount <= 2) {
             options.push(PlatformCallType.LegacyCall);
         } else if (mayEditWidgets || hasJitsiWidget) {
@@ -266,6 +267,10 @@ export const useRoomCall = (
         });
     }, [isViewingCall, room.roomId]);
 
+    // We hide the voice call button if it'd have the same effect as the video call button
+    const hideVoiceCallButton =
+        isManagedHybridWidgetEnabled(room.roomId) || !callOptions.includes(PlatformCallType.LegacyCall);
+
     /**
      * We've gone through all the steps
      */
@@ -279,5 +284,6 @@ export const useRoomCall = (
         isConnectedToCall: isConnectedToCall,
         hasActiveCallSession: hasActiveCallSession,
         callOptions,
+        showVoiceCallButton: !hideVoiceCallButton,
     };
 };


### PR DESCRIPTION
i.e. when it'd do the same thing as the video call button like in non-dm rooms

Fixes https://github.com/element-hq/wat-internal/issues/190
