### PR TITLE
Use LTS nodejs in github workflows

### DIFF
--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -56,6 +56,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             - name: Fetch layered build
               id: layered_build
@@ -121,6 +122,7 @@ jobs:
               with:
                   cache: "yarn"
                   cache-dependency-path: matrix-react-sdk/yarn.lock
+                  node-version: "lts/*"
 
             - name: Install dependencies
               working-directory: matrix-react-sdk
@@ -172,6 +174,7 @@ jobs:
               if: inputs.skip != true
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             - name: Install dependencies
               if: inputs.skip != true

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -25,6 +25,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             - name: Install Deps
               run: "./scripts/ci/install-deps.sh"
@@ -83,6 +84,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             # Does not need branch matching as only analyses this layer
             - name: Install Deps
@@ -100,6 +102,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             # Does not need branch matching as only analyses this layer
             - name: Install Deps
@@ -117,6 +120,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             # Does not need branch matching as only analyses this layer
             - name: Install Deps
@@ -134,6 +138,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             - name: Install Deps
               run: "scripts/ci/layered.sh"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
             - name: Yarn cache
               uses: actions/setup-node@v4
               with:
+                  node-version: "lts/*"
                   cache: "yarn"
 
             - name: Install Deps
@@ -115,6 +116,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version: "lts/*"
 
             - name: Run tests
               run: "./scripts/ci/app-tests.sh"


### PR DESCRIPTION
Currently our GH workflows all use nodejs 18, but that's not compatible with the stated support range of matrix-js-sdk, which requires the latest LTS nodejs; so, when we attermpt to `yarn install` on an older nodejs, we get an error.

Switch to LTS nodejs for all the places we set up nodejs.