### PR TITLE
Fix JS-SDK failing import

### DIFF
--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -6,7 +6,8 @@
         "resolveJsonModule": true,
         "esModuleInterop": true,
         "moduleResolution": "node",
-        "module": "es2022"
+        "module": "es2022",
+        "allowImportingTsExtensions": true
     },
     "include": [
         "**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "allowImportingTsExtensions": true,
         "experimentalDecorators": false,
         "emitDecoratorMetadata": false,
         "resolveJsonModule": true,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Due to https://github.com/matrix-org/matrix-js-sdk/pull/4377
Add `allowImportingTsExtensions` to our tsconfigs
