### PR TITLE
SlidingSync does not work when hosted on path other than / (root)

### DIFF
--- a/src/SlidingSyncManager.ts
+++ b/src/SlidingSyncManager.ts
@@ -405,7 +405,7 @@ export class SlidingSyncManager {
 
         const proxyUrl = await this.getProxyFromWellKnown(client);
         if (proxyUrl != undefined) {
-            const response = await fetch(new URL("/client/server.json", proxyUrl), {
+            const response = await fetch(new URL("client/server.json", proxyUrl), {
                 method: Method.Get,
                 signal: timeoutSignal(10 * 1000), // 10s
             });


### PR DESCRIPTION
When sliding-sync is hostet on the same domain, but in a sub path, the url resolution will fail.

Example:
base domain: matrix.example.com
sliding-sync: matrix.example.com/sliding-sync

the URL constructur `new URL("/client/server.json", proxyUrl)` will create the url _matrix.example.com/client/server.json_ and not as required _matrix.example.com/sliding-sync/client/server.json_.

Removing the leading slash from the will solve the issue as per the documentation [https://developer.mozilla.org/en-US/docs/Web/API/URL/URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)