### PR TITLE
Remove legacy crypto in playwright docker entrypoint

### DIFF
--- a/playwright/docker-entrypoint.sh
+++ b/playwright/docker-entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 yarn link
 yarn --cwd ../element-web install
 yarn --cwd ../element-web link matrix-react-sdk
-npx playwright test --update-snapshots --reporter line --project='Legacy Crypto' $@
+npx playwright test --update-snapshots --reporter line $@


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

The legacy crypto is no longer available:

```sh
Error: Project(s) "Legacy Crypto" not found. Available projects: ""
Error: Project(s) "Legacy Crypto" not found. Available projects: ""
    at filterProjects (/work/matrix-react-sdk/node_modules/playwright/lib/runner/projectUtils.js:67:11)
    at writeLastRunInfo (/work/matrix-react-sdk/node_modules/playwright/lib/runner/runner.js:144:54)
    at Runner.runAllTests (/work/matrix-react-sdk/node_modules/playwright/lib/runner/runner.js:82:11)
    at runTests (/work/matrix-react-sdk/node_modules/playwright/lib/program.js:205:85)
    at t.<anonymous> (/work/matrix-react-sdk/node_modules/playwright/lib/program.js:54:7)
```