### PR TITLE
Remove redundant call to `setCrypto`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,6 @@ module.exports = {
                             "!matrix-js-sdk/src/extensible_events_v1/InvalidEventError",
                             "!matrix-js-sdk/src/crypto",
                             "!matrix-js-sdk/src/crypto/aes",
-                            "!matrix-js-sdk/src/crypto/crypto",
                             "!matrix-js-sdk/src/crypto/keybackup",
                             "!matrix-js-sdk/src/crypto/deviceinfo",
                             "!matrix-js-sdk/src/crypto/key_passphrase",

--- a/test/Lifecycle-test.ts
+++ b/test/Lifecycle-test.ts
@@ -18,7 +18,6 @@ import { Crypto } from "@peculiar/webcrypto";
 import { logger } from "matrix-js-sdk/src/logger";
 import * as MatrixJs from "matrix-js-sdk/src/matrix";
 import { decodeBase64, encodeUnpaddedBase64 } from "matrix-js-sdk/src/matrix";
-import { setCrypto } from "matrix-js-sdk/src/crypto/crypto";
 import * as MatrixCryptoAes from "matrix-js-sdk/src/crypto/aes";
 import { mocked, MockedObject } from "jest-mock";
 import fetchMock from "fetch-mock-jest";
@@ -79,7 +78,6 @@ describe("Lifecycle", () => {
         delete global.localStorage;
         global.localStorage = realLocalStorage;
 
-        setCrypto(webCrypto);
         // @ts-ignore mocking
         delete window.crypto;
         window.crypto = webCrypto;
@@ -88,8 +86,6 @@ describe("Lifecycle", () => {
     });
 
     afterAll(() => {
-        setCrypto(windowCrypto);
-
         // @ts-ignore unmocking
         delete window.crypto;
         window.crypto = windowCrypto;


### PR DESCRIPTION
Since matrix-org/matrix-js-sdk#4292, this thing is a no-op.