### PR TITLE
Clear settings store cache on logout

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -1056,6 +1056,7 @@ export async function onLoggedOut(): Promise<void> {
     await clearStorage({ deleteEverything: true });
     LifecycleCustomisations.onLoggedOutAndStorageCleared?.();
     await PlatformPeg.get()?.clearStorage();
+    SettingsStore.reset();
 
     // Do this last, so we can make sure all storage has been cleared and all
     // customisations got the memo.

--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -134,6 +134,12 @@ export default class SettingsStore {
     // Counter used for generation of watcher IDs
     private static watcherCount = 1;
 
+    public static reset(): void {
+        for (const handler of Object.values(LEVEL_HANDLERS)) {
+            handler.reset();
+        }
+    }
+
     /**
      * Gets all the feature-style setting names.
      * @returns {string[]} The names of the feature settings.

--- a/src/settings/handlers/LocalEchoWrapper.ts
+++ b/src/settings/handlers/LocalEchoWrapper.ts
@@ -83,4 +83,9 @@ export default class LocalEchoWrapper extends SettingsHandler {
     public isSupported(): boolean {
         return this.handler.isSupported();
     }
+
+    public reset(): void {
+        this.cache = {};
+        this.handler.reset();
+    }
 }

--- a/src/settings/handlers/SettingsHandler.ts
+++ b/src/settings/handlers/SettingsHandler.ts
@@ -61,4 +61,9 @@ export default abstract class SettingsHandler {
      * @returns {boolean} True if this level is supported on the current device.
      */
     public abstract isSupported(): boolean;
+
+    /**
+     * Resets the handler, clearing any caches or other stored data. Called on user logout.
+     */
+    public reset(): void {}
 }

--- a/test/stores/WidgetLayoutStore-test.ts
+++ b/test/stores/WidgetLayoutStore-test.ts
@@ -57,6 +57,8 @@ describe("WidgetLayoutStore", () => {
             off: jest.fn(),
             getApps: () => mockApps,
         } as unknown as WidgetStore);
+
+        SettingsStore.reset();
     });
 
     beforeAll(() => {
@@ -156,9 +158,14 @@ describe("WidgetLayoutStore", () => {
         await store.start();
 
         expect(roomUpdateListener).toHaveBeenCalled();
-        expect(store.getContainerWidgets(mockRoom, Container.Top)).toEqual([mockApps[0]]);
+        expect(store.getContainerWidgets(mockRoom, Container.Top)).toEqual([]);
         expect(store.getContainerWidgets(mockRoom, Container.Center)).toEqual([]);
-        expect(store.getContainerWidgets(mockRoom, Container.Right)).toEqual([mockApps[1], mockApps[2], mockApps[3]]);
+        expect(store.getContainerWidgets(mockRoom, Container.Right)).toEqual([
+            mockApps[0],
+            mockApps[1],
+            mockApps[2],
+            mockApps[3],
+        ]);
     });
 
     it("should clear the layout and emit an update if there are no longer apps in the room", () => {
@@ -238,21 +245,15 @@ describe("WidgetLayoutStore", () => {
                   "widgets": {
                     "1": {
                       "container": "top",
-                      "height": 23,
-                      "index": 2,
-                      "width": 64,
+                      "height": undefined,
+                      "index": 0,
+                      "width": 100,
                     },
                     "2": {
-                      "container": "top",
-                      "height": 23,
-                      "index": 0,
-                      "width": 10,
+                      "container": "right",
                     },
                     "3": {
-                      "container": "top",
-                      "height": 23,
-                      "index": 1,
-                      "width": 26,
+                      "container": "right",
                     },
                     "4": {
                       "container": "right",


### PR DESCRIPTION
And clear it in the widget layout store test, also fixing the tests which didn't work individually as they actually relied on the state bleeding between tests.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
