### PR TITLE
Import base64 utils directly from js-sdk

### DIFF
--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -720,10 +720,15 @@ test.describe("Timeline", () => {
             ).toBeVisible();
         });
 
-        test("should render url previews", async ({ page, app, room, axe, checkA11y }) => {
+        test("should render url previews", async ({ page, app, room, axe, checkA11y, context }) => {
             axe.disableRules("color-contrast");
 
-            await page.route(
+            // Element Web uses a Service Worker to rewrite unauthenticated media requests to authenticated ones, but
+            // the page can't see this happening. We intercept the route at the BrowserContext to ensure we get it
+            // post-worker, but we can't waitForResponse on that, so the page context is still used there. Because
+            // the page doesn't see the rewrite, it waits for the unauthenticated route. This is only confusing until
+            // the js-sdk (and thus the app as a whole) switches to using authenticated endpoints by default, hopefully.
+            await context.route(
                 "**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
                 async (route) => {
                     await route.fulfill({
@@ -750,6 +755,7 @@ test.describe("Timeline", () => {
 
             const requestPromises: Promise<any>[] = [
                 page.waitForResponse("**/_matrix/media/v3/preview_url?url=https%3A%2F%2Fcall.element.io%2F&ts=*"),
+                // see page.route above for why we listen for the unauthenticated endpoint
                 page.waitForResponse("**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
             ];
 

--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -724,7 +724,7 @@ test.describe("Timeline", () => {
             axe.disableRules("color-contrast");
 
             await page.route(
-                "**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
+                "**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
                 async (route) => {
                     await route.fulfill({
                         path: "playwright/sample-files/riot.png",
@@ -750,7 +750,7 @@ test.describe("Timeline", () => {
 
             const requestPromises: Promise<any>[] = [
                 page.waitForResponse("**/_matrix/media/v3/preview_url?url=https%3A%2F%2Fcall.element.io%2F&ts=*"),
-                page.waitForResponse("**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
+                page.waitForResponse("**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
             ];
 
             await app.client.sendMessage(room.roomId, "https://call.element.io/");

--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -724,7 +724,7 @@ test.describe("Timeline", () => {
             axe.disableRules("color-contrast");
 
             await page.route(
-                "**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
+                "**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
                 async (route) => {
                     await route.fulfill({
                         path: "playwright/sample-files/riot.png",

--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -755,7 +755,7 @@ test.describe("Timeline", () => {
 
             const requestPromises: Promise<any>[] = [
                 page.waitForResponse("**/_matrix/media/v3/preview_url?url=https%3A%2F%2Fcall.element.io%2F&ts=*"),
-                // see page.route above for why we listen for the unauthenticated endpoint
+                // see context.route above for why we listen for the unauthenticated endpoint
                 page.waitForResponse("**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
             ];
 

--- a/playwright/e2e/timeline/timeline.spec.ts
+++ b/playwright/e2e/timeline/timeline.spec.ts
@@ -724,7 +724,7 @@ test.describe("Timeline", () => {
             axe.disableRules("color-contrast");
 
             await page.route(
-                "**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
+                "**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*",
                 async (route) => {
                     await route.fulfill({
                         path: "playwright/sample-files/riot.png",
@@ -750,7 +750,7 @@ test.describe("Timeline", () => {
 
             const requestPromises: Promise<any>[] = [
                 page.waitForResponse("**/_matrix/media/v3/preview_url?url=https%3A%2F%2Fcall.element.io%2F&ts=*"),
-                page.waitForResponse("**/_matrix/client/v1/media/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
+                page.waitForResponse("**/_matrix/media/v3/thumbnail/matrix.org/2022-08-16_yaiSVSRIsNFfxDnV?*"),
             ];
 
             await app.client.sendMessage(room.roomId, "https://call.element.io/");

--- a/src/utils/tokens/pickling.ts
+++ b/src/utils/tokens/pickling.ts
@@ -21,6 +21,9 @@ limitations under the License.
 // is used by Element Web's service worker, and importing `matrix` brings in ~1mb of stuff
 // we don't need. Instead, we ignore the import restriction and only bring in what we actually
 // need.
+// Note: `base64` is not public in the js-sdk, so if it changes/breaks, that's on us. We should
+// be okay with our frequent tests, locked versioning, etc though. We'll pick up problems well
+// before release.
 // eslint-disable-next-line no-restricted-imports
 import { encodeUnpaddedBase64 } from "matrix-js-sdk/src/base64";
 import { logger } from "matrix-js-sdk/src/logger";

--- a/src/utils/tokens/pickling.ts
+++ b/src/utils/tokens/pickling.ts
@@ -17,7 +17,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { encodeUnpaddedBase64 } from "matrix-js-sdk/src/matrix";
+// Note: we don't import the base64 utils from `matrix-js-sdk/src/matrix` because this file
+// is used by Element Web's service worker, and importing `matrix` brings in ~1mb of stuff
+// we don't need. Instead, we ignore the import restriction and only bring in what we actually
+// need.
+// eslint-disable-next-line no-restricted-imports
+import { encodeUnpaddedBase64 } from "matrix-js-sdk/src/base64";
 import { logger } from "matrix-js-sdk/src/logger";
 
 /**


### PR DESCRIPTION
`sw.js` in a production build was previously 1mb almost exactly. With this change, it's 37kb.