### PR TITLE
Element-R: Report events with withheld keys separately to Posthog.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/analytics-events": "^0.23.0",
+        "@matrix-org/analytics-events": "^0.24.0",
         "@matrix-org/emojibase-bindings": "^1.1.2",
         "@matrix-org/matrix-wysiwyg": "2.37.4",
         "@matrix-org/react-sdk-module-api": "^2.4.0",

--- a/src/DecryptionFailureTracker.ts
+++ b/src/DecryptionFailureTracker.ts
@@ -78,7 +78,10 @@ export class DecryptionFailureTracker {
             // Map JS-SDK error codes to tracker codes for aggregation
             switch (errorCode) {
                 case DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID:
+                case DecryptionFailureCode.MEGOLM_KEY_WITHHELD:
                     return "OlmKeysNotSentError";
+                case DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE:
+                    return "RoomKeysWithheldForUnverifiedDevice";
                 case DecryptionFailureCode.OLM_UNKNOWN_MESSAGE_INDEX:
                     return "OlmIndexError";
                 case DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP:

--- a/src/components/views/messages/DecryptionFailureBody.tsx
+++ b/src/components/views/messages/DecryptionFailureBody.tsx
@@ -23,8 +23,10 @@ import { IBodyProps } from "./IBodyProps";
 import { LocalDeviceVerificationStateContext } from "../../../contexts/LocalDeviceVerificationStateContext";
 
 function getErrorMessage(mxEvent: MatrixEvent, isVerified: boolean | undefined): string {
-    if (mxEvent.isEncryptedDisabledForUnverifiedDevices) return _t("timeline|decryption_failure|blocked");
     switch (mxEvent.decryptionFailureReason) {
+        case DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE:
+            return _t("timeline|decryption_failure|blocked");
+
         case DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP:
             return _t("timeline|decryption_failure|historical_event_no_key_backup");
 

--- a/test/DecryptionFailureTracker-test.ts
+++ b/test/DecryptionFailureTracker-test.ts
@@ -490,47 +490,22 @@ describe("DecryptionFailureTracker", function () {
 
         const now = Date.now();
 
-        const event1 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID,
-        });
-        tracker.addVisibleEvent(event1);
-        eventDecrypted(tracker, event1, now);
+        async function createAndTrackEventWithError(code: DecryptionFailureCode) {
+            const event = await createFailedDecryptionEvent({ code });
+            tracker.addVisibleEvent(event);
+            eventDecrypted(tracker, event, now);
+            return event;
+        }
 
-        const event2 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.OLM_UNKNOWN_MESSAGE_INDEX,
-        });
-        tracker.addVisibleEvent(event2);
-        eventDecrypted(tracker, event2, now);
-
-        const event3 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP,
-        });
-        tracker.addVisibleEvent(event3);
-        eventDecrypted(tracker, event3, now);
-
-        const event4 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED,
-        });
-        tracker.addVisibleEvent(event4);
-        eventDecrypted(tracker, event4, now);
-
-        const event5 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP,
-        });
-        tracker.addVisibleEvent(event5);
-        eventDecrypted(tracker, event5, now);
-
-        const event6 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED,
-        });
-        tracker.addVisibleEvent(event6);
-        eventDecrypted(tracker, event6, now);
-
-        const event7 = await createFailedDecryptionEvent({
-            code: DecryptionFailureCode.UNKNOWN_ERROR,
-        });
-        tracker.addVisibleEvent(event7);
-        eventDecrypted(tracker, event7, now);
+        await createAndTrackEventWithError(DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID);
+        await createAndTrackEventWithError(DecryptionFailureCode.OLM_UNKNOWN_MESSAGE_INDEX);
+        await createAndTrackEventWithError(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);
+        await createAndTrackEventWithError(DecryptionFailureCode.HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED);
+        await createAndTrackEventWithError(DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP);
+        await createAndTrackEventWithError(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
+        await createAndTrackEventWithError(DecryptionFailureCode.MEGOLM_KEY_WITHHELD);
+        await createAndTrackEventWithError(DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE);
+        await createAndTrackEventWithError(DecryptionFailureCode.UNKNOWN_ERROR);
 
         // Pretend "now" is Infinity
         tracker.checkFailures(Infinity);
@@ -542,6 +517,8 @@ describe("DecryptionFailureTracker", function () {
             "HistoricalMessage",
             "HistoricalMessage",
             "ExpectedDueToMembership",
+            "OlmKeysNotSentError",
+            "RoomKeysWithheldForUnverifiedDevice",
             "UnknownError",
         ]);
     });

--- a/test/components/views/messages/DecryptionFailureBody-test.tsx
+++ b/test/components/views/messages/DecryptionFailureBody-test.tsx
@@ -50,18 +50,15 @@ describe("DecryptionFailureBody", () => {
         expect(container).toMatchSnapshot();
     });
 
-    it(`Should display "The sender has blocked you from receiving this message"`, () => {
+    it(`Should display "The sender has blocked you from receiving this message"`, async () => {
         // When
-        const event = mkEvent({
-            type: "m.room.message",
-            room: "myfakeroom",
-            user: "myfakeuser",
-            content: {
-                msgtype: "m.bad.encrypted",
-            },
-            event: true,
+        const event = await mkDecryptionFailureMatrixEvent({
+            code: DecryptionFailureCode.MEGOLM_KEY_WITHHELD_FOR_UNVERIFIED_DEVICE,
+            msg: "withheld",
+            roomId: "myfakeroom",
+            sender: "myfakeuser",
         });
-        jest.spyOn(event, "isEncryptedDisabledForUnverifiedDevices", "get").mockReturnValue(true);
+
         const { container } = customRender(event);
 
         // Then

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,10 +1856,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@matrix-org/analytics-events@^0.23.0":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@matrix-org/analytics-events/-/analytics-events-0.23.1.tgz#206224f63e64b8cd892f704964204bce433bd189"
-  integrity sha512-+DuK5F313bZfO0jCsP7X3u0FQ09IM9Ujc9Zf//XoxzGThG9pvSYsEyNXQO7kUeQHwXlOobtVg1QcP172kN+h/g==
+"@matrix-org/analytics-events@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/analytics-events/-/analytics-events-0.24.0.tgz#21a64537ac975b18e1eb13d9fd0bdc7d448a6039"
+  integrity sha512-3FDdtqZ+5cMqVffWjFNOIQ7RDFN6XS11kqdtN2ps8uvq5ce8gT0yXQvK37WeKWKZZ5QAKeoMzGhud+lsVcb1xg==
 
 "@matrix-org/emojibase-bindings@^1.1.2":
   version "1.1.3"


### PR DESCRIPTION
If the sender has deliberately chosen to withhold the keys for a given room event, we should report it as a separate Posthog event.

Also, remove some references to deprecated methods.

Review by commit.

Partial fix to element-hq/element-web#27653.