### PR TITLE
Remove unused CryptoCallbacks implementations

### DIFF
--- a/src/MatrixClientPeg.ts
+++ b/src/MatrixClientPeg.ts
@@ -41,7 +41,6 @@ import MatrixClientBackedSettingsHandler from "./settings/handlers/MatrixClientB
 import * as StorageManager from "./utils/StorageManager";
 import IdentityAuthClient from "./IdentityAuthClient";
 import { crossSigningCallbacks } from "./SecurityManager";
-import { ModuleRunner } from "./modules/ModuleRunner";
 import { SlidingSyncManager } from "./SlidingSyncManager";
 import { _t, UserFriendlyError } from "./languageHandler";
 import { SettingLevel } from "./settings/SettingLevel";
@@ -451,11 +450,6 @@ class MatrixClientPegClass implements IMatrixClientPeg {
                 }
             },
         };
-
-        const dehydrationKeyCallback = ModuleRunner.instance.extensions.cryptoSetup.getDehydrationKeyCallback();
-        if (dehydrationKeyCallback) {
-            opts.cryptoCallbacks!.getDehydrationKey = dehydrationKeyCallback;
-        }
 
         this.matrixClient = createMatrixClient(opts);
         this.matrixClient.setGuest(Boolean(creds.guest));

--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -39,11 +39,6 @@ let secretStorageKeys: Record<string, Uint8Array> = {};
 let secretStorageKeyInfo: Record<string, SecretStorage.SecretStorageKeyDescription> = {};
 let secretStorageBeingAccessed = false;
 
-let dehydrationCache: {
-    key?: Uint8Array;
-    keyInfo?: SecretStorage.SecretStorageKeyDescription;
-} = {};
-
 /**
  * This can be used by other components to check if secret storage access is in
  * progress, so that we can e.g. avoid intermittently showing toasts during
@@ -117,14 +112,6 @@ async function getSecretStorageKey({
     if (secretStorageBeingAccessed && secretStorageKeys[keyId]) {
         logger.debug(`getSecretStorageKey: returning key ${keyId} from cache`);
         return [keyId, secretStorageKeys[keyId]];
-    }
-
-    if (dehydrationCache.key) {
-        if (await MatrixClientPeg.safeGet().checkSecretStorageKey(dehydrationCache.key, keyInfo)) {
-            logger.debug("getSecretStorageKey: returning key from dehydration cache");
-            cacheSecretStorageKey(keyId, keyInfo, dehydrationCache.key);
-            return [keyId, dehydrationCache.key];
-        }
     }
 
     const keyFromCustomisations = ModuleRunner.instance.extensions.cryptoSetup.getSecretStorageKey();

--- a/test/MatrixClientPeg-test.ts
+++ b/test/MatrixClientPeg-test.ts
@@ -16,16 +16,11 @@ limitations under the License.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import fetchMockJest from "fetch-mock-jest";
-import {
-    ProvideCryptoSetupExtensions,
-    SecretStorageKeyDescription,
-} from "@matrix-org/react-sdk-module-api/lib/lifecycles/CryptoSetupExtensions";
 
 import { advanceDateAndTime, stubClient } from "./test-utils";
 import { IMatrixClientPeg, MatrixClientPeg as peg } from "../src/MatrixClientPeg";
 import SettingsStore from "../src/settings/SettingsStore";
 import { SettingLevel } from "../src/settings/SettingLevel";
-import { ModuleRunner } from "../src/modules/ModuleRunner";
 
 jest.useFakeTimers();
 
@@ -76,78 +71,6 @@ describe("MatrixClientPeg", () => {
         expect(peg.userRegisteredWithinLastHours(0)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(1)).toBe(false);
         expect(peg.userRegisteredWithinLastHours(24)).toBe(false);
-    });
-
-    describe(".start extensions", () => {
-        let testPeg: IMatrixClientPeg;
-
-        beforeEach(() => {
-            // instantiate a MatrixClientPegClass instance, with a new MatrixClient
-            testPeg = new PegClass();
-            fetchMockJest.get("http://example.com/_matrix/client/versions", {});
-        });
-
-        describe("cryptoSetup extension", () => {
-            it("should call default cryptoSetup.getDehydrationKeyCallback", async () => {
-                const mockCryptoSetup = {
-                    SHOW_ENCRYPTION_SETUP_UI: true,
-                    examineLoginResponse: jest.fn(),
-                    persistCredentials: jest.fn(),
-                    getSecretStorageKey: jest.fn(),
-                    createSecretStorageKey: jest.fn(),
-                    catchAccessSecretStorageError: jest.fn(),
-                    setupEncryptionNeeded: jest.fn(),
-                    getDehydrationKeyCallback: jest.fn().mockReturnValue(null),
-                } as ProvideCryptoSetupExtensions;
-
-                // Ensure we have an instance before we set up spies
-                const instance = ModuleRunner.instance;
-                jest.spyOn(instance.extensions, "cryptoSetup", "get").mockReturnValue(mockCryptoSetup);
-
-                testPeg.replaceUsingCreds({
-                    accessToken: "SEKRET",
-                    homeserverUrl: "http://example.com",
-                    userId: "@user:example.com",
-                    deviceId: "TEST_DEVICE_ID",
-                });
-
-                expect(mockCryptoSetup.getDehydrationKeyCallback).toHaveBeenCalledTimes(1);
-            });
-
-            it("should call overridden cryptoSetup.getDehydrationKeyCallback", async () => {
-                const mockDehydrationKeyCallback = () => Uint8Array.from([0x11, 0x22, 0x33]);
-
-                const mockCryptoSetup = {
-                    SHOW_ENCRYPTION_SETUP_UI: true,
-                    examineLoginResponse: jest.fn(),
-                    persistCredentials: jest.fn(),
-                    getSecretStorageKey: jest.fn(),
-                    createSecretStorageKey: jest.fn(),
-                    catchAccessSecretStorageError: jest.fn(),
-                    setupEncryptionNeeded: jest.fn(),
-                    getDehydrationKeyCallback: jest.fn().mockReturnValue(mockDehydrationKeyCallback),
-                } as ProvideCryptoSetupExtensions;
-
-                // Ensure we have an instance before we set up spies
-                const instance = ModuleRunner.instance;
-                jest.spyOn(instance.extensions, "cryptoSetup", "get").mockReturnValue(mockCryptoSetup);
-
-                testPeg.replaceUsingCreds({
-                    accessToken: "SEKRET",
-                    homeserverUrl: "http://example.com",
-                    userId: "@user:example.com",
-                    deviceId: "TEST_DEVICE_ID",
-                });
-                expect(mockCryptoSetup.getDehydrationKeyCallback).toHaveBeenCalledTimes(1);
-
-                const client = testPeg.get();
-                const dehydrationKey = await client?.cryptoCallbacks.getDehydrationKey!(
-                    {} as SecretStorageKeyDescription,
-                    (key: Uint8Array) => true,
-                );
-                expect(dehydrationKey).toEqual(Uint8Array.from([0x11, 0x22, 0x33]));
-            });
-        });
     });
 
     describe(".start", () => {


### PR DESCRIPTION
Per https://github.com/matrix-org/matrix-js-sdk/pull/4376, `CryptoCallbacks.onSecretRequested` and `CryptoCallbacks.getDehydrationKey` are no longer used. We may as well remove the code that writes to them.

Suggest review commit-by-commit