### PR TITLE
Fix pin/unpin slowness and non refresh from the message action bar

### DIFF
--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -286,10 +286,6 @@ export function hasThreadSummary(event: MatrixEvent): boolean {
     return event.isThreadRoot && !!event.getThread()?.length && !!event.getThread()!.replyToEvent;
 }
 
-export function canPinEvent(event: MatrixEvent): boolean {
-    return !M_BEACON_INFO.matches(event.getType());
-}
-
 export const highlightEvent = (roomId: string, eventId: string): void => {
     defaultDispatcher.dispatch<ViewRoomPayload>({
         action: Action.ViewRoom,

--- a/src/utils/PinningUtils.ts
+++ b/src/utils/PinningUtils.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { MatrixEvent, EventType, M_POLL_START, MatrixClient, EventTimeline } from "matrix-js-sdk/src/matrix";
 
-import { canPinEvent, isContentActionable } from "./EventUtils";
+import { isContentActionable } from "./EventUtils";
 import SettingsStore from "../settings/SettingsStore";
 import { ReadPinsEventId } from "../components/views/right_panel/types";
 
@@ -31,7 +31,8 @@ export default class PinningUtils {
     ];
 
     /**
-     * Determines if the given event may be pinned.
+     * Determines if the given event can be pinned.
+     * This is a simple check to see if the event is of a type that can be pinned.
      * @param {MatrixEvent} event The event to check.
      * @return {boolean} True if the event may be pinned, false otherwise.
      */
@@ -62,7 +63,8 @@ export default class PinningUtils {
     }
 
     /**
-     * Determines if the given event may be pinned or unpinned.
+     * Determines if the given event may be pinned or unpinned by the current user.
+     * This checks if the user has the necessary permissions to pin or unpin the event, and if the event is pinnable.
      * @param matrixClient
      * @param mxEvent
      */
@@ -77,7 +79,7 @@ export default class PinningUtils {
             room
                 .getLiveTimeline()
                 .getState(EventTimeline.FORWARDS)
-                ?.mayClientSendStateEvent(EventType.RoomPinnedEvents, matrixClient) && canPinEvent(mxEvent),
+                ?.mayClientSendStateEvent(EventType.RoomPinnedEvents, matrixClient) && PinningUtils.isPinnable(mxEvent),
         );
     }
 

--- a/test/utils/PinningUtils-test.ts
+++ b/test/utils/PinningUtils-test.ts
@@ -20,7 +20,7 @@ import { mocked } from "jest-mock";
 import { createTestClient } from "../test-utils";
 import PinningUtils from "../../src/utils/PinningUtils";
 import SettingsStore from "../../src/settings/SettingsStore";
-import { canPinEvent, isContentActionable } from "../../src/utils/EventUtils";
+import { isContentActionable } from "../../src/utils/EventUtils";
 import { ReadPinsEventId } from "../../src/components/views/right_panel/types";
 
 jest.mock("../../src/utils/EventUtils", () => {
@@ -35,7 +35,6 @@ describe("PinningUtils", () => {
     const userId = "@alice:example.org";
 
     const mockedIsContentActionable = mocked(isContentActionable);
-    const mockedCanPinEvent = mocked(canPinEvent);
 
     let matrixClient: MatrixClient;
     let room: Room;
@@ -63,7 +62,6 @@ describe("PinningUtils", () => {
         // Enable feature pinning
         jest.spyOn(SettingsStore, "getValue").mockReturnValue(true);
         mockedIsContentActionable.mockImplementation(() => true);
-        mockedCanPinEvent.mockImplementation(() => true);
 
         matrixClient = createTestClient();
         room = new Room(roomId, matrixClient, userId);
@@ -171,8 +169,7 @@ describe("PinningUtils", () => {
         });
 
         test("should return false if event is not pinnable", () => {
-            mockedCanPinEvent.mockReturnValue(false);
-            const event = makePinEvent();
+            const event = makePinEvent({ type: EventType.RoomCreate });
 
             expect(PinningUtils.canPinOrUnpin(matrixClient, event)).toBe(false);
         });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

This PR:
- Improve doc of PinningUtils
- Use the `PinningUtils.isPinnable` instead of `canPinEvent` in order to use the same function to determine if an event is pinnable.
- Parallelize promises in order to reduce the slowness of the pin action
- Fix the pin/unpin icon is not updated in the message action bar when clicked.  Rerender the message action bar if there is a change in room pinned events.
