### PR TITLE
Make widget tests throw when a modal is shown

### DIFF
--- a/test/stores/widgets/StopGapWidgetDriver-test.ts
+++ b/test/stores/widgets/StopGapWidgetDriver-test.ts
@@ -48,6 +48,7 @@ import { StopGapWidgetDriver } from "../../../src/stores/widgets/StopGapWidgetDr
 import { stubClient } from "../../test-utils";
 import { ModuleRunner } from "../../../src/modules/ModuleRunner";
 import dis from "../../../src/dispatcher/dispatcher";
+import Modal from "../../../src/Modal";
 import SettingsStore from "../../../src/settings/SettingsStore";
 
 describe("StopGapWidgetDriver", () => {
@@ -66,6 +67,10 @@ describe("StopGapWidgetDriver", () => {
             false,
             "!1:example.org",
         );
+
+    jest.spyOn(Modal, "createDialog").mockImplementation(() => {
+        throw new Error("Should not have to create a dialog");
+    });
 
     beforeEach(() => {
         stubClient();
@@ -124,7 +129,6 @@ describe("StopGapWidgetDriver", () => {
             "org.matrix.msc3819.receive.to_device:m.call.replaces",
         ]);
 
-        // As long as this resolves, we'll know that it didn't try to pop up a modal
         const approvedCapabilities = await driver.validateCapabilities(requestedCapabilities);
         expect(approvedCapabilities).toEqual(requestedCapabilities);
     });


### PR DESCRIPTION
Instead of waiting for tests to time out if they show a dialog that they cannot interact with, throw an error immediately if a dialog is shown.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
