### PR TITLE
Add a github action to check the base branch

### DIFF
--- a/.github/workflows/pull_request_base_branch.yaml
+++ b/.github/workflows/pull_request_base_branch.yaml
@@ -1,0 +1,15 @@
+on:
+    pull_request:
+        types: [opened, edited, synchronize]
+jobs:
+    check_base_branch:
+        name: Check PR base branch
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v3
+              with:
+                  script: |
+                      const baseBranch = context.payload.pull_request.base.ref;
+                      if (!['develop', 'staging'].includes(baseBranch) && !baseBranch.startsWith('feat/')) {
+                          core.setFailed(`Invalid base branch: ${baseBranch}`);
+                      }

--- a/.github/workflows/pull_request_base_branch.yaml
+++ b/.github/workflows/pull_request_base_branch.yaml
@@ -1,3 +1,4 @@
+name: Pull Request Base Branch
 on:
     pull_request:
         types: [opened, edited, synchronize]


### PR DESCRIPTION
It should be very rare that we ever PR into a branch that isn't 'develop', 'staging' or a feature branch, and this will give us a failed check when stacking up PRs on top of one another until the one below it is merged.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
