### PR TITLE
Implement download_file in widget driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "matrix-encrypt-attachment": "^1.0.3",
         "matrix-events-sdk": "0.0.1",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
-        "matrix-widget-api": "^1.8.2",
+        "matrix-widget-api": "github:nordeck/matrix-widget-api#download-file",
         "memoize-one": "^6.0.0",
         "minimist": "^1.2.5",
         "oidc-client-ts": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "matrix-encrypt-attachment": "^1.0.3",
         "matrix-events-sdk": "0.0.1",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
-        "matrix-widget-api": "github:nordeck/matrix-widget-api#download-file",
+        "matrix-widget-api": "^1.9.0",
         "memoize-one": "^6.0.0",
         "minimist": "^1.2.5",
         "oidc-client-ts": "^3.0.1",

--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -689,9 +689,9 @@ export class StopGapWidgetDriver extends WidgetDriver {
      */
     public async downloadFile(contentUri: string): Promise<{ file: XMLHttpRequestBodyInit }> {
         const client = MatrixClientPeg.safeGet();
-        const media = new Media({mxc: contentUri}, client);
+        const media = new Media({ mxc: contentUri }, client);
         const response = await media.downloadSource();
         const blob = await response.blob();
-        return { file:  blob };
+        return { file: blob };
     }
 }

--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -73,6 +73,7 @@ import { navigateToPermalink } from "../../utils/permalinks/navigator";
 import { SdkContextClass } from "../../contexts/SDKContext";
 import { ModuleRunner } from "../../modules/ModuleRunner";
 import SettingsStore from "../../settings/SettingsStore";
+import { Media } from "../../customisations/Media";
 
 // TODO: Purge this from the universe
 
@@ -678,5 +679,19 @@ export class StopGapWidgetDriver extends WidgetDriver {
         const uploadResult = await client.uploadContent(file);
 
         return { contentUri: uploadResult.content_uri };
+    }
+
+    /**
+     * Download a file from the media repository on the homeserver.
+     *
+     * @param contentUri - the MXC URI of the file to download
+     * @returns an object with: file - response contents as Blob
+     */
+    public async downloadFile(contentUri: string): Promise<{ file: XMLHttpRequestBodyInit }> {
+        const client = MatrixClientPeg.safeGet();
+        const media = new Media({mxc: contentUri}, client);
+        const response = await media.downloadSource();
+        const blob = await response.blob();
+        return { file:  blob };
     }
 }

--- a/test/stores/widgets/StopGapWidgetDriver-test.ts
+++ b/test/stores/widgets/StopGapWidgetDriver-test.ts
@@ -629,13 +629,13 @@ describe("StopGapWidgetDriver", () => {
             // eslint-disable-next-line no-restricted-properties
             client.mxcUrlToHttp.mockImplementation((mxcUrl) => {
                 if (mxcUrl === "mxc://example.com/test_file") {
-                    return "https://example.com/_matrix/media/v3/download/test_file";
+                    return "https://example.com/_matrix/media/v3/download/example.com/test_file";
                 }
 
                 return null;
             });
 
-            fetchMockJest.get("https://example.com/_matrix/media/v3/download/test_file", "test contents");
+            fetchMockJest.get("https://example.com/_matrix/media/v3/download/example.com/test_file", "test contents");
 
             const result = await driver.downloadFile("mxc://example.com/test_file");
             // A type test is impossible here because of

--- a/test/stores/widgets/StopGapWidgetDriver-test.ts
+++ b/test/stores/widgets/StopGapWidgetDriver-test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { mocked, MockedObject } from "jest-mock";
+import fetchMockJest from "fetch-mock-jest";
 import {
     MatrixClient,
     ClientEvent,
@@ -614,6 +615,34 @@ describe("StopGapWidgetDriver", () => {
             });
 
             expect(client.uploadContent).toHaveBeenCalledWith("data");
+        });
+    });
+
+    describe("downloadFile", () => {
+        let driver: WidgetDriver;
+
+        beforeEach(() => {
+            driver = mkDefaultDriver();
+        });
+
+        it("should download a file and return the blob", async () => {
+            // eslint-disable-next-line no-restricted-properties
+            client.mxcUrlToHttp.mockImplementation((mxcUrl) => {
+                if (mxcUrl === "mxc://example.com/test_file") {
+                    return "https://example.com/_matrix/media/v3/download/test_file";
+                }
+
+                return null;
+            });
+
+            fetchMockJest.get("https://example.com/_matrix/media/v3/download/test_file", "test contents");
+
+            const result = await driver.downloadFile("mxc://example.com/test_file");
+            // A type test is impossible here because of
+            // https://github.com/jefflau/jest-fetch-mock/issues/209
+            // Tell TypeScript that file is a blob.
+            const file = result.file as Blob;
+            await expect(file.text()).resolves.toEqual("test contents");
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6952,9 +6952,10 @@ matrix-widget-api@^1.8.2:
     "@types/events" "^3.0.0"
     events "^3.2.0"
 
-"matrix-widget-api@github:nordeck/matrix-widget-api#download-file":
-  version "1.8.2"
-  resolved "https://codeload.github.com/nordeck/matrix-widget-api/tar.gz/7c06a33680cdef6873e5e70070db11e79ed39979"
+matrix-widget-api@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.9.0.tgz#884136b405bd3c56e4ea285095c9e01ec52b6b1f"
+  integrity sha512-au8mqralNDqrEvaVAkU37bXOb8I9SCe+ACdPk11QWw58FKstVq31q2wRz+qWA6J+42KJ6s1DggWbG/S3fEs3jw==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6952,6 +6952,13 @@ matrix-widget-api@^1.8.2:
     "@types/events" "^3.0.0"
     events "^3.2.0"
 
+"matrix-widget-api@github:nordeck/matrix-widget-api#download-file":
+  version "1.8.2"
+  resolved "https://codeload.github.com/nordeck/matrix-widget-api/tar.gz/7c06a33680cdef6873e5e70070db11e79ed39979"
+  dependencies:
+    "@types/events" "^3.0.0"
+    events "^3.2.0"
+
 md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"


### PR DESCRIPTION
Implement the widget API `download_file` in the widget driver.

Needs https://github.com/matrix-org/matrix-widget-api/pull/99

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
