### PR TITLE
Ignore desktop for minimum browser support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
         "jwt-decode": "4.0.0",
         "@floating-ui/react": "0.26.11",
         "@radix-ui/react-id": "1.1.0",
-        "caniuse-lite": "1.0.30001643",
-        "electron-to-chromium": "1.5.2"
+        "caniuse-lite": "1.0.30001643"
     },
     "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -95,7 +94,6 @@
         "css-tree": "^2.3.1",
         "diff-dom": "^5.0.0",
         "diff-match-patch": "^1.0.5",
-        "electron-to-chromium": "^1.5.2",
         "emojibase-regex": "15.3.2",
         "escape-html": "^1.0.3",
         "file-saver": "^2.0.5",

--- a/src/SupportedBrowser.ts
+++ b/src/SupportedBrowser.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import browserlist from "browserslist";
-import electronToChromium from "electron-to-chromium/versions";
 import PopOutIcon from "@vector-im/compound-design-tokens/assets/web/icons/pop-out";
 
 import { DeviceType, parseUserAgent } from "./utils/device/parseUserAgent";
@@ -46,14 +45,6 @@ function onDismissClick(): void {
 function getBrowserNameVersion(browser: string): [name: string, version: number] {
     const [browserName, browserVersion] = browser.split(" ");
     const browserNameLc = browserName.toLowerCase();
-    if (browserNameLc === "electron") {
-        // The electron-to-chromium map is keyed by the major and minor version of Electron
-        const chromiumVersion = electronToChromium[browserVersion.split(".").slice(0, 2).join(".")];
-        if (chromiumVersion) {
-            return ["chrome", parseInt(chromiumVersion, 10)];
-        }
-    }
-
     return [browserNameLc, parseInt(browserVersion, 10)];
 }
 
@@ -80,6 +71,12 @@ export function getBrowserSupport(): boolean {
     }
 
     if (details.client) {
+        // We don't care about the browser version for desktop devices
+        // We ship our own browser (electron) for desktop devices
+        if (details.deviceType === DeviceType.Desktop) {
+            return supported;
+        }
+
         const [browserName, browserVersion] = getBrowserNameVersion(details.client);
         const minimumVersion = minimumBrowserVersions.get(browserName);
         // Check both with the sub-version cut off and without as some browsers have less granular versioning e.g. Safari

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,10 +4389,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@1.5.2, electron-to-chromium@^1.4.820, electron-to-chromium@^1.5.2, electron-to-chromium@^1.5.4:
+electron-to-chromium@^1.4.820:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.2.tgz#6126ad229ce45e781ec54ca40db0504787f23d19"
   integrity sha512-kc4r3U3V3WLaaZqThjYz/Y6z8tJe+7K0bbjUVo3i+LWIypVdMx5nXCkwRe6SWbY6ILqLdc1rKcKmr3HoH7wjSQ==
+
+electron-to-chromium@^1.5.4:
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
+  integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
 
 emittery@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Closes https://github.com/element-hq/element-desktop/issues/1828
The element web team discussed about it. We decided to remove it from desktop since it's making more harm than good in this case.

Two uses cases:
- Element ships ED and we assure than the electron version shipped is working
- A third party can build another version of electron and is responsible to use the correct electron version. 
