### PR TITLE
Install deja-vu font in docker image

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.45.3-jammy
 WORKDIR /work/matrix-react-sdk
 VOLUME ["/work/element-web/node_modules"]
 
+# fonts-dejavu is needed for the same RTL rendering as on CI
 RUN apt-get update && apt-get -y install docker.io fonts-dejavu
 
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.45.3-jammy
 WORKDIR /work/matrix-react-sdk
 VOLUME ["/work/element-web/node_modules"]
 
-RUN apt-get update && apt-get -y install docker.io
+RUN apt-get update && apt-get -y install docker.io fonts-dejavu
 
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
 ENTRYPOINT ["bash", "/opt/docker-entrypoint.sh"]


### PR DESCRIPTION
Looks like the playwright image which is based on ubuntu does not come preinstalled with the dejavu fonts.
But the screenshot comparison in our CI happens on a version of ubuntu that does have the font.