### PR TITLE
Acknowledge `DeviceMute` widget actions

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -892,6 +892,10 @@ export class ElementCall extends Call {
         this.messaging!.on(`action:${ElementWidgetActions.TileLayout}`, this.onTileLayout);
         this.messaging!.on(`action:${ElementWidgetActions.SpotlightLayout}`, this.onSpotlightLayout);
         this.messaging!.on(`action:${ElementWidgetActions.HangupCall}`, this.onHangup);
+        this.messaging!.on(`action:${ElementWidgetActions.DeviceMute}`, async (ev) => {
+            ev.preventDefault();
+            await this.messaging!.transport.reply(ev.detail, {}); // ack
+        });
 
         if (!this.widget.data?.skipLobby) {
             // If we do not skip the lobby we need to wait until the widget has

--- a/src/stores/widgets/ElementWidgetActions.ts
+++ b/src/stores/widgets/ElementWidgetActions.ts
@@ -21,8 +21,6 @@ export enum ElementWidgetActions {
     JoinCall = "io.element.join",
     HangupCall = "im.vector.hangup",
     CallParticipants = "io.element.participants",
-    MuteVideo = "io.element.mute_video",
-    UnmuteVideo = "io.element.unmute_video",
     StartLiveStream = "im.vector.start_live_stream",
 
     // Actions for switching layouts
@@ -30,11 +28,11 @@ export enum ElementWidgetActions {
     SpotlightLayout = "io.element.spotlight_layout",
 
     OpenIntegrationManager = "integration_manager_open",
-
     /**
      * @deprecated Use MSC2931 instead
      */
     ViewRoom = "io.element.view_room",
+
     // This action type is used as a `fromWidget` and a `toWidget` action.
     // fromWidget: updates the client about the current device mute state
     // toWidget: the client requests a specific device mute configuration

--- a/src/stores/widgets/ElementWidgetActions.ts
+++ b/src/stores/widgets/ElementWidgetActions.ts
@@ -21,8 +21,6 @@ export enum ElementWidgetActions {
     JoinCall = "io.element.join",
     HangupCall = "im.vector.hangup",
     CallParticipants = "io.element.participants",
-    MuteAudio = "io.element.mute_audio",
-    UnmuteAudio = "io.element.unmute_audio",
     MuteVideo = "io.element.mute_video",
     UnmuteVideo = "io.element.unmute_video",
     StartLiveStream = "im.vector.start_live_stream",
@@ -37,6 +35,23 @@ export enum ElementWidgetActions {
      * @deprecated Use MSC2931 instead
      */
     ViewRoom = "io.element.view_room",
+    // This can be sent as from or to widget
+    // fromWidget: updates the client about the current device mute state
+    // toWidget: the client requests a specific device mute configuration
+    //   The reply will always be the resulting configuration
+    //   It is possible to sent an empty configuration to retrieve the current values or
+    //   just one of the fields to update that particular value
+    //   An undefined field means that EC will keep the mute state as is.
+    //   -> this will allow the client to only get the current state
+    //
+    // The data of the widget action request and the response are:
+    // {
+    //   audio_enabled?: boolean,
+    //   video_enabled?: boolean
+    // }
+    // NOTE: this is currently unused. Its only here to make EW aware
+    // of this action so it does not throw errors.
+    DeviceMute = "io.element.device_mute",
 }
 
 export interface IHangupCallApiRequest extends IWidgetApiRequest {

--- a/src/stores/widgets/ElementWidgetActions.ts
+++ b/src/stores/widgets/ElementWidgetActions.ts
@@ -35,7 +35,7 @@ export enum ElementWidgetActions {
      * @deprecated Use MSC2931 instead
      */
     ViewRoom = "io.element.view_room",
-    // This can be sent as from or to widget
+    // This action type is used as a `fromWidget` and a `toWidget` action.
     // fromWidget: updates the client about the current device mute state
     // toWidget: the client requests a specific device mute configuration
     //   The reply will always be the resulting configuration

--- a/test/models/Call-test.ts
+++ b/test/models/Call-test.ts
@@ -965,6 +965,18 @@ describe("ElementCall", () => {
             expect(messaging.transport.send).toHaveBeenCalledWith(ElementWidgetActions.TileLayout, {});
         });
 
+        it("acknowledges mute_device widget action", async () => {
+            await callConnectProcedure(call);
+            const preventDefault = jest.fn();
+            const mockEv = {
+                preventDefault,
+                detail: { video_enabled: false },
+            };
+            messaging.emit(`action:${ElementWidgetActions.DeviceMute}`, mockEv);
+            expect(messaging.transport.reply).toHaveBeenCalledWith({ video_enabled: false }, {});
+            expect(preventDefault).toHaveBeenCalled();
+        });
+
         it("emits events when connection state changes", async () => {
             // const wait = jest.spyOn(CallModule, "waitForEvent");
             const onConnectionState = jest.fn();


### PR DESCRIPTION
 This prevents sending the  default error response to the widget.
required for: https://github.com/element-hq/element-call/pull/2482
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
