### PR TITLE
Remove redundant entries from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
         "node": ">=20.0.0"
     },
     "main": "./src/index.ts",
-    "matrix_src_main": "./src/index.ts",
-    "matrix_lib_main": "./lib/index.ts",
-    "matrix_lib_typings": "./lib/index.d.ts",
     "matrix_i18n_extra_translation_funcs": [
         "UserFriendlyError"
     ],


### PR DESCRIPTION
As far as I can tell, these are never used, and they exist only to confuse everyone.

(There are similar entries in matrix-js-sdk which are used, for now, during the release process, but that doesn't apply to the react SDK AFAICT)