### PR TITLE
Hide pinned messages when grouped in timeline when feature pinning is disabled

### DIFF
--- a/src/components/structures/grouper/MainGrouper.tsx
+++ b/src/components/structures/grouper/MainGrouper.tsx
@@ -26,6 +26,7 @@ import DateSeparator from "../../views/messages/DateSeparator";
 import HistoryTile from "../../views/rooms/HistoryTile";
 import EventListSummary from "../../views/elements/EventListSummary";
 import { SeparatorKind } from "../../views/messages/TimelineSeparator";
+import SettingsStore from "../../../settings/SettingsStore";
 
 const groupedStateEvents = [
     EventType.RoomMember,
@@ -97,6 +98,12 @@ export class MainGrouper extends BaseGrouper {
             // absorb hidden events to not split the summary
             return;
         }
+
+        if (ev.getType() === EventType.RoomPinnedEvents && !SettingsStore.getValue("feature_pinning")) {
+            // If pinned messages are disabled, don't show the summary
+            return;
+        }
+
         this.events.push(wrappedEvent);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

When the message pinning is disabled, we are still displaying the pinned event in the timeline when grouped with other events. This PR is fixing this issue.

Since the bug is minor, not easily testable and the message pinning will leave beta soon. I didn't write a test.

| Before  | After |
| ------------- | ------------- |
| <img width="762" alt="Screenshot 2024-08-14 at 16 18 41" src="https://github.com/user-attachments/assets/87d153d2-ba06-4dfd-8065-6966d14f71eb"> |<img width="762" alt="Screenshot 2024-08-14 at 16 19 53" src="https://github.com/user-attachments/assets/2ec075e1-f4e7-4087-8f4b-bef89414921f">  |