### PR TITLE
Revert "Use multiple workers in Playwright CI to make use of multiple cores"

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     },
     testDir: "playwright/e2e",
     outputDir: "playwright/test-results",
-    workers: process.env.CI ? "50%" : 1,
+    workers: 1,
     retries: process.env.CI ? 2 : 0,
     reporter: process.env.CI ? [["blob"], ["github"]] : [["html", { outputFolder: "playwright/html-report" }]],
     snapshotDir: "playwright/snapshots",


### PR DESCRIPTION
Reverts matrix-org/matrix-react-sdk#12769

We are seeing a sudden increase in the number of flaky tests and I think having multiple worker processes within each runner is the cause. 