### PR TITLE
Set entrypoints to use ./lib rather than ./src

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "engines": {
         "node": ">=20.0.0"
     },
-    "main": "./src/index.ts",
-    "matrix_src_main": "./src/index.ts",
-    "matrix_lib_main": "./lib/index.ts",
-    "matrix_lib_typings": "./lib/index.d.ts",
+    "main": "./lib/index.ts",
+    "typings": "./lib/index.d.ts",
     "matrix_i18n_extra_translation_funcs": [
         "UserFriendlyError"
     ],


### PR DESCRIPTION
Currently, we replace the entrypoints in package.json during the release cycle. I think, historically, this was done to make element-web development easier, but that doesn't actually use these entrypoints (instead it imports from `src`).

Accordingly, I think the switcheroo is unnecessary; furthermore it causes a whole bunch of confusion by making the development environment different from the release environment, and it complicates our CI and release process.

In short, the switcheroo has to die. This change makes the switcheroo operation a no-op; if it's successful, we'll remove the operation altogether once we know we won't have to release from any older branches that require it.