### PR TITLE
Fix closing all modals

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -184,13 +184,6 @@ export class ModalManager extends TypedEventEmitter<ModalManagerEvent, HandlerMa
         this.reRender();
     }
 
-    /**
-     * @returns true if any modals are currently being displayed, otherwise false
-     */
-    public hasModals(): boolean {
-        return this.modals.length > 0;
-    }
-
     private buildModal<C extends ComponentType>(
         prom: Promise<C>,
         props?: ComponentProps<C>,

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -151,6 +151,24 @@ export class ModalManager extends TypedEventEmitter<ModalManagerEvent, HandlerMa
     }
 
     /**
+     * DEPRECATED.
+     * This is used only for tests. They should be using forceCloseAllModals but that
+     * caused a chunk of tests to fail, so for now they continue to use this.
+     *
+     * @param reason either "backgroundClick" or undefined
+     * @return whether a modal was closed
+     */
+    public closeCurrentModal(reason?: ModalCloseReason): boolean {
+        const modal = this.getCurrentModal();
+        if (!modal) {
+            return false;
+        }
+        modal.closeReason = reason;
+        modal.close();
+        return true;
+    }
+
+    /**
      * Forces closes all open modals. The modals onBeforeClose function will not be
      * run and the modal will not have a chance to prevent closing. Intended for
      * situations like the user logging out of the app.

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -491,7 +491,7 @@ class LoggedInView extends React.Component<IProps, IState> {
                 // even if we cancel because there are modals open, we still
                 // handled it: nothing else should happen.
                 handled = true;
-                if (Modal.hasModals()) {
+                if (Modal.hasDialogs()) {
                     return;
                 }
                 dis.dispatch({

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -488,11 +488,15 @@ class LoggedInView extends React.Component<IProps, IState> {
                 handled = true;
                 break;
             case KeyBindingAction.GoToHome:
+                // even if we cancel because there are modals open, we still
+                // handled it: nothing else should happen.
+                handled = true;
+                if (Modal.hasModals()) {
+                    return;
+                }
                 dis.dispatch({
                     action: Action.ViewHomePage,
                 });
-                Modal.closeAllModals();
-                handled = true;
                 break;
             case KeyBindingAction.ToggleSpacePanel:
                 dis.fire(Action.ToggleSpacePanel);

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -491,7 +491,7 @@ class LoggedInView extends React.Component<IProps, IState> {
                 dis.dispatch({
                     action: Action.ViewHomePage,
                 });
-                Modal.closeCurrentModal("homeKeyboardShortcut");
+                Modal.closeAllModals();
                 handled = true;
                 break;
             case KeyBindingAction.ToggleSpacePanel:

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1544,7 +1544,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             if (Lifecycle.isLoggingOut()) return;
 
             // A modal might have been open when we were logged out by the server
-            Modal.closeAllModals();
+            Modal.forceCloseAllModals();
 
             if (errObj.httpStatus === 401 && errObj.data && errObj.data["soft_logout"]) {
                 logger.warn("Soft logout issued by server - avoiding data deletion");

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1544,7 +1544,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             if (Lifecycle.isLoggingOut()) return;
 
             // A modal might have been open when we were logged out by the server
-            Modal.closeCurrentModal("Session.logged_out");
+            Modal.closeAllModals();
 
             if (errObj.httpStatus === 401 && errObj.data && errObj.data["soft_logout"]) {
                 logger.warn("Soft logout issued by server - avoiding data deletion");

--- a/test/Modal-test.ts
+++ b/test/Modal-test.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Modal from "../src/Modal";
+import QuestionDialog from "../src/components/views/dialogs/QuestionDialog";
+
+describe("Modal", () => {
+    test("forceCloseAllModals should close all open modals", () => {
+        Modal.createDialog(QuestionDialog, {
+            title: "Test dialog",
+            description: "This is a test dialog",
+            button: "Word",
+        });
+
+        expect(Modal.hasDialogs()).toBe(true);
+        Modal.forceCloseAllModals();
+        expect(Modal.hasDialogs()).toBe(false);
+    });
+});

--- a/test/components/structures/LoggedInView-test.tsx
+++ b/test/components/structures/LoggedInView-test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from "react";
-import { render, RenderResult, waitFor } from "@testing-library/react";
+import { render, RenderResult } from "@testing-library/react";
 import { ConditionKind, EventType, IPushRule, MatrixEvent, ClientEvent, PushRuleKind } from "matrix-js-sdk/src/matrix";
 import { MediaHandler } from "matrix-js-sdk/src/webrtc/mediaHandler";
 import { logger } from "matrix-js-sdk/src/logger";
@@ -32,7 +32,6 @@ import SettingsStore from "../../../src/settings/SettingsStore";
 import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Action } from "../../../src/dispatcher/actions";
 import Modal from "../../../src/Modal";
-import QuestionDialog from "../../../src/components/views/dialogs/QuestionDialog";
 
 describe("<LoggedInView />", () => {
     const userId = "@alice:domain.org";

--- a/test/components/structures/LoggedInView-test.tsx
+++ b/test/components/structures/LoggedInView-test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from "react";
-import { render, RenderResult } from "@testing-library/react";
+import { render, RenderResult, waitFor } from "@testing-library/react";
 import { ConditionKind, EventType, IPushRule, MatrixEvent, ClientEvent, PushRuleKind } from "matrix-js-sdk/src/matrix";
 import { MediaHandler } from "matrix-js-sdk/src/webrtc/mediaHandler";
 import { logger } from "matrix-js-sdk/src/logger";
@@ -31,6 +31,8 @@ import defaultDispatcher from "../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../src/settings/SettingsStore";
 import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Action } from "../../../src/dispatcher/actions";
+import Modal from "../../../src/Modal";
+import QuestionDialog from "../../../src/components/views/dialogs/QuestionDialog";
 
 describe("<LoggedInView />", () => {
     const userId = "@alice:domain.org";
@@ -397,5 +399,23 @@ describe("<LoggedInView />", () => {
         getComponent();
         await userEvent.keyboard("{Control>}f{/Control}");
         expect(defaultDispatcher.fire).toHaveBeenCalledWith(Action.FocusMessageSearch);
+    });
+
+    it("should go home on home shortcut", async () => {
+        jest.spyOn(defaultDispatcher, "dispatch");
+
+        getComponent();
+        await userEvent.keyboard("{Control>}{Alt>}h</Alt>{/Control}");
+        expect(defaultDispatcher.dispatch).toHaveBeenCalledWith({ action: Action.ViewHomePage });
+    });
+
+    it("should ignore home shortcut if dialogs are open", async () => {
+        jest.spyOn(defaultDispatcher, "dispatch");
+        jest.spyOn(Modal, "hasDialogs").mockReturnValue(true);
+
+        getComponent();
+
+        await userEvent.keyboard("{Control>}{Alt>}h</Alt>{/Control}");
+        expect(defaultDispatcher.dispatch).not.toHaveBeenCalledWith({ action: Action.ViewHomePage });
     });
 });

--- a/test/components/views/context_menus/RoomGeneralContextMenu-test.tsx
+++ b/test/components/views/context_menus/RoomGeneralContextMenu-test.tsx
@@ -36,7 +36,7 @@ import { mkMessage, stubClient } from "../../../test-utils/test-utils";
 import { shouldShowComponent } from "../../../../src/customisations/helpers/UIComponents";
 import { UIComponent } from "../../../../src/settings/UIFeature";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import Modal from "../../../../src/Modal";
+import { clearAllModals } from "../../../test-utils";
 
 jest.mock("../../../../src/customisations/helpers/UIComponents", () => ({
     shouldShowComponent: jest.fn(),
@@ -90,8 +90,8 @@ describe("RoomGeneralContextMenu", () => {
         onFinished = jest.fn();
     });
 
-    afterEach(() => {
-        Modal.closeCurrentModal("force");
+    afterEach(async () => {
+        await clearAllModals();
     });
 
     it("renders an empty context menu for archived rooms", async () => {

--- a/test/components/views/dialogs/InviteDialog-test.tsx
+++ b/test/components/views/dialogs/InviteDialog-test.tsx
@@ -25,6 +25,7 @@ import { mocked, Mocked } from "jest-mock";
 import InviteDialog from "../../../../src/components/views/dialogs/InviteDialog";
 import { InviteKind } from "../../../../src/components/views/dialogs/InviteDialogTypes";
 import {
+    clearAllModals,
     filterConsole,
     flushPromises,
     getMockClientWithEventEmitter,
@@ -40,7 +41,6 @@ import { SdkContextClass } from "../../../../src/contexts/SDKContext";
 import { IProfileInfo } from "../../../../src/hooks/useProfileInfo";
 import { DirectoryMember, startDmOnFirstMessage } from "../../../../src/utils/direct-messages";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import Modal from "../../../../src/Modal";
 
 const mockGetAccessToken = jest.fn().mockResolvedValue("getAccessToken");
 jest.mock("../../../../src/IdentityAuthClient", () =>
@@ -178,8 +178,8 @@ describe("InviteDialog", () => {
         SdkContextClass.instance.client = mockClient;
     });
 
-    afterEach(() => {
-        Modal.closeCurrentModal();
+    afterEach(async () => {
+        await clearAllModals();
         SdkContextClass.instance.onLoggedOut();
         SdkContextClass.instance.client = undefined;
     });

--- a/test/test-utils/utilities.ts
+++ b/test/test-utils/utilities.ts
@@ -202,27 +202,24 @@ export const waitEnoughCyclesForModal = async ({
  */
 export const clearAllModals = async (): Promise<void> => {
     // Prevent modals from leaking and polluting other tests
-    let keepClosingModals = true;
-    while (keepClosingModals) {
-        keepClosingModals = Modal.closeCurrentModal("End of test (clean-up)");
+    Modal.closeAllModals();
 
-        // Then wait for the screen to update (probably React rerender and async/await).
-        // Important for tests using Jest fake timers to not get into an infinite loop
-        // of removing the same modal because the promises don't flush otherwise.
-        //
-        // XXX: Maybe in the future with Jest 29.5.0+, we could use `runAllTimersAsync` instead.
+    // Then wait for the screen to update (probably React rerender and async/await).
+    // Important for tests using Jest fake timers to not get into an infinite loop
+    // of removing the same modal because the promises don't flush otherwise.
+    //
+    // XXX: Maybe in the future with Jest 29.5.0+, we could use `runAllTimersAsync` instead.
 
-        // this is called in some places where timers are not faked
-        // which causes a lot of noise in the console
-        // to make a hack even hackier check if timers are faked using a weird trick from github
-        // then call the appropriate promise flusher
-        // https://github.com/facebook/jest/issues/10555#issuecomment-1136466942
-        const jestTimersFaked = setTimeout.name === "setTimeout";
-        if (jestTimersFaked) {
-            await flushPromisesWithFakeTimers();
-        } else {
-            await flushPromises();
-        }
+    // this is called in some places where timers are not faked
+    // which causes a lot of noise in the console
+    // to make a hack even hackier check if timers are faked using a weird trick from github
+    // then call the appropriate promise flusher
+    // https://github.com/facebook/jest/issues/10555#issuecomment-1136466942
+    const jestTimersFaked = setTimeout.name === "setTimeout";
+    if (jestTimersFaked) {
+        await flushPromisesWithFakeTimers();
+    } else {
+        await flushPromises();
     }
 };
 

--- a/test/test-utils/utilities.ts
+++ b/test/test-utils/utilities.ts
@@ -202,7 +202,7 @@ export const waitEnoughCyclesForModal = async ({
  */
 export const clearAllModals = async (): Promise<void> => {
     // Prevent modals from leaking and polluting other tests
-    Modal.closeAllModals();
+    Modal.forceCloseAllModals();
 
     // Then wait for the screen to update (probably React rerender and async/await).
     // Important for tests using Jest fake timers to not get into an infinite loop
@@ -215,6 +215,10 @@ export const clearAllModals = async (): Promise<void> => {
     // to make a hack even hackier check if timers are faked using a weird trick from github
     // then call the appropriate promise flusher
     // https://github.com/facebook/jest/issues/10555#issuecomment-1136466942
+
+    // For even more ick, this shouldn't be necessary now that forceCloseAllModals() removes
+    // all modals synchronously, but in practice a whole bunch of tests start failing without
+    // this async wait in between tests because of other general flakiness.
     const jestTimersFaked = setTimeout.name === "setTimeout";
     if (jestTimersFaked) {
         await flushPromisesWithFakeTimers();

--- a/test/test-utils/utilities.ts
+++ b/test/test-utils/utilities.ts
@@ -202,28 +202,27 @@ export const waitEnoughCyclesForModal = async ({
  */
 export const clearAllModals = async (): Promise<void> => {
     // Prevent modals from leaking and polluting other tests
-    Modal.forceCloseAllModals();
+    let keepClosingModals = true;
+    while (keepClosingModals) {
+        keepClosingModals = Modal.closeCurrentModal();
 
-    // Then wait for the screen to update (probably React rerender and async/await).
-    // Important for tests using Jest fake timers to not get into an infinite loop
-    // of removing the same modal because the promises don't flush otherwise.
-    //
-    // XXX: Maybe in the future with Jest 29.5.0+, we could use `runAllTimersAsync` instead.
+        // Then wait for the screen to update (probably React rerender and async/await).
+        // Important for tests using Jest fake timers to not get into an infinite loop
+        // of removing the same modal because the promises don't flush otherwise.
+        //
+        // XXX: Maybe in the future with Jest 29.5.0+, we could use `runAllTimersAsync` instead.
 
-    // this is called in some places where timers are not faked
-    // which causes a lot of noise in the console
-    // to make a hack even hackier check if timers are faked using a weird trick from github
-    // then call the appropriate promise flusher
-    // https://github.com/facebook/jest/issues/10555#issuecomment-1136466942
-
-    // For even more ick, this shouldn't be necessary now that forceCloseAllModals() removes
-    // all modals synchronously, but in practice a whole bunch of tests start failing without
-    // this async wait in between tests because of other general flakiness.
-    const jestTimersFaked = setTimeout.name === "setTimeout";
-    if (jestTimersFaked) {
-        await flushPromisesWithFakeTimers();
-    } else {
-        await flushPromises();
+        // this is called in some places where timers are not faked
+        // which causes a lot of noise in the console
+        // to make a hack even hackier check if timers are faked using a weird trick from github
+        // then call the appropriate promise flusher
+        // https://github.com/facebook/jest/issues/10555#issuecomment-1136466942
+        const jestTimersFaked = setTimeout.name === "setTimeout";
+        if (jestTimersFaked) {
+            await flushPromisesWithFakeTimers();
+        } else {
+            await flushPromises();
+        }
     }
 };
 


### PR DESCRIPTION
We used `Modal.closeCurrentModal()` in a bunch of places, in all cases (as far as I can see: it wasn't commented) we meant to close all open modals. This swaps that function for one that closes all open modals.

Also types the close reason which claimed to be something in a comment, of course, was wrong because a load of places passed their own random string which was never used.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
