### PR TITLE
The pinned message banner or list are triggering  🎉 effect.

### DIFF
--- a/src/hooks/usePinnedEvents.ts
+++ b/src/hooks/usePinnedEvents.ts
@@ -126,7 +126,7 @@ async function fetchPinnedEvent(room: Room, pinnedEventId: string, cli: MatrixCl
     // Decrypt the event if it's encrypted
     // Can happen when the tab is refreshed and the pinned events card is opened directly
     if (localEvent?.isEncrypted()) {
-        await cli.decryptEventIfNeeded(localEvent);
+        await cli.decryptEventIfNeeded(localEvent, { emit: false });
     }
 
     // If the event is available locally, return it if it's pinnable
@@ -150,7 +150,7 @@ async function fetchPinnedEvent(room: Room, pinnedEventId: string, cli: MatrixCl
 
         // Decrypt the event if it's encrypted
         if (event.isEncrypted()) {
-            await cli.decryptEventIfNeeded(event);
+            await cli.decryptEventIfNeeded(event, { emit: false });
         }
 
         // Handle poll events


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

The banner or the list try to decrypt the pinned events.
The room listen to decrypted event and will fire the 🎉 effect if the decrypted event has the 🎉 emoji.

In this case, we are decrypting locally the event to display it so we don't need to fire the event.
