### PR TITLE
Add a prefix to file, poll, image, video and audio in the pinned message banner

### DIFF
--- a/res/css/views/rooms/_PinnedMessageBanner.pcss
+++ b/res/css/views/rooms/_PinnedMessageBanner.pcss
@@ -94,6 +94,10 @@
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+
+            .mx_PinnedMessageBanner_prefix {
+                font: var(--cpd-font-body-sm-semibold);
+            }
         }
 
         .mx_PinnedMessageBanner_redactedMessage {

--- a/src/components/views/rooms/PinnedMessageBanner.tsx
+++ b/src/components/views/rooms/PinnedMessageBanner.tsx
@@ -17,7 +17,7 @@
 import React, { JSX, useEffect, useMemo, useState } from "react";
 import { Icon as PinIcon } from "@vector-im/compound-design-tokens/icons/pin-solid.svg";
 import { Button } from "@vector-im/compound-web";
-import { MatrixEvent, MsgType, Room } from "matrix-js-sdk/src/matrix";
+import { M_POLL_START, MatrixEvent, MsgType, Room } from "matrix-js-sdk/src/matrix";
 import classNames from "classnames";
 
 import { usePinnedEvents, useSortedFetchedPinnedEvents } from "../../../hooks/usePinnedEvents";
@@ -146,7 +146,7 @@ function EventPreview({ pinnedEvent }: EventPreviewProps): JSX.Element | null {
     const preview = useEventPreview(pinnedEvent);
     if (!preview) return null;
 
-    const prefix = getPreviewPrefix(pinnedEvent.getContent().msgtype as MsgType);
+    const prefix = getPreviewPrefix(pinnedEvent.getType(), pinnedEvent.getContent().msgtype as MsgType);
     if (!prefix) return <span className="mx_PinnedMessageBanner_message">{preview}</span>;
 
     return (
@@ -177,10 +177,17 @@ function useEventPreview(pinnedEvent: MatrixEvent | null): string | null {
 }
 
 /**
- * Get the prefix for the preview based on the message type.
+ * Get the prefix for the preview based on the type and the message type.
+ * @param type
  * @param msgType
  */
-function getPreviewPrefix(msgType: MsgType): string | null {
+function getPreviewPrefix(type: string, msgType: MsgType): string | null {
+    switch (type) {
+        case M_POLL_START.name:
+            return _t("room|pinned_message_banner|prefix|poll");
+        default:
+    }
+
     switch (msgType) {
         case MsgType.Audio:
             return _t("room|pinned_message_banner|prefix|audio");

--- a/src/components/views/rooms/PinnedMessageBanner.tsx
+++ b/src/components/views/rooms/PinnedMessageBanner.tsx
@@ -17,7 +17,7 @@
 import React, { JSX, useEffect, useMemo, useState } from "react";
 import { Icon as PinIcon } from "@vector-im/compound-design-tokens/icons/pin-solid.svg";
 import { Button } from "@vector-im/compound-web";
-import { MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
+import { MatrixEvent, MsgType, Room } from "matrix-js-sdk/src/matrix";
 import classNames from "classnames";
 
 import { usePinnedEvents, useSortedFetchedPinnedEvents } from "../../../hooks/usePinnedEvents";
@@ -146,7 +146,23 @@ function EventPreview({ pinnedEvent }: EventPreviewProps): JSX.Element | null {
     const preview = useEventPreview(pinnedEvent);
     if (!preview) return null;
 
-    return <span className="mx_PinnedMessageBanner_message">{preview}</span>;
+    const prefix = getPreviewPrefix(pinnedEvent.getContent().msgtype as MsgType);
+    if (!prefix) return <span className="mx_PinnedMessageBanner_message">{preview}</span>;
+
+    return (
+        <span className="mx_PinnedMessageBanner_message">
+            {_t(
+                "room|pinned_message_banner|preview",
+                {
+                    prefix,
+                    preview,
+                },
+                {
+                    bold: (sub) => <span className="mx_PinnedMessageBanner_prefix">{sub}</span>,
+                },
+            )}
+        </span>
+    );
 }
 
 /**
@@ -158,6 +174,25 @@ function useEventPreview(pinnedEvent: MatrixEvent | null): string | null {
         if (!pinnedEvent || pinnedEvent.isRedacted() || pinnedEvent.isDecryptionFailure()) return null;
         return MessagePreviewStore.instance.generatePreviewForEvent(pinnedEvent);
     }, [pinnedEvent]);
+}
+
+/**
+ * Get the prefix for the preview based on the message type.
+ * @param msgType
+ */
+function getPreviewPrefix(msgType: MsgType): string | null {
+    switch (msgType) {
+        case MsgType.Audio:
+            return _t("room|pinned_message_banner|prefix|audio");
+        case MsgType.Image:
+            return _t("room|pinned_message_banner|prefix|image");
+        case MsgType.Video:
+            return _t("room|pinned_message_banner|prefix|video");
+        case MsgType.File:
+            return _t("room|pinned_message_banner|prefix|file");
+        default:
+            return null;
+    }
 }
 
 const MAX_INDICATORS = 3;

--- a/src/components/views/rooms/PinnedMessageBanner.tsx
+++ b/src/components/views/rooms/PinnedMessageBanner.tsx
@@ -147,10 +147,15 @@ function EventPreview({ pinnedEvent }: EventPreviewProps): JSX.Element | null {
     if (!preview) return null;
 
     const prefix = getPreviewPrefix(pinnedEvent.getType(), pinnedEvent.getContent().msgtype as MsgType);
-    if (!prefix) return <span className="mx_PinnedMessageBanner_message">{preview}</span>;
+    if (!prefix)
+        return (
+            <span className="mx_PinnedMessageBanner_message" data-testid="banner-message">
+                {preview}
+            </span>
+        );
 
     return (
-        <span className="mx_PinnedMessageBanner_message">
+        <span className="mx_PinnedMessageBanner_message" data-testid="banner-message">
             {_t(
                 "room|pinned_message_banner|preview",
                 {

--- a/src/components/views/rooms/PinnedMessageBanner.tsx
+++ b/src/components/views/rooms/PinnedMessageBanner.tsx
@@ -59,7 +59,7 @@ export function PinnedMessageBanner({ room, permalinkCreator }: PinnedMessageBan
     const [currentEventIndex, setCurrentEventIndex] = useState(eventCount - 1);
     // When the number of pinned messages changes, we want to display the last message
     useEffect(() => {
-        setCurrentEventIndex((currentEventIndex) => eventCount - 1);
+        setCurrentEventIndex(() => eventCount - 1);
     }, [eventCount]);
 
     const pinnedEvent = pinnedEvents[currentEventIndex];

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2053,6 +2053,13 @@
             "button_view_all": "View all",
             "description": "This room has pinned messages. Click to view them.",
             "go_to_message": "View the pinned message in the timeline.",
+            "prefix": {
+                "audio": "Audio",
+                "file": "File",
+                "image": "Image",
+                "video": "Video"
+            },
+            "preview": "<bold>%(prefix)s:</bold> %(preview)s",
             "title": "<bold>%(index)s of %(length)s</bold> Pinned messages"
         },
         "read_topic": "Click to read topic",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2057,6 +2057,7 @@
                 "audio": "Audio",
                 "file": "File",
                 "image": "Image",
+                "poll": "Poll",
                 "video": "Video"
             },
             "preview": "<bold>%(prefix)s:</bold> %(preview)s",

--- a/test/components/views/rooms/__snapshots__/PinnedMessageBanner-test.tsx.snap
+++ b/test/components/views/rooms/__snapshots__/PinnedMessageBanner-test.tsx.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<PinnedMessageBanner /> should display display a poll event 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="This room has pinned messages. Click to view them."
+    class="mx_PinnedMessageBanner"
+    data-single-message="true"
+    data-testid="pinned-message-banner"
+  >
+    <button
+      aria-label="View the pinned message in the timeline."
+      class="mx_PinnedMessageBanner_main"
+      type="button"
+    >
+      <div
+        class="mx_PinnedMessageBanner_content"
+      >
+        <div
+          class="mx_PinnedMessageBanner_Indicators"
+        >
+          <div
+            class="mx_PinnedMessageBanner_Indicator mx_PinnedMessageBanner_Indicator--active"
+            data-testid="banner-indicator"
+          />
+        </div>
+        <div
+          class="mx_PinnedMessageBanner_PinIcon"
+          width="20"
+        />
+        <span
+          class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
+        >
+          <span>
+            <span
+              class="mx_PinnedMessageBanner_prefix"
+            >
+              Poll:
+            </span>
+             Alice?
+          </span>
+        </span>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<PinnedMessageBanner /> should display the last message when the pinned event array changed 1`] = `
 <DocumentFragment>
   <div
@@ -51,6 +98,7 @@ exports[`<PinnedMessageBanner /> should display the last message when the pinned
         </div>
         <span
           class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
         >
           Third pinned message
         </span>
@@ -64,6 +112,194 @@ exports[`<PinnedMessageBanner /> should display the last message when the pinned
       tabindex="0"
     >
       View all
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<PinnedMessageBanner /> should display the m.audio event type 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="This room has pinned messages. Click to view them."
+    class="mx_PinnedMessageBanner"
+    data-single-message="true"
+    data-testid="pinned-message-banner"
+  >
+    <button
+      aria-label="View the pinned message in the timeline."
+      class="mx_PinnedMessageBanner_main"
+      type="button"
+    >
+      <div
+        class="mx_PinnedMessageBanner_content"
+      >
+        <div
+          class="mx_PinnedMessageBanner_Indicators"
+        >
+          <div
+            class="mx_PinnedMessageBanner_Indicator mx_PinnedMessageBanner_Indicator--active"
+            data-testid="banner-indicator"
+          />
+        </div>
+        <div
+          class="mx_PinnedMessageBanner_PinIcon"
+          width="20"
+        />
+        <span
+          class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
+        >
+          <span>
+            <span
+              class="mx_PinnedMessageBanner_prefix"
+            >
+              Audio:
+            </span>
+             Message with m.audio type
+          </span>
+        </span>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<PinnedMessageBanner /> should display the m.file event type 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="This room has pinned messages. Click to view them."
+    class="mx_PinnedMessageBanner"
+    data-single-message="true"
+    data-testid="pinned-message-banner"
+  >
+    <button
+      aria-label="View the pinned message in the timeline."
+      class="mx_PinnedMessageBanner_main"
+      type="button"
+    >
+      <div
+        class="mx_PinnedMessageBanner_content"
+      >
+        <div
+          class="mx_PinnedMessageBanner_Indicators"
+        >
+          <div
+            class="mx_PinnedMessageBanner_Indicator mx_PinnedMessageBanner_Indicator--active"
+            data-testid="banner-indicator"
+          />
+        </div>
+        <div
+          class="mx_PinnedMessageBanner_PinIcon"
+          width="20"
+        />
+        <span
+          class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
+        >
+          <span>
+            <span
+              class="mx_PinnedMessageBanner_prefix"
+            >
+              File:
+            </span>
+             Message with m.file type
+          </span>
+        </span>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<PinnedMessageBanner /> should display the m.image event type 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="This room has pinned messages. Click to view them."
+    class="mx_PinnedMessageBanner"
+    data-single-message="true"
+    data-testid="pinned-message-banner"
+  >
+    <button
+      aria-label="View the pinned message in the timeline."
+      class="mx_PinnedMessageBanner_main"
+      type="button"
+    >
+      <div
+        class="mx_PinnedMessageBanner_content"
+      >
+        <div
+          class="mx_PinnedMessageBanner_Indicators"
+        >
+          <div
+            class="mx_PinnedMessageBanner_Indicator mx_PinnedMessageBanner_Indicator--active"
+            data-testid="banner-indicator"
+          />
+        </div>
+        <div
+          class="mx_PinnedMessageBanner_PinIcon"
+          width="20"
+        />
+        <span
+          class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
+        >
+          <span>
+            <span
+              class="mx_PinnedMessageBanner_prefix"
+            >
+              Image:
+            </span>
+             Message with m.image type
+          </span>
+        </span>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<PinnedMessageBanner /> should display the m.video event type 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="This room has pinned messages. Click to view them."
+    class="mx_PinnedMessageBanner"
+    data-single-message="true"
+    data-testid="pinned-message-banner"
+  >
+    <button
+      aria-label="View the pinned message in the timeline."
+      class="mx_PinnedMessageBanner_main"
+      type="button"
+    >
+      <div
+        class="mx_PinnedMessageBanner_content"
+      >
+        <div
+          class="mx_PinnedMessageBanner_Indicators"
+        >
+          <div
+            class="mx_PinnedMessageBanner_Indicator mx_PinnedMessageBanner_Indicator--active"
+            data-testid="banner-indicator"
+          />
+        </div>
+        <div
+          class="mx_PinnedMessageBanner_PinIcon"
+          width="20"
+        />
+        <span
+          class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
+        >
+          <span>
+            <span
+              class="mx_PinnedMessageBanner_prefix"
+            >
+              Video:
+            </span>
+             Message with m.video type
+          </span>
+        </span>
+      </div>
     </button>
   </div>
 </DocumentFragment>
@@ -116,6 +352,7 @@ exports[`<PinnedMessageBanner /> should render 2 pinned event 1`] = `
         </div>
         <span
           class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
         >
           Second pinned message
         </span>
@@ -185,6 +422,7 @@ exports[`<PinnedMessageBanner /> should render 4 pinned event 1`] = `
         </div>
         <span
           class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
         >
           Fourth pinned message
         </span>
@@ -233,6 +471,7 @@ exports[`<PinnedMessageBanner /> should render a single pinned event 1`] = `
         />
         <span
           class="mx_PinnedMessageBanner_message"
+          data-testid="banner-message"
         >
           First pinned message
         </span>


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).

Add a prefix for file, poll, image, audio and video in the pinning message banner.

Examples:
<img width="1063" alt="Screenshot 2024-09-03 at 16 35 10" src="https://github.com/user-attachments/assets/d8a5ecf3-9dda-4a93-a880-7f8cbdd6ad16">
<img width="1063" alt="Screenshot 2024-09-03 at 16 35 05" src="https://github.com/user-attachments/assets/af929257-3b1a-4a8a-8b9f-406d092471bf">
<img width="1063" alt="Screenshot 2024-09-03 at 16 34 58" src="https://github.com/user-attachments/assets/62e005a5-a041-4565-a786-39882ae91798">

