### PR TITLE
Extract `focus_search` dispatch action into enum

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -458,9 +458,7 @@ class LoggedInView extends React.Component<IProps, IState> {
                 handled = true;
                 break;
             case KeyBindingAction.SearchInRoom:
-                dis.dispatch({
-                    action: "focus_search",
-                });
+                dis.fire(Action.FocusMessageSearch);
                 handled = true;
                 break;
         }

--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1196,7 +1196,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                     );
                 }
                 break;
-            case "focus_search":
+            case Action.FocusMessageSearch:
                 this.onSearchClick();
                 break;
 

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -388,4 +388,9 @@ export enum Action {
      * Opens right panel with 3pid invite information
      */
     View3pidInvite = "view_3pid_invite",
+
+    /**
+     * Opens right panel room summary and focuses the search input
+     */
+    FocusMessageSearch = "focus_search",
 }

--- a/test/components/structures/LoggedInView-test.tsx
+++ b/test/components/structures/LoggedInView-test.tsx
@@ -390,7 +390,7 @@ describe("<LoggedInView />", () => {
         });
     });
 
-    it("should fire FocusRoomSearch on Ctrl+F when enabled", async () => {
+    it("should fire FocusMessageSearch on Ctrl+F when enabled", async () => {
         jest.spyOn(defaultDispatcher, "fire");
         await SettingsStore.setValue("ctrlFForSearch", null, SettingLevel.DEVICE, true);
 

--- a/test/components/structures/LoggedInView-test.tsx
+++ b/test/components/structures/LoggedInView-test.tsx
@@ -19,6 +19,7 @@ import { render, RenderResult } from "@testing-library/react";
 import { ConditionKind, EventType, IPushRule, MatrixEvent, ClientEvent, PushRuleKind } from "matrix-js-sdk/src/matrix";
 import { MediaHandler } from "matrix-js-sdk/src/webrtc/mediaHandler";
 import { logger } from "matrix-js-sdk/src/logger";
+import userEvent from "@testing-library/user-event";
 
 import LoggedInView from "../../../src/components/structures/LoggedInView";
 import { SDKContext } from "../../../src/contexts/SDKContext";
@@ -26,6 +27,10 @@ import { StandardActions } from "../../../src/notifications/StandardActions";
 import ResizeNotifier from "../../../src/utils/ResizeNotifier";
 import { flushPromises, getMockClientWithEventEmitter, mockClientMethodsUser } from "../../test-utils";
 import { TestSdkContext } from "../../TestSdkContext";
+import defaultDispatcher from "../../../src/dispatcher/dispatcher";
+import SettingsStore from "../../../src/settings/SettingsStore";
+import { SettingLevel } from "../../../src/settings/SettingLevel";
+import { Action } from "../../../src/dispatcher/actions";
 
 describe("<LoggedInView />", () => {
     const userId = "@alice:domain.org";
@@ -383,5 +388,14 @@ describe("<LoggedInView />", () => {
                 expect(mockClient.setPushRuleActions).not.toHaveBeenCalled();
             });
         });
+    });
+
+    it("should fire FocusRoomSearch on Ctrl+F when enabled", async () => {
+        jest.spyOn(defaultDispatcher, "fire");
+        await SettingsStore.setValue("ctrlFForSearch", null, SettingLevel.DEVICE, true);
+
+        getComponent();
+        await userEvent.keyboard("{Control>}f{/Control}");
+        expect(defaultDispatcher.fire).toHaveBeenCalledWith(Action.FocusMessageSearch);
     });
 });


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-react-sdk/pull/12677

The old value is retained for compatibility with existing modules/customisations